### PR TITLE
fix: import moment-timezone in time.ts so CLI compile of inThePast timestamp filters works

### DIFF
--- a/packages/common/src/utils/time.ts
+++ b/packages/common/src/utils/time.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { isWeekDay, type WeekDay } from './timeFrames';
 
 // from 0 (Monday) to 6 (Sunday) to 0 (Sunday) to 6 (Saturday)


### PR DESCRIPTION
## Summary

`lightdash compile` in the CLI crashes with `getMomentDateWithCustomStartOfWeek(...).tz is not a function` when a dbt metric defines an `inThePast` filter against a `timestamp` dimension.

`getMomentDateWithCustomStartOfWeek` (in `packages/common/src/utils/time.ts`) imported plain `moment`, whose objects have no `.tz()` method. `filtersCompiler.ts` calls `.tz(timezone)` on that result in the relative-date operator paths (`IN_THE_PAST` etc.).

`.tz` only exists once `moment-timezone` has patched the shared `moment` singleton. On the server and frontend that always happens (moment-timezone is loaded elsewhere first), so the bug is invisible there. In the **ncc-bundled CLI**, `time.ts`'s `moment` reference isn't guaranteed to be the patched one at call time, so `.tz` is `undefined` and compile crashes.

## Fix

Import `moment-timezone` in `time.ts` (the package is already a dependency and is already imported by other files in `common`, including `filtersCompiler.ts`). This guarantees `.tz` is present regardless of bundling/load order.

## Notes

- **why** — the plain-`moment` import dates to 2023. The crash only became reachable when `.tz()` was applied to the `IN_THE_PAST` path (#21637, Apr 2026), which is why reports only surfaced recently and only via the CLI.

Closes #24176