### PR TITLE
fix(ai): ai agents struggling/generating incorrect filters

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -755,8 +755,15 @@ Notes:
             ],
             "type": "object",
           },
-          "customMetrics": {
-            "description": "Define new metric columns the explore doesn't already have. Two kinds:
+          "description": {
+            "description": "A descriptive summary or explanation for the chart.",
+            "type": "string",
+          },
+          "queryConfig": {
+            "additionalProperties": false,
+            "properties": {
+              "customMetrics": {
+                "description": "Define new metric columns the explore doesn't already have. Two kinds:
 
 (1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
     (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
@@ -790,2427 +797,814 @@ Example B — "Revenue by month with year-over-year comparison"
   queryConfig.dimensions: ["orders_order_date_month"]
   queryConfig.metrics: ["orders_revenue"]
   customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }], ",
-            "items": {
-              "anyOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "baseDimensionName": {
-                      "description": "Name of the base dimension/column this metric calculates from",
-                      "type": "string",
-                    },
-                    "description": {
-                      "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
-                      "type": "string",
-                    },
-                    "filters": {
-                      "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name., ",
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "filter": {
-                            "anyOf": [
-                              {
+                "items": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "baseDimensionName": {
+                          "description": "Name of the base dimension/column this metric calculates from",
+                          "type": "string",
+                        },
+                        "description": {
+                          "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                          "type": "string",
+                        },
+                        "filters": {
+                          "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name., ",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "filter": {
                                 "anyOf": [
                                   {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "boolean",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "boolean",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "isNull",
-                                          "notNull",
-                                        ],
-                                        "type": "string",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "boolean",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "boolean",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "equals",
-                                          "notEquals",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "type": "boolean",
-                                        },
-                                        "maxItems": 1,
-                                        "minItems": 1,
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                ],
-                              },
-                              {
-                                "anyOf": [
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "string",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "string",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "isNull",
-                                          "notNull",
-                                        ],
-                                        "type": "string",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "string",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "string",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "equals",
-                                          "notEquals",
-                                          "startsWith",
-                                          "endsWith",
-                                          "include",
-                                          "doesNotInclude",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "type": "string",
-                                        },
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                ],
-                              },
-                              {
-                                "anyOf": [
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "number",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "number",
-                                          "percentile",
-                                          "median",
-                                          "average",
-                                          "count",
-                                          "count_distinct",
-                                          "sum",
-                                          "sum_distinct",
-                                          "average_distinct",
-                                          "min",
-                                          "max",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "isNull",
-                                          "notNull",
-                                        ],
-                                        "type": "string",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "number",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "number",
-                                          "percentile",
-                                          "median",
-                                          "average",
-                                          "count",
-                                          "count_distinct",
-                                          "sum",
-                                          "sum_distinct",
-                                          "average_distinct",
-                                          "min",
-                                          "max",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "equals",
-                                          "notEquals",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "type": "number",
-                                        },
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "number",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "number",
-                                          "percentile",
-                                          "median",
-                                          "average",
-                                          "count",
-                                          "count_distinct",
-                                          "sum",
-                                          "sum_distinct",
-                                          "average_distinct",
-                                          "min",
-                                          "max",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "lessThan",
-                                          "lessThanOrEqual",
-                                          "greaterThan",
-                                          "greaterThanOrEqual",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "type": "number",
-                                        },
-                                        "maxItems": 1,
-                                        "minItems": 1,
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "number",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "number",
-                                          "percentile",
-                                          "median",
-                                          "average",
-                                          "count",
-                                          "count_distinct",
-                                          "sum",
-                                          "sum_distinct",
-                                          "average_distinct",
-                                          "min",
-                                          "max",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "inBetween",
-                                          "notInBetween",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "type": "number",
-                                        },
-                                        "maxItems": 2,
-                                        "minItems": 2,
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                ],
-                              },
-                              {
-                                "anyOf": [
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "isNull",
-                                          "notNull",
-                                        ],
-                                        "type": "string",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "equals",
-                                          "notEquals",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "anyOf": [
-                                            {
-                                              "format": "date",
-                                              "type": "string",
-                                            },
-                                            {
-                                              "format": "date-time",
-                                              "type": "string",
-                                            },
-                                          ],
-                                        },
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "inThePast",
-                                          "notInThePast",
-                                          "inTheNext",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "settings": {
+                                    "anyOf": [
+                                      {
                                         "additionalProperties": false,
                                         "properties": {
-                                          "completed": {
-                                            "type": "boolean",
+                                          "fieldFilterType": {
+                                            "const": "boolean",
+                                            "type": "string",
                                           },
-                                          "unitOfTime": {
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
                                             "enum": [
-                                              "days",
-                                              "weeks",
-                                              "months",
-                                              "quarters",
-                                              "years",
+                                              "boolean",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
                                             ],
                                             "type": "string",
                                           },
                                         },
                                         "required": [
-                                          "completed",
-                                          "unitOfTime",
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
                                         ],
                                         "type": "object",
                                       },
-                                      "values": {
-                                        "items": {
-                                          "type": "number",
-                                        },
-                                        "maxItems": 1,
-                                        "minItems": 1,
-                                        "type": "array",
-                                      },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                      "settings",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "inTheCurrent",
-                                          "notInTheCurrent",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "settings": {
+                                      {
                                         "additionalProperties": false,
                                         "properties": {
-                                          "completed": {
-                                            "const": false,
-                                            "type": "boolean",
+                                          "fieldFilterType": {
+                                            "const": "boolean",
+                                            "type": "string",
                                           },
-                                          "unitOfTime": {
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
                                             "enum": [
-                                              "days",
-                                              "weeks",
-                                              "months",
-                                              "quarters",
-                                              "years",
+                                              "boolean",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "boolean",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "string",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "string",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
                                             ],
                                             "type": "string",
                                           },
                                         },
                                         "required": [
-                                          "completed",
-                                          "unitOfTime",
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
                                         ],
                                         "type": "object",
                                       },
-                                      "values": {
-                                        "items": {
-                                          "const": 1,
-                                          "type": "number",
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "string",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "string",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                              "startsWith",
+                                              "endsWith",
+                                              "include",
+                                              "doesNotInclude",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "string",
+                                            },
+                                            "type": "array",
+                                          },
                                         },
-                                        "maxItems": 1,
-                                        "minItems": 1,
-                                        "type": "array",
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
                                       },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
-                                      "settings",
                                     ],
-                                    "type": "object",
                                   },
                                   {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "enum": [
-                                          "lessThan",
-                                          "lessThanOrEqual",
-                                          "greaterThan",
-                                          "greaterThanOrEqual",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "anyOf": [
-                                            {
-                                              "format": "date",
-                                              "type": "string",
-                                            },
-                                            {
-                                              "format": "date-time",
-                                              "type": "string",
-                                            },
-                                          ],
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "number",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "number",
+                                              "percentile",
+                                              "median",
+                                              "average",
+                                              "count",
+                                              "count_distinct",
+                                              "sum",
+                                              "sum_distinct",
+                                              "average_distinct",
+                                              "min",
+                                              "max",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
                                         },
-                                        "maxItems": 1,
-                                        "minItems": 1,
-                                        "type": "array",
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
                                       },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "number",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "number",
+                                              "percentile",
+                                              "median",
+                                              "average",
+                                              "count",
+                                              "count_distinct",
+                                              "sum",
+                                              "sum_distinct",
+                                              "average_distinct",
+                                              "min",
+                                              "max",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "number",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "number",
+                                              "percentile",
+                                              "median",
+                                              "average",
+                                              "count",
+                                              "count_distinct",
+                                              "sum",
+                                              "sum_distinct",
+                                              "average_distinct",
+                                              "min",
+                                              "max",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "lessThan",
+                                              "lessThanOrEqual",
+                                              "greaterThan",
+                                              "greaterThanOrEqual",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "number",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "number",
+                                              "percentile",
+                                              "median",
+                                              "average",
+                                              "count",
+                                              "count_distinct",
+                                              "sum",
+                                              "sum_distinct",
+                                              "average_distinct",
+                                              "min",
+                                              "max",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inBetween",
+                                              "notInBetween",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
                                     ],
-                                    "type": "object",
                                   },
                                   {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "fieldFilterType": {
-                                        "const": "date",
-                                        "type": "string",
-                                      },
-                                      "fieldId": {
-                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                        "type": "string",
-                                      },
-                                      "fieldType": {
-                                        "enum": [
-                                          "date",
-                                          "timestamp",
-                                        ],
-                                        "type": "string",
-                                      },
-                                      "operator": {
-                                        "const": "inBetween",
-                                        "type": "string",
-                                      },
-                                      "values": {
-                                        "items": {
-                                          "anyOf": [
-                                            {
-                                              "format": "date",
-                                              "type": "string",
-                                            },
-                                            {
-                                              "format": "date-time",
-                                              "type": "string",
-                                            },
-                                          ],
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "isNull",
+                                              "notNull",
+                                            ],
+                                            "type": "string",
+                                          },
                                         },
-                                        "maxItems": 2,
-                                        "minItems": 2,
-                                        "type": "array",
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                        ],
+                                        "type": "object",
                                       },
-                                    },
-                                    "required": [
-                                      "fieldId",
-                                      "fieldType",
-                                      "fieldFilterType",
-                                      "operator",
-                                      "values",
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "equals",
+                                              "notEquals",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "format": "date",
+                                                  "type": "string",
+                                                },
+                                                {
+                                                  "format": "date-time",
+                                                  "type": "string",
+                                                },
+                                              ],
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inThePast",
+                                              "notInThePast",
+                                              "inTheNext",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "settings": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "completed": {
+                                                "type": "boolean",
+                                              },
+                                              "unitOfTime": {
+                                                "enum": [
+                                                  "days",
+                                                  "weeks",
+                                                  "months",
+                                                  "quarters",
+                                                  "years",
+                                                ],
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "completed",
+                                              "unitOfTime",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                          "settings",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "inTheCurrent",
+                                              "notInTheCurrent",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "settings": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "completed": {
+                                                "const": false,
+                                                "type": "boolean",
+                                              },
+                                              "unitOfTime": {
+                                                "enum": [
+                                                  "days",
+                                                  "weeks",
+                                                  "months",
+                                                  "quarters",
+                                                  "years",
+                                                ],
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "completed",
+                                              "unitOfTime",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "const": 1,
+                                              "type": "number",
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                          "settings",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "enum": [
+                                              "lessThan",
+                                              "lessThanOrEqual",
+                                              "greaterThan",
+                                              "greaterThanOrEqual",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "format": "date",
+                                                  "type": "string",
+                                                },
+                                                {
+                                                  "format": "date-time",
+                                                  "type": "string",
+                                                },
+                                              ],
+                                            },
+                                            "maxItems": 1,
+                                            "minItems": 1,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "fieldFilterType": {
+                                            "const": "date",
+                                            "type": "string",
+                                          },
+                                          "fieldId": {
+                                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                            "type": "string",
+                                          },
+                                          "fieldType": {
+                                            "enum": [
+                                              "date",
+                                              "timestamp",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          "operator": {
+                                            "const": "inBetween",
+                                            "type": "string",
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "format": "date",
+                                                  "type": "string",
+                                                },
+                                                {
+                                                  "format": "date-time",
+                                                  "type": "string",
+                                                },
+                                              ],
+                                            },
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "fieldId",
+                                          "fieldType",
+                                          "fieldFilterType",
+                                          "operator",
+                                          "values",
+                                        ],
+                                        "type": "object",
+                                      },
                                     ],
-                                    "type": "object",
                                   },
                                 ],
                               },
+                              "table": {
+                                "description": "Table name this filter field belongs to",
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "filter",
+                              "table",
                             ],
+                            "type": "object",
                           },
-                          "table": {
-                            "description": "Table name this filter field belongs to",
-                            "type": "string",
-                          },
+                          "type": "array",
                         },
