### PR TITLE
fix: preserve custom format expressions on saved chart additional metrics

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -23,7 +23,6 @@ import {
     getItemId,
     isCustomBinDimension,
     isCustomSqlDimension,
-    isFormat,
     isFormulaTableCalculation,
     isSqlTableCalculation,
     isTemplateTableCalculation,
@@ -572,9 +571,9 @@ export class SavedChartModel {
             hidden: additionalMetric.hidden,
             round: additionalMetric.round,
             compact: additionalMetric.compact,
-            format: isFormat(additionalMetric.format)
-                ? additionalMetric.format
-                : undefined,
+            // format can be a legacy Format enum value or a custom format
+            // expression (e.g. '$#,##0.00'), so it must be passed through as-is
+            format: additionalMetric.format,
             percentile: additionalMetric.percentile,
             ...(additionalMetric.distinct_keys
                 ? {


### PR DESCRIPTION
## Problem

Period-over-period (PoP) metrics inherit the base metric's `format` when created, and the formatting renders correctly in the explorer. But once the chart is saved, the PoP column loses its formatting on reload — in the saved chart view, dashboards, exports, and subsequent edit sessions. Removing and re-adding the PoP makes it look right again, until the next save.

The format string is persisted correctly in `saved_queries_version_additional_metrics.format`, but `SavedChartModel.convertDbSavedChartAdditionalMetricToAdditionalMetric` gates it through `isFormat()`, which only accepts legacy `Format` enum values (`usd`, `percent`, ...). Custom format expressions (e.g. `$#,##0.00`) — the modern, non-deprecated representation — are silently dropped on load. The guard dates back to #6248, before format expressions existed.

This is also why #21588 didn't fully fix the issue: it fixed copying the format at PoP creation, but the load path kept stripping it.

## Fix

Pass the stored `format` string through as-is. `AdditionalMetric.format` is already typed `Format | string`, and all formatting consumers go through `getFormatExpression` → `hasValidFormatExpression`, which validates expressions and routes legacy enum values through `getCustomFormat` unchanged — so invalid strings are still handled gracefully, and there are no API or type shape changes.

This also fixes the second consumer of the converter (`findChartsWithCustomFields` → `findReplaceableCustomFields`): its required `formatMatch` comparison was operating on dropped formats, producing both missed matches and false-positive "replaceable" suggestions for custom metrics with format expressions.

No data migration needed — the DB always stored the format; existing affected charts self-heal on next load.

## How to reproduce

1. Pick a metric whose YAML format is an expression (e.g. `format: "$#,##0.00"` — not a legacy value like `usd`), add a time dimension, and add a period comparison.
2. Both columns render formatted in the explorer.
3. Save the chart → the PoP column loses its formatting.

Legacy enum formats and UI format overrides are unaffected, which is why this was hard to reproduce.

Closes: PROD-8265
Closes: #24180
