### PR TITLE
fix: widen slack profile photo url column to prevent save error

### DIFF
--- a/packages/backend/src/database/migrations/20260612151235_widen_slack_app_profile_photo_url.ts
+++ b/packages/backend/src/database/migrations/20260612151235_widen_slack_app_profile_photo_url.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const SlackAuthTokensTableName = 'slack_auth_tokens';
+
+// Profile photo URLs (e.g. signed CDN/object-storage URLs) can exceed the
+// varchar(255) Knex default, which caused saves to fail. 2048 is the de-facto
+// safe URL length. Widening is a metadata-only change in Postgres (no rewrite).
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.string('app_profile_photo_url', 2048).nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SlackAuthTokensTableName, (table) => {
+        table.string('app_profile_photo_url', 255).nullable().alter();
+    });
+}

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -52,7 +52,11 @@ const SLACK_INSTALL_URL = `/api/v1/slack/install/`;
 
 const formSchema = z.object({
     notificationChannel: z.string().min(1).nullable(),
-    appProfilePhotoUrl: z.string().url().nullable(),
+    appProfilePhotoUrl: z
+        .string()
+        .url({ message: 'Enter a valid URL' })
+        .max(2048, { message: 'URL must be 2048 characters or fewer' })
+        .nullable(),
     slackChannelProjectMappings: z.array(
         z.object({
             projectUuid: z


### PR DESCRIPTION
## What & why

The `app_profile_photo_url` column on `slack_auth_tokens` used Knex's default `varchar(255)`, so a long but valid profile-photo URL (e.g. a signed CDN/object-storage URL) overflowed the column and `PUT /slack/custom-settings` failed with a 500.

## Changes

- **Migration**: widen `app_profile_photo_url` to `varchar(2048)` (the de-facto safe URL length). This is a metadata-only change in Postgres — no table rewrite.
- **Frontend**: add a matching `.max(2048)` to the Slack settings Zod schema so an over-long URL surfaces an inline validation message instead of triggering the "Failed to update Slack app settings" server-error toast.

## Testing

- Migration applied locally; column confirmed at `varchar(2048)`.
- Backend + frontend typecheck and lint pass on the changed files.

Closes: #24242