-                        "required": [
-                          "filter",
-                          "table",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                    "kind": {
-                      "const": "aggregation",
-                      "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
-                      "type": "string",
-                    },
-                    "label": {
-                      "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
-                      "type": "string",
-                    },
-                    "table": {
-                      "description": "Table name where the base column exists. Match with available dimensions in the explore.",
-                      "type": "string",
-                    },
-                    "type": {
-                      "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
-                      "enum": [
-                        "average",
-                        "count",
-                        "count_distinct",
-                        "max",
-                        "min",
-                        "sum",
-                        "percentile",
-                        "median",
-                      ],
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "kind",
-                    "name",
-                    "label",
-                    "description",
-                    "baseDimensionName",
-                    "table",
-                    "type",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "baseMetricId": {
-                      "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
-                      "type": "string",
-                    },
-                    "granularity": {
-                      "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
-                      "enum": [
-                        "DAY",
-                        "WEEK",
-                        "MONTH",
-                        "QUARTER",
-                        "YEAR",
-                      ],
-                      "type": "string",
-                    },
-                    "kind": {
-                      "const": "periodComparison",
-                      "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
-                      "type": "string",
-                    },
-                    "periodOffset": {
-                      "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
-                      "minimum": 1,
-                      "type": "integer",
-                    },
-                    "timeDimensionId": {
-                      "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "kind",
-                    "baseMetricId",
-                    "timeDimensionId",
-                    "granularity",
-                    "periodOffset",
-                  ],
-                  "type": "object",
-                },
-              ],
-            },
-            "type": "array",
-          },
-          "description": {
-            "description": "A descriptive summary or explanation for the chart.",
-            "type": "string",
-          },
-          "filters": {
-            "additionalProperties": false,
-            "description": ", ",
-            "properties": {
-              "dimensions": {
-                "description": ", ",
-                "items": {
-                  "anyOf": [
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "boolean",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "boolean",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "boolean",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "boolean",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "boolean",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "string",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "string",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "string",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "string",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                                "startsWith",
-                                "endsWith",
-                                "include",
-                                "doesNotInclude",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "string",
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "lessThan",
-                                "lessThanOrEqual",
-                                "greaterThan",
-                                "greaterThanOrEqual",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inBetween",
-                                "notInBetween",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 2,
-                              "minItems": 2,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inThePast",
-                                "notInThePast",
-                                "inTheNext",
-                              ],
-                              "type": "string",
-                            },
-                            "settings": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "completed": {
-                                  "type": "boolean",
-                                },
-                                "unitOfTime": {
-                                  "enum": [
-                                    "days",
-                                    "weeks",
-                                    "months",
-                                    "quarters",
-                                    "years",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "completed",
-                                "unitOfTime",
-                              ],
-                              "type": "object",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                            "settings",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inTheCurrent",
-                                "notInTheCurrent",
-                              ],
-                              "type": "string",
-                            },
-                            "settings": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "completed": {
-                                  "const": false,
-                                  "type": "boolean",
-                                },
-                                "unitOfTime": {
-                                  "enum": [
-                                    "days",
-                                    "weeks",
-                                    "months",
-                                    "quarters",
-                                    "years",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "completed",
-                                "unitOfTime",
-                              ],
-                              "type": "object",
-                            },
-                            "values": {
-                              "items": {
-                                "const": 1,
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                            "settings",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "lessThan",
-                                "lessThanOrEqual",
-                                "greaterThan",
-                                "greaterThanOrEqual",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "const": "inBetween",
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "maxItems": 2,
-                              "minItems": 2,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                "type": "array",
-              },
-              "metrics": {
-                "description": ", ",
-                "items": {
-                  "anyOf": [
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "boolean",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "boolean",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "boolean",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "boolean",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "boolean",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "string",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "string",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "string",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "string",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                                "startsWith",
-                                "endsWith",
-                                "include",
-                                "doesNotInclude",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "string",
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "lessThan",
-                                "lessThanOrEqual",
-                                "greaterThan",
-                                "greaterThanOrEqual",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "number",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "number",
-                                "percentile",
-                                "median",
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "sum",
-                                "sum_distinct",
-                                "average_distinct",
-                                "min",
-                                "max",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inBetween",
-                                "notInBetween",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 2,
-                              "minItems": 2,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "isNull",
-                                "notNull",
-                              ],
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "equals",
-                                "notEquals",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inThePast",
-                                "notInThePast",
-                                "inTheNext",
-                              ],
-                              "type": "string",
-                            },
-                            "settings": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "completed": {
-                                  "type": "boolean",
-                                },
-                                "unitOfTime": {
-                                  "enum": [
-                                    "days",
-                                    "weeks",
-                                    "months",
-                                    "quarters",
-                                    "years",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "completed",
-                                "unitOfTime",
-                              ],
-                              "type": "object",
-                            },
-                            "values": {
-                              "items": {
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                            "settings",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "inTheCurrent",
-                                "notInTheCurrent",
-                              ],
-                              "type": "string",
-                            },
-                            "settings": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "completed": {
-                                  "const": false,
-                                  "type": "boolean",
-                                },
-                                "unitOfTime": {
-                                  "enum": [
-                                    "days",
-                                    "weeks",
-                                    "months",
-                                    "quarters",
-                                    "years",
-                                  ],
-                                  "type": "string",
-                                },
-                              },
-                              "required": [
-                                "completed",
-                                "unitOfTime",
-                              ],
-                              "type": "object",
-                            },
-                            "values": {
-                              "items": {
-                                "const": 1,
-                                "type": "number",
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                            "settings",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "enum": [
-                                "lessThan",
-                                "lessThanOrEqual",
-                                "greaterThan",
-                                "greaterThanOrEqual",
-                              ],
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "maxItems": 1,
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldFilterType": {
-                              "const": "date",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "fieldType": {
-                              "enum": [
-                                "date",
-                                "timestamp",
-                              ],
-                              "type": "string",
-                            },
-                            "operator": {
-                              "const": "inBetween",
-                              "type": "string",
-                            },
-                            "values": {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "format": "date",
-                                    "type": "string",
-                                  },
-                                  {
-                                    "format": "date-time",
-                                    "type": "string",
-                                  },
-                                ],
-                              },
-                              "maxItems": 2,
-                              "minItems": 2,
-                              "type": "array",
-                            },
-                          },
-                          "required": [
-                            "fieldId",
-                            "fieldType",
-                            "fieldFilterType",
-                            "operator",
-                            "values",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                "type": "array",
-              },
-              "tableCalculations": {
-                "description": ", ",
-                "items": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "fieldFilterType": {
-                          "const": "number",
+                        "kind": {
+                          "const": "aggregation",
+                          "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
                           "type": "string",
                         },
-                        "fieldId": {
-                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                        "label": {
+                          "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
                           "type": "string",
                         },
-                        "fieldType": {
+                        "name": {
+                          "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                          "type": "string",
+                        },
+                        "table": {
+                          "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                          "type": "string",
+                        },
+                        "type": {
+                          "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
                           "enum": [
-                            "number",
-                            "percentile",
-                            "median",
                             "average",
                             "count",
                             "count_distinct",
-                            "sum",
-                            "sum_distinct",
-                            "average_distinct",
-                            "min",
                             "max",
-                          ],
-                          "type": "string",
-                        },
-                        "operator": {
-                          "enum": [
-                            "isNull",
-                            "notNull",
+                            "min",
+                            "sum",
+                            "percentile",
+                            "median",
                           ],
                           "type": "string",
                         },
                       },
                       "required": [
-                        "fieldId",
-                        "fieldType",
-                        "fieldFilterType",
-                        "operator",
+                        "kind",
+                        "name",
+                        "label",
+                        "description",
+                        "baseDimensionName",
+                        "table",
+                        "type",
                       ],
                       "type": "object",
                     },
                     {
                       "additionalProperties": false,
                       "properties": {
-                        "fieldFilterType": {
-                          "const": "number",
+                        "baseMetricId": {
+                          "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
                           "type": "string",
                         },
-                        "fieldId": {
-                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "fieldType": {
+                        "granularity": {
+                          "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
                           "enum": [
-                            "number",
-                            "percentile",
-                            "median",
-                            "average",
-                            "count",
-                            "count_distinct",
-                            "sum",
-                            "sum_distinct",
-                            "average_distinct",
-                            "min",
-                            "max",
+                            "DAY",
+                            "WEEK",
+                            "MONTH",
+                            "QUARTER",
+                            "YEAR",
                           ],
                           "type": "string",
                         },
-                        "operator": {
-                          "enum": [
-                            "equals",
-                            "notEquals",
-                          ],
+                        "kind": {
+                          "const": "periodComparison",
+                          "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
                           "type": "string",
                         },
-                        "values": {
-                          "items": {
-                            "type": "number",
-                          },
-                          "type": "array",
+                        "periodOffset": {
+                          "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                          "minimum": 1,
+                          "type": "integer",
+                        },
+                        "timeDimensionId": {
+                          "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                          "type": "string",
                         },
                       },
                       "required": [
-                        "fieldId",
-                        "fieldType",
-                        "fieldFilterType",
-                        "operator",
-                        "values",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "fieldFilterType": {
-                          "const": "number",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "fieldType": {
-                          "enum": [
-                            "number",
-                            "percentile",
-                            "median",
-                            "average",
-                            "count",
-                            "count_distinct",
-                            "sum",
-                            "sum_distinct",
-                            "average_distinct",
-                            "min",
-                            "max",
-                          ],
-                          "type": "string",
-                        },
-                        "operator": {
-                          "enum": [
-                            "lessThan",
-                            "lessThanOrEqual",
-                            "greaterThan",
-                            "greaterThanOrEqual",
-                          ],
-                          "type": "string",
-                        },
-                        "values": {
-                          "items": {
-                            "type": "number",
-                          },
-                          "maxItems": 1,
-                          "minItems": 1,
-                          "type": "array",
-                        },
-                      },
-                      "required": [
-                        "fieldId",
-                        "fieldType",
-                        "fieldFilterType",
-                        "operator",
-                        "values",
-                      ],
-                      "type": "object",
-                    },
-                    {
-                      "additionalProperties": false,
-                      "properties": {
-                        "fieldFilterType": {
-                          "const": "number",
-                          "type": "string",
-                        },
-                        "fieldId": {
-                          "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                          "type": "string",
-                        },
-                        "fieldType": {
-                          "enum": [
-                            "number",
-                            "percentile",
-                            "median",
-                            "average",
-                            "count",
-                            "count_distinct",
-                            "sum",
-                            "sum_distinct",
-                            "average_distinct",
-                            "min",
-                            "max",
-                          ],
-                          "type": "string",
-                        },
-                        "operator": {
-                          "enum": [
-                            "inBetween",
-                            "notInBetween",
-                          ],
-                          "type": "string",
-                        },
-                        "values": {
-                          "items": {
-                            "type": "number",
-                          },
-                          "maxItems": 2,
-                          "minItems": 2,
-                          "type": "array",
-                        },
-                      },
-                      "required": [
-                        "fieldId",
-                        "fieldType",
-                        "fieldFilterType",
-                        "operator",
-                        "values",
+                        "kind",
+                        "baseMetricId",
+                        "timeDimensionId",
+                        "granularity",
+                        "periodOffset",
                       ],
                       "type": "object",
                     },
@@ -3218,23 +1612,6 @@ Example B — "Revenue by month with year-over-year comparison"
                 },
                 "type": "array",
               },
-              "type": {
-                "description": "Type of filter group operation",
-                "enum": [
-                  "and",
-                  "or",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "type",
-            ],
-            "type": "object",
-          },
-          "queryConfig": {
-            "additionalProperties": false,
-            "properties": {
               "dimensions": {
                 "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
                 "items": {
@@ -3249,6 +1626,7 @@ Example B — "Revenue by month with year-over-year comparison"
               },
               "filters": {
                 "additionalProperties": false,
+                "description": ", ",
                 "properties": {
                   "dimensions": {
                     "description": ", ",
@@ -4907,17 +3285,8 @@ Example B — "Revenue by month with year-over-year comparison"
                 },
                 "type": "array",
               },
-            },
-            "required": [
-              "exploreName",
-              "dimensions",
-              "metrics",
-              "sorts",
-            ],
-            "type": "object",
-          },
-          "tableCalculations": {
-            "description": "
+              "tableCalculations": {
+                "description": "
 Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
 
 **Available Types:**
@@ -4930,250 +3299,250 @@ Table calculations perform row-by-row calculations on query results without coll
 - Multiple calculations can be combined in a single query
 - All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
 , ",
-            "items": {
-              "anyOf": [
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "orderBy": {
-                      "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "fieldId": {
-                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "order": {
-                            "description": ", ",
-                            "enum": [
-                              "asc",
-                              "desc",
-                            ],
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "fieldId",
-                        ],
-                        "type": "object",
-                      },
-                      "minItems": 1,
-                      "type": "array",
-                    },
-                    "partitionBy": {
-                      "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                      "items": {
-                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "type": "array",
-                    },
-                    "type": {
-                      "const": "percent_change_from_previous",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "fieldId",
-                    "orderBy",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "orderBy": {
-                      "description": "Specifies the order in which rows are processed by the table calculation.
-For time-series: typically order by date/time ascending.
-For rankings: order by the metric you want to rank, descending for highest-first.",
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "fieldId": {
-                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "order": {
-                            "description": ", ",
-                            "enum": [
-                              "asc",
-                              "desc",
-                            ],
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "fieldId",
-                        ],
-                        "type": "object",
-                      },
-                      "minItems": 1,
-                      "type": "array",
-                    },
-                    "partitionBy": {
-                      "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                      "items": {
-                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "type": "array",
-                    },
-                    "type": {
-                      "const": "percent_of_previous_value",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "fieldId",
-                    "orderBy",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "partitionBy": {
-                      "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows)., ",
-                      "items": {
-                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "type": "array",
-                    },
-                    "type": {
-                      "const": "percent_of_column_total",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "fieldId",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "type": {
-                      "const": "rank_in_column",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "fieldId",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "type": {
-                      "const": "running_total",
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "fieldId",
-                  ],
-                  "type": "object",
-                },
-                {
-                  "additionalProperties": false,
-                  "properties": {
-                    "displayName": {
-                      "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                      "type": "string",
-                    },
-                    "fieldId": {
-                      "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                      "type": "string",
-                    },
-                    "frame": {
+                "items": {
+                  "anyOf": [
+                    {
                       "additionalProperties": false,
-                      "description": "Defines which rows to include in calculation. Null uses database defaults.
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "orderBy": {
+                          "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "fieldId": {
+                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                "type": "string",
+                              },
+                              "order": {
+                                "description": ", ",
+                                "enum": [
+                                  "asc",
+                                  "desc",
+                                ],
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "fieldId",
+                            ],
+                            "type": "object",
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                        },
+                        "partitionBy": {
+                          "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                          "items": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "type": {
+                          "const": "percent_change_from_previous",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "fieldId",
+                        "orderBy",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "orderBy": {
+                          "description": "Specifies the order in which rows are processed by the table calculation.
+For time-series: typically order by date/time ascending.
+For rankings: order by the metric you want to rank, descending for highest-first.",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "fieldId": {
+                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                "type": "string",
+                              },
+                              "order": {
+                                "description": ", ",
+                                "enum": [
+                                  "asc",
+                                  "desc",
+                                ],
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "fieldId",
+                            ],
+                            "type": "object",
+                          },
+                          "minItems": 1,
+                          "type": "array",
+                        },
+                        "partitionBy": {
+                          "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                          "items": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "type": {
+                          "const": "percent_of_previous_value",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "fieldId",
+                        "orderBy",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "partitionBy": {
+                          "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows)., ",
+                          "items": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "type": {
+                          "const": "percent_of_column_total",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "fieldId",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "type": {
+                          "const": "rank_in_column",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "fieldId",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "type": {
+                          "const": "running_total",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "fieldId",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "displayName": {
+                          "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                          "type": "string",
+                        },
+                        "fieldId": {
+                          "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error, Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                          "type": "string",
+                        },
+                        "frame": {
+                          "additionalProperties": false,
+                          "description": "Defines which rows to include in calculation. Null uses database defaults.
 
 **Common patterns:**
 - Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
@@ -5184,121 +3553,121 @@ Empty array or null: single partition (calculations across all rows)., ",
 - Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
 - Aggregates WITHOUT ORDER BY: Entire partition (all rows)
 - Ranking functions: Always use entire partition (frame clause has no effect), ",
-                      "properties": {
-                        "end": {
-                          "additionalProperties": false,
-                          "description": "End boundary (required)",
                           "properties": {
-                            "offset": {
-                              "description": "Number of rows for PRECEDING/FOLLOWING, ",
-                              "exclusiveMinimum": 0,
-                              "type": "integer",
-                            },
-                            "type": {
-                              "enum": [
-                                "unbounded_preceding",
-                                "preceding",
-                                "current_row",
-                                "following",
-                                "unbounded_following",
+                            "end": {
+                              "additionalProperties": false,
+                              "description": "End boundary (required)",
+                              "properties": {
+                                "offset": {
+                                  "description": "Number of rows for PRECEDING/FOLLOWING, ",
+                                  "exclusiveMinimum": 0,
+                                  "type": "integer",
+                                },
+                                "type": {
+                                  "enum": [
+                                    "unbounded_preceding",
+                                    "preceding",
+                                    "current_row",
+                                    "following",
+                                    "unbounded_following",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "type",
                               ],
-                              "type": "string",
+                              "type": "object",
                             },
-                          },
-                          "required": [
-                            "type",
-                          ],
-                          "type": "object",
-                        },
-                        "frameType": {
-                          "description": "Frame type:
+                            "frameType": {
+                              "description": "Frame type:
 - rows: Physical row count
 - range: Logical value-based (includes peer rows with same ORDER BY value)",
-                          "enum": [
-                            "rows",
-                            "range",
-                          ],
-                          "type": "string",
-                        },
-                        "start": {
-                          "additionalProperties": false,
-                          "description": "Start boundary. Null for single-boundary syntax., ",
-                          "properties": {
-                            "offset": {
-                              "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING"), ",
-                              "exclusiveMinimum": 0,
-                              "type": "integer",
-                            },
-                            "type": {
                               "enum": [
-                                "unbounded_preceding",
-                                "preceding",
-                                "current_row",
-                                "following",
-                                "unbounded_following",
+                                "rows",
+                                "range",
                               ],
                               "type": "string",
                             },
+                            "start": {
+                              "additionalProperties": false,
+                              "description": "Start boundary. Null for single-boundary syntax., ",
+                              "properties": {
+                                "offset": {
+                                  "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING"), ",
+                                  "exclusiveMinimum": 0,
+                                  "type": "integer",
+                                },
+                                "type": {
+                                  "enum": [
+                                    "unbounded_preceding",
+                                    "preceding",
+                                    "current_row",
+                                    "following",
+                                    "unbounded_following",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "type",
+                              ],
+                              "type": "object",
+                            },
                           },
                           "required": [
-                            "type",
+                            "frameType",
+                            "end",
                           ],
                           "type": "object",
                         },
-                      },
-                      "required": [
-                        "frameType",
-                        "end",
-                      ],
-                      "type": "object",
-                    },
-                    "name": {
-                      "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                      "type": "string",
-                    },
-                    "orderBy": {
-                      "description": "Specifies the order in which rows are processed by the table calculation.
+                        "name": {
+                          "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                          "type": "string",
+                        },
+                        "orderBy": {
+                          "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first., ",
-                      "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                          "fieldId": {
-                            "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                            "type": "string",
-                          },
-                          "order": {
-                            "description": ", ",
-                            "enum": [
-                              "asc",
-                              "desc",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "fieldId": {
+                                "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                "type": "string",
+                              },
+                              "order": {
+                                "description": ", ",
+                                "enum": [
+                                  "asc",
+                                  "desc",
+                                ],
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "fieldId",
                             ],
-                            "type": "string",
+                            "type": "object",
                           },
+                          "type": "array",
                         },
-                        "required": [
-                          "fieldId",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                    "partitionBy": {
-                      "description": "Fields to PARTITION BY - divides result set into independent groups.
+                        "partitionBy": {
+                          "description": "Fields to PARTITION BY - divides result set into independent groups.
 Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
 Empty array or null: single partition (calculations across all rows)., ",
-                      "items": {
-                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "type": "array",
-                    },
-                    "type": {
-                      "const": "window_function",
-                      "type": "string",
-                    },
-                    "windowFunction": {
-                      "description": "Type of window function to apply.
+                          "items": {
+                            "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "type": "array",
+                        },
+                        "type": {
+                          "const": "window_function",
+                          "type": "string",
+                        },
+                        "windowFunction": {
+                          "description": "Type of window function to apply.
 
 **Ranking functions** (fieldId optional, ignored if provided):
 - row_number: Sequential numbering (1, 2, 3...)
@@ -5312,31 +3681,40 @@ Empty array or null: single partition (calculations across all rows)., ",
 - count: Count values within frame
 - min: Minimum value within frame
 - max: Maximum value within frame",
-                      "enum": [
-                        "row_number",
-                        "percent_rank",
-                        "cume_dist",
-                        "rank",
-                        "sum",
-                        "avg",
-                        "count",
-                        "min",
-                        "max",
+                          "enum": [
+                            "row_number",
+                            "percent_rank",
+                            "cume_dist",
+                            "rank",
+                            "sum",
+                            "avg",
+                            "count",
+                            "min",
+                            "max",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "displayName",
+                        "type",
+                        "windowFunction",
                       ],
-                      "type": "string",
+                      "type": "object",
                     },
-                  },
-                  "required": [
-                    "name",
-                    "displayName",
-                    "type",
-                    "windowFunction",
                   ],
-                  "type": "object",
                 },
-              ],
+                "type": "array",
+              },
             },
-            "type": "array",
+            "required": [
+              "exploreName",
+              "dimensions",
+              "metrics",
+              "sorts",
+            ],
+            "type": "object",
           },
           "title": {
             "description": "A descriptive title for the chart",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1364,734 +1364,741 @@ Recommended Dashboard Structure:
                   },
                 ],
               },
-              "customMetrics": {
-                "anyOf": [
-                  {
-                    "items": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "baseDimensionName": {
-                              "description": "Name of the base dimension/column this metric calculates from",
-                              "type": "string",
-                            },
-                            "description": {
-                              "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
-                              "type": "string",
-                            },
-                            "filters": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "filter": {
-                                        "anyOf": [
-                                          {
+              "description": {
+                "description": "A descriptive summary or explanation for the chart.",
+                "type": "string",
+              },
+              "queryConfig": {
+                "additionalProperties": false,
+                "properties": {
+                  "customMetrics": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "baseDimensionName": {
+                                  "description": "Name of the base dimension/column this metric calculates from",
+                                  "type": "string",
+                                },
+                                "description": {
+                                  "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                                  "type": "string",
+                                },
+                                "filters": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "filter": {
                                             "anyOf": [
                                               {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "const": "boolean",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldId": {
-                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldType": {
-                                                    "enum": [
-                                                      "boolean",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "isNull",
-                                                      "notNull",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "equals",
-                                                      "notEquals",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "boolean",
-                                                    },
-                                                    "maxItems": 1,
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                            ],
-                                          },
-                                          {
-                                            "anyOf": [
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "const": "string",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldId": {
-                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldType": {
-                                                    "enum": [
-                                                      "string",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "isNull",
-                                                      "notNull",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "equals",
-                                                      "notEquals",
-                                                      "startsWith",
-                                                      "endsWith",
-                                                      "include",
-                                                      "doesNotInclude",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "string",
-                                                    },
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                            ],
-                                          },
-                                          {
-                                            "anyOf": [
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "const": "number",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldId": {
-                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldType": {
-                                                    "enum": [
-                                                      "number",
-                                                      "percentile",
-                                                      "median",
-                                                      "average",
-                                                      "count",
-                                                      "count_distinct",
-                                                      "sum",
-                                                      "sum_distinct",
-                                                      "average_distinct",
-                                                      "min",
-                                                      "max",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "isNull",
-                                                      "notNull",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "equals",
-                                                      "notEquals",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "number",
-                                                    },
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "lessThan",
-                                                      "lessThanOrEqual",
-                                                      "greaterThan",
-                                                      "greaterThanOrEqual",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "number",
-                                                    },
-                                                    "maxItems": 1,
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "inBetween",
-                                                      "notInBetween",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "number",
-                                                    },
-                                                    "maxItems": 2,
-                                                    "minItems": 2,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                            ],
-                                          },
-                                          {
-                                            "anyOf": [
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "const": "date",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldId": {
-                                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                                    "type": "string",
-                                                  },
-                                                  "fieldType": {
-                                                    "enum": [
-                                                      "date",
-                                                      "timestamp",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "isNull",
-                                                      "notNull",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "equals",
-                                                      "notEquals",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "anyOf": [
-                                                        {
-                                                          "format": "date",
-                                                          "type": "string",
-                                                        },
-                                                        {
-                                                          "format": "date-time",
-                                                          "type": "string",
-                                                        },
-                                                      ],
-                                                    },
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "inThePast",
-                                                      "notInThePast",
-                                                      "inTheNext",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "settings": {
+                                                "anyOf": [
+                                                  {
                                                     "additionalProperties": false,
                                                     "properties": {
-                                                      "completed": {
-                                                        "type": "boolean",
+                                                      "fieldFilterType": {
+                                                        "const": "boolean",
+                                                        "type": "string",
                                                       },
-                                                      "unitOfTime": {
+                                                      "fieldId": {
+                                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldType": {
                                                         "enum": [
-                                                          "days",
-                                                          "weeks",
-                                                          "months",
-                                                          "quarters",
-                                                          "years",
+                                                          "boolean",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "isNull",
+                                                          "notNull",
                                                         ],
                                                         "type": "string",
                                                       },
                                                     },
                                                     "required": [
-                                                      "completed",
-                                                      "unitOfTime",
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
                                                     ],
                                                     "type": "object",
                                                   },
-                                                  "values": {
-                                                    "items": {
-                                                      "type": "number",
-                                                    },
-                                                    "maxItems": 1,
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                  "settings",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "inTheCurrent",
-                                                      "notInTheCurrent",
-                                                    ],
-                                                    "type": "string",
-                                                  },
-                                                  "settings": {
+                                                  {
                                                     "additionalProperties": false,
                                                     "properties": {
-                                                      "completed": {
-                                                        "const": false,
-                                                        "type": "boolean",
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
                                                       },
-                                                      "unitOfTime": {
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
                                                         "enum": [
-                                                          "days",
-                                                          "weeks",
-                                                          "months",
-                                                          "quarters",
-                                                          "years",
+                                                          "equals",
+                                                          "notEquals",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "boolean",
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "const": "string",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldId": {
+                                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldType": {
+                                                        "enum": [
+                                                          "string",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "isNull",
+                                                          "notNull",
                                                         ],
                                                         "type": "string",
                                                       },
                                                     },
                                                     "required": [
-                                                      "completed",
-                                                      "unitOfTime",
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
                                                     ],
                                                     "type": "object",
                                                   },
-                                                  "values": {
-                                                    "items": {
-                                                      "const": 1,
-                                                      "type": "number",
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "equals",
+                                                          "notEquals",
+                                                          "startsWith",
+                                                          "endsWith",
+                                                          "include",
+                                                          "doesNotInclude",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string",
+                                                        },
+                                                        "type": "array",
+                                                      },
                                                     },
-                                                    "maxItems": 1,
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
-                                                  "settings",
-                                                ],
-                                                "type": "object",
-                                              },
-                                              {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "enum": [
-                                                      "lessThan",
-                                                      "lessThanOrEqual",
-                                                      "greaterThan",
-                                                      "greaterThanOrEqual",
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
                                                     ],
-                                                    "type": "string",
+                                                    "type": "object",
                                                   },
-                                                  "values": {
-                                                    "items": {
-                                                      "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
-                                                    },
-                                                    "maxItems": 1,
-                                                    "minItems": 1,
-                                                    "type": "array",
-                                                  },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
                                                 ],
-                                                "type": "object",
                                               },
                                               {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                  "fieldFilterType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                                  },
-                                                  "fieldId": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                                  },
-                                                  "fieldType": {
-                                                    "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                                  },
-                                                  "operator": {
-                                                    "const": "inBetween",
-                                                    "type": "string",
-                                                  },
-                                                  "values": {
-                                                    "items": {
-                                                      "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                "anyOf": [
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "const": "number",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldId": {
+                                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldType": {
+                                                        "enum": [
+                                                          "number",
+                                                          "percentile",
+                                                          "median",
+                                                          "average",
+                                                          "count",
+                                                          "count_distinct",
+                                                          "sum",
+                                                          "sum_distinct",
+                                                          "average_distinct",
+                                                          "min",
+                                                          "max",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "isNull",
+                                                          "notNull",
+                                                        ],
+                                                        "type": "string",
+                                                      },
                                                     },
-                                                    "maxItems": 2,
-                                                    "minItems": 2,
-                                                    "type": "array",
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                    ],
+                                                    "type": "object",
                                                   },
-                                                },
-                                                "required": [
-                                                  "fieldId",
-                                                  "fieldType",
-                                                  "fieldFilterType",
-                                                  "operator",
-                                                  "values",
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "equals",
+                                                          "notEquals",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "number",
+                                                        },
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "lessThan",
+                                                          "lessThanOrEqual",
+                                                          "greaterThan",
+                                                          "greaterThanOrEqual",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "number",
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "inBetween",
+                                                          "notInBetween",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "number",
+                                                        },
+                                                        "maxItems": 2,
+                                                        "minItems": 2,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
                                                 ],
-                                                "type": "object",
+                                              },
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "const": "date",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldId": {
+                                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                        "type": "string",
+                                                      },
+                                                      "fieldType": {
+                                                        "enum": [
+                                                          "date",
+                                                          "timestamp",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "isNull",
+                                                          "notNull",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "equals",
+                                                          "notEquals",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "format": "date",
+                                                              "type": "string",
+                                                            },
+                                                            {
+                                                              "format": "date-time",
+                                                              "type": "string",
+                                                            },
+                                                          ],
+                                                        },
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "inThePast",
+                                                          "notInThePast",
+                                                          "inTheNext",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "settings": {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                          "completed": {
+                                                            "type": "boolean",
+                                                          },
+                                                          "unitOfTime": {
+                                                            "enum": [
+                                                              "days",
+                                                              "weeks",
+                                                              "months",
+                                                              "quarters",
+                                                              "years",
+                                                            ],
+                                                            "type": "string",
+                                                          },
+                                                        },
+                                                        "required": [
+                                                          "completed",
+                                                          "unitOfTime",
+                                                        ],
+                                                        "type": "object",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "number",
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                      "settings",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "inTheCurrent",
+                                                          "notInTheCurrent",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "settings": {
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                          "completed": {
+                                                            "const": false,
+                                                            "type": "boolean",
+                                                          },
+                                                          "unitOfTime": {
+                                                            "enum": [
+                                                              "days",
+                                                              "weeks",
+                                                              "months",
+                                                              "quarters",
+                                                              "years",
+                                                            ],
+                                                            "type": "string",
+                                                          },
+                                                        },
+                                                        "required": [
+                                                          "completed",
+                                                          "unitOfTime",
+                                                        ],
+                                                        "type": "object",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "const": 1,
+                                                          "type": "number",
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                      "settings",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "enum": [
+                                                          "lessThan",
+                                                          "lessThanOrEqual",
+                                                          "greaterThan",
+                                                          "greaterThanOrEqual",
+                                                        ],
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                      "fieldFilterType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                      },
+                                                      "fieldId": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                      },
+                                                      "fieldType": {
+                                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                      },
+                                                      "operator": {
+                                                        "const": "inBetween",
+                                                        "type": "string",
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                        },
+                                                        "maxItems": 2,
+                                                        "minItems": 2,
+                                                        "type": "array",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "fieldId",
+                                                      "fieldType",
+                                                      "fieldFilterType",
+                                                      "operator",
+                                                      "values",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                ],
                                               },
                                             ],
                                           },
+                                          "table": {
+                                            "description": "Table name this filter field belongs to",
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "filter",
+                                          "table",
                                         ],
+                                        "type": "object",
                                       },
-                                      "table": {
-                                        "description": "Table name this filter field belongs to",
-                                        "type": "string",
-                                      },
+                                      "type": "array",
                                     },
-                                    "required": [
-                                      "filter",
-                                      "table",
-                                    ],
-                                    "type": "object",
-                                  },
-                                  "type": "array",
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
                                 },
-                                {
-                                  "type": "null",
+                                "kind": {
+                                  "const": "aggregation",
+                                  "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                                  "type": "string",
                                 },
+                                "label": {
+                                  "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                                  "type": "string",
+                                },
+                                "table": {
+                                  "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                                  "enum": [
+                                    "average",
+                                    "count",
+                                    "count_distinct",
+                                    "max",
+                                    "min",
+                                    "sum",
+                                    "percentile",
+                                    "median",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "kind",
+                                "name",
+                                "label",
+                                "description",
+                                "baseDimensionName",
+                                "table",
+                                "type",
+                                "filters",
                               ],
-                              "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                              "type": "object",
                             },
-                            "kind": {
-                              "const": "aggregation",
-                              "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
-                              "type": "string",
-                            },
-                            "label": {
-                              "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
-                              "type": "string",
-                            },
-                            "name": {
-                              "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
-                              "type": "string",
-                            },
-                            "table": {
-                              "description": "Table name where the base column exists. Match with available dimensions in the explore.",
-                              "type": "string",
-                            },
-                            "type": {
-                              "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
-                              "enum": [
-                                "average",
-                                "count",
-                                "count_distinct",
-                                "max",
-                                "min",
-                                "sum",
-                                "percentile",
-                                "median",
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "baseMetricId": {
+                                  "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                                  "type": "string",
+                                },
+                                "granularity": {
+                                  "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                                  "enum": [
+                                    "DAY",
+                                    "WEEK",
+                                    "MONTH",
+                                    "QUARTER",
+                                    "YEAR",
+                                  ],
+                                  "type": "string",
+                                },
+                                "kind": {
+                                  "const": "periodComparison",
+                                  "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                                  "type": "string",
+                                },
+                                "periodOffset": {
+                                  "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                                  "minimum": 1,
+                                  "type": "integer",
+                                },
+                                "timeDimensionId": {
+                                  "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "kind",
+                                "baseMetricId",
+                                "timeDimensionId",
+                                "granularity",
+                                "periodOffset",
                               ],
-                              "type": "string",
+                              "type": "object",
                             },
-                          },
-                          "required": [
-                            "kind",
-                            "name",
-                            "label",
-                            "description",
-                            "baseDimensionName",
-                            "table",
-                            "type",
-                            "filters",
                           ],
-                          "type": "object",
                         },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "baseMetricId": {
-                              "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
-                              "type": "string",
-                            },
-                            "granularity": {
-                              "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
-                              "enum": [
-                                "DAY",
-                                "WEEK",
-                                "MONTH",
-                                "QUARTER",
-                                "YEAR",
-                              ],
-                              "type": "string",
-                            },
-                            "kind": {
-                              "const": "periodComparison",
-                              "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
-                              "type": "string",
-                            },
-                            "periodOffset": {
-                              "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
-                              "minimum": 1,
-                              "type": "integer",
-                            },
-                            "timeDimensionId": {
-                              "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "kind",
-                            "baseMetricId",
-                            "timeDimensionId",
-                            "granularity",
-                            "periodOffset",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                    },
-                    "type": "array",
-                  },
-                  {
-                    "type": "null",
-                  },
-                ],
-                "description": "Define new metric columns the explore doesn't already have. Two kinds:
+                        "type": "array",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "Define new metric columns the explore doesn't already have. Two kinds:
 
 (1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
     (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
@@ -2125,24 +2132,7 @@ Example B — "Revenue by month with year-over-year comparison"
   queryConfig.dimensions: ["orders_order_date_month"]
   queryConfig.metrics: ["orders_revenue"]
   customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
-              },
-              "description": {
-                "description": "A descriptive summary or explanation for the chart.",
-                "type": "string",
-              },
-              "filters": {
-                "anyOf": [
-                  {
-                    "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/filters",
                   },
-                  {
-                    "type": "null",
-                  },
-                ],
-              },
-              "queryConfig": {
-                "additionalProperties": false,
-                "properties": {
                   "dimensions": {
                     "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
                     "items": {
@@ -2156,76 +2146,83 @@ Example B — "Revenue by month with year-over-year comparison"
                     "type": "string",
                   },
                   "filters": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "dimensions": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "dimensions": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                                    },
+                                    {
+                                      "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                                    },
+                                    {
+                                      "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                                    },
+                                    {
+                                      "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
+                                    },
+                                  ],
                                 },
-                                {
-                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "metrics": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items",
                                 },
-                                {
-                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                          },
+                          "tableCalculations": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
                                 },
-                                {
-                                  "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
-                                },
-                              ],
-                            },
-                            "type": "array",
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
                           },
-                          {
-                            "type": "null",
+                          "type": {
+                            "description": "Type of filter group operation",
+                            "enum": [
+                              "and",
+                              "or",
+                            ],
+                            "type": "string",
                           },
+                        },
+                        "required": [
+                          "type",
+                          "dimensions",
+                          "metrics",
+                          "tableCalculations",
                         ],
+                        "type": "object",
                       },
-                      "metrics": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/filters/properties/dimensions/anyOf/0/items",
-                            },
-                            "type": "array",
-                          },
-                          {
-                            "type": "null",
-                          },
-                        ],
+                      {
+                        "type": "null",
                       },
-                      "tableCalculations": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "$ref": "#/properties/visualizations/items/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
-                            },
-                            "type": "array",
-                          },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                      },
-                      "type": {
-                        "description": "Type of filter group operation",
-                        "enum": [
-                          "and",
-                          "or",
-                        ],
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "type",
-                      "dimensions",
-                      "metrics",
-                      "tableCalculations",
                     ],
-                    "type": "object",
                   },
                   "limit": {
                     "description": "The total number of data points / rows allowed on the chart.",
@@ -2272,317 +2269,263 @@ Example B — "Revenue by month with year-over-year comparison"
                     },
                     "type": "array",
                   },
-                },
-                "required": [
-                  "exploreName",
-                  "dimensions",
-                  "metrics",
-                  "sorts",
-                  "limit",
-                ],
-                "type": "object",
-              },
-              "tableCalculations": {
-                "anyOf": [
-                  {
-                    "items": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                              "type": "string",
-                            },
-                            "fieldId": {
-                              "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "name": {
-                              "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                              "type": "string",
-                            },
-                            "orderBy": {
-                              "description": "Specifies the order in which rows are processed by the table calculation.
+                  "tableCalculations": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                                  "type": "string",
+                                },
+                                "fieldId": {
+                                  "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                                  "type": "string",
+                                },
+                                "orderBy": {
+                                  "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                              "items": {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "fieldId": {
-                                    "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string",
-                                  },
-                                  "order": {
-                                    "anyOf": [
-                                      {
-                                        "enum": [
-                                          "asc",
-                                          "desc",
-                                        ],
+                                  "items": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fieldId": {
+                                        "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
                                         "type": "string",
                                       },
-                                      {
-                                        "type": "null",
+                                      "order": {
+                                        "anyOf": [
+                                          {
+                                            "enum": [
+                                              "asc",
+                                              "desc",
+                                            ],
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "null",
+                                          },
+                                        ],
                                       },
+                                    },
+                                    "required": [
+                                      "fieldId",
+                                      "order",
                                     ],
+                                    "type": "object",
                                   },
-                                },
-                                "required": [
-                                  "fieldId",
-                                  "order",
-                                ],
-                                "type": "object",
-                              },
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                            "partitionBy": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                    "type": "string",
-                                  },
+                                  "minItems": 1,
                                   "type": "array",
                                 },
-                                {
-                                  "type": "null",
-                                },
-                              ],
-                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+                                "partitionBy": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                        "type": "string",
+                                      },
+                                      "type": "array",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
 Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
 Empty array or null: single partition (calculations across all rows).",
+                                },
+                                "type": {
+                                  "const": "percent_change_from_previous",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "fieldId",
+                                "orderBy",
+                                "partitionBy",
+                              ],
+                              "type": "object",
                             },
