### PR TITLE
chore: embed data apps as standalone content

### DIFF
--- a/packages/backend/src/auth/account/account.mock.ts
+++ b/packages/backend/src/auth/account/account.mock.ts
@@ -97,6 +97,8 @@ export function buildAccount({
         allowAllDashboards: false,
         chartUuids: [],
         allowAllCharts: false,
+        allowAllApps: false,
+        appUuids: [],
         createdAt: '2021-01-01',
         user: {
             userUuid: 'test-user-uuid',
@@ -114,6 +116,8 @@ export function buildAccount({
             allowAllDashboards: false,
             chartUuids: [],
             allowAllCharts: false,
+            allowAllApps: false,
+            appUuids: [],
             createdAt: '2024-01-01',
             encodedSecret: 'test-encoded-secret',
             user: {

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -24,6 +24,8 @@ describe('account', () => {
             allowAllDashboards: false,
             chartUuids: [],
             allowAllCharts: false,
+            allowAllApps: false,
+            appUuids: [],
             createdAt: '2021-01-01',
             user: {
                 userUuid: 'test-user-uuid',

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -254,6 +254,7 @@ export const lightdashConfigMock: LightdashConfig = {
         allowAll: {
             dashboards: false,
             charts: false,
+            apps: false,
         },
         events: undefined,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1318,6 +1318,7 @@ export type LightdashConfig = {
         allowAll: {
             dashboards: boolean;
             charts: boolean;
+            apps: boolean;
         };
         events?: {
             enabled: boolean;
@@ -2417,6 +2418,7 @@ export const parseConfig = (): LightdashConfig => {
                     'true',
                 charts:
                     process.env.EMBED_ALLOW_ALL_CHARTS_BY_DEFAULT === 'true',
+                apps: process.env.EMBED_ALLOW_ALL_APPS_BY_DEFAULT === 'true',
             },
             events: {
                 enabled: process.env.EMBED_EVENT_SYSTEM_ENABLED === 'true',

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -11,6 +11,7 @@ import {
     type ApiCreateAppSchedulerResponse,
     type ApiDeleteAppResponse,
     type ApiDuplicateAppResponse,
+    type ApiEmbedProjectAppsResponse,
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
     type ApiMyAppsResponse,
@@ -81,6 +82,30 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * List the project's data apps (for the embed config allowlist picker).
+     * @summary List project data apps
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('listProjectApps')
+    async listProjectApps(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiEmbedProjectAppsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.getAppGenerateService().listAppsForProject(
+            toSessionUser(req.account),
+            projectUuid,
+        );
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -192,11 +192,11 @@ export class EmbedController extends BaseController {
     }
 
     /**
-     * This endpoint is used for updating the embed config for dashboards and charts.
+     * This endpoint is used for updating the embed config for dashboards, charts, and data apps.
      * @summary Update embed config
      * @param req
      * @param projectUuid
-     * @param body Contains dashboardUuids, allowAllDashboards, chartUuids, allowAllCharts
+     * @param body Contains dashboardUuids, allowAllDashboards, chartUuids, allowAllCharts, appUuids, allowAllApps
      * @returns Empty response with status 'ok'
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
@@ -696,13 +696,18 @@ export class EmbedController extends BaseController {
             ),
         );
 
+        // Embeds have no real name; an empty firstName crashes naive
+        // `firstName[0].toUpperCase()` avatar helpers, so derive a non-empty one.
+        const email = account.user.email ?? '';
+        const firstName = email.split('@')[0] || 'Guest';
+
         return {
             status: 'ok',
             results: {
                 userUuid: account.user.id,
-                firstName: '',
+                firstName,
                 lastName: '',
-                email: account.user.email ?? '',
+                email,
                 role: 'embed',
                 organizationUuid:
                     account.embed.organization.organizationUuid ?? '',

--- a/packages/backend/src/ee/database/migrations/20260612120000_add_apps_to_embedding.ts
+++ b/packages/backend/src/ee/database/migrations/20260612120000_add_apps_to_embedding.ts
@@ -1,0 +1,49 @@
+import { Knex } from 'knex';
+
+const EMBEDDING_TABLE_NAME = 'embedding';
+const fields = {
+    allow_all_apps: 'allow_all_apps',
+    app_uuids: 'app_uuids',
+};
+
+export async function up(knex: Knex): Promise<void> {
+    if (
+        !(await knex.schema.hasColumn(
+            EMBEDDING_TABLE_NAME,
+            fields.allow_all_apps,
+        ))
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            // Broad opt-in: secure-by-default, standalone data-app embeds are
+            // off until a project admin explicitly enables them.
+            table.boolean(fields.allow_all_apps).notNullable().defaultTo(false);
+        });
+    }
+    if (
+        !(await knex.schema.hasColumn(EMBEDDING_TABLE_NAME, fields.app_uuids))
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            // Per-app allowlist for standalone data-app embeds, mirroring
+            // chart_uuids.
+            table
+                .specificType(fields.app_uuids, 'text[]')
+                .notNullable()
+                .defaultTo('{}');
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(EMBEDDING_TABLE_NAME, fields.app_uuids)) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.dropColumn(fields.app_uuids);
+        });
+    }
+    if (
+        await knex.schema.hasColumn(EMBEDDING_TABLE_NAME, fields.allow_all_apps)
+    ) {
+        await knex.schema.alterTable(EMBEDDING_TABLE_NAME, (table) => {
+            table.dropColumn(fields.allow_all_apps);
+        });
+    }
+}

--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -1,5 +1,6 @@
 import { Embed, NotFoundError, UpdateEmbed } from '@lightdash/common';
 import { Knex } from 'knex';
+import { AppsTableName } from '../../database/entities/apps';
 import { DashboardsTableName } from '../../database/entities/dashboards';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
 
@@ -22,6 +23,8 @@ export class EmbedModel {
                 'embedding.allow_all_dashboards',
                 'embedding.chart_uuids',
                 'embedding.allow_all_charts',
+                'embedding.allow_all_apps',
+                'embedding.app_uuids',
                 'embedding.created_at',
                 'users.user_uuid',
                 'users.first_name',
@@ -49,21 +52,28 @@ export class EmbedModel {
             );
         }
 
-        const dashboards = await this.database(DashboardsTableName)
-            .select()
-            .whereIn('dashboard_uuid', embed.dashboard_uuids)
-            .whereNull('deleted_at');
+        const [dashboards, charts, apps] = await Promise.all([
+            this.database(DashboardsTableName)
+                .select()
+                .whereIn('dashboard_uuid', embed.dashboard_uuids)
+                .whereNull('deleted_at'),
+            this.database(SavedChartsTableName)
+                .select()
+                .whereIn('saved_query_uuid', embed.chart_uuids)
+                .whereNull('deleted_at'),
+            this.database(AppsTableName)
+                .select()
+                .whereIn('app_id', embed.app_uuids)
+                .whereNull('deleted_at'),
+        ]);
 
         const validDashboardUuids = dashboards.map(
             (dashboard) => dashboard.dashboard_uuid,
         );
 
-        const charts = await this.database(SavedChartsTableName)
-            .select()
-            .whereIn('saved_query_uuid', embed.chart_uuids)
-            .whereNull('deleted_at');
-
         const validChartUuids = charts.map((chart) => chart.saved_query_uuid);
+
+        const validAppUuids = apps.map((app) => app.app_id);
 
         return {
             projectUuid: embed.project_uuid,
@@ -77,6 +87,8 @@ export class EmbedModel {
             allowAllDashboards: embed.allow_all_dashboards,
             chartUuids: validChartUuids,
             allowAllCharts: embed.allow_all_charts,
+            allowAllApps: embed.allow_all_apps,
+            appUuids: validAppUuids,
             createdAt: embed.created_at,
             user: embed.user_uuid
                 ? {
@@ -96,6 +108,8 @@ export class EmbedModel {
         allowAllDashboards: boolean = false,
         chartUuids: string[] = [],
         allowAllCharts: boolean = false,
+        appUuids: string[] = [],
+        allowAllApps: boolean = false,
     ): Promise<void> {
         await this.database('embedding')
             .insert({
@@ -106,6 +120,8 @@ export class EmbedModel {
                 allow_all_dashboards: allowAllDashboards,
                 chart_uuids: chartUuids,
                 allow_all_charts: allowAllCharts,
+                allow_all_apps: allowAllApps,
+                app_uuids: appUuids,
             })
             .onConflict('project_uuid')
             .merge();
@@ -133,6 +149,8 @@ export class EmbedModel {
             allowAllDashboards,
             chartUuids,
             allowAllCharts,
+            allowAllApps,
+            appUuids,
         }: UpdateEmbed,
     ): Promise<void> {
         await this.database('embedding')
@@ -141,6 +159,8 @@ export class EmbedModel {
                 allow_all_dashboards: allowAllDashboards,
                 chart_uuids: chartUuids,
                 allow_all_charts: allowAllCharts,
+                allow_all_apps: allowAllApps,
+                app_uuids: appUuids,
             })
             .where('project_uuid', projectUuid);
     }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -35,6 +35,7 @@ import {
     type ChartSampleData,
     type DataAppClaudeModel,
     type DataAppTemplate,
+    type EmbedProjectApp,
     type PromoteAppAction,
     type PromoteAppDiff,
     type SessionUser,
@@ -4759,6 +4760,30 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         };
     }
 
+    /**
+     * List all (non-deleted) data apps in a project — used by the embed config
+     * UI to populate the standalone-app allowlist picker.
+     */
+    async listAppsForProject(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<EmbedProjectApp[]> {
+        await this.assertDataAppsEnabled(user);
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
+        const apps = await this.appModel.listAppsByProject(projectUuid);
+        return apps.map((app) => ({ appUuid: app.app_id, name: app.name }));
+    }
+
     async listMyApps(
         user: SessionUser,
         paginateArgs?: { page: number; pageSize: number },
@@ -5375,12 +5400,16 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
      * the resolved latest ready version so the frontend doesn't need a
      * separate round-trip to find it.
      *
-     * The token is issued only when the data app is referenced by a tile on
-     * a dashboard in the embed's allowlist (or `allowAllDashboards` is set),
-     * mirroring how embedded charts are gated by whitelisted dashboards.
-     * The app must live in the embed's project — preview environments where
-     * the dashboard tile references a source-project app are explicitly out
-     * of scope and surface as a 404 to the frontend.
+     * Authorization depends on the embed content type:
+     * - standalone `dataApp` embed: the signed JWT names this exact app and
+     *   self-authorizes it (the project opted in via `allow_all_apps` or the
+     *   `app_uuids` allowlist, enforced at account build); a mismatched appUuid
+     *   is rejected outright.
+     * - dashboard-tile embed: the app must be referenced by a tile on a
+     *   dashboard in the embed's allowlist (or `allowAllDashboards`), mirroring
+     *   how embedded charts are gated by whitelisted dashboards.
+     * The app must live in the embed's project — source-project apps (preview
+     * environments) are out of scope and surface as a 404 to the frontend.
      */
     async getEmbedAppPreviewToken(
         account: AnonymousAccount,
@@ -5414,7 +5443,20 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             );
         }
 
-        if (!account.embed.allowAllDashboards) {
+        if (account.access.content.type === 'dataApp') {
+            // A standalone data app JWT authorizes EXACTLY its named app
+            // (already gated at account build in
+            // EmbedService.getAccountFromJwt). Requesting any other app is
+            // denied — we must NOT fall through to the dashboard-allowlist gate,
+            // which could otherwise mint a token for an app that merely sits on
+            // an allowlisted dashboard, bypassing the per-app `app_uuids`
+            // allowlist.
+            if (account.access.content.appUuid !== appUuid) {
+                throw new ForbiddenError(
+                    'This embed is not authorized for this data app',
+                );
+            }
+        } else if (!account.embed.allowAllDashboards) {
             const dashboardsWithApp =
                 await this.appModel.findDashboardsContainingApp(
                     appUuid,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -239,6 +239,25 @@ describe('EmbedService', () => {
         });
     });
 
+    describe('getContentUuidFromJwt', () => {
+        test('resolves standalone dataApp content carrying the appUuid', async () => {
+            const content = await service.getContentUuidFromJwt(
+                {
+                    content: { type: 'dataApp', appUuid: 'app-123' },
+                    exp: Date.now() / 1000 + 3600,
+                },
+                mockProjectUuid,
+            );
+            expect(content).toEqual({
+                appUuid: 'app-123',
+                dashboardUuid: undefined,
+                chartUuids: [],
+                type: 'dataApp',
+                explores: [],
+            });
+        });
+    });
+
     describe('searchFilterValues', () => {
         test('scopes dashboard lookup to the requested project', async () => {
             const dashboardUuid = 'dashboard-1';

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -6,6 +6,7 @@ import {
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiExecuteAsyncDashboardSqlChartQueryResults,
     ApiSqlChart,
+    assertUnreachable,
     CalculateSubtotalsFromQuery,
     CalculateTotalFromQuery,
     CommercialFeatureFlags,
@@ -208,6 +209,8 @@ export class EmbedService extends BaseService {
         let urlPath: string;
         if (jwtData.content.type === 'chart') {
             urlPath = `/embed/${projectUuid}/chart/${jwtData.content.contentId}#${jwtToken}`;
+        } else if (jwtData.content.type === 'dataApp') {
+            urlPath = `/embed/${projectUuid}/app/${jwtData.content.appUuid}#${jwtToken}`;
         } else {
             urlPath = `/embed/${projectUuid}#${jwtToken}`;
         }
@@ -286,6 +289,8 @@ export class EmbedService extends BaseService {
             this.lightdashConfig.embedding.allowAll.dashboards,
             data.chartUuids,
             this.lightdashConfig.embedding.allowAll.charts,
+            data.appUuids,
+            this.lightdashConfig.embedding.allowAll.apps,
         );
 
         return this.getConfig(account, projectUuid);
@@ -332,6 +337,8 @@ export class EmbedService extends BaseService {
             allowAllDashboards,
             chartUuids,
             allowAllCharts,
+            allowAllApps,
+            appUuids,
         }: UpdateEmbed,
     ) {
         const auditedAbility = this.createAuditedAbility(account);
@@ -361,6 +368,8 @@ export class EmbedService extends BaseService {
             allowAllDashboards,
             chartUuids,
             allowAllCharts,
+            allowAllApps,
+            appUuids,
         });
     }
 
@@ -455,7 +464,8 @@ export class EmbedService extends BaseService {
     }
 
     /**
-     * Extract content UUID (dashboard or chart) from JWT based on content type
+     * Extract content (dashboard, chart, or data app) from the JWT based on
+     * its content type.
      */
     async getContentUuidFromJwt(
         decodedToken: CreateEmbedJwt,
@@ -481,6 +491,20 @@ export class EmbedService extends BaseService {
                 chartUuids: [chart.uuid],
                 type: 'chart',
                 explores: [chart.tableName],
+            };
+        }
+
+        if (decodedToken.content.type === 'dataApp') {
+            // Standalone data app embed: the JWT names the app directly and
+            // self-authorizes it. The app's existence + project + ready version
+            // are validated downstream in getEmbedAppPreviewToken (which has the
+            // app model); here we only carry the appUuid through.
+            return {
+                appUuid: decodedToken.content.appUuid,
+                dashboardUuid: undefined,
+                chartUuids: [],
+                type: 'dataApp',
+                explores: [],
             };
         }
 
@@ -1592,40 +1616,55 @@ export class EmbedService extends BaseService {
     ) {
         const { type, dashboardUuid, chartUuids } = account.access.content;
 
-        // Handle chart embeds (direct chart access)
-        if (type === 'chart') {
-            // Validate that the requested chart matches the embedded chart
-            if (!chartUuids.includes(savedChartUuid)) {
+        switch (type) {
+            // Handle chart embeds (direct chart access)
+            case 'chart': {
+                // Validate that the requested chart matches the embedded chart
+                if (!chartUuids.includes(savedChartUuid)) {
+                    throw new ForbiddenError(
+                        `Not authorized to access chart ${savedChartUuid}`,
+                    );
+                }
+
+                const chart = await this.savedChartModel.get(savedChartUuid);
+
+                if (chart.projectUuid !== projectUuid) {
+                    throw new NotFoundError(
+                        `Chart ${savedChartUuid} not found in project ${projectUuid}`,
+                    );
+                }
+
+                const explore = await this.projectModel.getExploreFromCache(
+                    projectUuid,
+                    chart.tableName,
+                );
+
+                if (isExploreError(explore)) {
+                    throw new ForbiddenError(
+                        `Explore ${chart.tableName} on project ${projectUuid} has errors : ${explore.errors}`,
+                    );
+                }
+
+                return {
+                    dashboardUuid: undefined,
+                    chart,
+                    explore,
+                    metricQuery: chart.metricQuery,
+                };
+            }
+            case 'dataApp':
+                // Data app JWTs have no saved-chart grants; reject explicitly
+                // rather than falling into the dashboard-tile path.
                 throw new ForbiddenError(
-                    `Not authorized to access chart ${savedChartUuid}`,
+                    'Data app embeds cannot access saved charts',
                 );
-            }
-
-            const chart = await this.savedChartModel.get(savedChartUuid);
-
-            if (chart.projectUuid !== projectUuid) {
-                throw new NotFoundError(
-                    `Chart ${savedChartUuid} not found in project ${projectUuid}`,
+            case 'dashboard':
+                break;
+            default:
+                return assertUnreachable(
+                    type,
+                    `Unknown embed content type: ${type}`,
                 );
-            }
-
-            const explore = await this.projectModel.getExploreFromCache(
-                projectUuid,
-                chart.tableName,
-            );
-
-            if (isExploreError(explore)) {
-                throw new ForbiddenError(
-                    `Explore ${chart.tableName} on project ${projectUuid} has errors : ${explore.errors}`,
-                );
-            }
-
-            return {
-                dashboardUuid: undefined,
-                chart,
-                explore,
-                metricQuery: chart.metricQuery,
-            };
         }
 
         // Handle dashboard embeds (chart via tile)
@@ -2246,6 +2285,24 @@ export class EmbedService extends BaseService {
                     throw new NotFoundError(
                         'Cannot verify JWT. Content not found',
                     );
+                }
+
+                // Secure-by-default: a standalone data app embed is honoured
+                // only when the project opted the app in — via the broad
+                // `allow_all_apps` toggle or the per-app `app_uuids` allowlist.
+                // Enforced here (fail-closed) so it blocks BOTH the app's metric
+                // queries and the preview-token mint — enabling dashboard/chart
+                // embeds does not silently enable arbitrary-query app embeds.
+                if (content.type === 'dataApp') {
+                    const appAuthorized =
+                        embed.allowAllApps ||
+                        (content.appUuid !== undefined &&
+                            embed.appUuids.includes(content.appUuid));
+                    if (!appAuthorized) {
+                        throw new ForbiddenError(
+                            'This data app is not authorized for standalone embedding',
+                        );
+                    }
                 }
 
                 return fromJwt({

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1707,6 +1707,12 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 allowAllCharts: { dataType: 'boolean', required: true },
+                allowAllApps: { dataType: 'boolean', required: true },
+                appUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
                 createdAt: { dataType: 'string', required: true },
                 user: {
                     dataType: 'union',
@@ -1769,6 +1775,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                appUuids: { dataType: 'array', array: { dataType: 'string' } },
                 chartUuids: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -1787,6 +1794,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                appUuids: { dataType: 'array', array: { dataType: 'string' } },
+                allowAllApps: { dataType: 'boolean' },
                 allowAllCharts: { dataType: 'boolean' },
                 chartUuids: {
                     dataType: 'array',
@@ -1954,6 +1963,38 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CommonDataAppEmbedJwtContent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                parameterInteractivity: { dataType: 'undefined' },
+                dashboardFiltersInteractivity: { dataType: 'undefined' },
+                isPreview: { dataType: 'boolean' },
+                projectUuid: { dataType: 'string' },
+                type: { dataType: 'enum', enums: ['dataApp'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedJwtContentDataApp: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'CommonDataAppEmbedJwtContent' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        appUuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     EmbedWriteActions: {
         dataType: 'refAlias',
         type: {
@@ -1994,6 +2035,7 @@ const models: TsoaRoute.Models = {
                         { ref: 'EmbedJwtContentDashboardUuid' },
                         { ref: 'EmbedJwtContentDashboardSlug' },
                         { ref: 'EmbedJwtContentChart' },
+                        { ref: 'EmbedJwtContentDataApp' },
                     ],
                     required: true,
                 },
@@ -8342,6 +8384,39 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    EmbedProjectApp: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                appUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_EmbedProjectApp-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'EmbedProjectApp' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiEmbedProjectAppsResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_EmbedProjectApp-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__questions-string-Array__': {
         dataType: 'refAlias',
         type: {
@@ -12482,11 +12557,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12544,11 +12619,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12585,11 +12660,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12791,7 +12866,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12799,7 +12874,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12814,7 +12893,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12822,11 +12901,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -13131,13 +13206,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13164,13 +13239,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13222,6 +13297,130 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -13256,130 +13455,6 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13408,17 +13483,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13543,6 +13618,14 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                uuid: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13552,14 +13635,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13641,6 +13716,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13707,77 +13853,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['updated'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13875,6 +13950,10 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13884,10 +13963,6 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                             },
                                         },
                                         {
@@ -13898,11 +13973,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13937,14 +14012,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13963,11 +14038,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13984,25 +14059,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14092,6 +14148,13 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
+                                                                                    'dimension',
+                                                                                ],
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -14099,8 +14162,20 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    null,
                                                                                 ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -14144,11 +14219,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14163,11 +14238,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14182,11 +14257,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -42629,6 +42704,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'generateApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_listProjectApps: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.listProjectApps,
+        ),
+
+        async function AppGenerateController_listProjectApps(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_listProjectApps,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listProjectApps',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1711,6 +1711,15 @@
                     "allowAllCharts": {
                         "type": "boolean"
                     },
+                    "allowAllApps": {
+                        "type": "boolean"
+                    },
+                    "appUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "createdAt": {
                         "type": "string"
                     },
@@ -1730,6 +1739,8 @@
                     "allowAllDashboards",
                     "chartUuids",
                     "allowAllCharts",
+                    "allowAllApps",
+                    "appUuids",
                     "createdAt",
                     "user"
                 ],
@@ -1773,6 +1784,12 @@
             },
             "CreateEmbedRequestBody": {
                 "properties": {
+                    "appUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "chartUuids": {
                         "items": {
                             "type": "string"
@@ -1790,6 +1807,15 @@
             },
             "UpdateEmbed": {
                 "properties": {
+                    "appUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allowAllApps": {
+                        "type": "boolean"
+                    },
                     "allowAllCharts": {
                         "type": "boolean"
                     },
@@ -1997,6 +2023,41 @@
                     }
                 ]
             },
+            "CommonDataAppEmbedJwtContent": {
+                "properties": {
+                    "parameterInteractivity": {},
+                    "dashboardFiltersInteractivity": {},
+                    "isPreview": {
+                        "type": "boolean"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["dataApp"],
+                        "nullable": false
+                    }
+                },
+                "required": ["type"],
+                "type": "object"
+            },
+            "EmbedJwtContentDataApp": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CommonDataAppEmbedJwtContent"
+                    },
+                    {
+                        "properties": {
+                            "appUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["appUuid"],
+                        "type": "object"
+                    }
+                ]
+            },
             "EmbedWriteActions": {
                 "properties": {
                     "spaceUuid": {
@@ -2056,6 +2117,9 @@
                             },
                             {
                                 "$ref": "#/components/schemas/EmbedJwtContentChart"
+                            },
+                            {
+                                "$ref": "#/components/schemas/EmbedJwtContentDataApp"
                             }
                         ]
                     }
@@ -9732,6 +9796,39 @@
                 "required": ["prompt"],
                 "type": "object"
             },
+            "EmbedProjectApp": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "appUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "appUuid"],
+                "type": "object",
+                "description": "Minimal app shape for the embed config's standalone-app allowlist picker."
+            },
+            "ApiSuccess_EmbedProjectApp-Array_": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/EmbedProjectApp"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiEmbedProjectAppsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_EmbedProjectApp-Array_"
+            },
             "ApiSuccess__questions-string-Array__": {
                 "properties": {
                     "results": {
@@ -14048,8 +14145,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14107,8 +14204,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14132,6 +14229,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -14198,16 +14308,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14355,19 +14465,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14377,8 +14487,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14408,6 +14518,66 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "false",
+                                                                                        "not_applicable",
+                                                                                        "true"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "description",
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "label",
+                                                                                "name",
+                                                                                "fieldId"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14434,66 +14604,6 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "description",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
-                                                                                "label",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14504,8 +14614,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "explore",
                                                                     "fields",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14518,10 +14628,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14529,8 +14639,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "exploreLabel",
                                                                                 "reason",
+                                                                                "exploreLabel",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14613,6 +14723,12 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14620,27 +14736,47 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "slug",
-                                                    "status",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "slug",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "label": {
+                                                                    "type": "string"
+                                                                },
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "label",
+                                                                "kind"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14666,32 +14802,6 @@
                                                             "updated",
                                                             null
                                                         ],
-                                                        "nullable": true
-                                                    },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "prUrl": {
@@ -14735,6 +14845,9 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14742,16 +14855,13 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
+                                                    "name",
                                                     "slug",
-                                                    "status",
-                                                    "name"
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14761,8 +14871,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14774,10 +14884,6 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -14817,17 +14923,21 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
+                                                                "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -8,6 +8,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
+import { validate as isValidUuid } from 'uuid';
 import {
     AnalyticsAppViewsTableName,
     AnalyticsChartViewsTableName,
@@ -159,6 +160,11 @@ export class AnalyticsModel {
     }
 
     async addAppViewEvent(appId: string, userUuid: string): Promise<void> {
+        // Embed/anonymous viewers carry a synthesized non-UUID id (external::…)
+        // that can't be written to the uuid user_uuid column; skip their row.
+        if (!isValidUuid(userUuid)) {
+            return;
+        }
         await this.database.transaction(async (trx) => {
             await trx(AnalyticsAppViewsTableName).insert({
                 app_id: appId,

--- a/packages/backend/src/services/PermissionsService/PermissionsService.ts
+++ b/packages/backend/src/services/PermissionsService/PermissionsService.ts
@@ -1,4 +1,9 @@
-import { AnonymousAccount, ForbiddenError, OssEmbed } from '@lightdash/common';
+import {
+    AnonymousAccount,
+    assertUnreachable,
+    ForbiddenError,
+    OssEmbed,
+} from '@lightdash/common';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { BaseService } from '../BaseService';
 
@@ -69,22 +74,33 @@ export class PermissionsService extends BaseService {
             );
         }
 
-        if (content.type === 'dashboard' && content.dashboardUuid) {
-            return this.checkEmbeddedDashboardPermission(
-                content.dashboardUuid,
-                savedChartUuid,
-                embed,
-            );
+        switch (content.type) {
+            case 'dashboard':
+                if (!content.dashboardUuid) {
+                    throw new ForbiddenError(
+                        'Invalid access for embed permissions',
+                    );
+                }
+                return this.checkEmbeddedDashboardPermission(
+                    content.dashboardUuid,
+                    savedChartUuid,
+                    embed,
+                );
+            case 'chart':
+                return PermissionsService.checkEmbeddedChartPermissions(
+                    savedChartUuid,
+                    embed,
+                );
+            case 'dataApp':
+                throw new ForbiddenError(
+                    'Data app embeds cannot access charts',
+                );
+            default:
+                return assertUnreachable(
+                    content.type,
+                    'Invalid access for embed permissions',
+                );
         }
-
-        if (content.type === 'chart') {
-            return PermissionsService.checkEmbeddedChartPermissions(
-                savedChartUuid,
-                embed,
-            );
-        }
-
-        throw new ForbiddenError('Invalid access for embed permissions');
     }
 
     /**

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -46,6 +46,8 @@ const embed: OssEmbed = {
     allowAllDashboards: false,
     chartUuids: [],
     allowAllCharts: false,
+    allowAllApps: false,
+    appUuids: [],
     createdAt: '2021-01-01',
     user: {
         firstName: 'John',
@@ -761,5 +763,122 @@ describe('Embedded dashboard abilities', () => {
                 ),
             ).toBe(false);
         });
+    });
+});
+
+const defineAbilityForDataAppEmbedUser = (
+    embedUser: CreateEmbedJwt,
+    appUuid: string,
+): MemberAbility => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    applyEmbeddedAbility(
+        embedUser,
+        { appUuid, type: 'dataApp', chartUuids: [], explores: [] },
+        embed,
+        'external-id-1',
+        builder,
+    );
+    return builder.build();
+};
+
+describe('Embedded data app abilities', () => {
+    const appUuid = 'app-uuid-1';
+    const projectUuid = 'project-uuid-1';
+    const dataAppEmbedUser: CreateEmbedJwt = {
+        content: { type: 'dataApp', appUuid },
+        exp: Date.now() / 1000 + 3600,
+    };
+
+    it('grants unconstrained view:Explore so the app can run arbitrary queries', () => {
+        const ability = defineAbilityForDataAppEmbedUser(
+            dataAppEmbedUser,
+            appUuid,
+        );
+        expect(
+            ability.can(
+                'view',
+                subject('Explore', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid,
+                }),
+            ),
+        ).toBe(true);
+        // Unconstrained: any explore name is allowed (NOT scoped like the
+        // chart grant's exploreNames: { $all: ... }).
+        expect(
+            ability.can(
+                'view',
+                subject('Explore', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid,
+                    exploreNames: ['some_arbitrary_explore'],
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it('grants view:DataApp for the named app (scoped) + view:Project', () => {
+        const ability = defineAbilityForDataAppEmbedUser(
+            dataAppEmbedUser,
+            appUuid,
+        );
+        // Scoped to the named app: the subject must carry metadata.appUuid.
+        expect(
+            ability.can(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid,
+                    metadata: { appUuid },
+                }),
+            ),
+        ).toBe(true);
+        // A DIFFERENT app is NOT authorized by this JWT (per-app scoping —
+        // prevents a JWT for app A minting app B's preview token).
+        expect(
+            ability.can(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid,
+                    metadata: { appUuid: 'a-different-app-uuid' },
+                }),
+            ),
+        ).toBe(false);
+        expect(
+            ability.can(
+                'view',
+                subject('Project', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it('does not grant access to a different project', () => {
+        const ability = defineAbilityForDataAppEmbedUser(
+            dataAppEmbedUser,
+            appUuid,
+        );
+        expect(
+            ability.can(
+                'view',
+                subject('Explore', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid: 'different-project-uuid',
+                }),
+            ),
+        ).toBe(false);
+        expect(
+            ability.can(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: organization.organizationUuid,
+                    projectUuid: 'different-project-uuid',
+                    metadata: { appUuid },
+                }),
+            ),
+        ).toBe(false);
     });
 });

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -2,6 +2,7 @@ import { type AbilityBuilder } from '@casl/ability';
 import flow from 'lodash/flow';
 import { isDashboardContent, type CreateEmbedJwt } from '../ee';
 import type { EmbedContent, OssEmbed } from '../types/auth';
+import assertUnreachable from '../utils/assertUnreachable';
 import type { MemberAbility } from './types';
 
 type EmbeddedAbilityBuilderPayload = {
@@ -110,6 +111,43 @@ const chartAbilities: EmbeddedAbilityBuilder = ({
     return { embedUser, content, embed, builder, externalId };
 };
 
+const dataAppAbilities: EmbeddedAbilityBuilder = ({
+    embedUser,
+    content,
+    embed,
+    externalId,
+    builder,
+}) => {
+    const { organization } = embed;
+    const { can } = builder;
+
+    can('view', 'Project', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embed.projectUuid,
+    });
+
+    // A standalone data app runs arbitrary metric queries against any explore
+    // in the project. The Explore grant MUST be unconstrained (no exploreNames)
+    // — a scoped grant would 403 queries the app legitimately needs. Rows are
+    // still filtered at query time by the JWT's user attributes
+    // (getFilteredExplore). Same trust model as a dashboard's canViewDataApps.
+    can('view', 'Explore', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embed.projectUuid,
+    });
+
+    // Scope to the named app (defense in depth): the preview-token mint checks
+    // view:DataApp with metadata.appUuid, so this grant authorizes ONLY this
+    // app — a JWT for app A cannot pass the check for app B.
+    can('view', 'DataApp', {
+        organizationUuid: organization.organizationUuid,
+        projectUuid: embed.projectUuid,
+        'metadata.appUuid': content.appUuid,
+    });
+
+    return { embedUser, content, embed, builder, externalId };
+};
+
 const exploreAbilities: EmbeddedAbilityBuilder = ({
     embedUser,
     content,
@@ -160,14 +198,14 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
         content.type === 'dashboard' ? 'Dashboard' : 'SavedChart';
 
     // Common abilities for both dashboard and chart
-    if (permissions.canExportImages) {
+    if ('canExportImages' in permissions && permissions.canExportImages) {
         can('export', subjectType, {
             organizationUuid: organization.organizationUuid,
             type: 'images',
         });
     }
 
-    if (permissions.canExportCsv) {
+    if ('canExportCsv' in permissions && permissions.canExportCsv) {
         can('export', subjectType, {
             organizationUuid: organization.organizationUuid,
             type: 'csv',
@@ -199,6 +237,26 @@ const dashboardTypeAbilities = [
 
 const chartTypeAbilities = [chartAbilities, exportAbilities, exploreAbilities];
 
+const dataAppTypeAbilities = [dataAppAbilities];
+
+const getEmbeddedAbilitiesForType = (
+    type: EmbedContent['type'],
+): EmbeddedAbilityBuilder[] => {
+    switch (type) {
+        case 'chart':
+            return chartTypeAbilities;
+        case 'dataApp':
+            return dataAppTypeAbilities;
+        case 'dashboard':
+            return dashboardTypeAbilities;
+        default:
+            return assertUnreachable(
+                type,
+                `Unknown embed content type: ${type}`,
+            );
+    }
+};
+
 export function applyEmbeddedAbility(
     embedUser: CreateEmbedJwt,
     content: EmbedContent,
@@ -210,9 +268,7 @@ export function applyEmbeddedAbility(
         throw new Error('Content is required');
     }
 
-    const abilities =
-        content.type === 'chart' ? chartTypeAbilities : dashboardTypeAbilities;
-    const applyAbilities = flow(abilities);
+    const applyAbilities = flow(getEmbeddedAbilitiesForType(content.type));
 
     applyAbilities({
         embedUser,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -293,6 +293,14 @@ export type ApiAppSummary = {
     lastVersionStatus: AppVersionStatus | null;
 };
 
+/** Minimal app shape for the embed config's standalone-app allowlist picker. */
+export type EmbedProjectApp = {
+    appUuid: string;
+    name: string;
+};
+
+export type ApiEmbedProjectAppsResponse = ApiSuccess<EmbedProjectApp[]>;
+
 /**
  * Sample of rows from a chart's underlying query, captured at request time
  * and inlined into the sandbox alongside the chart's metric query. Opt-in

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -17,6 +17,7 @@ export type DecodedEmbed = Omit<Embed, 'encodedSecret'> & {
 export type CreateEmbedRequestBody = {
     dashboardUuids?: string[];
     chartUuids?: string[];
+    appUuids?: string[];
 };
 
 export type UpdateEmbed = {
@@ -25,6 +26,8 @@ export type UpdateEmbed = {
     // TODO: Make these required in Settings UI PR
     chartUuids?: string[];
     allowAllCharts?: boolean;
+    allowAllApps?: boolean;
+    appUuids?: string[];
 };
 
 export type GetEmbedDashboardRequest = {
@@ -162,6 +165,12 @@ export const EmbedJwtSchema = z
                     isPreview: z.boolean().optional(),
                 })
                 .merge(ChartInteractivityOptionsSchema),
+            z.object({
+                type: z.literal('dataApp'),
+                projectUuid: z.string().optional(),
+                appUuid: z.string(),
+                isPreview: z.boolean().optional(),
+            }),
         ]),
         writeActions: EmbedWriteActionsSchema.optional(),
         iat: z.number().optional(),
@@ -221,11 +230,28 @@ export type EmbedJwtContentChart = CommonChartEmbedJwtContent & {
     contentId: string;
 };
 
+// A standalone data app embed: the JWT names a single app and self-authorizes
+// it (no dashboard). v1 carries no interactivity flags — filters/export are out
+// of scope. `dashboardFiltersInteractivity`/`parameterInteractivity` are typed
+// as `undefined` so the shared `fromJwt` reads stay assignable (matches chart).
+type CommonDataAppEmbedJwtContent = {
+    type: 'dataApp';
+    projectUuid?: string;
+    isPreview?: boolean;
+    dashboardFiltersInteractivity?: undefined;
+    parameterInteractivity?: undefined;
+};
+
+export type EmbedJwtContentDataApp = CommonDataAppEmbedJwtContent & {
+    appUuid: string;
+};
+
 export type CreateEmbedJwt = {
     content:
         | EmbedJwtContentDashboardUuid
         | EmbedJwtContentDashboardSlug
-        | EmbedJwtContentChart;
+        | EmbedJwtContentChart
+        | EmbedJwtContentDataApp;
     writeActions?: EmbedWriteActions;
     userAttributes?: { [key: string]: string };
     user?: {

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -69,6 +69,8 @@ export type OssEmbed = {
     allowAllDashboards: boolean;
     chartUuids: string[];
     allowAllCharts: boolean;
+    allowAllApps: boolean;
+    appUuids: string[];
     createdAt: string;
     user: Pick<LightdashUser, 'userUuid' | 'firstName' | 'lastName'> | null;
 };
@@ -95,8 +97,10 @@ export type EmbedContent = {
     chartUuids: string[];
     /** Explores available to the embedded dashboard */
     explores: string[];
+    /** The data app UUID the JWT may have access to (standalone app embed) */
+    appUuid?: string;
     /** The type of content */
-    type: 'dashboard' | 'chart';
+    type: 'dashboard' | 'chart' | 'dataApp';
 };
 
 export type EmbedAccess = {

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -12,6 +12,7 @@ import AiAgentsNotAuthorizedPage from './pages/AiAgents/AiAgentsNotAuthorizedPag
 import { AiAgentsRootLayout } from './pages/AiAgents/AiAgentsRootLayout';
 import AiAgentThreadSharePage from './pages/AiAgents/AiAgentThreadSharePage';
 import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
+import EmbedApp from './pages/EmbedApp';
 import EmbedChart from './pages/EmbedChart';
 import EmbedDashboard from './pages/EmbedDashboard';
 import EmbedExplore from './pages/EmbedExplore';
@@ -44,6 +45,14 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                 element: (
                     <TrackPage name={PageName.EMBED_SAVED_CHART}>
                         <EmbedChart />
+                    </TrackPage>
+                ),
+            },
+            {
+                path: '/embed/:projectUuid/app/:appUuid',
+                element: (
+                    <TrackPage name={PageName.EMBED_DATA_APP}>
+                        <EmbedApp />
                     </TrackPage>
                 ),
             },

--- a/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedApp/components/EmbedApp.tsx
@@ -1,0 +1,62 @@
+import { Box, Loader, Stack } from '@mantine-8/core';
+import { IconAppsOff } from '@tabler/icons-react';
+import { type FC } from 'react';
+import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
+import AppIframePreview from '../../../../../features/apps/AppIframePreview';
+import { useEmbedAppPreviewToken } from '../../../../../features/apps/hooks/useEmbedAppPreviewToken';
+import { usePreviewOrigin } from '../../../../../features/apps/previewOrigin';
+
+type Props = {
+    appUuid: string;
+    projectUuid: string;
+};
+
+/**
+ * Standalone (no-dashboard) embed of a single data app — the EmbedDataAppTile
+ * render path minus the TileBase chrome and the dashboard-filter plumbing. The
+ * preview token is minted via the embed endpoint (self-authorized by the
+ * `dataApp` JWT); the sandboxed iframe + postMessage bridge are identical.
+ */
+const EmbedApp: FC<Props> = ({ appUuid, projectUuid }) => {
+    const previewOrigin = usePreviewOrigin();
+    const tokenQuery = useEmbedAppPreviewToken(projectUuid, appUuid);
+
+    const previewUrl = tokenQuery.data
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${tokenQuery.data.version}/t/${tokenQuery.data.token}/#transport=postMessage&projectUuid=${projectUuid}`
+        : undefined;
+
+    const statusCode = tokenQuery.error?.error?.statusCode;
+    const isNotFound = statusCode === 404;
+    const isForbidden = statusCode === 403;
+
+    return (
+        <Box h="100vh" w="100%">
+            {isNotFound ? (
+                <SuboptimalState
+                    icon={IconAppsOff}
+                    title="Data app not available"
+                    description="This data app no longer exists or hasn't finished building yet."
+                />
+            ) : isForbidden ? (
+                <SuboptimalState
+                    icon={IconAppsOff}
+                    title="No access"
+                    description="This data app isn't authorized for this embed."
+                />
+            ) : tokenQuery.isLoading || !previewUrl ? (
+                <Stack align="center" justify="center" h="100%">
+                    <Loader size="sm" />
+                </Stack>
+            ) : (
+                <AppIframePreview
+                    src={previewUrl}
+                    expectedPreviewOrigin={previewOrigin}
+                    identityKey={`${appUuid}:${tokenQuery.data!.version}`}
+                    dashboardFilters={undefined}
+                />
+            )}
+        </Box>
+    );
+};
+
+export default EmbedApp;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
@@ -1,6 +1,7 @@
 import {
     type DashboardBasicDetails,
     type DecodedEmbed,
+    type EmbedProjectApp,
     type SavedChart,
     type UpdateEmbed,
 } from '@lightdash/common';
@@ -13,14 +14,26 @@ const EmbedAllowListForm: FC<{
     embedConfig: DecodedEmbed;
     dashboards: DashboardBasicDetails[];
     charts: Pick<SavedChart, 'uuid' | 'name'>[];
+    apps: EmbedProjectApp[];
+    showDataApps: boolean;
     onSave: (values: UpdateEmbed) => void;
-}> = ({ disabled, embedConfig, dashboards, charts, onSave }) => {
+}> = ({
+    disabled,
+    embedConfig,
+    dashboards,
+    charts,
+    apps,
+    showDataApps,
+    onSave,
+}) => {
     const form = useForm({
         initialValues: {
             allowAllDashboards: embedConfig.allowAllDashboards,
             dashboardUuids: embedConfig.dashboardUuids,
             allowAllCharts: embedConfig.allowAllCharts,
             chartUuids: embedConfig.chartUuids,
+            allowAllApps: embedConfig.allowAllApps,
+            appUuids: embedConfig.appUuids,
         },
     });
 
@@ -30,6 +43,8 @@ const EmbedAllowListForm: FC<{
             allowAllDashboards: values.allowAllDashboards,
             chartUuids: values.chartUuids,
             allowAllCharts: values.allowAllCharts,
+            appUuids: values.appUuids,
+            allowAllApps: values.allowAllApps,
         });
     });
 
@@ -98,12 +113,49 @@ const EmbedAllowListForm: FC<{
                         {...form.getInputProps('chartUuids')}
                     />
                 )}
+                {showDataApps && (
+                    <>
+                        <Switch
+                            name="allowAllApps"
+                            label="Allow all data apps"
+                            {...form.getInputProps('allowAllApps', {
+                                type: 'checkbox',
+                            })}
+                        />
+                        {!form.values.allowAllApps && (
+                            <MultiSelect
+                                required={!form.values.allowAllApps}
+                                label={'Data apps'}
+                                data={apps.map((app) => ({
+                                    value: app.appUuid,
+                                    label: app.name,
+                                }))}
+                                disabled={
+                                    disabled ||
+                                    apps.length === 0 ||
+                                    form.values.allowAllApps
+                                }
+                                defaultValue={[]}
+                                placeholder={
+                                    apps.length === 0
+                                        ? 'No data apps available to embed'
+                                        : 'Select a data app...'
+                                }
+                                searchable
+                                description="Only these data apps will be allowed to be embedded standalone."
+                                {...form.getInputProps('appUuids')}
+                            />
+                        )}
+                    </>
+                )}
                 <Flex justify="flex-end" gap="sm">
                     <Button
                         type="submit"
                         disabled={
                             disabled ||
-                            (dashboards.length === 0 && charts.length === 0)
+                            (dashboards.length === 0 &&
+                                charts.length === 0 &&
+                                (!showDataApps || apps.length === 0))
                         }
                     >
                         Save changes

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -297,6 +297,124 @@ func main() {
 `,
 };
 
+const dataAppIframeCodeTemplates: Record<SnippetLanguage, string> = {
+    [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
+const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
+const projectUuid = '{{projectUuid}}';
+const appUuid = '{{appUuid}}';
+const data = {
+    content: {
+        type: 'dataApp',
+        projectUuid: projectUuid,
+        appUuid: appUuid,
+    },
+    user: {
+        externalId: {{externalId}},
+        email: {{email}}
+    },
+    userAttributes: {{userAttributes}},
+};
+const token = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+const url = \`{{siteUrl}}/embed/\${projectUuid}/app/\${appUuid}#\${token}\`;
+`,
+    [SnippetLanguage.PYTHON]: `import datetime
+import jwt # pip install pyjwt
+
+key = "secret" # replace with your secret
+projectUuid = '{{projectUuid}}'
+appUuid = '{{appUuid}}'
+
+data = {
+    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1), # replace with your expiration time,
+    "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+    "content": {
+        "type": "dataApp",
+        "projectUuid": projectUuid,
+        "appUuid": appUuid,
+    },
+    "user": {
+        "externalId": {{externalId}},
+        "email": {{email}}
+    },
+    "userAttributes": {{userAttributes}},
+};
+token = jwt.encode(data, key, algorithm="HS256")
+url = f"{{siteUrl}}/embed/{projectUuid}/app/{appUuid}#{token}"
+`,
+    [SnippetLanguage.GO]: `
+package main
+
+import (
+    "fmt"
+    "time"
+
+    jwt "github.com/dgrijalva/jwt-go"
+)
+
+const LIGHTDASH_EMBED_SECRET = "secret" // replace with your secret
+const projectUuid = "{{projectUuid}}"
+const appUuid = "{{appUuid}}"
+
+func main() {
+    {{externalIdDef}}
+    {{emailDef}}
+
+    // Define the custom claims structure
+    type CustomClaims struct {
+        Content struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AppUuid     string \`json:"appUuid"\`
+        } \`json:"content"\`
+        UserAttributes map[string]string \`json:"userAttributes"\`
+        jwt.StandardClaims
+        User *struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        } \`json:"user,omitempty"\`
+    }
+
+    // Create the claims
+    claims := CustomClaims{
+        Content: struct {
+            Type        string \`json:"type"\`
+            ProjectUuid string \`json:"projectUuid"\`
+            AppUuid     string \`json:"appUuid"\`
+        }{
+            Type:        "dataApp",
+            ProjectUuid: projectUuid,
+            AppUuid:     appUuid,
+        },
+        User: &struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        }{
+            ExternalId: {{externalIdUsage}},
+            Email:      {{emailUsage}},
+        },
+        UserAttributes: map[string]string{{userAttributes}},
+        StandardClaims: jwt.StandardClaims{
+            ExpiresAt: time.Now().Add(time.Hour).Unix(), // replace with your expiration
+        },
+    }
+
+    // Create the token
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+    // Sign the token with the secret
+    signedToken, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    if err != nil {
+        panic(err)
+    }
+
+    // Construct the URL
+    url := fmt.Sprintf("{{siteUrl}}/embed/%s/app/%s#%s", projectUuid, appUuid, signedToken)
+    fmt.Println("URL:", url)
+
+}
+`,
+};
+
 const dashboardIframeCodeTemplates: Record<SnippetLanguage, string> = {
     [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
 const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
@@ -858,6 +976,10 @@ const getBackendCodeSnippet = (
             mode === 'iframe'
                 ? dashboardIframeCodeTemplates[language]
                 : dashboardSdkCodeTemplates[language];
+    } else if (data.content.type === 'dataApp') {
+        // Standalone data apps are iframe-only — there is no React SDK
+        // component for them yet.
+        codeTemplate = dataAppIframeCodeTemplates[language];
     } else {
         codeTemplate =
             mode === 'iframe'
@@ -897,15 +1019,30 @@ const getBackendCodeSnippet = (
         .replace('{{emailUsage}}', emailForGo.usage)
         .replace(
             '{{canViewUnderlyingData}}',
-            languageBoolean(language, data.content.canViewUnderlyingData),
+            languageBoolean(
+                language,
+                'canViewUnderlyingData' in data.content
+                    ? data.content.canViewUnderlyingData
+                    : undefined,
+            ),
         )
         .replace(
             '{{canExportCsv}}',
-            languageBoolean(language, data.content.canExportCsv),
+            languageBoolean(
+                language,
+                'canExportCsv' in data.content
+                    ? data.content.canExportCsv
+                    : undefined,
+            ),
         )
         .replace(
             '{{canExportImages}}',
-            languageBoolean(language, data.content.canExportImages),
+            languageBoolean(
+                language,
+                'canExportImages' in data.content
+                    ? data.content.canExportImages
+                    : undefined,
+            ),
         );
 
     const contentType = data.content.type;
@@ -980,6 +1117,15 @@ const getBackendCodeSnippet = (
                     data.content.contentId || '<CHART_UUID>',
                 );
             }
+            break;
+        case 'dataApp':
+            // Replace data app specific variables
+            codeTemplate = codeTemplate.replace(
+                '{{appUuid}}',
+                'appUuid' in data.content
+                    ? data.content.appUuid || '<APP_UUID>'
+                    : '<APP_UUID>',
+            );
             break;
         default:
             assertUnreachable(
@@ -1074,6 +1220,10 @@ export const EmbeddedChart = ({ embedJwt }: EmbeddedChartProps) => (
     />
 );
 `;
+        case 'dataApp':
+            // No SDK component for standalone data app embeds yet — they use
+            // the iframe URL directly.
+            return '';
         default:
             return assertUnreachable(
                 contentType,

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAppForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAppForm.tsx
@@ -1,0 +1,334 @@
+import {
+    type ApiError,
+    type CreateEmbedJwt,
+    type EmbedJwtContentDataApp,
+    type EmbedProjectApp,
+    type EmbedUrl,
+    type IntrinsicUserAttributes,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Button,
+    Flex,
+    Group,
+    Input,
+    Paper,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Title,
+} from '@mantine-8/core';
+import { useMantineColorScheme } from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { lightdashApi } from '../../../../api';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import useToaster from '../../../../hooks/toaster/useToaster';
+import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
+import useUser from '../../../../hooks/user/useUser';
+import EmbedCodeSnippet from './EmbedCodeSnippet';
+
+const useEmbedUrlCreateMutation = (projectUuid: string) => {
+    const { showToastError } = useToaster();
+    return useMutation<EmbedUrl, ApiError, CreateEmbedJwt>(
+        (data: CreateEmbedJwt) =>
+            lightdashApi<EmbedUrl>({
+                url: `/embed/${projectUuid}/get-embed-url`,
+                method: 'POST',
+                body: JSON.stringify(data),
+            }),
+        {
+            mutationKey: ['create-embed-url'],
+            onError: (error) => {
+                showToastError({
+                    title: `We couldn't create your embed url.`,
+                    subtitle: error.error.message,
+                });
+            },
+        },
+    );
+};
+
+type FormValues = {
+    appUuid: string | undefined;
+    expiresIn: string;
+    userAttributes: Array<{
+        uuid: string;
+        key: string;
+        value: string;
+    }>;
+    externalId?: string;
+} & IntrinsicUserAttributes;
+
+const EmbedPreviewAppForm: FC<{
+    projectUuid: string;
+    siteUrl: string;
+    apps: EmbedProjectApp[];
+}> = ({ projectUuid, siteUrl, apps }) => {
+    const { mutateAsync: createEmbedUrl } =
+        useEmbedUrlCreateMutation(projectUuid);
+    const { colorScheme } = useMantineColorScheme();
+    const { data: user } = useUser(true);
+
+    const form = useForm<FormValues>({
+        initialValues: {
+            appUuid: undefined,
+            expiresIn: '1 hour',
+            userAttributes: [{ uuid: uuidv4(), key: '', value: '' }] as Array<{
+                uuid: string;
+                key: string;
+                value: string;
+            }>,
+            email: user?.email,
+        },
+        validate: {
+            appUuid: (value: undefined | string) => {
+                return value && value.length > 0
+                    ? null
+                    : 'Data app is required';
+            },
+        },
+    });
+    const { onSubmit, values: formValues } = form;
+
+    const convertFormValuesToCreateEmbedJwt = useCallback(
+        (
+            values: FormValues,
+            isPreview: boolean = false,
+        ): Omit<CreateEmbedJwt, 'content'> & {
+            content: EmbedJwtContentDataApp;
+        } => {
+            return {
+                expiresIn: values.expiresIn,
+                content: {
+                    type: 'dataApp',
+                    projectUuid,
+                    appUuid: values.appUuid!,
+                    isPreview,
+                },
+                userAttributes: values.userAttributes.reduce(
+                    (acc, item) => ({
+                        ...acc,
+                        [item.key]: item.value,
+                    }),
+                    {},
+                ),
+                user: {
+                    externalId: values.externalId,
+                    email: values.email,
+                },
+            };
+        },
+        [projectUuid],
+    );
+
+    const handlePreview = useCallback(async () => {
+        const state = form.validate();
+        if (state.hasErrors) {
+            return;
+        }
+
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(formValues, true),
+        );
+        // Open data.url in a new tab, matching the current app color scheme
+        const previewUrl = new URL(data.url);
+        previewUrl.searchParams.set('theme', colorScheme);
+        window.open(previewUrl.toString(), '_blank');
+    }, [
+        formValues,
+        form,
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        colorScheme,
+    ]);
+
+    const generateUrl = useCallback(async () => {
+        const data = await createEmbedUrl(
+            convertFormValuesToCreateEmbedJwt(form.values),
+        );
+        // Match the current app color scheme
+        const url = new URL(data.url);
+        url.searchParams.set('theme', colorScheme);
+        return url.toString();
+    }, [
+        convertFormValuesToCreateEmbedJwt,
+        createEmbedUrl,
+        form.values,
+        colorScheme,
+    ]);
+
+    const { handleCopy } = useAsyncClipboard(generateUrl);
+    const handleCopySubmit = onSubmit(handleCopy);
+
+    return (
+        <form id="generate-embed-url-app" onSubmit={handleCopySubmit}>
+            <Stack gap="md" mb="md">
+                <Select
+                    required
+                    label="Data app"
+                    data={apps.map((app) => ({
+                        value: app.appUuid,
+                        label: app.name,
+                    }))}
+                    placeholder={
+                        apps.length === 0
+                            ? 'No data apps available to embed'
+                            : 'Select a data app...'
+                    }
+                    disabled={apps.length === 0}
+                    searchable
+                    {...form.getInputProps('appUuid')}
+                />
+
+                <Stack gap="xs">
+                    <Text size="sm" fw={500}>
+                        Expires in
+                    </Text>
+                    <SegmentedControl
+                        value={form.values.expiresIn}
+                        onChange={(value) =>
+                            form.setFieldValue('expiresIn', value)
+                        }
+                        radius="md"
+                        data={[
+                            { label: '1 hour', value: '1 hour' },
+                            { label: '1 day', value: '1 day' },
+                            { label: '1 week', value: '1 week' },
+                            { label: '30 days', value: '30 days' },
+                            { label: '1 year', value: '1 year' },
+                        ]}
+                        size="xs"
+                    />
+                </Stack>
+
+                <Paper p="md" withBorder>
+                    <Stack gap="md">
+                        <Title order={6}>Identification & Security</Title>
+                        <Stack gap="xs">
+                            <Input.Wrapper label="User identifier">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="1234"
+                                    {...form.getInputProps('externalId')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User email">
+                                <TextInput
+                                    size="xs"
+                                    placeholder="Type an email to add as intrinsic user attribute"
+                                    {...form.getInputProps('email')}
+                                />
+                            </Input.Wrapper>
+
+                            <Input.Wrapper label="User attributes">
+                                <Stack gap="xs" mt="xs">
+                                    {form.values.userAttributes.map(
+                                        (item, index) => (
+                                            <Group
+                                                key={item.uuid}
+                                                gap="xs"
+                                                wrap="nowrap"
+                                            >
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. user_country"
+                                                    flex={1}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.key`,
+                                                    )}
+                                                />
+                                                <TextInput
+                                                    size="xs"
+                                                    placeholder="E.g. US"
+                                                    flex={1}
+                                                    {...form.getInputProps(
+                                                        `userAttributes.${index}.value`,
+                                                    )}
+                                                />
+                                                <ActionIcon
+                                                    variant="light"
+                                                    color="red"
+                                                    onClick={() =>
+                                                        form.removeListItem(
+                                                            'userAttributes',
+                                                            index,
+                                                        )
+                                                    }
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                    />
+                                                </ActionIcon>
+                                            </Group>
+                                        ),
+                                    )}
+                                    <Button
+                                        size="xs"
+                                        variant="default"
+                                        leftSection={
+                                            <MantineIcon icon={IconPlus} />
+                                        }
+                                        onClick={() =>
+                                            form.insertListItem(
+                                                'userAttributes',
+                                                {
+                                                    key: '',
+                                                    value: '',
+                                                    uuid: uuidv4(),
+                                                },
+                                            )
+                                        }
+                                    >
+                                        Add attribute
+                                    </Button>
+                                </Stack>
+                            </Input.Wrapper>
+                        </Stack>
+                    </Stack>
+                </Paper>
+
+                <Flex justify="flex-end" gap="sm">
+                    <Button
+                        variant="light"
+                        leftSection={<MantineIcon icon={IconEye} />}
+                        onClick={handlePreview}
+                    >
+                        Preview
+                    </Button>
+                    <Button
+                        variant="default"
+                        type="submit"
+                        leftSection={<MantineIcon icon={IconLink} />}
+                    >
+                        Generate & copy URL
+                    </Button>
+                </Flex>
+            </Stack>
+
+            <Stack gap="md" mb="md">
+                <Stack gap="xs">
+                    <Title order={5}>Iframe embed code</Title>
+                    <Text c="dimmed" fz="sm">
+                        Use this for iframe or direct embedding with a full
+                        embed URL.
+                    </Text>
+                </Stack>
+                <EmbedCodeSnippet
+                    mode="iframe"
+                    projectUuid={projectUuid}
+                    siteUrl={siteUrl}
+                    data={convertFormValuesToCreateEmbedJwt(formValues)}
+                />
+            </Stack>
+        </form>
+    );
+};
+
+export default EmbedPreviewAppForm;

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     type ApiError,
     type CreateEmbedJwt,
     type DecodedEmbed,
@@ -25,11 +26,14 @@ import {
     SettingsGridCard,
 } from '../../../../components/common/Settings/SettingsCard';
 import SuboptimalState from '../../../../components/common/SuboptimalState/SuboptimalState';
+import { useProjectApps } from '../../../../features/apps/hooks/useProjectApps';
 import { useDashboards } from '../../../../hooks/dashboard/useDashboards';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useCharts } from '../../../../hooks/useCharts';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../../providers/App/useApp';
 import EmbedAllowListForm from './EmbedAllowListForm';
+import EmbedPreviewAppForm from './EmbedPreviewAppForm';
 import EmbedPreviewChartForm from './EmbedPreviewChartForm';
 import EmbedPreviewDashboardForm from './EmbedPreviewDashboardForm';
 import EmbedWriteActionsForm from './EmbedWriteActionsForm';
@@ -87,6 +91,8 @@ const useEmbedConfigUpdateMutation = (projectUuid: string) => {
             allowAllDashboards,
             chartUuids,
             allowAllCharts,
+            appUuids,
+            allowAllApps,
         }: UpdateEmbed) =>
             lightdashApi<null>({
                 url: `/embed/${projectUuid}/config`,
@@ -96,6 +102,8 @@ const useEmbedConfigUpdateMutation = (projectUuid: string) => {
                     allowAllDashboards,
                     chartUuids,
                     allowAllCharts,
+                    appUuids,
+                    allowAllApps,
                 }),
             }),
         {
@@ -126,15 +134,20 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     );
 
     const { isLoading: isLoadingCharts, data: charts } = useCharts(projectUuid);
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled === true;
+    const { isLoading: isLoadingApps, data: apps } = useProjectApps(
+        dataAppsEnabled ? projectUuid : undefined,
+    );
     const { mutate: createEmbedConfig, isLoading: isCreating } =
         useEmbedConfigCreateMutation(projectUuid);
     const { mutate: updateEmbedConfig, isLoading: isUpdating } =
         useEmbedConfigUpdateMutation(projectUuid);
     const [writeActions, setWriteActions] =
         useState<CreateEmbedJwt['writeActions']>();
-    const [activeTab, setActiveTab] = useState<'dashboards' | 'charts'>(
-        'dashboards',
-    );
+    const [activeTab, setActiveTab] = useState<
+        'dashboards' | 'charts' | 'apps'
+    >('dashboards');
 
     const isSaving = isCreating || isUpdating;
     const allowedDashboards = useMemo(() => {
@@ -149,7 +162,23 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
         );
     }, [dashboards, embedConfig]);
 
-    if (isLoading || isLoadingDashboards || isLoadingCharts || !health.data) {
+    const allowedApps = useMemo(() => {
+        if (!apps || !embedConfig) {
+            return [];
+        }
+        if (embedConfig.allowAllApps) {
+            return apps;
+        }
+        return apps.filter((app) => embedConfig.appUuids.includes(app.appUuid));
+    }, [apps, embedConfig]);
+
+    if (
+        isLoading ||
+        isLoadingDashboards ||
+        isLoadingCharts ||
+        (dataAppsEnabled && isLoadingApps) ||
+        !health.data
+    ) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Loading embed config" loading />
@@ -252,6 +281,8 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     embedConfig={embedConfig}
                     dashboards={dashboards || []}
                     charts={charts || []}
+                    apps={apps || []}
+                    showDataApps={dataAppsEnabled}
                     onSave={updateEmbedConfig}
                 />
             </SettingsCard>
@@ -267,7 +298,9 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     value={activeTab}
                     onChange={(value) =>
                         setActiveTab(
-                            value === 'charts' ? 'charts' : 'dashboards',
+                            value === 'charts' || value === 'apps'
+                                ? value
+                                : 'dashboards',
                         )
                     }
                     keepMounted
@@ -275,6 +308,9 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                     <Tabs.List>
                         <Tabs.Tab value="dashboards">Dashboards</Tabs.Tab>
                         <Tabs.Tab value="charts">Charts</Tabs.Tab>
+                        {dataAppsEnabled && (
+                            <Tabs.Tab value="apps">Data apps</Tabs.Tab>
+                        )}
                     </Tabs.List>
                     <Tabs.Panel value="dashboards">
                         <Stack mt="md">
@@ -314,6 +350,17 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
                             />
                         </Stack>
                     </Tabs.Panel>
+                    {dataAppsEnabled && (
+                        <Tabs.Panel value="apps">
+                            <Stack mt="md">
+                                <EmbedPreviewAppForm
+                                    projectUuid={projectUuid}
+                                    siteUrl={health.data.siteUrl}
+                                    apps={allowedApps}
+                                />
+                            </Stack>
+                        </Tabs.Panel>
+                    )}
                 </Tabs>
             </SettingsCard>
         </Stack>

--- a/packages/frontend/src/ee/pages/EmbedApp.tsx
+++ b/packages/frontend/src/ee/pages/EmbedApp.tsx
@@ -1,0 +1,39 @@
+import { Box } from '@mantine-8/core';
+import { IconUnlink } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useParams } from 'react-router';
+import SuboptimalState from '../../components/common/SuboptimalState/SuboptimalState';
+import EmbedApp from '../features/embed/EmbedApp/components/EmbedApp';
+import useEmbed from '../providers/Embed/useEmbed';
+
+const EmbedAppPage: FC = () => {
+    const { appUuid: appUuidFromParams } = useParams<{ appUuid?: string }>();
+    const { embedToken, projectUuid, appUuid: appUuidFromContext } = useEmbed();
+
+    // Prefer the embed-context value (SDK mode) over the URL param, mirroring
+    // EmbedChart — SDK customers may have an unrelated appUuid in their app URL.
+    const appUuid = appUuidFromContext ?? appUuidFromParams;
+
+    if (!embedToken) {
+        return (
+            <Box mt="md">
+                <SuboptimalState
+                    icon={IconUnlink}
+                    title="This embed link is not valid"
+                />
+            </Box>
+        );
+    }
+
+    if (!projectUuid || !appUuid) {
+        return (
+            <Box mt="md">
+                <SuboptimalState icon={IconUnlink} title="Missing app ID" />
+            </Box>
+        );
+    }
+
+    return <EmbedApp appUuid={appUuid} projectUuid={projectUuid} />;
+};
+
+export default EmbedAppPage;

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -31,6 +31,7 @@ type Props = {
     onBackToDashboard?: () => void;
     savedChart?: SavedChart;
     savedQueryUuid?: string;
+    appUuid?: string;
 };
 
 const decodeEmbedJwtPayload = (
@@ -67,6 +68,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     onBackToDashboard,
     savedChart,
     savedQueryUuid,
+    appUuid,
 }) => {
     const embedToken = encodedToken || window.location.hash.replace('#', '');
     const [isInitialized, setIsInitialized] = useState(false);
@@ -154,6 +156,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             onExplore,
             savedChart,
             savedQueryUuid,
+            appUuid,
             onBackToDashboard,
             mode,
             theme: embedThemeParams.theme,
@@ -173,6 +176,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         onExplore,
         savedChart,
         savedQueryUuid,
+        appUuid,
         onBackToDashboard,
         mode,
         embedThemeParams.theme,

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -44,6 +44,8 @@ export interface EmbedContext {
     savedChart?: SavedChart;
     // The UUID of the saved query being viewed in an embedded Chart
     savedQueryUuid?: string;
+    // The UUID of the data app being viewed in a standalone embedded App
+    appUuid?: string;
     // The mode of the embed: 'sdk' when embedded via SDK (no URL sync), 'direct' when navigating directly to /embed (sync URL)
     mode: EmbedMode;
     // Theme color scheme for the embed, set via ?theme=light|dark URL param

--- a/packages/frontend/src/features/apps/hooks/useProjectApps.ts
+++ b/packages/frontend/src/features/apps/hooks/useProjectApps.ts
@@ -1,0 +1,23 @@
+import { type ApiError, type EmbedProjectApp } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const getProjectApps = async (
+    projectUuid: string,
+): Promise<EmbedProjectApp[]> =>
+    lightdashApi<EmbedProjectApp[]>({
+        method: 'GET',
+        url: `/ee/projects/${projectUuid}/apps`,
+        body: undefined,
+    });
+
+/**
+ * Lists the project's (non-deleted) data apps — used to populate the embed
+ * config's standalone-app allowlist picker.
+ */
+export const useProjectApps = (projectUuid: string | undefined) =>
+    useQuery<EmbedProjectApp[], ApiError>({
+        queryKey: ['project-apps', projectUuid],
+        queryFn: () => getProjectApps(projectUuid!),
+        enabled: !!projectUuid,
+    });

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -52,6 +52,7 @@ export enum PageName {
     EMBED_DASHBOARD = 'embed_dashboard',
     EMBED_SAVED_CHART = 'embed_saved_chart',
     EMBED_EXPLORE = 'embed_explore',
+    EMBED_DATA_APP = 'embed_data_app',
     CATALOG = 'catalog',
     METRICS_CATALOG = 'metrics_catalog',
     FUNNEL_BUILDER = 'funnel_builder',


### PR DESCRIPTION
### Embed data apps as standalone content

**This adds standalone embedding for data apps** — an app in its own iframe via `/embed/{projectUuid}/app/{appUuid}#{jwt}`, no dashboard required. It introduces a fourth embed-JWT content type, `dataApp` (alongside `dashboard`/`chart`/`explore`), which names the app it authorizes, mirroring how chart embeds work. Access is gated server-side by a new per-project config: an `app_uuids` allowlist and an `allow_all_apps` switch on the `embedding` table (one migration, both default-off), enforced fail-closed at account build in `EmbedService.getAccountFromJwt`.

**On authorization:** a `dataApp` JWT receives `view:Project`, an **unconstrained** `view:Explore` for the project, and `view:DataApp` scoped to the named app (`jwtAbility.ts`). The unconstrained Explore grant is deliberate — apps run arbitrary metric queries, so embedding an app means accepting project-wide column access for that token; row-level filtering via the JWT's user attributes is unchanged (`getFilteredExplore`). The grant carries no chart/dashboard/export abilities, and content-type dispatch (`applyEmbeddedAbility`, `checkEmbedPermissions`, `_prepareSavedChartForCalculation`) is now exhaustive with `assertUnreachable`, so a dataApp token is explicitly rejected on chart/dashboard endpoints rather than implicitly. Token minting for the iframe goes through a new `GET /embed/:projectUuid/apps/:appUuid/preview-token` endpoint, which resolves the latest ready version and rejects any appUuid other than the one signed into the JWT — a token for app A can never render app B, even if B sits on an allowlisted dashboard.

Frontend adds the `EmbedApp` page (reuses `AppIframePreview` and the existing postMessage bridge — render path is identical to dashboard app tiles, minus tile chrome and filters), plus embed-settings support: an "Allowed content" section for apps (switch + multiselect, fed by a new `GET /ee/projects/:projectUuid/apps` endpoint) and a "Data apps" preview tab with iframe code snippets for Node/Python/Go. All of it is gated behind `FeatureFlags.EnableDataApps`. Smaller fixes along the way: embed `user-info` now derives a non-empty `firstName` from the email (empty string crashed avatar-initial code in app bundles), app-view analytics skips non-UUID embed identities instead of throwing, and `EmbedModel.get` runs its three allowlist-validation queries in parallel.