### PR TITLE
feat(ai-review): show write-back PR check status in verification panel

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -1,4 +1,4 @@
-import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { CiCheckState, type AiAgentReviewItemSummary } from '@lightdash/common';
 import {
     Anchor,
     Button,
@@ -11,6 +11,7 @@ import {
 } from '@mantine-8/core';
 import {
     IconArrowUpRight,
+    IconChecks,
     IconCircleCheck,
     IconCircleCheckFilled,
     IconColumns,
@@ -28,6 +29,7 @@ import {
     useAiAgentReviewItemPrDiff,
     useProjectUpstreamDiff,
 } from '../../hooks/useAiAgentAdmin';
+import { usePullRequestCiChecks } from '../../hooks/usePullRequestCiChecks';
 import { ReviewFieldsModal } from './ReviewFieldsModal';
 import { ReviewPrDiffModal } from './ReviewPrDiffModal';
 import { ReviewValidationModal } from './ReviewValidationModal';
@@ -45,6 +47,21 @@ type Props = {
 const getPrNumber = (prUrl: string): string | null => {
     const match = prUrl.match(/\/pull\/(\d+)/);
     return match ? match[1] : null;
+};
+
+// A single colour-coded phrase for the Checks row, prioritising whatever needs
+// attention: failures first, then in-flight runs, else all passed.
+const summariseChecks = (
+    checks: { state: CiCheckState }[],
+): { color: string; label: string } | null => {
+    if (checks.length === 0) return null;
+    const count = (state: CiCheckState) =>
+        checks.filter((c) => c.state === state).length;
+    const failed = count(CiCheckState.FAILURE);
+    const pending = count(CiCheckState.PENDING);
+    if (failed > 0) return { color: 'red.8', label: `${failed} failing` };
+    if (pending > 0) return { color: 'yellow.8', label: `${pending} running` };
+    return { color: 'green.8', label: `${checks.length} passed` };
 };
 
 const Row: FC<{
@@ -85,6 +102,16 @@ export const ReviewVerificationPanel: FC<Props> = ({
         useAiAgentReviewItemPrDiff(reviewItem.fingerprint, {
             enabled: !!linkedPrUrl,
         });
+
+    // The write-back PR lives in the source project's git repo, so its
+    // installation resolves the CI checks. No commit is pinned here — the
+    // backend falls back to the PR's live head.
+    const { data: ciChecks } = usePullRequestCiChecks(
+        remediation?.sourceProjectUuid,
+        linkedPrUrl,
+        null,
+    );
+    const checksSummary = ciChecks ? summariseChecks(ciChecks.checks) : null;
 
     const { data: upstreamDiff, isLoading: isLoadingFields } =
         useProjectUpstreamDiff(previewProjectUuid ?? undefined, {
@@ -196,6 +223,30 @@ export const ReviewVerificationPanel: FC<Props> = ({
                                 }
                             />
                         </UnstyledButton>
+                    )}
+
+                    {linkedPrUrl && checksSummary && (
+                        <Anchor
+                            className={styles.row}
+                            href={`${linkedPrUrl}/checks`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            underline="never"
+                        >
+                            <Row
+                                icon={IconChecks}
+                                label="Checks"
+                                trailing={
+                                    <Text
+                                        fz="sm"
+                                        fw={600}
+                                        c={checksSummary.color}
+                                    >
+                                        {checksSummary.label}
+                                    </Text>
+                                }
+                            />
+                        </Anchor>
                     )}
 
                     {showFieldsRow && (


### PR DESCRIPTION
## Description

Adds a **Checks** row to the AI review Verification panel showing the CI status of the write-back pull request. It reuses the existing `/ai-writeback/ci-checks` endpoint (and its 15s polling), so the count updates live while checks run, then settles. The row links to the PR's checks page on GitHub and hides entirely when the PR has no CI configured.

Ports the GitHub Actions status already shown on write-back PR cards in the agent chat to the review verification panel — no backend or API change.

The icon is the same neutral `IconChecks` used by the panel's other rows; only the count on the right carries colour, prioritising whatever needs attention:

```
Pull request #112        ↗
Changes               +8 −0
Checks              3 passed     ← green   (all passed)
Checks              2 failing    ← red     (any failure)
Checks              2 running    ← yellow  (any in-flight)
Fields               +5 ~1 −0
Validator               0
```

## Test plan

- [ ] Open a review thread whose remediation PR has GitHub Actions — the Checks row appears with a coloured count and links to `<pr>/checks`.
- [ ] While a check is running, the count reads "N running" and refreshes (~15s) to "N passed" / "N failing" without a reload.
- [ ] A PR with no CI configured shows no Checks row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)