-                            "type": {
-                              "const": "percent_change_from_previous",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "fieldId",
-                            "orderBy",
-                            "partitionBy",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                            },
-                            "fieldId": {
-                              "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "name": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                            },
-                            "orderBy": {
-                              "description": "Specifies the order in which rows are processed by the table calculation.
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                                },
+                                "fieldId": {
+                                  "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                                },
+                                "orderBy": {
+                                  "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                              "items": {
-                                "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                              },
-                              "minItems": 1,
-                              "type": "array",
-                            },
-                            "partitionBy": {
-                              "anyOf": [
-                                {
                                   "items": {
-                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                    "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
                                   },
+                                  "minItems": 1,
                                   "type": "array",
                                 },
-                                {
-                                  "type": "null",
-                                },
-                              ],
-                              "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                            },
-                            "type": {
-                              "const": "percent_of_previous_value",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "fieldId",
-                            "orderBy",
-                            "partitionBy",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                            },
-                            "fieldId": {
-                              "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "name": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                            },
-                            "partitionBy": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                  },
-                                  "type": "array",
-                                },
-                                {
-                                  "type": "null",
-                                },
-                              ],
-                              "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                            },
-                            "type": {
-                              "const": "percent_of_column_total",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "fieldId",
-                            "partitionBy",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                            },
-                            "fieldId": {
-                              "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "name": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                            },
-                            "type": {
-                              "const": "rank_in_column",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "fieldId",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                            },
-                            "fieldId": {
-                              "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "name": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                            },
-                            "type": {
-                              "const": "running_total",
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "fieldId",
-                          ],
-                          "type": "object",
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "displayName": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                            },
-                            "fieldId": {
-                              "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": [
-                                "string",
-                                "null",
-                              ],
-                            },
-                            "frame": {
-                              "anyOf": [
-                                {
-                                  "additionalProperties": false,
-                                  "properties": {
-                                    "end": {
-                                      "additionalProperties": false,
-                                      "description": "End boundary (required)",
-                                      "properties": {
-                                        "offset": {
-                                          "anyOf": [
-                                            {
-                                              "exclusiveMinimum": 0,
-                                              "type": "integer",
-                                            },
-                                            {
-                                              "type": "null",
-                                            },
-                                          ],
-                                          "description": "Number of rows for PRECEDING/FOLLOWING",
-                                        },
-                                        "type": {
-                                          "enum": [
-                                            "unbounded_preceding",
-                                            "preceding",
-                                            "current_row",
-                                            "following",
-                                            "unbounded_following",
-                                          ],
-                                          "type": "string",
-                                        },
+                                "partitionBy": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
                                       },
-                                      "required": [
-                                        "type",
-                                        "offset",
-                                      ],
-                                      "type": "object",
+                                      "type": "array",
                                     },
-                                    "frameType": {
-                                      "description": "Frame type:
-- rows: Physical row count
-- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                      "enum": [
-                                        "rows",
-                                        "range",
-                                      ],
-                                      "type": "string",
+                                    {
+                                      "type": "null",
                                     },
-                                    "start": {
-                                      "anyOf": [
-                                        {
+                                  ],
+                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                                },
+                                "type": {
+                                  "const": "percent_of_previous_value",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "fieldId",
+                                "orderBy",
+                                "partitionBy",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                                },
+                                "fieldId": {
+                                  "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                                },
+                                "partitionBy": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                      },
+                                      "type": "array",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                                },
+                                "type": {
+                                  "const": "percent_of_column_total",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "fieldId",
+                                "partitionBy",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                                },
+                                "fieldId": {
+                                  "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                                },
+                                "type": {
+                                  "const": "rank_in_column",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "fieldId",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                                },
+                                "fieldId": {
+                                  "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                                },
+                                "type": {
+                                  "const": "running_total",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "fieldId",
+                              ],
+                              "type": "object",
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "displayName": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                                },
+                                "fieldId": {
+                                  "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": [
+                                    "string",
+                                    "null",
+                                  ],
+                                },
+                                "frame": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "end": {
                                           "additionalProperties": false,
+                                          "description": "End boundary (required)",
                                           "properties": {
                                             "offset": {
                                               "anyOf": [
@@ -2594,7 +2537,7 @@ Empty array or null: single partition (calculations across all rows).",
                                                   "type": "null",
                                                 },
                                               ],
-                                              "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                              "description": "Number of rows for PRECEDING/FOLLOWING",
                                             },
                                             "type": {
                                               "enum": [
@@ -2613,25 +2556,69 @@ Empty array or null: single partition (calculations across all rows).",
                                           ],
                                           "type": "object",
                                         },
-                                        {
-                                          "type": "null",
+                                        "frameType": {
+                                          "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                                          "enum": [
+                                            "rows",
+                                            "range",
+                                          ],
+                                          "type": "string",
                                         },
+                                        "start": {
+                                          "anyOf": [
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "offset": {
+                                                  "anyOf": [
+                                                    {
+                                                      "exclusiveMinimum": 0,
+                                                      "type": "integer",
+                                                    },
+                                                    {
+                                                      "type": "null",
+                                                    },
+                                                  ],
+                                                  "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                                },
+                                                "type": {
+                                                  "enum": [
+                                                    "unbounded_preceding",
+                                                    "preceding",
+                                                    "current_row",
+                                                    "following",
+                                                    "unbounded_following",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "type",
+                                                "offset",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "type": "null",
+                                            },
+                                          ],
+                                          "description": "Start boundary. Null for single-boundary syntax.",
+                                        },
+                                      },
+                                      "required": [
+                                        "frameType",
+                                        "start",
+                                        "end",
                                       ],
-                                      "description": "Start boundary. Null for single-boundary syntax.",
+                                      "type": "object",
                                     },
-                                  },
-                                  "required": [
-                                    "frameType",
-                                    "start",
-                                    "end",
+                                    {
+                                      "type": "null",
+                                    },
                                   ],
-                                  "type": "object",
-                                },
-                                {
-                                  "type": "null",
-                                },
-                              ],
-                              "description": "Defines which rows to include in calculation. Null uses database defaults.
+                                  "description": "Defines which rows to include in calculation. Null uses database defaults.
 
 **Common patterns:**
 - Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
@@ -2642,48 +2629,48 @@ Empty array or null: single partition (calculations across all rows).",
 - Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
 - Aggregates WITHOUT ORDER BY: Entire partition (all rows)
 - Ranking functions: Always use entire partition (frame clause has no effect)",
-                            },
-                            "name": {
-                              "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                            },
-                            "orderBy": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                                  },
-                                  "type": "array",
                                 },
-                                {
-                                  "type": "null",
+                                "name": {
+                                  "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
                                 },
-                              ],
-                              "description": "Specifies the order in which rows are processed by the table calculation.
+                                "orderBy": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                                      },
+                                      "type": "array",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                            },
-                            "partitionBy": {
-                              "anyOf": [
-                                {
-                                  "items": {
-                                    "$ref": "#/properties/visualizations/items/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                                  },
-                                  "type": "array",
                                 },
-                                {
-                                  "type": "null",
-                                },
-                              ],
-                              "description": "Fields to PARTITION BY - divides result set into independent groups.
+                                "partitionBy": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                      },
+                                      "type": "array",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
+                                  "description": "Fields to PARTITION BY - divides result set into independent groups.
 Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
 Empty array or null: single partition (calculations across all rows).",
-                            },
-                            "type": {
-                              "const": "window_function",
-                              "type": "string",
-                            },
-                            "windowFunction": {
-                              "description": "Type of window function to apply.
+                                },
+                                "type": {
+                                  "const": "window_function",
+                                  "type": "string",
+                                },
+                                "windowFunction": {
+                                  "description": "Type of window function to apply.
 
 **Ranking functions** (fieldId optional, ignored if provided):
 - row_number: Sequential numbering (1, 2, 3...)
@@ -2697,41 +2684,41 @@ Empty array or null: single partition (calculations across all rows).",
 - count: Count values within frame
 - min: Minimum value within frame
 - max: Maximum value within frame",
-                              "enum": [
-                                "row_number",
-                                "percent_rank",
-                                "cume_dist",
-                                "rank",
-                                "sum",
-                                "avg",
-                                "count",
-                                "min",
-                                "max",
+                                  "enum": [
+                                    "row_number",
+                                    "percent_rank",
+                                    "cume_dist",
+                                    "rank",
+                                    "sum",
+                                    "avg",
+                                    "count",
+                                    "min",
+                                    "max",
+                                  ],
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "name",
+                                "displayName",
+                                "type",
+                                "windowFunction",
+                                "fieldId",
+                                "orderBy",
+                                "partitionBy",
+                                "frame",
                               ],
-                              "type": "string",
+                              "type": "object",
                             },
-                          },
-                          "required": [
-                            "name",
-                            "displayName",
-                            "type",
-                            "windowFunction",
-                            "fieldId",
-                            "orderBy",
-                            "partitionBy",
-                            "frame",
                           ],
-                          "type": "object",
                         },
