### PR TITLE
fix(ai-review): wait for preview compile before verification; skip reviews on preview projects

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -334,6 +334,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     writebackPreviewService:
                         repository.getWritebackPreviewService<WritebackPreviewService>(),
+                    jobModel: models.getJobModel(),
                 }),
             aiRouterService: ({ models, repository, context }) =>
                 new AiRouterService({
@@ -362,6 +363,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiOrganizationSettingsModel:
                         models.getAiOrganizationSettingsModel(),
                     catalogModel: models.getCatalogModel(),
+                    projectModel: models.getProjectModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
                 }),

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1,3 +1,4 @@
+import { ProjectType } from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AiPromptTableName } from '../database/entities/ai';
@@ -201,6 +202,20 @@ describe('AiAgentReviewClassifierModel', () => {
 
     afterEach(() => {
         tracker.reset();
+    });
+
+    describe('listTurnReviewCandidates', () => {
+        it('excludes turns from preview projects', async () => {
+            tracker.on.select(AiPromptTableName).responseOnce([]);
+
+            await model.listTurnReviewCandidates({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain('project_type');
+            expect(query.bindings).toContain(ProjectType.PREVIEW);
+        });
     });
 
     describe('createRun', () => {

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1,4 +1,4 @@
-import { QueryExecutionContext } from '@lightdash/common';
+import { ProjectType, QueryExecutionContext } from '@lightdash/common';
 import type {
     AiAgentConfigSnapshot,
     AiAgentEvidenceExcerpt,
@@ -29,6 +29,7 @@ import type {
     AiAgentTurnSignal,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { ProjectTableName } from '../../database/entities/projects';
 import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import { QueryHistoryTableName } from '../../database/entities/queryHistory';
 import {
@@ -718,6 +719,11 @@ export class AiAgentReviewClassifierModel {
                 'slack_thread.ai_thread_uuid',
                 'thread.ai_thread_uuid',
             )
+            .join(
+                `${ProjectTableName} as project`,
+                'project.project_uuid',
+                'thread.project_uuid',
+            )
             .select<BaseCandidateRow[]>({
                 ai_prompt_uuid: 'prompt.ai_prompt_uuid',
                 ai_thread_uuid: 'prompt.ai_thread_uuid',
@@ -740,6 +746,9 @@ export class AiAgentReviewClassifierModel {
             })
             .where('thread.organization_uuid', args.organizationUuid)
             .whereNotNull('thread.agent_uuid')
+            // Preview projects host writeback verification threads — reviewing
+            // them would feed the reviewer's own output back into itself.
+            .whereNot('project.project_type', ProjectType.PREVIEW)
             .whereIn('thread.created_from', ['web_app', 'slack'])
             .where((builder) => {
                 void builder

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,6 +1,7 @@
 import {
     AiAgentEvalRunJobPayload,
     AiAgentReviewClassifierJobPayload,
+    AiAgentReviewRemediationCompileJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewRemediationRunJobPayload,
     AiAgentReviewWritebackJobPayload,
@@ -102,6 +103,23 @@ export class CommercialSchedulerClient extends SchedulerClient {
                 runAt,
                 maxAttempts: 1,
                 jobKey: `ai-agent-review-remediation-preview:${payload.remediationUuid}`,
+            },
+        );
+        return { jobId };
+    }
+
+    async aiAgentReviewRemediationCompile(
+        payload: AiAgentReviewRemediationCompileJobPayload,
+        runAt: Date = new Date(),
+    ) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE,
+            payload,
+            {
+                runAt,
+                maxAttempts: 1,
+                jobKey: `ai-agent-review-remediation-compile:${payload.remediationUuid}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -105,6 +105,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     payload,
                 );
             },
+            [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: async (
+                payload,
+                _helpers,
+            ) => {
+                await this.aiAgentAdminService.pollReviewRemediationCompile(
+                    payload,
+                );
+            },
             [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: async (
                 payload,
                 helpers,

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1,6 +1,7 @@
 import { Ability } from '@casl/ability';
 import {
     AiAgentReviewRemediation,
+    JobStatusType,
     OrganizationMemberRole,
     PullRequestProvider,
     type AiAgentReviewItemSummary,
@@ -30,7 +31,9 @@ const PROMPT_UUID = '00000000-0000-0000-0000-000000000007';
 const PREVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000008';
 const PREVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000009';
 const PREVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000010';
+const COMPILE_JOB_UUID = '00000000-0000-0000-0000-000000000011';
 const SITE_URL = 'https://app.lightdash.cloud';
+const PR_URL = 'https://github.com/acme/dbt/pull/42';
 
 const makeReviewItem = (
     overrides: Partial<AiAgentReviewItemSummary> = {},
@@ -130,6 +133,11 @@ const makeService = ({
     schedulerClient = {},
     githubAppInstallationsModel = {},
     gitlabAppInstallationsModel = {},
+    aiWritebackService = {},
+    pullRequestsModel = {},
+    writebackPreviewService = {},
+    jobModel = {},
+    userModel = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
@@ -139,6 +147,11 @@ const makeService = ({
     schedulerClient?: Record<string, unknown>;
     githubAppInstallationsModel?: Record<string, unknown>;
     gitlabAppInstallationsModel?: Record<string, unknown>;
+    aiWritebackService?: Record<string, unknown>;
+    pullRequestsModel?: Record<string, unknown>;
+    writebackPreviewService?: Record<string, unknown>;
+    jobModel?: Record<string, unknown>;
+    userModel?: Record<string, unknown>;
 } = {}) =>
     new AiAgentAdminService({
         analytics: { track: jest.fn() },
@@ -163,6 +176,20 @@ const makeService = ({
             updateReviewRemediationStatus: jest
                 .fn()
                 .mockResolvedValue(undefined),
+            getPromotedFingerprintScope: jest.fn().mockResolvedValue({
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+            }),
+            updateReviewItemWritebackProgress: jest
+                .fn()
+                .mockResolvedValue(undefined),
+            setReviewItemPrLink: jest.fn().mockResolvedValue(undefined),
+            setReviewRemediationPullRequest: jest
+                .fn()
+                .mockResolvedValue(undefined),
+            setReviewItemWritebackStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
             ...aiAgentReviewClassifierModel,
         },
         featureFlagService: {
@@ -178,11 +205,32 @@ const makeService = ({
             getPreviewAiAgentUuid: jest
                 .fn()
                 .mockResolvedValue(PREVIEW_AGENT_UUID),
+            findExploresFromCache: jest.fn().mockResolvedValue({}),
             ...projectModel,
         },
-        aiWritebackService: {},
+        aiWritebackService: {
+            run: jest.fn().mockResolvedValue({ prUrl: PR_URL }),
+            ...aiWritebackService,
+        },
         projectContextService: {},
-        pullRequestsModel: {},
+        pullRequestsModel: {
+            findByProjectAndUrl: jest
+                .fn()
+                .mockResolvedValue({ pullRequestUuid: 'pull-request-1' }),
+            ...pullRequestsModel,
+        },
+        writebackPreviewService: {
+            createPreviewForPullRequest: jest.fn().mockResolvedValue({
+                previewProjectUuid: PREVIEW_PROJECT_UUID,
+                previewUrl: `${SITE_URL}/projects/${PREVIEW_PROJECT_UUID}/home`,
+                compileJobUuid: COMPILE_JOB_UUID,
+            }),
+            ...writebackPreviewService,
+        },
+        jobModel: {
+            get: jest.fn().mockResolvedValue({ jobStatus: JobStatusType.DONE }),
+            ...jobModel,
+        },
         githubAppInstallationsModel: {
             getInstallationId: jest.fn().mockResolvedValue('installation-1'),
             findInstallationId: jest.fn().mockResolvedValue(undefined),
@@ -201,7 +249,10 @@ const makeService = ({
                 .mockResolvedValue({ jobId: 'job-1' }),
             ...schedulerClient,
         },
-        userModel: {},
+        userModel: {
+            findSessionUserByUUID: jest.fn().mockResolvedValue(makeAdminUser()),
+            ...userModel,
+        },
         lightdashConfig: {
             siteUrl: SITE_URL,
             appRuntime: { e2bApiKey: 'e2b-api-key' },
@@ -683,6 +734,293 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
         });
         expect(
             schedulerClient.aiAgentReviewRemediationPreview,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('instructs the verification agent to stay on governed explores', async () => {
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest.fn().mockResolvedValue({
+                threadUuid: PREVIEW_THREAD_UUID,
+                promptUuid: 'prompt-uuid-1',
+            }),
+            updateThreadTitle: jest.fn().mockResolvedValue(undefined),
+        };
+        const service = makeService({ aiAgentModel });
+        (getPullRequestComments as jest.Mock).mockResolvedValue([
+            `Preview ready: ${SITE_URL}/projects/${PREVIEW_PROJECT_UUID}/tables`,
+        ]);
+
+        await service.pollReviewRemediationPreview({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            prUrl: PR_URL,
+            startedAt: Date.now(),
+        });
+
+        expect(aiAgentModel.createWebAppThreadWithPrompt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt: expect.objectContaining({
+                    prompt: expect.stringContaining(
+                        'do not fall back to raw SQL',
+                    ),
+                }),
+            }),
+        );
+    });
+});
+
+describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
+    const payload = {
+        fingerprint: 'fingerprint-1',
+        organizationUuid: ORGANIZATION_UUID,
+        projectUuid: PROJECT_UUID,
+        userUuid: USER_UUID,
+        remediationUuid: REMEDIATION_UUID,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('enqueues a compile poll instead of seeding the verification thread inline', async () => {
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest.fn(),
+            updateThreadTitle: jest.fn(),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-2' }),
+        };
+        const service = makeService({ aiAgentModel, schedulerClient });
+
+        await service.runReviewItemWritebackJob(payload);
+
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+                userUuid: USER_UUID,
+                fingerprint: 'fingerprint-1',
+                remediationUuid: REMEDIATION_UUID,
+                previewProjectUuid: PREVIEW_PROJECT_UUID,
+                compileJobUuid: COMPILE_JOB_UUID,
+                startedAt: expect.any(Number),
+            }),
+        );
+        expect(
+            aiAgentModel.createWebAppThreadWithPrompt,
+        ).not.toHaveBeenCalled();
+        expect(
+            schedulerClient.aiAgentReviewRemediationRun,
+        ).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService.pollReviewRemediationCompile', () => {
+    const payload = {
+        organizationUuid: ORGANIZATION_UUID,
+        projectUuid: PROJECT_UUID,
+        userUuid: USER_UUID,
+        fingerprint: 'fingerprint-1',
+        remediationUuid: REMEDIATION_UUID,
+        previewProjectUuid: PREVIEW_PROJECT_UUID,
+        compileJobUuid: COMPILE_JOB_UUID,
+        startedAt: Date.now(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('seeds the verification thread once the compile job is done', async () => {
+        const jobModel = {
+            get: jest.fn().mockResolvedValue({ jobStatus: JobStatusType.DONE }),
+        };
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest.fn().mockResolvedValue({
+                threadUuid: PREVIEW_THREAD_UUID,
+                promptUuid: 'prompt-uuid-1',
+            }),
+            updateThreadTitle: jest.fn().mockResolvedValue(undefined),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest.fn(),
+            aiAgentReviewRemediationRun: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+        };
+        const aiAgentReviewClassifierModel = {
+            setReviewRemediationPreviewThread: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            jobModel,
+            aiAgentModel,
+            schedulerClient,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.pollReviewRemediationCompile(payload);
+
+        expect(jobModel.get).toHaveBeenCalledWith(COMPILE_JOB_UUID);
+        expect(aiAgentModel.createWebAppThreadWithPrompt).toHaveBeenCalledWith(
+            expect.objectContaining({
+                thread: expect.objectContaining({
+                    projectUuid: PREVIEW_PROJECT_UUID,
+                }),
+            }),
+        );
+        expect(
+            aiAgentReviewClassifierModel.setReviewRemediationPreviewThread,
+        ).toHaveBeenCalled();
+        expect(schedulerClient.aiAgentReviewRemediationRun).toHaveBeenCalled();
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('re-enqueues itself while the compile job is still running', async () => {
+        const jobModel = {
+            get: jest
+                .fn()
+                .mockResolvedValue({ jobStatus: JobStatusType.RUNNING }),
+        };
+        const aiAgentModel = {
+            createWebAppThreadWithPrompt: jest.fn(),
+            updateThreadTitle: jest.fn(),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+            aiAgentReviewRemediationRun: jest.fn(),
+        };
+        const service = makeService({
+            jobModel,
+            aiAgentModel,
+            schedulerClient,
+        });
+
+        await service.pollReviewRemediationCompile(payload);
+
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).toHaveBeenCalledWith(payload, expect.any(Date));
+        expect(
+            aiAgentModel.createWebAppThreadWithPrompt,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('fails the remediation when the compile job errors', async () => {
+        const jobModel = {
+            get: jest
+                .fn()
+                .mockResolvedValue({ jobStatus: JobStatusType.ERROR }),
+        };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest.fn(),
+            aiAgentReviewRemediationRun: jest.fn(),
+        };
+        const aiAgentReviewClassifierModel = {
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            jobModel,
+            schedulerClient,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.pollReviewRemediationCompile(payload);
+
+        expect(
+            aiAgentReviewClassifierModel.updateReviewRemediationStatus,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'failed',
+            errorMessage: 'Preview project failed to compile',
+        });
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('fails the remediation when the compile does not finish in time', async () => {
+        const jobModel = { get: jest.fn() };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest.fn(),
+            aiAgentReviewRemediationRun: jest.fn(),
+        };
+        const aiAgentReviewClassifierModel = {
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            jobModel,
+            schedulerClient,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.pollReviewRemediationCompile({
+            ...payload,
+            startedAt: Date.now() - 11 * 60_000,
+        });
+
+        expect(
+            aiAgentReviewClassifierModel.updateReviewRemediationStatus,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            status: 'failed',
+            errorMessage: 'Preview project did not compile in time',
+        });
+        expect(jobModel.get).not.toHaveBeenCalled();
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the remediation is no longer pr_open', async () => {
+        const jobModel = { get: jest.fn() };
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest.fn(),
+            aiAgentReviewRemediationRun: jest.fn(),
+        };
+        const aiAgentReviewClassifierModel = {
+            getReviewRemediation: jest
+                .fn()
+                .mockResolvedValue(makeRemediation({ status: 'resolved' })),
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            jobModel,
+            schedulerClient,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.pollReviewRemediationCompile(payload);
+
+        expect(jobModel.get).not.toHaveBeenCalled();
+        expect(
+            aiAgentReviewClassifierModel.updateReviewRemediationStatus,
+        ).not.toHaveBeenCalled();
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
         ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -6,17 +6,20 @@ import {
     AiAgentReviewItemPrDiff,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
+    AiAgentReviewRemediationCompileJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
     AlreadyExistsError,
+    assertUnreachable,
     DbtProjectType,
     extractPreviewProjectUuidFromUrl,
     extractPreviewUrlFromComments,
     FeatureFlags,
     ForbiddenError,
     getErrorMessage,
+    JobStatusType,
     KnexPaginateArgs,
     KnexPaginatedData,
     MissingConfigError,
@@ -45,6 +48,7 @@ import { type LightdashConfig } from '../../config/parseConfig';
 import { isUniqueConstraintViolation } from '../../database/errors';
 import { type GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { type GitlabAppInstallationsModel } from '../../models/GitlabAppInstallations/GitlabAppInstallationsModel';
+import { type JobModel } from '../../models/JobModel/JobModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { type PullRequestsModel } from '../../models/PullRequestsModel';
 import { type UserModel } from '../../models/UserModel';
@@ -78,6 +82,7 @@ type AiAgentAdminServiceDependencies = {
     userModel: UserModel;
     lightdashConfig: LightdashConfig;
     writebackPreviewService: WritebackPreviewService;
+    jobModel: JobModel;
 };
 
 const parsePullRequestUrl = (
@@ -117,6 +122,8 @@ const activeRemediationStatuses = new Set([
 
 const REVIEW_PREVIEW_POLL_INTERVAL_MS = 25_000;
 const REVIEW_PREVIEW_WAIT_TIMEOUT_MS = 10 * 60_000;
+const PREVIEW_COMPILE_POLL_INTERVAL_MS = 10_000;
+const PREVIEW_COMPILE_WAIT_TIMEOUT_MS = 10 * 60_000;
 
 const unavailableWritebackEligibility = (
     reason: AiAgentReviewItemWritebackBlockedReason,
@@ -294,6 +301,8 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly writebackPreviewService: WritebackPreviewService;
 
+    private readonly jobModel: JobModel;
+
     constructor(dependencies: AiAgentAdminServiceDependencies) {
         super();
         this.analytics = dependencies.analytics;
@@ -315,6 +324,7 @@ export class AiAgentAdminService extends BaseService {
         this.userModel = dependencies.userModel;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.writebackPreviewService = dependencies.writebackPreviewService;
+        this.jobModel = dependencies.jobModel;
     }
 
     private checkOrganizationAdminAccess(user: SessionUser): void {
@@ -1196,12 +1206,23 @@ export class AiAgentAdminService extends BaseService {
                 if (preview) {
                     terminalMessage = `Opened pull request · Preview: ${preview.previewUrl}`;
                     if (remediationUuid && pullRequest) {
-                        await this.setReviewRemediationPreviewFromProject({
-                            organizationUuid,
-                            remediationUuid,
-                            previewProjectUuid: preview.previewProjectUuid,
-                            userUuid,
-                        });
+                        // The verification agent snapshots the preview's
+                        // explores at run start, so prompting before the
+                        // compile finishes makes it report a false negative.
+                        // The wait runs as a self-rescheduling poll job so no
+                        // worker slot is held and a deploy can't strand it.
+                        await this.schedulerClient.aiAgentReviewRemediationCompile(
+                            {
+                                organizationUuid,
+                                projectUuid,
+                                userUuid,
+                                fingerprint,
+                                remediationUuid,
+                                previewProjectUuid: preview.previewProjectUuid,
+                                compileJobUuid: preview.compileJobUuid,
+                                startedAt: Date.now(),
+                            },
+                        );
                     }
                 }
                 await setTerminal('completed', terminalMessage);
@@ -1297,6 +1318,77 @@ export class AiAgentAdminService extends BaseService {
         }
     }
 
+    /**
+     * Self-rescheduling poll: checks the preview's compile job and only seeds
+     * the verification thread once the explores exist — the verification agent
+     * snapshots explores at run start, so prompting earlier produces a false
+     * negative. Runs as short scheduler jobs (state lives in the job queue) so
+     * no worker slot is held and a deploy mid-wait can't strand it.
+     */
+    async pollReviewRemediationCompile(
+        payload: AiAgentReviewRemediationCompileJobPayload,
+    ): Promise<void> {
+        const {
+            organizationUuid,
+            remediationUuid,
+            previewProjectUuid,
+            compileJobUuid,
+            startedAt,
+            userUuid,
+        } = payload;
+
+        // Status guard must run before the timeout: a poll firing after the
+        // remediation reached a terminal state must not overwrite that state.
+        const remediation =
+            await this.aiAgentReviewClassifierModel.getReviewRemediation({
+                organizationUuid,
+                remediationUuid,
+            });
+        if (!remediation || remediation.status !== 'pr_open') {
+            return;
+        }
+
+        const failRemediation = (errorMessage: string) =>
+            this.aiAgentReviewClassifierModel.updateReviewRemediationStatus({
+                remediationUuid,
+                organizationUuid,
+                status: 'failed',
+                errorMessage,
+            });
+
+        if (Date.now() - startedAt > PREVIEW_COMPILE_WAIT_TIMEOUT_MS) {
+            await failRemediation('Preview project did not compile in time');
+            return;
+        }
+
+        const job = await this.jobModel.get(compileJobUuid);
+        switch (job.jobStatus) {
+            case JobStatusType.DONE:
+                await this.setReviewRemediationPreviewFromProject({
+                    organizationUuid,
+                    remediationUuid,
+                    previewProjectUuid,
+                    userUuid,
+                });
+                return;
+            case JobStatusType.ERROR:
+                await failRemediation('Preview project failed to compile');
+                return;
+            case JobStatusType.STARTED:
+            case JobStatusType.RUNNING:
+                await this.schedulerClient.aiAgentReviewRemediationCompile(
+                    payload,
+                    new Date(Date.now() + PREVIEW_COMPILE_POLL_INTERVAL_MS),
+                );
+                return;
+            default:
+                assertUnreachable(
+                    job.jobStatus,
+                    `Unknown job status for compile job ${compileJobUuid}`,
+                );
+        }
+    }
+
     private static buildReviewVerificationPrompt(
         linkedPrUrl: string | null,
     ): string {
@@ -1306,6 +1398,8 @@ export class AiAgentAdminService extends BaseService {
             }. The conversation where the original question went wrong is attached as context.`,
             '',
             "Re-run the user's original question end-to-end against this project. Then compare the outcome with the attached conversation and state clearly whether the issue is resolved. Point out anything that still looks wrong.",
+            '',
+            'Answer through the governed explores only — do not fall back to raw SQL against the warehouse for the comparison. If the explores cannot be queried, report that instead of computing the answer another way.',
         ].join('\n');
     }
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -1,6 +1,7 @@
 import {
     FeatureFlags,
     ForbiddenError,
+    ProjectType,
     type AiAgentReviewClassifierJudgeOutput,
     type AiAgentReviewClassifierTurnCandidate,
 } from '@lightdash/common';
@@ -297,6 +298,9 @@ describe('AiAgentReviewClassifierService', () => {
     const catalogModel = {
         getCatalogItemsSummary: jest.fn(),
     };
+    const projectModel = {
+        getSummary: jest.fn(),
+    };
     const judgeTurn = jest.fn();
 
     const service = new AiAgentReviewClassifierService({
@@ -304,6 +308,7 @@ describe('AiAgentReviewClassifierService', () => {
         aiAgentModel: aiAgentModel as never,
         aiOrganizationSettingsModel,
         catalogModel: catalogModel as never,
+        projectModel: projectModel as never,
         featureFlagService,
         lightdashConfig: {} as never,
         judgeTurn,
@@ -342,6 +347,13 @@ describe('AiAgentReviewClassifierService', () => {
             groupAccess: [],
             userAccess: [],
             spaceAccess: [],
+        });
+        projectModel.getSummary.mockResolvedValue({
+            name: 'Jaffle Shop',
+            projectUuid: PROJECT_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            type: ProjectType.DEFAULT,
+            upstreamProjectUuid: null,
         });
         catalogModel.getCatalogItemsSummary.mockResolvedValue([
             {
@@ -645,6 +657,29 @@ describe('AiAgentReviewClassifierService', () => {
                 }),
             }),
         );
+    });
+
+    it('skips live review for preview projects', async () => {
+        projectModel.getSummary.mockResolvedValue({
+            name: 'Preview: fix-branch',
+            projectUuid: PROJECT_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            type: ProjectType.PREVIEW,
+            upstreamProjectUuid: PROJECT_UUID,
+        });
+
+        const result = await service.runLiveEvent({
+            eventType: 'response_saved',
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            agentUuid: AGENT_UUID,
+            threadUuid: THREAD_UUID,
+            promptUuid: PROMPT_UUID,
+        });
+
+        expect(result).toBeNull();
+        expect(model.listTurnReviewCandidates).not.toHaveBeenCalled();
+        expect(model.createRun).not.toHaveBeenCalled();
     });
 
     it('reviews only the target turn when it has no predecessor (first turn)', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -6,6 +6,7 @@ import {
     ForbiddenError,
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
+    ProjectType,
     type AiAgentAvailableCapability,
     type AiAgentConfigSnapshot,
     type AiAgentConfigurationSetting,
@@ -27,6 +28,7 @@ import { createHash } from 'crypto';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { type CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type AiAgentModel } from '../models/AiAgentModel';
@@ -73,6 +75,7 @@ type AiAgentReviewClassifierServiceDependencies = {
     aiAgentModel: AiAgentModel;
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
     catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
+    projectModel: Pick<ProjectModel, 'getSummary'>;
     featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
     judgeTurn?: AiAgentReviewClassifierJudge;
@@ -222,6 +225,8 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly catalogModel: Pick<CatalogModel, 'getCatalogItemsSummary'>;
 
+    private readonly projectModel: Pick<ProjectModel, 'getSummary'>;
+
     private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
 
     private readonly featureFlagService: FeatureFlagService;
@@ -236,6 +241,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             dependencies.aiAgentReviewClassifierModel;
         this.aiAgentModel = dependencies.aiAgentModel;
         this.catalogModel = dependencies.catalogModel;
+        this.projectModel = dependencies.projectModel;
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
         this.featureFlagService = dependencies.featureFlagService;
@@ -303,6 +309,18 @@ export class AiAgentReviewClassifierService extends BaseService {
     async runLiveEvent(
         args: RunLiveEventArgs,
     ): Promise<AiAgentReviewClassifierRunResult | null> {
+        // Preview projects are scratch environments — most notably the ones
+        // writeback remediation spins up to verify its own fixes. Reviewing
+        // those turns would feed the reviewer's output back into itself.
+        const project = await this.projectModel.getSummary(args.projectUuid);
+        if (project.type === ProjectType.PREVIEW) {
+            this.debugLog('LiveEventSkippedPreviewProject', {
+                projectUuid: args.projectUuid,
+                promptUuid: args.promptUuid,
+            });
+            return null;
+        }
+
         const listCandidate = (promptUuid: string) =>
             this.aiAgentReviewClassifierModel.listTurnReviewCandidates({
                 organizationUuid: args.organizationUuid,

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -179,6 +179,14 @@ const getTagsForTask: {
         'ai_agent_review.remediation_uuid': payload.remediationUuid,
     }),
 
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid,
+        'ai_agent_review.fingerprint': payload.fingerprint,
+        'ai_agent_review.remediation_uuid': payload.remediationUuid,
+    }),
+
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'project.uuid': payload.projectUuid,

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -207,6 +207,14 @@ export type AiAgentReviewRemediationPreviewJobPayload = TraceTaskBase & {
     startedAt: number;
 };
 
+export type AiAgentReviewRemediationCompileJobPayload = TraceTaskBase & {
+    fingerprint: string;
+    remediationUuid: string;
+    previewProjectUuid: string;
+    compileJobUuid: string;
+    startedAt: number;
+};
+
 export type AiAgentReviewRemediationRunJobPayload = TraceTaskBase & {
     fingerprint: string;
     remediationUuid: string;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
     type AiAgentReviewClassifierJobPayload,
+    type AiAgentReviewRemediationCompileJobPayload,
     type AiAgentReviewRemediationPreviewJobPayload,
     type AiAgentReviewRemediationRunJobPayload,
     type AiAgentReviewWritebackJobPayload,
@@ -67,6 +68,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_CLASSIFIER: 'aiAgentReviewClassifier',
     AI_AGENT_REVIEW_WRITEBACK: 'aiAgentReviewWriteback',
     AI_AGENT_REVIEW_REMEDIATION_PREVIEW: 'aiAgentReviewRemediationPreview',
+    AI_AGENT_REVIEW_REMEDIATION_COMPILE: 'aiAgentReviewRemediationCompile',
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
@@ -156,6 +158,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
+    [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
@@ -169,6 +172,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_CLASSIFIER]: AiAgentReviewClassifierJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_WRITEBACK]: AiAgentReviewWritebackJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
+    [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;


### PR DESCRIPTION
## Problem

When a review finding's writeback opens a PR, the remediation flow spins up a preview project and immediately seeds a verification prompt on the cloned agent. The preview's `COMPILE_PROJECT` job is still running at that point (the prompt fired ~4s after project creation in a traced run; the compile took ~14s), and the agent run snapshots `availableExplores` once at run start — so `generateVisualization` failed with `Explore not found` for the entire run even after the compile landed mid-run, while the live-querying catalog tools (`findExplores`/`findFields`) did see the new metric.

Faced with those contradictory signals, the agent fell back to raw `runSql` against the warehouse — bypassing the explore's `sql_filter` — and reported confident but ungoverned numbers plus a false "issue only partially resolved" verdict.

On top of that, the verification thread's turns were themselves picked up by the review classifier, feeding the reviewer's own verification output back into review findings.

## Changes

- New `aiAgentReviewRemediationCompile` scheduler task: a self-rescheduling poll (10s interval, 10 min timeout via `startedAt`) that checks the preview's compile job and only seeds the verification thread once it is `DONE`. Mirrors the existing `aiAgentReviewRemediationPreview` poll pattern — each poll is a short job, state lives in the job queue, so no worker slot is held during the wait and a deploy or pod restart mid-wait cannot strand the remediation (the writeback job itself has `maxAttempts: 1`, so an inline wait would have been killed permanently). Compile failure or timeout marks the remediation `failed` with a clear message; a poll firing after the remediation left `pr_open` is a no-op.
- The verification prompt now instructs the agent to answer through governed explores only and to report — not work around — explores that can't be queried.
- Review classification skips preview projects entirely:
  - `runLiveEvent` exits early when the event's project is a `PREVIEW` project.
  - `listTurnReviewCandidates` joins `projects` and excludes preview-project threads, so org-wide backfill/batch runs can't sweep them in either.

## Regression analysis

- **Writeback remediation flow**: verification now starts up to ~compile-duration later (typically seconds, bounded at 10 min). The writeback job itself finishes sooner — it ends after enqueueing the poll instead of blocking until verification is seeded, matching how the CI-comment preview path already behaves.
- **Review classification on real (non-preview) projects**: unchanged. The new `projects` join is an inner join on `thread.project_uuid`; threads on deleted projects were already unreviewable.
- **Preview projects**: lose review classification by design. No existing feature depends on reviewing preview turns.
- **`createPreviewForPullRequest` callers**: unchanged — the wait lives in the remediation flow only, so the in-thread writeback path (agent replying with a preview link mid-conversation) does not block on compile.

## Testing

- Unit tests: compile-poll enqueue from the writeback job; poll behavior for DONE / RUNNING (re-enqueue) / ERROR / timeout / stale-status guard; the governed-explores prompt instruction; the live-event preview guard; and the candidate-query preview exclusion.
- Root cause traced end-to-end on a live instance (thread/tool-call/job timeline from the production DB).

Relates: ZAP-486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
