### PR TITLE
feat: add FE PDF exports for data apps

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -435,7 +435,7 @@ The preview iframe uses `sandbox="allow-scripts allow-modals allow-downloads all
 - The iframe cannot access the parent page's cookies or storage
 - The iframe cannot make credentialed requests to the Lightdash API directly
 - All API communication goes through a `postMessage` bridge
-- The iframe can trigger user-initiated downloads for backend-generated CSV/XLSX exports
+- The iframe can trigger user-initiated downloads for backend-generated CSV/XLSX exports and client-generated PDF files
 
 `allow-modals` is enabled so that PDF Report templates (and any generated app that wants a Print button) can call
 `window.print()`. It also enables `alert`/`confirm`/`prompt`, which are an accepted trade-off: the iframe is still
@@ -443,8 +443,13 @@ isolated from the parent origin, the browser attributes dialog origins to the if
 already build an equivalent in-iframe HTML form.
 
 `allow-downloads` is enabled so generated apps can save CSV/XLSX exports produced by the Lightdash backend download
-pipeline. It does not grant parent-origin access; the app still schedules and polls export jobs through the
-parent-mediated SDK bridge.
+pipeline, and so PDF Report apps can save client-generated PDF files. It does not grant parent-origin access; the app
+still schedules and polls backend export jobs through the parent-mediated SDK bridge.
+
+PDF Report templates generate downloads in the iframe with pre-installed client-side libraries: `html-to-image`
+rasterizes the rendered report pages and `jspdf` writes the PDF file. This keeps PDF export independent of direct API
+access, but the output is image-based rather than selectable/searchable text. `window.print()` remains available as an
+optional Print action.
 
 ### PostMessage Bridge (`useAppSdkBridge`)
 

--- a/packages/backend/src/ee/services/AppGenerateService/templates.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/templates.ts
@@ -20,6 +20,7 @@ Build a slideshow-style data app:
 const PDF_REPORT_INSTRUCTIONS = `[Starter template: PDF Report]
 Build a print-optimized report:
 - Layout for A4/Letter portrait pages with comfortable internal padding.