-                      ],
-                    },
-                    "type": "array",
-                  },
-                  {
-                    "type": "null",
-                  },
-                ],
-                "description": "
+                        "type": "array",
+                      },
+                      {
+                        "type": "null",
+                      },
+                    ],
+                    "description": "
 Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
 
 **Available Types:**
@@ -2744,6 +2731,19 @@ Table calculations perform row-by-row calculations on query results without coll
 - Multiple calculations can be combined in a single query
 - All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
 ",
+                  },
+                },
+                "required": [
+                  "exploreName",
+                  "dimensions",
+                  "metrics",
+                  "sorts",
+                  "limit",
+                  "customMetrics",
+                  "tableCalculations",
+                  "filters",
+                ],
+                "type": "object",
               },
               "title": {
                 "description": "A descriptive title for the chart",
@@ -2753,11 +2753,8 @@ Table calculations perform row-by-row calculations on query results without coll
             "required": [
               "title",
               "description",
-              "customMetrics",
-              "tableCalculations",
               "queryConfig",
               "chartConfig",
-              "filters",
             ],
             "type": "object",
           },
@@ -4238,734 +4235,741 @@ Notes:
             },
           ],
         },
-        "customMetrics": {
-          "anyOf": [
-            {
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "baseDimensionName": {
-                        "description": "Name of the base dimension/column this metric calculates from",
-                        "type": "string",
-                      },
-                      "description": {
-                        "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
-                        "type": "string",
-                      },
-                      "filters": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "additionalProperties": false,
-                              "properties": {
-                                "filter": {
-                                  "anyOf": [
-                                    {
+        "description": {
+          "description": "A descriptive summary or explanation for the chart.",
+          "type": "string",
+        },
+        "queryConfig": {
+          "additionalProperties": false,
+          "properties": {
+            "customMetrics": {
+              "anyOf": [
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "baseDimensionName": {
+                            "description": "Name of the base dimension/column this metric calculates from",
+                            "type": "string",
+                          },
+                          "description": {
+                            "description": "Brief explanation of what the metric represents, how it is calculated, and why it matters.",
+                            "type": "string",
+                          },
+                          "filters": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "filter": {
                                       "anyOf": [
                                         {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "const": "boolean",
-                                              "type": "string",
-                                            },
-                                            "fieldId": {
-                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                              "type": "string",
-                                            },
-                                            "fieldType": {
-                                              "enum": [
-                                                "boolean",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "isNull",
-                                                "notNull",
-                                              ],
-                                              "type": "string",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "equals",
-                                                "notEquals",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "type": "boolean",
-                                              },
-                                              "maxItems": 1,
-                                              "minItems": 1,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                      ],
-                                    },
-                                    {
-                                      "anyOf": [
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "const": "string",
-                                              "type": "string",
-                                            },
-                                            "fieldId": {
-                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                              "type": "string",
-                                            },
-                                            "fieldType": {
-                                              "enum": [
-                                                "string",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "isNull",
-                                                "notNull",
-                                              ],
-                                              "type": "string",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "equals",
-                                                "notEquals",
-                                                "startsWith",
-                                                "endsWith",
-                                                "include",
-                                                "doesNotInclude",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "type": "string",
-                                              },
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                      ],
-                                    },
-                                    {
-                                      "anyOf": [
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "const": "number",
-                                              "type": "string",
-                                            },
-                                            "fieldId": {
-                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                              "type": "string",
-                                            },
-                                            "fieldType": {
-                                              "enum": [
-                                                "number",
-                                                "percentile",
-                                                "median",
-                                                "average",
-                                                "count",
-                                                "count_distinct",
-                                                "sum",
-                                                "sum_distinct",
-                                                "average_distinct",
-                                                "min",
-                                                "max",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "isNull",
-                                                "notNull",
-                                              ],
-                                              "type": "string",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "equals",
-                                                "notEquals",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "type": "number",
-                                              },
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "lessThan",
-                                                "lessThanOrEqual",
-                                                "greaterThan",
-                                                "greaterThanOrEqual",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "type": "number",
-                                              },
-                                              "maxItems": 1,
-                                              "minItems": 1,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "inBetween",
-                                                "notInBetween",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "type": "number",
-                                              },
-                                              "maxItems": 2,
-                                              "minItems": 2,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                      ],
-                                    },
-                                    {
-                                      "anyOf": [
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "const": "date",
-                                              "type": "string",
-                                            },
-                                            "fieldId": {
-                                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                                              "type": "string",
-                                            },
-                                            "fieldType": {
-                                              "enum": [
-                                                "date",
-                                                "timestamp",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "isNull",
-                                                "notNull",
-                                              ],
-                                              "type": "string",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "equals",
-                                                "notEquals",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "anyOf": [
-                                                  {
-                                                    "format": "date",
-                                                    "type": "string",
-                                                  },
-                                                  {
-                                                    "format": "date-time",
-                                                    "type": "string",
-                                                  },
-                                                ],
-                                              },
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "inThePast",
-                                                "notInThePast",
-                                                "inTheNext",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "settings": {
+                                          "anyOf": [
+                                            {
                                               "additionalProperties": false,
                                               "properties": {
-                                                "completed": {
-                                                  "type": "boolean",
+                                                "fieldFilterType": {
+                                                  "const": "boolean",
+                                                  "type": "string",
                                                 },
-                                                "unitOfTime": {
+                                                "fieldId": {
+                                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                  "type": "string",
+                                                },
+                                                "fieldType": {
                                                   "enum": [
-                                                    "days",
-                                                    "weeks",
-                                                    "months",
-                                                    "quarters",
-                                                    "years",
+                                                    "boolean",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "isNull",
+                                                    "notNull",
                                                   ],
                                                   "type": "string",
                                                 },
                                               },
                                               "required": [
-                                                "completed",
-                                                "unitOfTime",
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
                                               ],
                                               "type": "object",
                                             },
-                                            "values": {
-                                              "items": {
-                                                "type": "number",
-                                              },
-                                              "maxItems": 1,
-                                              "minItems": 1,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                            "settings",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "inTheCurrent",
-                                                "notInTheCurrent",
-                                              ],
-                                              "type": "string",
-                                            },
-                                            "settings": {
+                                            {
                                               "additionalProperties": false,
                                               "properties": {
-                                                "completed": {
-                                                  "const": false,
-                                                  "type": "boolean",
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
                                                 },
-                                                "unitOfTime": {
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
                                                   "enum": [
-                                                    "days",
-                                                    "weeks",
-                                                    "months",
-                                                    "quarters",
-                                                    "years",
+                                                    "equals",
+                                                    "notEquals",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "boolean",
+                                                  },
+                                                  "maxItems": 1,
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "const": "string",
+                                                  "type": "string",
+                                                },
+                                                "fieldId": {
+                                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                  "type": "string",
+                                                },
+                                                "fieldType": {
+                                                  "enum": [
+                                                    "string",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "isNull",
+                                                    "notNull",
                                                   ],
                                                   "type": "string",
                                                 },
                                               },
                                               "required": [
-                                                "completed",
-                                                "unitOfTime",
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
                                               ],
                                               "type": "object",
                                             },
-                                            "values": {
-                                              "items": {
-                                                "const": 1,
-                                                "type": "number",
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "equals",
+                                                    "notEquals",
+                                                    "startsWith",
+                                                    "endsWith",
+                                                    "include",
+                                                    "doesNotInclude",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string",
+                                                  },
+                                                  "type": "array",
+                                                },
                                               },
-                                              "maxItems": 1,
-                                              "minItems": 1,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
-                                            "settings",
-                                          ],
-                                          "type": "object",
-                                        },
-                                        {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "lessThan",
-                                                "lessThanOrEqual",
-                                                "greaterThan",
-                                                "greaterThanOrEqual",
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
                                               ],
-                                              "type": "string",
+                                              "type": "object",
                                             },
-                                            "values": {
-                                              "items": {
-                                                "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
-                                              },
-                                              "maxItems": 1,
-                                              "minItems": 1,
-                                              "type": "array",
-                                            },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
                                           ],
-                                          "type": "object",
                                         },
                                         {
-                                          "additionalProperties": false,
-                                          "properties": {
-                                            "fieldFilterType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
-                                            },
-                                            "fieldId": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
-                                            },
-                                            "fieldType": {
-                                              "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
-                                            },
-                                            "operator": {
-                                              "const": "inBetween",
-                                              "type": "string",
-                                            },
-                                            "values": {
-                                              "items": {
-                                                "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                          "anyOf": [
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "const": "number",
+                                                  "type": "string",
+                                                },
+                                                "fieldId": {
+                                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                  "type": "string",
+                                                },
+                                                "fieldType": {
+                                                  "enum": [
+                                                    "number",
+                                                    "percentile",
+                                                    "median",
+                                                    "average",
+                                                    "count",
+                                                    "count_distinct",
+                                                    "sum",
+                                                    "sum_distinct",
+                                                    "average_distinct",
+                                                    "min",
+                                                    "max",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "isNull",
+                                                    "notNull",
+                                                  ],
+                                                  "type": "string",
+                                                },
                                               },
-                                              "maxItems": 2,
-                                              "minItems": 2,
-                                              "type": "array",
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                              ],
+                                              "type": "object",
                                             },
-                                          },
-                                          "required": [
-                                            "fieldId",
-                                            "fieldType",
-                                            "fieldFilterType",
-                                            "operator",
-                                            "values",
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "equals",
+                                                    "notEquals",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "number",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "lessThan",
+                                                    "lessThanOrEqual",
+                                                    "greaterThan",
+                                                    "greaterThanOrEqual",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "number",
+                                                  },
+                                                  "maxItems": 1,
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "inBetween",
+                                                    "notInBetween",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "number",
+                                                  },
+                                                  "maxItems": 2,
+                                                  "minItems": 2,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
                                           ],
-                                          "type": "object",
+                                        },
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "const": "date",
+                                                  "type": "string",
+                                                },
+                                                "fieldId": {
+                                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                                  "type": "string",
+                                                },
+                                                "fieldType": {
+                                                  "enum": [
+                                                    "date",
+                                                    "timestamp",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "isNull",
+                                                    "notNull",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "equals",
+                                                    "notEquals",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "anyOf": [
+                                                      {
+                                                        "format": "date",
+                                                        "type": "string",
+                                                      },
+                                                      {
+                                                        "format": "date-time",
+                                                        "type": "string",
+                                                      },
+                                                    ],
+                                                  },
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "inThePast",
+                                                    "notInThePast",
+                                                    "inTheNext",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "settings": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "completed": {
+                                                      "type": "boolean",
+                                                    },
+                                                    "unitOfTime": {
+                                                      "enum": [
+                                                        "days",
+                                                        "weeks",
+                                                        "months",
+                                                        "quarters",
+                                                        "years",
+                                                      ],
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "completed",
+                                                    "unitOfTime",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "number",
+                                                  },
+                                                  "maxItems": 1,
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                                "settings",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "inTheCurrent",
+                                                    "notInTheCurrent",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "settings": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "completed": {
+                                                      "const": false,
+                                                      "type": "boolean",
+                                                    },
+                                                    "unitOfTime": {
+                                                      "enum": [
+                                                        "days",
+                                                        "weeks",
+                                                        "months",
+                                                        "quarters",
+                                                        "years",
+                                                      ],
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "completed",
+                                                    "unitOfTime",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "const": 1,
+                                                    "type": "number",
+                                                  },
+                                                  "maxItems": 1,
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                                "settings",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "enum": [
+                                                    "lessThan",
+                                                    "lessThanOrEqual",
+                                                    "greaterThan",
+                                                    "greaterThanOrEqual",
+                                                  ],
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                  },
+                                                  "maxItems": 1,
+                                                  "minItems": 1,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "fieldFilterType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
+                                                },
+                                                "fieldId": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldId",
+                                                },
+                                                "fieldType": {
+                                                  "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
+                                                },
+                                                "operator": {
+                                                  "const": "inBetween",
+                                                  "type": "string",
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
+                                                  },
+                                                  "maxItems": 2,
+                                                  "minItems": 2,
+                                                  "type": "array",
+                                                },
+                                              },
+                                              "required": [
+                                                "fieldId",
+                                                "fieldType",
+                                                "fieldFilterType",
+                                                "operator",
+                                                "values",
+                                              ],
+                                              "type": "object",
+                                            },
+                                          ],
                                         },
                                       ],
                                     },
