### PR TITLE
feat: add Fields diff to AI review verification card

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewFieldsModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewFieldsModal.module.css
@@ -1,0 +1,36 @@
+.row {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    padding: 6px var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.row:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldGray-1)
+    );
+}
+
+.label {
+    flex: 1;
+    min-width: 0;
+}
+
+.action {
+    opacity: 0;
+    transition: opacity 100ms ease;
+}
+
+.row:hover .action,
+.action:focus-within {
+    opacity: 1;
+}
+
+.action button:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldGray-2)
+    );
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewFieldsModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewFieldsModal.tsx
@@ -1,0 +1,183 @@
+import {
+    ChartType,
+    type CreateSavedChartVersion,
+    type UpstreamFieldChangeKind,
+    type UpstreamFieldDiff,
+} from '@lightdash/common';
+import { Button, Center, Group, Loader, Stack, Text } from '@mantine-8/core';
+import {
+    Icon123,
+    IconAbc,
+    IconChartBar,
+    IconCircle,
+    IconColumns,
+    IconMinus,
+    IconPlus,
+} from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { getExplorerUrlFromCreateSavedChartVersion } from '../../../../../hooks/useExplorerRoute';
+import styles from './ReviewFieldsModal.module.css';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    fields: UpstreamFieldDiff[];
+    isLoading: boolean;
+};
+
+const CHANGE_LABEL: Record<UpstreamFieldChangeKind, string> = {
+    added: 'Added',
+    label_changed: 'Updated',
+    removed: 'Removed',
+};
+
+const CHANGE_ICON: Record<UpstreamFieldChangeKind, typeof IconPlus> = {
+    added: IconPlus,
+    label_changed: IconCircle,
+    removed: IconMinus,
+};
+
+const CHANGE_COLOR: Record<UpstreamFieldChangeKind, string> = {
+    added: 'green.7',
+    label_changed: 'yellow.7',
+    removed: 'red.7',
+};
+
+const CHANGE_ORDER: UpstreamFieldChangeKind[] = [
+    'added',
+    'label_changed',
+    'removed',
+];
+
+const buildChartVersion = (
+    field: UpstreamFieldDiff,
+): CreateSavedChartVersion => {
+    const fieldId = `${field.tableName}_${field.fieldName}`;
+    const isMetric = field.fieldType === 'metric';
+    return {
+        tableName: field.exploreName,
+        metricQuery: {
+            exploreName: field.exploreName,
+            dimensions: isMetric ? [] : [fieldId],
+            metrics: isMetric ? [fieldId] : [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+            customDimensions: [],
+        },
+        chartConfig: { type: ChartType.TABLE },
+        tableConfig: { columnOrder: [] },
+        pivotConfig: undefined,
+    };
+};
+
+const fieldLabel = (field: UpstreamFieldDiff): string =>
+    field.previewLabel ?? field.upstreamLabel ?? field.fieldName;
+
+const fieldTypeRank = (field: UpstreamFieldDiff): number => {
+    if (field.fieldType === 'dimension') return 0;
+    if (field.fieldType === 'metric') return 1;
+    return 2;
+};
+
+// Dimensions first, then metrics, alphabetical by label within each.
+const compareFields = (a: UpstreamFieldDiff, b: UpstreamFieldDiff): number =>
+    fieldTypeRank(a) - fieldTypeRank(b) ||
+    fieldLabel(a).localeCompare(fieldLabel(b));
+
+export const ReviewFieldsModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+    fields,
+    isLoading,
+}) => {
+    const groups = CHANGE_ORDER.map((change) => ({
+        change,
+        fields: fields
+            .filter((field) => field.change === change)
+            .sort(compareFields),
+    })).filter((group) => group.fields.length > 0);
+
+    const handleCreateChart = (field: UpstreamFieldDiff) => {
+        const { pathname, search } = getExplorerUrlFromCreateSavedChartVersion(
+            projectUuid,
+            buildChartVersion(field),
+        );
+        window.open(`${pathname}?${search}`, '_blank', 'noopener,noreferrer');
+    };
+
+    const renderField = (field: UpstreamFieldDiff) => (
+        <div
+            key={`${field.exploreName}.${field.tableName}.${field.fieldType}.${field.fieldName}`}
+            className={styles.row}
+        >
+            <MantineIcon
+                icon={field.fieldType === 'metric' ? Icon123 : IconAbc}
+                size="lg"
+                color={field.fieldType === 'metric' ? 'orange.6' : 'blue.6'}
+            />
+            <Text fz="sm" fw={500} className={styles.label} truncate>
+                {fieldLabel(field)}
+            </Text>
+            {field.change === 'added' && (
+                <div className={styles.action}>
+                    <Button
+                        size="compact-xs"
+                        variant="subtle"
+                        leftSection={
+                            <MantineIcon icon={IconChartBar} size="sm" />
+                        }
+                        onClick={() => handleCreateChart(field)}
+                    >
+                        Create chart
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Fields"
+            icon={IconColumns}
+            size="md"
+        >
+            {isLoading ? (
+                <Center py="xl">
+                    <Loader size="md" color="gray" />
+                </Center>
+            ) : fields.length === 0 ? (
+                <Text fz="sm" c="dimmed" py="md">
+                    No field changes between this preview and its upstream
+                    project.
+                </Text>
+            ) : (
+                <Stack gap="md">
+                    {groups.map((group) => (
+                        <Stack key={group.change} gap={2}>
+                            <Group gap={6} mb={2}>
+                                <MantineIcon
+                                    icon={CHANGE_ICON[group.change]}
+                                    size="sm"
+                                    color={CHANGE_COLOR[group.change]}
+                                />
+                                <Text fz="sm" fw={600}>
+                                    {CHANGE_LABEL[group.change]}
+                                </Text>
+                            </Group>
+                            {group.fields.map(renderField)}
+                        </Stack>
+                    ))}
+                </Stack>
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -13,16 +13,21 @@ import {
     IconArrowUpRight,
     IconCircleCheck,
     IconCircleCheckFilled,
+    IconColumns,
     IconFileDiff,
     IconGitPullRequest,
     IconListCheck,
     IconMessages,
     IconRefresh,
 } from '@tabler/icons-react';
-import { useState, type FC, type ReactNode } from 'react';
+import { useMemo, useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { useAiAgentReviewItemPrDiff } from '../../hooks/useAiAgentAdmin';
+import {
+    useAiAgentReviewItemPrDiff,
+    useProjectUpstreamDiff,
+} from '../../hooks/useAiAgentAdmin';
+import { ReviewFieldsModal } from './ReviewFieldsModal';
 import { ReviewPrDiffModal } from './ReviewPrDiffModal';
 import styles from './ReviewVerificationPanel.module.css';
 
@@ -63,12 +68,14 @@ export const ReviewVerificationPanel: FC<Props> = ({
     onMarkDone,
 }) => {
     const [diffOpened, setDiffOpened] = useState(false);
+    const [fieldsOpened, setFieldsOpened] = useState(false);
     const remediation = reviewItem.remediation ?? null;
     const linkedPrUrl = remediation?.linkedPrUrl ?? null;
     const prNumber = linkedPrUrl ? getPrNumber(linkedPrUrl) : null;
     const isResolved = reviewItem.status === 'resolved';
-    const validatorUrl = remediation?.previewProjectUuid
-        ? `/generalSettings/projectManagement/${remediation.previewProjectUuid}/validator`
+    const previewProjectUuid = remediation?.previewProjectUuid ?? null;
+    const validatorUrl = previewProjectUuid
+        ? `/generalSettings/projectManagement/${previewProjectUuid}/validator`
         : null;
     const sourceThreadUrl =
         remediation &&
@@ -78,6 +85,22 @@ export const ReviewVerificationPanel: FC<Props> = ({
         useAiAgentReviewItemPrDiff(reviewItem.fingerprint, {
             enabled: !!linkedPrUrl,
         });
+
+    const { data: upstreamDiff, isLoading: isLoadingFields } =
+        useProjectUpstreamDiff(previewProjectUuid ?? undefined, {
+            enabled: !!previewProjectUuid,
+        });
+    const fields = useMemo(() => upstreamDiff?.fields ?? [], [upstreamDiff]);
+    const fieldCounts = useMemo(
+        () => ({
+            added: fields.filter((f) => f.change === 'added').length,
+            updated: fields.filter((f) => f.change === 'label_changed').length,
+            removed: fields.filter((f) => f.change === 'removed').length,
+        }),
+        [fields],
+    );
+    const showFieldsRow =
+        !!previewProjectUuid && (isLoadingFields || fields.length > 0);
 
     return (
         <div className={styles.gutter}>
@@ -109,6 +132,32 @@ export const ReviewVerificationPanel: FC<Props> = ({
                 </Text>
 
                 <Stack gap={2}>
+                    {linkedPrUrl && (
+                        <Anchor
+                            className={styles.row}
+                            href={linkedPrUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            underline="never"
+                        >
+                            <Row
+                                icon={IconGitPullRequest}
+                                label={
+                                    prNumber
+                                        ? `Pull request #${prNumber}`
+                                        : 'Pull request'
+                                }
+                                trailing={
+                                    <MantineIcon
+                                        icon={IconArrowUpRight}
+                                        size="sm"
+                                        color="dimmed"
+                                    />
+                                }
+                            />
+                        </Anchor>
+                    )}
+
                     {linkedPrUrl && (
                         <UnstyledButton
                             className={styles.row}
@@ -145,30 +194,52 @@ export const ReviewVerificationPanel: FC<Props> = ({
                         </UnstyledButton>
                     )}
 
-                    {linkedPrUrl && (
-                        <Anchor
+                    {showFieldsRow && (
+                        <UnstyledButton
                             className={styles.row}
-                            href={linkedPrUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            underline="never"
+                            onClick={() => setFieldsOpened(true)}
                         >
                             <Row
-                                icon={IconGitPullRequest}
-                                label={
-                                    prNumber
-                                        ? `Pull request #${prNumber}`
-                                        : 'Pull request'
-                                }
+                                icon={IconColumns}
+                                label="Fields"
                                 trailing={
-                                    <MantineIcon
-                                        icon={IconArrowUpRight}
-                                        size="sm"
-                                        color="dimmed"
-                                    />
+                                    isLoadingFields ? (
+                                        <Loader size={12} color="gray" />
+                                    ) : (
+                                        <Text fz="sm" fw={600}>
+                                            <Text
+                                                span
+                                                fz="sm"
+                                                fw={600}
+                                                c="green.8"
+                                            >
+                                                +{fieldCounts.added}
+                                            </Text>{' '}
+                                            {fieldCounts.updated > 0 && (
+                                                <>
+                                                    <Text
+                                                        span
+                                                        fz="sm"
+                                                        fw={600}
+                                                        c="yellow.8"
+                                                    >
+                                                        ~{fieldCounts.updated}
+                                                    </Text>{' '}
+                                                </>
+                                            )}
+                                            <Text
+                                                span
+                                                fz="sm"
+                                                fw={600}
+                                                c="red.8"
+                                            >
+                                                −{fieldCounts.removed}
+                                            </Text>
+                                        </Text>
+                                    )
                                 }
                             />
-                        </Anchor>
+                        </UnstyledButton>
                     )}
 
                     {validatorUrl && (
@@ -258,6 +329,16 @@ export const ReviewVerificationPanel: FC<Props> = ({
                 diff={prDiff}
                 isLoading={isLoadingPrDiff}
             />
+
+            {previewProjectUuid && (
+                <ReviewFieldsModal
+                    opened={fieldsOpened}
+                    onClose={() => setFieldsOpened(false)}
+                    projectUuid={previewProjectUuid}
+                    fields={fields}
+                    isLoading={isLoadingFields}
+                />
+            )}
         </div>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -12,6 +12,7 @@ import {
     type ApiAiAgentSummaryResponse,
     type ApiAiAgentVerifiedArtifactsResponse,
     type ApiError,
+    type ApiUpstreamDiffResponse,
     type UpdateAiAgentReviewItemStatus,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
@@ -239,6 +240,30 @@ export const useAiAgentReviewItemPrDiff = (
         enabled: options?.enabled ?? true,
         retry: false,
         // Each fetch costs ~2 GitHub API calls per changed file — keep it warm.
+        staleTime: 5 * 60_000,
+    });
+};
+
+const getProjectUpstreamDiff = async (projectUuid: string) => {
+    return lightdashApi<ApiUpstreamDiffResponse['results']>({
+        version: 'v1',
+        url: `/projects/${projectUuid}/upstreamDiff`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+// Diffs a preview project's fields against the project it was copied from.
+// Errors (e.g. project is not a preview) are surfaced via the query state.
+export const useProjectUpstreamDiff = (
+    projectUuid: string | undefined,
+    options?: { enabled?: boolean },
+) => {
+    return useQuery<ApiUpstreamDiffResponse['results'], ApiError>({
+        queryKey: ['project-upstream-diff', projectUuid],
+        queryFn: () => getProjectUpstreamDiff(projectUuid!),
+        enabled: (options?.enabled ?? true) && !!projectUuid,
+        retry: false,
         staleTime: 5 * 60_000,
     });
 };


### PR DESCRIPTION
## Summary

PR 2 of 3. Adds a **Fields** row to the AI review verification card that opens a modal listing the preview's added / updated / removed fields, with a per-added-field **Create chart** shortcut. Also moves the Pull request row to the top of the card.

Stacks on top of PR 1 (#24244), which added the `GET …/upstreamDiff` endpoint this consumes.

## Changes

**Frontend**
- `useProjectUpstreamDiff(projectUuid)` — react-query hook over `GET …/upstreamDiff`.
- `ReviewFieldsModal` — fields grouped by change (Added/Updated/Removed), dimensions before metrics and alphabetical within each, colored `Abc`/`123` type icons, black group headings with a colored `+`/`o`/`−` icon. **Create chart** (revealed on row hover) deep-links into the explorer with the field pre-selected via `create_saved_chart_version` — no chart is persisted.
- `ReviewVerificationPanel` — new **Fields** row (with `+added ~updated −removed` counts) above Validate; Pull request row moved to the top.

## Layout

```
Verification
  ⑂ Pull request #102        ↗
  🗎 Changes          +15 −0
  ▦ Fields        +5 ~3 −2   -> opens modal
  ☑ Validate                 ↗

Fields (modal)
  + Added
      Total Revenue            Create chart
      Guest Checkout Flag      Create chart
  o Updated
      Order Status
  − Removed
      Signup Date
```

## Test plan

- [x] `pnpm -F frontend typecheck:fast`, `pnpm -F frontend lint` (clean for touched files)
- [x] Manual: row shows correct counts; modal groups + sorts fields; Create chart opens the explorer in a new tab with the field selected; row hidden when the project has no upstream/changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)