+- Include a Download PDF button that uses the pre-installed \`html-to-image\` and \`jspdf\` packages to save the rendered report directly from the browser. Track an exporting state, disable the button while data or PDF generation is loading, and show a spinner or "Exporting..." label.
 - Set \`@page { margin: 0; size: A4 }\` so the design fills the sheet edge-to-edge — apply your own padding inside each page (e.g. \`p-12\`) instead of relying on the browser's default page margin (which is ugly and shrinks the canvas).
 - Use a clean, document-style typography hierarchy (title, section headings, body).
 - Render charts at fixed widths so they reflow across pages cleanly.
@@ -27,6 +28,7 @@ Build a print-optimized report:
 - Include a title page header (title, subtitle, generated-on date) and section dividers.
 - Apply CSS \`@media print\` rules and \`page-break-inside: avoid\` on cards and figures.
 - Note: browsers may inject their own header/footer on printed pages (URL, page number, date), controlled by the user's print dialog — not removable via CSS. Keep critical content away from the very top and bottom edges so it doesn't sit underneath.
+- \`window.print()\` can be a secondary Print action, but do not rely on it for the Download PDF button.
 - Prefer narrative copy with charts as supporting evidence, not a dense dashboard grid.`;
 
 export const getTemplateInstructions = (

--- a/sandboxes/data-apps/template/package.json
+++ b/sandboxes/data-apps/template/package.json
@@ -28,6 +28,7 @@
         "d3-sankey": "0.12.3",
         "date-fns": "3.6.0",
         "html-to-image": "1.11.13",
+        "jspdf": "4.2.1",
         "lodash-es": "4.18.1",
         "lucide-react": "0.469.0",
         "react": "19.2.5",

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -19,7 +19,7 @@ Don't verify your own output. **After you Write or Edit a file, do not Read it b
 
 ### Approved packages
 
-`react`, `react-dom`, `@lightdash/query-sdk`, `recharts`, `d3`, `d3-sankey`, `d3-cloud`, `@tanstack/react-query`, `@tanstack/react-table`, `@tanstack/react-virtual`, `react-resizable-panels`, `date-fns`, `lodash-es`, `lucide-react`, `clsx`, `tailwind-merge`, `class-variance-authority`
+`react`, `react-dom`, `@lightdash/query-sdk`, `recharts`, `d3`, `d3-sankey`, `d3-cloud`, `@tanstack/react-query`, `@tanstack/react-table`, `@tanstack/react-virtual`, `react-resizable-panels`, `date-fns`, `html-to-image`, `jspdf`, `lodash-es`, `lucide-react`, `clsx`, `tailwind-merge`, `class-variance-authority`
 
 ### Pre-installed shadcn/ui components
 
@@ -559,6 +559,100 @@ Rules:
 - Track export state (`exporting`, `isExporting`, etc.), disable export controls while awaiting `downloadResults()`, and show a spinner or "Exporting..." label until the promise settles.
 - Show a toast or inline note if the returned result has `truncated: true`.
 
+### Client-side PDF downloads
+
+For PDF Report templates, or whenever the user asks for a PDF download, use the pre-installed `html-to-image` and `jspdf` packages. Do not load PDF libraries from a CDN or ask to install packages.
+
+PDF downloads are image-based: they preserve the visible report exactly, but the exported text is not selectable/searchable. Keep `window.print()` only as a secondary Print action if useful; the Download PDF button should save a file directly.
+
+Rules:
+
+- Render each PDF page or section in a stable DOM container, e.g. `.pdf-page`, with fixed printable dimensions or aspect ratio.
+- Include a Download PDF button in the report toolbar/header.
+- Track `isExportingPdf`, disable the button while report data is loading or PDF generation is running, and show a spinner or "Exporting..." label until the promise settles.
+- Use chart value labels in PDF reports because exported pages cannot be hovered.
+- Avoid capturing scroll containers with hidden content. Capture page-sized elements that already contain the full content intended for export.
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { toPng } from 'html-to-image';
+import { jsPDF } from 'jspdf';
+import { Download, Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+async function imageLoaded(src: string) {
+    const image = new Image();
+    image.src = src;
+    await new Promise<void>((resolve, reject) => {
+        image.onload = () => resolve();
+        image.onerror = reject;
+    });
+    return image;
+}
+
+async function downloadPdfFromPages(
+    pages: HTMLElement[],
+    filename = 'report.pdf',
+) {
+    const pdf = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
+    const pageWidth = pdf.internal.pageSize.getWidth();
+    const pageHeight = pdf.internal.pageSize.getHeight();
+
+    for (let index = 0; index < pages.length; index += 1) {
+        if (index > 0) pdf.addPage();
+
+        const dataUrl = await toPng(pages[index], {
+            cacheBust: true,
+            pixelRatio: 2,
+            backgroundColor: '#ffffff',
+        });
+        const image = await imageLoaded(dataUrl);
+        const scale = Math.min(pageWidth / image.width, pageHeight / image.height);
+        const width = image.width * scale;
+        const height = image.height * scale;
+
+        pdf.addImage(dataUrl, 'PNG', (pageWidth - width) / 2, 0, width, height);
+    }
+
+    pdf.save(filename.endsWith('.pdf') ? filename : `${filename}.pdf`);
+}
+
+export function PdfReport() {
+    const reportRef = useRef<HTMLDivElement | null>(null);
+    const [isExportingPdf, setIsExportingPdf] = useState(false);
+
+    async function exportPdf() {
+        if (!reportRef.current) return;
+        setIsExportingPdf(true);
+        try {
+            const pages = Array.from(
+                reportRef.current.querySelectorAll<HTMLElement>('.pdf-page'),
+            );
+            await downloadPdfFromPages(
+                pages.length > 0 ? pages : [reportRef.current],
+                'executive-report.pdf',
+            );
+        } finally {
+            setIsExportingPdf(false);
+        }
+    }
+
+    return (
+        <>
+            <Button disabled={isExportingPdf} onClick={exportPdf}>
+                {isExportingPdf ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                    <Download className="mr-2 h-4 w-4" />
+                )}
+                {isExportingPdf ? 'Exporting...' : 'Download PDF'}
+            </Button>
+            <div ref={reportRef}>{/* .pdf-page report sections */}</div>
+        </>
+    );
+}
+```
+
 ### Underlying data
 
 Use `getUnderlyingData()` when the user asks to inspect the rows behind a metric in a chart, KPI, or table. It runs Lightdash's native "View underlying data" query for the already-loaded result row.
@@ -786,6 +880,7 @@ Every component that uses `useLightdash()` **must** show a loading spinner while
 Every user-triggered async data action must also show a loading state while it is waiting:
 
 - `downloadResults()` and `downloadUnderlyingData()` exports: disable export controls and show a spinner or "Exporting..." label until the promise settles.
+- PDF exports: disable the Download PDF button and show a spinner or "Exporting..." label until the file has been saved.
 - `getUnderlyingData()` requests: show a spinner in the dialog/sheet/table area until rows arrive.
 - Drilldown queries: show a spinner in the drilldown dialog while the drill query loads.
 - `refetch()` flows: show an inline refresh spinner or disabled refreshing state.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #23759 

### Description:

Adds PDF downloads of Data Apps. This PR makes it possible to download as *image-based* PDFs. 

Text PDFs are out of scope. 
