### PR TITLE
feat: open validator in a modal from AI review card

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
@@ -11,6 +11,14 @@
     flex-direction: column;
 }
 
+.paperFlush {
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+}
+
 .tableContainer {
     max-height: calc(100dvh - 370px);
 }

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -118,6 +118,7 @@ export type ValidatorTableProps = {
     showConfigWarnings: boolean;
     setShowConfigWarnings: (show: boolean) => void;
     lastValidatedAt: Date | null;
+    flush?: boolean;
 };
 
 export const ValidatorTable: FC<ValidatorTableProps> = ({
@@ -138,6 +139,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
     showConfigWarnings,
     setShowConfigWarnings,
     lastValidatedAt,
+    flush = false,
 }) => {
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
@@ -358,7 +360,7 @@ export const ValidatorTable: FC<ValidatorTableProps> = ({
         ),
         mantinePaperProps: {
             shadow: undefined,
-            className: classes.paper,
+            className: flush ? classes.paperFlush : classes.paper,
         },
         mantineTableHeadRowProps: {
             className: classes.headerRow,

--- a/packages/frontend/src/components/SettingsValidator/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/index.tsx
@@ -24,9 +24,10 @@ import { ChartConfigurationErrorModal } from './ValidatorTable/ChartConfiguratio
 import { FixDashboardFilterModal } from './ValidatorTable/FixDashboardFilterModal';
 import { FixValidationErrorModal } from './ValidatorTable/FixValidationErrorModal';
 
-export const SettingsValidator: FC<{ projectUuid: string }> = ({
-    projectUuid,
-}) => {
+export const SettingsValidator: FC<{
+    projectUuid: string;
+    flush?: boolean;
+}> = ({ projectUuid, flush = false }) => {
     const [isValidating, setIsValidating] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch] = useDebouncedValue(searchQuery, 300);
@@ -120,22 +121,24 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                     setSelectedConfigError(undefined);
                 }}
             />
-            <Group gap="md" justify="space-between" mb="md">
-                <Text c="dimmed">
-                    Use the project validator to check what content is broken in
-                    your project.
-                </Text>
-                <Button
-                    size="xs"
-                    onClick={() => {
-                        setIsValidating(true);
-                        validateProject();
-                    }}
-                    loading={isValidating}
-                >
-                    Run validation
-                </Button>
-            </Group>
+            {!flush && (
+                <Group gap="md" justify="space-between" mb="md">
+                    <Text c="dimmed">
+                        Use the project validator to check what content is
+                        broken in your project.
+                    </Text>
+                    <Button
+                        size="xs"
+                        onClick={() => {
+                            setIsValidating(true);
+                            validateProject();
+                        }}
+                        loading={isValidating}
+                    >
+                        Run validation
+                    </Button>
+                </Group>
+            )}
 
             {isLoading ? (
                 <Paper withBorder shadow="sm">
@@ -177,6 +180,7 @@ export const SettingsValidator: FC<{ projectUuid: string }> = ({
                     showConfigWarnings={showConfigWarnings}
                     setShowConfigWarnings={setShowConfigWarnings}
                     lastValidatedAt={lastValidatedAt}
+                    flush={flush}
                 />
             ) : (
                 <Paper withBorder shadow="sm">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewValidationModal.tsx
@@ -1,0 +1,29 @@
+import { IconListCheck } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { SettingsValidator } from '../../../../../components/SettingsValidator';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+};
+
+export const ReviewValidationModal: FC<Props> = ({
+    opened,
+    onClose,
+    projectUuid,
+}) => {
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Validator"
+            icon={IconListCheck}
+            size="80vw"
+            modalBodyProps={{ px: 0, py: 0 }}
+        >
+            <SettingsValidator projectUuid={projectUuid} flush />
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -23,12 +23,14 @@ import {
 import { useMemo, useState, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useProjectValidation } from '../../../../../hooks/validation/useValidation';
 import {
     useAiAgentReviewItemPrDiff,
     useProjectUpstreamDiff,
 } from '../../hooks/useAiAgentAdmin';
 import { ReviewFieldsModal } from './ReviewFieldsModal';
 import { ReviewPrDiffModal } from './ReviewPrDiffModal';
+import { ReviewValidationModal } from './ReviewValidationModal';
 import styles from './ReviewVerificationPanel.module.css';
 
 type Props = {
@@ -69,14 +71,12 @@ export const ReviewVerificationPanel: FC<Props> = ({
 }) => {
     const [diffOpened, setDiffOpened] = useState(false);
     const [fieldsOpened, setFieldsOpened] = useState(false);
+    const [validationOpened, setValidationOpened] = useState(false);
     const remediation = reviewItem.remediation ?? null;
     const linkedPrUrl = remediation?.linkedPrUrl ?? null;
     const prNumber = linkedPrUrl ? getPrNumber(linkedPrUrl) : null;
     const isResolved = reviewItem.status === 'resolved';
     const previewProjectUuid = remediation?.previewProjectUuid ?? null;
-    const validatorUrl = previewProjectUuid
-        ? `/generalSettings/projectManagement/${previewProjectUuid}/validator`
-        : null;
     const sourceThreadUrl =
         remediation &&
         `/projects/${remediation.sourceProjectUuid}/ai-agents/${remediation.sourceAgentUuid}/threads/${remediation.sourceThreadUuid}`;
@@ -101,6 +101,10 @@ export const ReviewVerificationPanel: FC<Props> = ({
     );
     const showFieldsRow =
         !!previewProjectUuid && (isLoadingFields || fields.length > 0);
+
+    const { data: validationErrors, isLoading: isLoadingValidation } =
+        useProjectValidation(previewProjectUuid);
+    const validationErrorCount = validationErrors?.length ?? 0;
 
     return (
         <div className={styles.gutter}>
@@ -242,25 +246,33 @@ export const ReviewVerificationPanel: FC<Props> = ({
                         </UnstyledButton>
                     )}
 
-                    {validatorUrl && (
-                        <Anchor
+                    {previewProjectUuid && (
+                        <UnstyledButton
                             className={styles.row}
-                            component={Link}
-                            to={validatorUrl}
-                            underline="never"
+                            onClick={() => setValidationOpened(true)}
                         >
                             <Row
                                 icon={IconListCheck}
-                                label="Validate"
+                                label="Validator"
                                 trailing={
-                                    <MantineIcon
-                                        icon={IconArrowUpRight}
-                                        size="sm"
-                                        color="dimmed"
-                                    />
+                                    isLoadingValidation ? (
+                                        <Loader size={12} color="gray" />
+                                    ) : (
+                                        <Text
+                                            fz="sm"
+                                            fw={600}
+                                            c={
+                                                validationErrorCount > 0
+                                                    ? 'red.8'
+                                                    : 'green.8'
+                                            }
+                                        >
+                                            {validationErrorCount}
+                                        </Text>
+                                    )
                                 }
                             />
-                        </Anchor>
+                        </UnstyledButton>
                     )}
 
                     {sourceThreadUrl && (
@@ -337,6 +349,14 @@ export const ReviewVerificationPanel: FC<Props> = ({
                     projectUuid={previewProjectUuid}
                     fields={fields}
                     isLoading={isLoadingFields}
+                />
+            )}
+
+            {previewProjectUuid && (
+                <ReviewValidationModal
+                    opened={validationOpened}
+                    onClose={() => setValidationOpened(false)}
+                    projectUuid={previewProjectUuid}
                 />
             )}
         </div>


### PR DESCRIPTION
## Summary

PR 3 of 3. Turns the verification card's **Validate** entry from a redirect to the project-settings validator page into an in-place **Validator** modal that embeds the existing validator table, and surfaces the preview's validation-error count on the row.

Stacks on top of PR 2 (#24245).

## Changes

**Frontend**
- `ReviewValidationModal` — full-bleed modal rendering the existing `SettingsValidator` for the preview project (its search/source/warnings toolbar, error table, and fix flows come for free).
- `SettingsValidator` + `ValidatorTable` gain an opt-in `flush` prop (default `false`, so the settings page is unchanged) that hides the page header and drops the table's outer border/shadow/radius for embedding.
- `ReviewVerificationPanel` — the Validate row becomes a button opening the modal, labelled **Validator**, with a trailing error count (red when > 0, green `0`); reuses `useProjectValidation`.

## Before / after

```
Before:  ☑ Validate   ↗   (navigates to /generalSettings/.../validator)
After:   ☑ Validator  3       (opens modal; 3 = validation error count)
```

## Test plan

- [x] `pnpm -F frontend typecheck:fast`, `pnpm -F frontend lint` (clean for touched files)
- [x] `flush` defaults off — settings validator page renders unchanged (header + bordered table)
- [x] Manual: row shows error count; modal opens the validator table for the preview; search/filter/fix flows work inside the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)