+                                    "table": {
+                                      "description": "Table name this filter field belongs to",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "filter",
+                                    "table",
                                   ],
+                                  "type": "object",
                                 },
-                                "table": {
-                                  "description": "Table name this filter field belongs to",
-                                  "type": "string",
-                                },
+                                "type": "array",
                               },
-                              "required": [
-                                "filter",
-                                "table",
-                              ],
-                              "type": "object",
-                            },
-                            "type": "array",
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
                           },
-                          {
-                            "type": "null",
+                          "kind": {
+                            "const": "aggregation",
+                            "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
+                            "type": "string",
                           },
+                          "label": {
+                            "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
+                            "type": "string",
+                          },
+                          "name": {
+                            "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
+                            "type": "string",
+                          },
+                          "table": {
+                            "description": "Table name where the base column exists. Match with available dimensions in the explore.",
+                            "type": "string",
+                          },
+                          "type": {
+                            "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
+                            "enum": [
+                              "average",
+                              "count",
+                              "count_distinct",
+                              "max",
+                              "min",
+                              "sum",
+                              "percentile",
+                              "median",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "kind",
+                          "name",
+                          "label",
+                          "description",
+                          "baseDimensionName",
+                          "table",
+                          "type",
+                          "filters",
                         ],
-                        "description": "Optional filters for conditional metrics. Each filter needs fieldId (from findFields) and table name.",
+                        "type": "object",
                       },
-                      "kind": {
-                        "const": "aggregation",
-                        "description": "Custom metric defined by applying an aggregation to a base dimension. Use when the requested metric does not yet exist in the explore (e.g. "average customer age", "count of completed orders").",
-                        "type": "string",
-                      },
-                      "label": {
-                        "description": "Human-readable label for the metric (e.g., "Average Customer Age", "Total Revenue")",
-                        "type": "string",
-                      },
-                      "name": {
-                        "description": "Unique metric name using snake_case (e.g., "avg_customer_age", "total_revenue")",
-                        "type": "string",
-                      },
-                      "table": {
-                        "description": "Table name where the base column exists. Match with available dimensions in the explore.",
-                        "type": "string",
-                      },
-                      "type": {
-                        "description": "Aggregation type. If the base dimension type is STRING, TIMESTAMP, DATE, BOOLEAN, use COUNT_DISTINCT, COUNT, MIN, MAX. If NUMBER, use MIN, MAX, SUM, PERCENTILE, MEDIAN, AVERAGE, COUNT_DISTINCT, COUNT. If BOOLEAN, use COUNT_DISTINCT, COUNT.",
-                        "enum": [
-                          "average",
-                          "count",
-                          "count_distinct",
-                          "max",
-                          "min",
-                          "sum",
-                          "percentile",
-                          "median",
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "baseMetricId": {
+                            "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
+                            "type": "string",
+                          },
+                          "granularity": {
+                            "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
+                            "enum": [
+                              "DAY",
+                              "WEEK",
+                              "MONTH",
+                              "QUARTER",
+                              "YEAR",
+                            ],
+                            "type": "string",
+                          },
+                          "kind": {
+                            "const": "periodComparison",
+                            "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
+                            "type": "string",
+                          },
+                          "periodOffset": {
+                            "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
+                            "minimum": 1,
+                            "type": "integer",
+                          },
+                          "timeDimensionId": {
+                            "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "kind",
+                          "baseMetricId",
+                          "timeDimensionId",
+                          "granularity",
+                          "periodOffset",
                         ],
-                        "type": "string",
+                        "type": "object",
                       },
-                    },
-                    "required": [
-                      "kind",
-                      "name",
-                      "label",
-                      "description",
-                      "baseDimensionName",
-                      "table",
-                      "type",
-                      "filters",
                     ],
-                    "type": "object",
                   },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "baseMetricId": {
-                        "description": "Field ID of the metric to shift. Must appear in queryConfig.metrics OR be an aggregation custom metric defined in this same customMetrics array. Format: "table_metric_name".",
-                        "type": "string",
-                      },
-                      "granularity": {
-                        "description": "Bucket unit for the offset. Must equal the bucket encoded in timeDimensionId's suffix.",
-                        "enum": [
-                          "DAY",
-                          "WEEK",
-                          "MONTH",
-                          "QUARTER",
-                          "YEAR",
-                        ],
-                        "type": "string",
-                      },
-                      "kind": {
-                        "const": "periodComparison",
-                        "description": "Custom metric that compares a base metric against itself shifted back in time. Use for "month-over-month", "year-over-year", "vs last quarter", "compared to N periods ago".",
-                        "type": "string",
-                      },
-                      "periodOffset": {
-                        "description": "Number of bucket units (granularity) to look back. >= 1. For year-over-year on monthly buckets: granularity=MONTH, periodOffset=12.",
-                        "minimum": 1,
-                        "type": "integer",
-                      },
-                      "timeDimensionId": {
-                        "description": "Field ID of the time dimension to anchor the shift on. Must be present in queryConfig.dimensions. Format: "table_column_granularity" — the suffix encodes the bucket (e.g. "..._month" → MONTH bucket).",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "kind",
-                      "baseMetricId",
-                      "timeDimensionId",
-                      "granularity",
-                      "periodOffset",
-                    ],
-                    "type": "object",
-                  },
-                ],
-              },
-              "type": "array",
-            },
-            {
-              "type": "null",
-            },
-          ],
-          "description": "Define new metric columns the explore doesn't already have. Two kinds:
+                  "type": "array",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+              "description": "Define new metric columns the explore doesn't already have. Two kinds:
 
 (1) kind: "aggregation" — a NEW metric built by aggregating a base dimension
     (SUM, AVG, COUNT, COUNT_DISTINCT, MIN, MAX, PERCENTILE, MEDIAN).
