### PR TITLE
fix(ai-review): exclude config warnings from validator count

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -1,4 +1,8 @@
-import { CiCheckState, type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    CiCheckState,
+    ValidationErrorType,
+    type AiAgentReviewItemSummary,
+} from '@lightdash/common';
 import {
     Anchor,
     Button,
@@ -131,7 +135,12 @@ export const ReviewVerificationPanel: FC<Props> = ({
 
     const { data: validationErrors, isLoading: isLoadingValidation } =
         useProjectValidation(previewProjectUuid);
-    const validationErrorCount = validationErrors?.length ?? 0;
+    // Match the validator modal, which hides chart-configuration warnings by
+    // default — so the count here lines up with what the modal shows.
+    const validationErrorCount =
+        validationErrors?.filter(
+            (e) => e.errorType !== ValidationErrorType.ChartConfiguration,
+        ).length ?? 0;
 
     return (
         <div className={styles.gutter}>


### PR DESCRIPTION
## Summary

The Verification panel's **Validator** row showed `7` for a preview project while the validator modal showed `2` for the same project. The row counted chart-configuration warnings that the modal hides by default, so the two surfaces disagreed.

## Root cause

The row counts the raw result of `useProjectValidation` (`GET /validate?fromSettings=false`), which returns every validation result — including `chart configuration` warnings. The validator modal (`SettingsValidator`) fetches with `includeChartConfigWarnings: false` (its `showConfigWarnings` toggle defaults off), so it excludes them. The two counted different sets.

```ts
// ReviewVerificationPanel.tsx — counted all results, warnings included
const validationErrorCount = validationErrors?.length ?? 0; // 7
```

## Fix

Exclude `ChartConfiguration` warnings from the count so it matches the validator modal's default view.

- `ReviewVerificationPanel.tsx` — filter `ValidationErrorType.ChartConfiguration` out of `validationErrorCount`.

The modal's "show config warnings" toggle is unchanged; the row mirrors its default (off).

## Before / After

```
Validation results for the preview project (7 total)
  chart configuration  ▮▮▮▮▮  5   ← hidden by modal, now excluded from row
  metric               ▮      1   ← real error, kept
  chart (on dashboard) ▮      1   ← real error, kept

Validator row:   before 7   →   after 2   (now matches the modal)
```

## Test plan

- [x] `pnpm -F frontend lint`
- [x] Verified against live data: v1 `/validate` returns 7 (5 config warnings + 1 metric + 1 chart); filtered count = 2.
- [ ] Manual: open a review thread whose preview project has config warnings — Validator reads 2, matching the modal.
- [ ] Manual: enable "show config warnings" in the modal — modal grows; the row stays at the real-error count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)