@@ -4999,24 +5003,7 @@ Example B — "Revenue by month with year-over-year comparison"
   queryConfig.dimensions: ["orders_order_date_month"]
   queryConfig.metrics: ["orders_revenue"]
   customMetrics: [{ kind: "periodComparison", baseMetricId: "orders_revenue", timeDimensionId: "orders_order_date_month", granularity: "MONTH", periodOffset: 12 }]",
-        },
-        "description": {
-          "description": "A descriptive summary or explanation for the chart.",
-          "type": "string",
-        },
-        "filters": {
-          "anyOf": [
-            {
-              "$ref": "#/properties/queryConfig/properties/filters",
             },
-            {
-              "type": "null",
-            },
-          ],
-        },
-        "queryConfig": {
-          "additionalProperties": false,
-          "properties": {
             "dimensions": {
               "description": "The field ids for the dimensions to group the metrics by. dimensions[0] is the primary grouping (x-axis for charts). dimensions[1+] create additional grouping levels.",
               "items": {
@@ -5030,76 +5017,83 @@ Example B — "Revenue by month with year-over-year comparison"
               "type": "string",
             },
             "filters": {
-              "additionalProperties": false,
-              "properties": {
-                "dimensions": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "anyOf": [
-                          {
-                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dimensions": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0",
+                              },
+                              {
+                                "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                              },
+                              {
+                                "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                              },
+                              {
+                                "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
+                              },
+                            ],
                           },
-                          {
-                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1",
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "metrics": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/queryConfig/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items",
                           },
-                          {
-                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
+                    },
+                    "tableCalculations": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
                           },
-                          {
-                            "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3",
-                          },
-                        ],
-                      },
-                      "type": "array",
+                          "type": "array",
+                        },
+                        {
+                          "type": "null",
+                        },
+                      ],
                     },
-                    {
-                      "type": "null",
+                    "type": {
+                      "description": "Type of filter group operation",
+                      "enum": [
+                        "and",
+                        "or",
+                      ],
+                      "type": "string",
                     },
+                  },
+                  "required": [
+                    "type",
+                    "dimensions",
+                    "metrics",
+                    "tableCalculations",
                   ],
+                  "type": "object",
                 },
-                "metrics": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "$ref": "#/properties/queryConfig/properties/filters/properties/dimensions/anyOf/0/items",
-                      },
-                      "type": "array",
-                    },
-                    {
-                      "type": "null",
-                    },
-                  ],
+                {
+                  "type": "null",
                 },
-                "tableCalculations": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "$ref": "#/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2",
-                      },
-                      "type": "array",
-                    },
-                    {
-                      "type": "null",
-                    },
-                  ],
-                },
-                "type": {
-                  "description": "Type of filter group operation",
-                  "enum": [
-                    "and",
-                    "or",
-                  ],
-                  "type": "string",
-                },
-              },
-              "required": [
-                "type",
-                "dimensions",
-                "metrics",
-                "tableCalculations",
               ],
-              "type": "object",
             },
             "limit": {
               "description": "The total number of data points / rows allowed on the chart.",
@@ -5146,317 +5140,263 @@ Example B — "Revenue by month with year-over-year comparison"
               },
               "type": "array",
             },
-          },
-          "required": [
-            "exploreName",
-            "dimensions",
-            "metrics",
-            "sorts",
-            "limit",
-          ],
-          "type": "object",
-        },
-        "tableCalculations": {
-          "anyOf": [
-            {
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "description": "Display name for the table calculation, e.g. "MoM revenue change"",
-                        "type": "string",
-                      },
-                      "fieldId": {
-                        "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "name": {
-                        "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
-                        "type": "string",
-                      },
-                      "orderBy": {
-                        "description": "Specifies the order in which rows are processed by the table calculation.
+            "tableCalculations": {
+              "anyOf": [
+                {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "description": "Display name for the table calculation, e.g. "MoM revenue change"",
+                            "type": "string",
+                          },
+                          "fieldId": {
+                            "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "name": {
+                            "description": "Unique name for the table calculation, e.g. "percent_change_from_previous"",
+                            "type": "string",
+                          },
+                          "orderBy": {
+                            "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                        "items": {
-                          "additionalProperties": false,
-                          "properties": {
-                            "fieldId": {
-                              "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
-                            "order": {
-                              "anyOf": [
-                                {
-                                  "enum": [
-                                    "asc",
-                                    "desc",
-                                  ],
+                            "items": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "fieldId": {
+                                  "description": "Field to order by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
                                   "type": "string",
                                 },
-                                {
-                                  "type": "null",
+                                "order": {
+                                  "anyOf": [
+                                    {
+                                      "enum": [
+                                        "asc",
+                                        "desc",
+                                      ],
+                                      "type": "string",
+                                    },
+                                    {
+                                      "type": "null",
+                                    },
+                                  ],
                                 },
+                              },
+                              "required": [
+                                "fieldId",
+                                "order",
                               ],
+                              "type": "object",
                             },
-                          },
-                          "required": [
-                            "fieldId",
-                            "order",
-                          ],
-                          "type": "object",
-                        },
-                        "minItems": 1,
-                        "type": "array",
-                      },
-                      "partitionBy": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                              "type": "string",
-                            },
+                            "minItems": 1,
                             "type": "array",
                           },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+                          "partitionBy": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "description": ""fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                                  "type": "string",
+                                },
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "Fields to PARTITION BY - divides result set into independent groups.
 Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
 Empty array or null: single partition (calculations across all rows).",
+                          },
+                          "type": {
+                            "const": "percent_change_from_previous",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "fieldId",
+                          "orderBy",
+                          "partitionBy",
+                        ],
+                        "type": "object",
                       },
-                      "type": {
-                        "const": "percent_change_from_previous",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "fieldId",
-                      "orderBy",
-                      "partitionBy",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                      },
-                      "fieldId": {
-                        "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "name": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                      },
-                      "orderBy": {
-                        "description": "Specifies the order in which rows are processed by the table calculation.
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                          },
+                          "fieldId": {
+                            "description": "Field whose values you want to compare "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "name": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                          },
+                          "orderBy": {
+                            "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                        "items": {
-                          "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                        },
-                        "minItems": 1,
-                        "type": "array",
-                      },
-                      "partitionBy": {
-                        "anyOf": [
-                          {
                             "items": {
-                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                              "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
                             },
+                            "minItems": 1,
                             "type": "array",
                           },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                        "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                      },
-                      "type": {
-                        "const": "percent_of_previous_value",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "fieldId",
-                      "orderBy",
-                      "partitionBy",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                      },
-                      "fieldId": {
-                        "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "name": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                      },
-                      "partitionBy": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                            },
-                            "type": "array",
-                          },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                        "description": "Fields to PARTITION BY - divides result set into independent groups.
-Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
-Empty array or null: single partition (calculations across all rows).",
-                      },
-                      "type": {
-                        "const": "percent_of_column_total",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "fieldId",
-                      "partitionBy",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                      },
-                      "fieldId": {
-                        "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "name": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                      },
-                      "type": {
-                        "const": "rank_in_column",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "fieldId",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                      },
-                      "fieldId": {
-                        "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": "string",
-                      },
-                      "name": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                      },
-                      "type": {
-                        "const": "running_total",
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "fieldId",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "displayName": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
-                      },
-                      "fieldId": {
-                        "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
-                        "type": [
-                          "string",
-                          "null",
-                        ],
-                      },
-                      "frame": {
-                        "anyOf": [
-                          {
-                            "additionalProperties": false,
-                            "properties": {
-                              "end": {
-                                "additionalProperties": false,
-                                "description": "End boundary (required)",
-                                "properties": {
-                                  "offset": {
-                                    "anyOf": [
-                                      {
-                                        "exclusiveMinimum": 0,
-                                        "type": "integer",
-                                      },
-                                      {
-                                        "type": "null",
-                                      },
-                                    ],
-                                    "description": "Number of rows for PRECEDING/FOLLOWING",
-                                  },
-                                  "type": {
-                                    "enum": [
-                                      "unbounded_preceding",
-                                      "preceding",
-                                      "current_row",
-                                      "following",
-                                      "unbounded_following",
-                                    ],
-                                    "type": "string",
-                                  },
+                          "partitionBy": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
                                 },
-                                "required": [
-                                  "type",
-                                  "offset",
-                                ],
-                                "type": "object",
+                                "type": "array",
                               },
-                              "frameType": {
-                                "description": "Frame type:
-- rows: Physical row count
-- range: Logical value-based (includes peer rows with same ORDER BY value)",
-                                "enum": [
-                                  "rows",
-                                  "range",
-                                ],
-                                "type": "string",
+                              {
+                                "type": "null",
                               },
-                              "start": {
-                                "anyOf": [
-                                  {
+                            ],
+                            "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                          },
+                          "type": {
+                            "const": "percent_of_previous_value",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "fieldId",
+                          "orderBy",
+                          "partitionBy",
+                        ],
+                        "type": "object",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                          },
+                          "fieldId": {
+                            "description": "Field to calculate percentage of column total "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "name": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                          },
+                          "partitionBy": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                },
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "Fields to PARTITION BY - divides result set into independent groups.
+Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
+Empty array or null: single partition (calculations across all rows).",
+                          },
+                          "type": {
+                            "const": "percent_of_column_total",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "fieldId",
+                          "partitionBy",
+                        ],
+                        "type": "object",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                          },
+                          "fieldId": {
+                            "description": "Field to rank by "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "name": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                          },
+                          "type": {
+                            "const": "rank_in_column",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                          },
+                          "fieldId": {
+                            "description": "Field to calculate running total of "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": "string",
+                          },
+                          "name": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
+                          },
+                          "type": {
+                            "const": "running_total",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "fieldId",
+                        ],
+                        "type": "object",
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "displayName": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/displayName",
+                          },
+                          "fieldId": {
+                            "description": "Field to aggregate (required for sum/avg/count/min/max, not used for row_number/percent_rank/cume_dist/rank) "fieldId" must come from the previously searched Fields; otherwise, it will throw an error",
+                            "type": [
+                              "string",
+                              "null",
+                            ],
+                          },
+                          "frame": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "end": {
                                     "additionalProperties": false,
+                                    "description": "End boundary (required)",
                                     "properties": {
                                       "offset": {
                                         "anyOf": [
@@ -5468,7 +5408,7 @@ Empty array or null: single partition (calculations across all rows).",
                                             "type": "null",
                                           },
                                         ],
-                                        "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                        "description": "Number of rows for PRECEDING/FOLLOWING",
                                       },
                                       "type": {
                                         "enum": [
@@ -5487,25 +5427,69 @@ Empty array or null: single partition (calculations across all rows).",
                                     ],
                                     "type": "object",
                                   },
-                                  {
-                                    "type": "null",
+                                  "frameType": {
+                                    "description": "Frame type:
+- rows: Physical row count
+- range: Logical value-based (includes peer rows with same ORDER BY value)",
+                                    "enum": [
+                                      "rows",
+                                      "range",
+                                    ],
+                                    "type": "string",
                                   },
+                                  "start": {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "offset": {
+                                            "anyOf": [
+                                              {
+                                                "exclusiveMinimum": 0,
+                                                "type": "integer",
+                                              },
+                                              {
+                                                "type": "null",
+                                              },
+                                            ],
+                                            "description": "Number of rows for PRECEDING/FOLLOWING (e.g., 6 for "6 PRECEDING")",
+                                          },
+                                          "type": {
+                                            "enum": [
+                                              "unbounded_preceding",
+                                              "preceding",
+                                              "current_row",
+                                              "following",
+                                              "unbounded_following",
+                                            ],
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "type",
+                                          "offset",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      {
+                                        "type": "null",
+                                      },
+                                    ],
+                                    "description": "Start boundary. Null for single-boundary syntax.",
+                                  },
+                                },
+                                "required": [
+                                  "frameType",
+                                  "start",
+                                  "end",
                                 ],
-                                "description": "Start boundary. Null for single-boundary syntax.",
+                                "type": "object",
                               },
-                            },
-                            "required": [
-                              "frameType",
-                              "start",
-                              "end",
+                              {
+                                "type": "null",
+                              },
                             ],
-                            "type": "object",
-                          },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                        "description": "Defines which rows to include in calculation. Null uses database defaults.
+                            "description": "Defines which rows to include in calculation. Null uses database defaults.
 
 **Common patterns:**
 - Moving average (N periods): {frameType: "rows", start: {type: "preceding", offset: N-1}, end: {type: "current_row"}}
@@ -5516,48 +5500,48 @@ Empty array or null: single partition (calculations across all rows).",
 - Aggregates WITH ORDER BY: RANGE UNBOUNDED PRECEDING AND CURRENT ROW (cumulative)
 - Aggregates WITHOUT ORDER BY: Entire partition (all rows)
 - Ranking functions: Always use entire partition (frame clause has no effect)",
-                      },
-                      "name": {
-                        "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
-                      },
-                      "orderBy": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
-                            },
-                            "type": "array",
                           },
-                          {
-                            "type": "null",
+                          "name": {
+                            "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/name",
                           },
-                        ],
-                        "description": "Specifies the order in which rows are processed by the table calculation.
+                          "orderBy": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/orderBy/items",
+                                },
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "Specifies the order in which rows are processed by the table calculation.
 For time-series: typically order by date/time ascending.
 For rankings: order by the metric you want to rank, descending for highest-first.",
-                      },
-                      "partitionBy": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "$ref": "#/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
-                            },
-                            "type": "array",
                           },
-                          {
-                            "type": "null",
-                          },
-                        ],
-                        "description": "Fields to PARTITION BY - divides result set into independent groups.
+                          "partitionBy": {
+                            "anyOf": [
+                              {
+                                "items": {
+                                  "$ref": "#/properties/queryConfig/properties/tableCalculations/anyOf/0/items/anyOf/0/properties/partitionBy/anyOf/0/items",
+                                },
+                                "type": "array",
+                              },
+                              {
+                                "type": "null",
+                              },
+                            ],
+                            "description": "Fields to PARTITION BY - divides result set into independent groups.
 Each partition calculates independently (rankings restart, percentages sum to 100% per partition).
 Empty array or null: single partition (calculations across all rows).",
-                      },
-                      "type": {
-                        "const": "window_function",
-                        "type": "string",
-                      },
-                      "windowFunction": {
-                        "description": "Type of window function to apply.
+                          },
+                          "type": {
+                            "const": "window_function",
+                            "type": "string",
+                          },
+                          "windowFunction": {
+                            "description": "Type of window function to apply.
 
 **Ranking functions** (fieldId optional, ignored if provided):
 - row_number: Sequential numbering (1, 2, 3...)
@@ -5571,41 +5555,41 @@ Empty array or null: single partition (calculations across all rows).",
 - count: Count values within frame
 - min: Minimum value within frame
 - max: Maximum value within frame",
-                        "enum": [
-                          "row_number",
-                          "percent_rank",
-                          "cume_dist",
-                          "rank",
-                          "sum",
-                          "avg",
-                          "count",
-                          "min",
-                          "max",
+                            "enum": [
+                              "row_number",
+                              "percent_rank",
+                              "cume_dist",
+                              "rank",
+                              "sum",
+                              "avg",
+                              "count",
+                              "min",
+                              "max",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "displayName",
+                          "type",
+                          "windowFunction",
+                          "fieldId",
+                          "orderBy",
+                          "partitionBy",
+                          "frame",
                         ],
-                        "type": "string",
+                        "type": "object",
                       },
-                    },
-                    "required": [
-                      "name",
-                      "displayName",
-                      "type",
-                      "windowFunction",
-                      "fieldId",
-                      "orderBy",
-                      "partitionBy",
-                      "frame",
                     ],
-                    "type": "object",
                   },
-                ],
-              },
-              "type": "array",
-            },
-            {
-              "type": "null",
-            },
-          ],
-          "description": "
+                  "type": "array",
+                },
+                {
+                  "type": "null",
+                },
+              ],
+              "description": "
 Table calculations perform row-by-row calculations on query results without collapsing rows. Similar to SQL window functions.
 
 **Available Types:**
@@ -5618,6 +5602,19 @@ Table calculations perform row-by-row calculations on query results without coll
 - Multiple calculations can be combined in a single query
 - All fields referenced must exist in the query (dimensions, metrics, or other table calculations)
 ",
+            },
+          },
+          "required": [
+            "exploreName",
+            "dimensions",
+            "metrics",
+            "sorts",
+            "limit",
+            "customMetrics",
+            "tableCalculations",
+            "filters",
+          ],
+          "type": "object",
         },
         "title": {
           "description": "A descriptive title for the chart",
@@ -5627,11 +5624,8 @@ Table calculations perform row-by-row calculations on query results without coll
       "required": [
         "title",
         "description",
-        "customMetrics",
-        "tableCalculations",
         "queryConfig",
         "chartConfig",
-        "filters",
       ],
       "type": "object",
     },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts
@@ -1,0 +1,89 @@
+import {
+    toolRunQueryArgsSchema,
+    toolRunQueryArgsSchemaTransformed,
+    toolRunQueryArgsSchemaV1,
+    toolRunQueryArgsSchemaV2,
+} from './toolRunQueryArgs';
+
+const baseQueryConfig = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_month'],
+    metrics: ['orders_revenue'],
+    sorts: [],
+    limit: 500,
+};
+
+const baseArgs = {
+    title: 'Revenue by month',
+    description: 'Monthly revenue trend',
+    chartConfig: null,
+};
+
+describe('toolRunQueryArgsSchema', () => {
+    it('uses the V2 queryConfig shape for the current schema', () => {
+        const v2Args = {
+            ...baseArgs,
+            queryConfig: {
+                ...baseQueryConfig,
+                customMetrics: null,
+                tableCalculations: null,
+                filters: null,
+            },
+        };
+
+        expect(toolRunQueryArgsSchemaV2.safeParse(v2Args).success).toBe(true);
+        expect(toolRunQueryArgsSchema.safeParse(v2Args).success).toBe(true);
+    });
+
+    it('keeps V1 available for strict parsing of old tool args', () => {
+        const v1Args = {
+            ...baseArgs,
+            customMetrics: null,
+            tableCalculations: null,
+            queryConfig: baseQueryConfig,
+            filters: null,
+        };
+
+        expect(toolRunQueryArgsSchemaV1.safeParse(v1Args).success).toBe(true);
+        expect(toolRunQueryArgsSchema.safeParse(v1Args).success).toBe(false);
+    });
+
+    it('normalizes V1 and V2 args to the same internal shape', () => {
+        const v1Args = {
+            ...baseArgs,
+            customMetrics: null,
+            tableCalculations: null,
+            queryConfig: baseQueryConfig,
+            filters: null,
+        };
+        const v2Args = {
+            ...baseArgs,
+            queryConfig: {
+                ...baseQueryConfig,
+                customMetrics: null,
+                tableCalculations: null,
+                filters: null,
+            },
+        };
+
+        const v1Parsed = toolRunQueryArgsSchemaTransformed.parse(v1Args);
+        const v2Parsed = toolRunQueryArgsSchemaTransformed.parse(v2Args);
+
+        expect(v1Parsed).toMatchObject({
+            title: baseArgs.title,
+            description: baseArgs.description,
+            customMetrics: null,
+            tableCalculations: null,
+            queryConfig: baseQueryConfig,
+            chartConfig: null,
+        });
+        expect(v2Parsed).toMatchObject({
+            title: baseArgs.title,
+            description: baseArgs.description,
+            customMetrics: null,
+            tableCalculations: null,
+            queryConfig: baseQueryConfig,
+            chartConfig: null,
+        });
+    });
+});

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -18,7 +18,7 @@ import {
 import { mcpAsyncQueryUuidSchema } from './toolQueryResultSchemas';
 
 // Query configuration schema - what data to fetch
-const queryConfigSchema = z.object({
+const queryConfigBaseSchema = z.object({
     exploreName: z
         .string()
         .describe(
@@ -45,11 +45,16 @@ const queryConfigSchema = z.object({
         .describe(
             'The total number of data points / rows allowed on the chart.',
         ),
-    // External LLMs frequently nest filters inside queryConfig instead of at
-    // the top level. Accepting them here prevents Zod from silently stripping
-    // the key. The transform in `toolRunQueryArgsSchemaTransformed` lifts
-    // nested filters to the top level.
-    filters: filtersSchemaV2.optional(),
+});
+
+const queryConfigSchemaV1 = queryConfigBaseSchema.extend({
+    filters: filtersSchemaV2.nullable().default(null),
+});
+
+const queryConfigSchemaV2 = queryConfigBaseSchema.extend({
+    customMetrics: customMetricsSchema,
+    tableCalculations: tableCalcsSchema,
+    filters: filtersSchemaV2.nullable(),
 });
 
 // Chart-specific configuration for rendering hints
@@ -161,34 +166,85 @@ Notes:
 ${MCP_QUERY_COMMON_NOTES}
 `;
 
-export const toolRunQueryArgsSchema = createToolSchema()
+export const toolRunQueryArgsSchemaV1 = createToolSchema()
     .extend({
         ...visualizationMetadataSchema.shape,
-        customMetrics: customMetricsSchema,
-        tableCalculations: tableCalcsSchema,
-        queryConfig: queryConfigSchema,
-        chartConfig: chartConfigSchema,
-        filters: filtersSchemaV2.nullable(),
+        customMetrics: customMetricsSchema.default(null),
+        tableCalculations: tableCalcsSchema.default(null),
+        queryConfig: queryConfigSchemaV1,
+        chartConfig: chartConfigSchema.default(null),
+        filters: filtersSchemaV2.nullable().default(null),
     })
     .build();
 
-export type ToolRunQueryArgs = z.infer<typeof toolRunQueryArgsSchema>;
-
-export const toolRunQueryArgsSchemaTransformed = toolRunQueryArgsSchema
+export const toolRunQueryArgsSchemaV2 = createToolSchema()
     .extend({
-        customMetrics: customMetricsSchema
-            .default(null)
-            .pipe(customMetricsSchemaTransformed),
-        tableCalculations: tableCalcsSchema.default(null),
-        chartConfig: chartConfigSchema.default(null),
+        ...visualizationMetadataSchema.shape,
+        queryConfig: queryConfigSchemaV2,
+        chartConfig: chartConfigSchema,
     })
-    .transform((data) => {
-        // LLMs often nest filters inside queryConfig instead of at the top
-        // level. Prefer top-level filters, fall back to queryConfig.filters.
-        const resolvedFilters =
-            data.filters ?? data.queryConfig.filters ?? null;
+    .build();
+
+export const toolRunQueryArgsSchema = toolRunQueryArgsSchemaV2;
+
+export type ToolRunQueryArgsV1 = z.infer<typeof toolRunQueryArgsSchemaV1>;
+export type ToolRunQueryArgsV2 = z.infer<typeof toolRunQueryArgsSchemaV2>;
+
+type ToolRunQueryArgsQueryConfigV2Fields = Pick<
+    ToolRunQueryArgsV2['queryConfig'],
+    'customMetrics' | 'tableCalculations' | 'filters'
+>;
+
+type ToolRunQueryArgsV1Compat = ToolRunQueryArgsV1 & {
+    queryConfig: ToolRunQueryArgsV1['queryConfig'] &
+        Partial<ToolRunQueryArgsQueryConfigV2Fields>;
+};
+
+type ToolRunQueryArgsV2Compat = ToolRunQueryArgsV2 &
+    Partial<ToolRunQueryArgsQueryConfigV2Fields>;
+
+export type ToolRunQueryArgs =
+    | ToolRunQueryArgsV1Compat
+    | ToolRunQueryArgsV2Compat;
+
+const toolRunQueryArgsSchemaCompat = createToolSchema()
+    .extend({
+        ...visualizationMetadataSchema.shape,
+        customMetrics: customMetricsSchema.default(null),
+        tableCalculations: tableCalcsSchema.default(null),
+        queryConfig: queryConfigBaseSchema.extend({
+            customMetrics: customMetricsSchema.default(null),
+            tableCalculations: tableCalcsSchema.default(null),
+            filters: filtersSchemaV2.nullable().default(null),
+        }),
+        chartConfig: chartConfigSchema.default(null),
+        filters: filtersSchemaV2.nullable().default(null),
+    })
+    .build();
+
+export const toolRunQueryArgsSchemaTransformed =
+    toolRunQueryArgsSchemaCompat.transform((data) => {
+        const resolvedCustomMetrics =
+            data.queryConfig.customMetrics ?? data.customMetrics;
+        const resolvedTableCalculations =
+            data.queryConfig.tableCalculations ?? data.tableCalculations;
+        const resolvedFilters = data.queryConfig.filters ?? data.filters;
+
         return {
-            ...data,
+            title: data.title,
+            description: data.description,
+            customMetrics: customMetricsSchemaTransformed.parse(
+                resolvedCustomMetrics,
+            ),
+            tableCalculations: resolvedTableCalculations,
+            queryConfig: {
+                exploreName: data.queryConfig.exploreName,
+                dimensions: data.queryConfig.dimensions,
+                metrics: data.queryConfig.metrics,
+                sorts: data.queryConfig.sorts,
+                limit: data.queryConfig.limit,
+            },
+            chartConfig: data.chartConfig,
             filters: filtersSchemaTransformed.parse(resolvedFilters),
         };
     });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/QueryResultToolCallDescription.tsx
@@ -1,17 +1,19 @@
-import { type ToolRunQueryArgs } from '@lightdash/common';
+import {
+    type ToolRunQueryArgs,
+    type ToolRunQueryArgsV2,
+} from '@lightdash/common';
 import { Group, Text } from '@mantine-8/core';
 import type { FC } from 'react';
 import { ToolCallChip } from '../ToolCallChip';
 import { formatFieldName } from '../utils/formatFieldName';
 
-type QueryResultToolCallDescriptionProps = Pick<
-    ToolRunQueryArgs,
-    | 'title'
-    | 'queryConfig'
-    | 'chartConfig'
-    | 'customMetrics'
-    | 'tableCalculations'
->;
+type QueryResultToolCallDescriptionProps = {
+    title: ToolRunQueryArgs['title'];
+    queryConfig: ToolRunQueryArgs['queryConfig'];
+    chartConfig: ToolRunQueryArgs['chartConfig'];
+    customMetrics: ToolRunQueryArgsV2['queryConfig']['customMetrics'];
+    tableCalculations: ToolRunQueryArgsV2['queryConfig']['tableCalculations'];
+};
 
 export const QueryResultToolCallDescription: FC<
     QueryResultToolCallDescriptionProps

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -169,13 +169,21 @@ export const ToolCallDescription: FC<{
         case 'generateVisualization':
         case 'runQuery':
             const queryToolArgs = toolCall.toolArgs as ToolRunQueryArgs;
+            const customMetrics =
+                queryToolArgs.queryConfig.customMetrics ??
+                queryToolArgs.customMetrics ??
+                null;
+            const tableCalculations =
+                queryToolArgs.queryConfig.tableCalculations ??
+                queryToolArgs.tableCalculations ??
+                null;
             return (
                 <QueryResultToolCallDescription
                     title={queryToolArgs.title}
                     queryConfig={queryToolArgs.queryConfig}
                     chartConfig={queryToolArgs.chartConfig}
-                    customMetrics={queryToolArgs.customMetrics}
-                    tableCalculations={queryToolArgs.tableCalculations}
+                    customMetrics={customMetrics}
+                    tableCalculations={tableCalculations}
                 />
             );
         case 'generateBarVizConfig':


### PR DESCRIPTION
Closes ZAP-9
Closes https://github.com/lightdash/lightdash/issues/17269

Agents kept generating filters (date filters especially) in the wrong place or in invalid combinations, because the run-query tool accepted filters both at the top level and nested inside `queryConfig`.

This introduces a versioned run-query tool schema: V2 moves `filters`, `customMetrics` and `tableCalculations` inside `queryConfig`, where models naturally put them. V1 payloads are still accepted, so the change is fully backward compatible.

### Affected tool contracts

Verified via a scripted per-tool diff of the contract snapshots against `main` — only these changed, everything else is byte-identical:

| Surface | Affected |
|---|---|
| AI agent tools (28) | `generateVisualization`, `generateDashboard` |
| MCP tools (26) | `run_metric_query` |
| MCP prompts (27) | `run_metric_query` |

`generateVisualization` / `run_metric_query` are the runQuery tool itself; `generateDashboard` changed because dashboard tiles embed the same query-config schema.

Investigation posted internally: https://lightdash.slack.com/archives/C08S88JT17W/p1781275450201669
