### PR TITLE
feat(ai-review): PR activity feed + thread PR overview card

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -382,6 +382,8 @@ import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTable,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationEventsTable,
+    AiAgentReviewRemediationEventsTableName,
     AiAgentReviewRemediationTable,
     AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTable,
@@ -556,6 +558,7 @@ declare module 'knex/types/tables' {
         [AiAgentTurnSignalTableName]: AiAgentTurnSignalTable;
         [AiAgentReviewItemTableName]: AiAgentReviewItemTable;
         [AiAgentReviewRemediationTableName]: AiAgentReviewRemediationTable;
+        [AiAgentReviewRemediationEventsTableName]: AiAgentReviewRemediationEventsTable;
         [AiAgentGroupAccessTableName]: AiAgentGroupAccessTable;
         [AiAgentIntegrationTableName]: AiAgentIntegrationTable;
         [AiAgentSlackIntegrationTableName]: AiAgentSlackIntegrationTable;

--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -850,6 +850,10 @@ export const getPullRequest = async ({
      */
     mergeableState: string;
     draft: boolean;
+    title: string;
+    additions: number;
+    deletions: number;
+    changedFiles: number;
 }> => {
     const { octokit, headers } = getOctokit(installationId, token);
 
@@ -869,6 +873,10 @@ export const getPullRequest = async ({
             mergeable: response.data.mergeable,
             mergeableState: response.data.mergeable_state,
             draft: response.data.draft === true,
+            title: response.data.title,
+            additions: response.data.additions,
+            deletions: response.data.deletions,
+            changedFiles: response.data.changed_files,
         };
     } catch (e) {
         throw new UnexpectedGitError(getErrorMessage(e));

--- a/packages/backend/src/database/entities/pullRequests.ts
+++ b/packages/backend/src/database/entities/pullRequests.ts
@@ -14,6 +14,7 @@ export type DbPullRequest = {
     repo: string;
     pr_number: number;
     pr_url: string;
+    summary: string | null;
     created_at: Date;
 };
 
@@ -31,5 +32,7 @@ export type PullRequestsTable = Knex.CompositeTableType<
         | 'repo'
         | 'pr_number'
         | 'pr_url'
-    >
+    > &
+        Partial<Pick<DbPullRequest, 'summary'>>,
+    Pick<DbPullRequest, 'summary'>
 >;

--- a/packages/backend/src/database/migrations/20260612160001_add_summary_to_pull_requests.ts
+++ b/packages/backend/src/database/migrations/20260612160001_add_summary_to_pull_requests.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const pullRequestsTable = 'pull_requests';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(pullRequestsTable, (table) => {
+        table.text('summary').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(pullRequestsTable, (table) => {
+        table.dropColumn('summary');
+    });
+}

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -3,6 +3,7 @@ import {
     AiAgentAdminSort,
     AiAgentReviewItemStatus,
     ApiAiAgentAdminConversationsResponse,
+    ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemResponse,
     ApiAiAgentReviewItemsResponse,
@@ -181,6 +182,29 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results: await this.getAiAgentAdminService().getReviewItem(
+                toSessionUser(req.account),
+                fingerprint,
+            ),
+        };
+    }
+
+    /**
+     * Get the remediation activity feed for a review item
+     * @summary Get AI agent review item activity
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-items/{fingerprint}/activity')
+    @OperationId('getAiAgentReviewItemActivity')
+    async getReviewItemActivity(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+    ): Promise<ApiAiAgentReviewItemActivityResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().getReviewItemActivity(
                 toSessionUser(req.account),
                 fingerprint,
             ),

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -24,6 +24,7 @@ import {
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
+    ApiAiAgentThreadPullRequestResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadShareResponse,
     ApiAiAgentThreadStreamRequest,
@@ -749,6 +750,33 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: await this.getAiAgentService().getAgentThread(
+                toSessionUser(req.account),
+                agentUuid,
+                threadUuid,
+            ),
+        };
+    }
+
+    /**
+     * Get the writeback pull request associated with a thread — the PR the
+     * agent opened in this thread, or the PR a verification thread verifies.
+     * @summary Get AI agent thread pull request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{agentUuid}/threads/{threadUuid}/pull-request')
+    @OperationId('getAgentThreadPullRequest')
+    async getAgentThreadPullRequest(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+    ): Promise<ApiAiAgentThreadPullRequestResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentService().getThreadPullRequest(
                 toSessionUser(req.account),
                 agentUuid,
                 threadUuid,

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -15,6 +15,8 @@ import type {
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemWritebackStatus,
+    AiAgentReviewRemediationEventDetail,
+    AiAgentReviewRemediationEventType,
     AiAgentReviewRemediationStatus,
     AiAgentRootCause,
     AiAgentRuntimeContextSnapshot,
@@ -171,6 +173,37 @@ export type AiAgentTurnSignalTable = Knex.CompositeTableType<
 
 export const AiAgentReviewItemTableName = 'ai_agent_review_item';
 export const AiAgentReviewRemediationTableName = 'ai_agent_review_remediation';
+export const AiAgentReviewRemediationEventsTableName =
+    'ai_agent_review_remediation_events';
+
+export type DbAiAgentReviewRemediationEvent = {
+    ai_agent_review_remediation_event_uuid: string;
+    ai_agent_review_remediation_uuid: string;
+    organization_uuid: string;
+    event_type: AiAgentReviewRemediationEventType;
+    occurred_at: Date;
+    payload: AiAgentReviewRemediationEventDetail['payload'];
+    created_by_user_uuid: string | null;
+    created_at: Date;
+};
+
+export type AiAgentReviewRemediationEventsTable = Knex.CompositeTableType<
+    DbAiAgentReviewRemediationEvent,
+    Pick<
+        DbAiAgentReviewRemediationEvent,
+        | 'ai_agent_review_remediation_uuid'
+        | 'organization_uuid'
+        | 'event_type'
+        | 'occurred_at'
+    > &
+        Partial<
+            Pick<
+                DbAiAgentReviewRemediationEvent,
+                'payload' | 'created_by_user_uuid'
+            >
+        >,
+    never
+>;
 
 export type DbAiAgentReviewItem = {
     ai_agent_review_item_uuid: string;

--- a/packages/backend/src/ee/database/migrations/20260612160000_add_ai_agent_review_remediation_events.ts
+++ b/packages/backend/src/ee/database/migrations/20260612160000_add_ai_agent_review_remediation_events.ts
@@ -1,0 +1,53 @@
+import { Knex } from 'knex';
+
+const eventsTable = 'ai_agent_review_remediation_events';
+const remediationTable = 'ai_agent_review_remediation';
+const organizationsTable = 'organizations';
+const usersTable = 'users';
+const eventsByRemediationIndex =
+    'ai_agent_review_remediation_events_remediation_occurred_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(eventsTable, (table) => {
+        table
+            .uuid('ai_agent_review_remediation_event_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_agent_review_remediation_uuid')
+            .notNullable()
+            .references('ai_agent_review_remediation_uuid')
+            .inTable(remediationTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE')
+            .index();
+        table.text('event_type').notNullable();
+        table.timestamp('occurred_at', { useTz: true }).notNullable();
+        table.jsonb('payload').notNullable().defaultTo('{}');
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(
+            ['ai_agent_review_remediation_uuid', 'occurred_at'],
+            eventsByRemediationIndex,
+        );
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(eventsTable);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -307,6 +307,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getGithubAppInstallationsModel(),
                     aiAgentToolsService:
                         repository.getAiAgentToolsService<AiAgentToolsService>(),
+                    pullRequestsModel: models.getPullRequestsModel(),
+                    aiAgentReviewClassifierModel:
+                        models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, repository, context, clients }) =>

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -5,6 +5,7 @@ import { AiPromptTableName } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationEventsTableName,
     AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
 } from '../database/entities/aiAgentReviewClassifier';
@@ -23,6 +24,7 @@ const TURN_SIGNAL_UUID = '00000000-0000-0000-0000-000000000009';
 const REMEDIATION_UUID = '00000000-0000-0000-0000-000000000010';
 const PULL_REQUEST_UUID = '00000000-0000-0000-0000-000000000011';
 const PREVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000012';
+const USER_UUID = '00000000-0000-0000-0000-000000000013';
 const PREVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000013';
 const PREVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000014';
 const SEEN_AT = new Date('2026-05-26T10:00:00.000Z');
@@ -215,6 +217,148 @@ describe('AiAgentReviewClassifierModel', () => {
             const [query] = tracker.history.select;
             expect(query.sql).toContain('project_type');
             expect(query.bindings).toContain(ProjectType.PREVIEW);
+        });
+    });
+
+    describe('remediation events', () => {
+        it('emits a failed event when a remediation is marked failed', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(1);
+            tracker.on
+                .insert(AiAgentReviewRemediationEventsTableName)
+                .responseOnce([]);
+
+            await model.updateReviewRemediationStatus({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                status: 'failed',
+                errorMessage: 'Preview project failed to compile',
+            });
+
+            const [insert] = tracker.history.insert;
+            expect(insert.sql).toContain(
+                AiAgentReviewRemediationEventsTableName,
+            );
+            expect(insert.bindings).toContain('failed');
+            expect(
+                insert.bindings.some(
+                    (b: unknown) =>
+                        typeof b === 'string' &&
+                        b.includes('Preview project failed to compile'),
+                ),
+            ).toBe(true);
+        });
+
+        it('emits a resolved event with the resolving user as actor', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(1);
+            tracker.on
+                .insert(AiAgentReviewRemediationEventsTableName)
+                .responseOnce([]);
+
+            await model.updateReviewRemediationStatus({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                status: 'resolved',
+                resolvedByUserUuid: USER_UUID,
+            });
+
+            const [insert] = tracker.history.insert;
+            expect(insert.bindings).toContain('resolved');
+            expect(insert.bindings).toContain(USER_UUID);
+        });
+
+        it('does not emit an event when no remediation row matched', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(0);
+
+            await model.updateReviewRemediationStatus({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                status: 'failed',
+                errorMessage: 'boom',
+            });
+
+            expect(tracker.history.insert).toHaveLength(0);
+        });
+
+        it('does not emit events for non-terminal status updates', async () => {
+            tracker.on
+                .update(AiAgentReviewRemediationTableName)
+                .responseOnce(1);
+
+            await model.updateReviewRemediationStatus({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                status: 'running',
+            });
+
+            expect(tracker.history.insert).toHaveLength(0);
+        });
+
+        it('creates a moment event with an explicit occurred_at', async () => {
+            tracker.on
+                .insert(AiAgentReviewRemediationEventsTableName)
+                .responseOnce([]);
+            const occurredAt = new Date('2026-06-12T10:40:41.000Z');
+
+            await model.createRemediationEvent({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                event: {
+                    eventType: 'preview_compiled',
+                    payload: { previewProjectUuid: PROJECT_UUID },
+                },
+                occurredAt,
+            });
+
+            const [insert] = tracker.history.insert;
+            expect(insert.bindings).toContain('preview_compiled');
+            expect(insert.bindings).toContainEqual(occurredAt);
+        });
+
+        it('lists remediation events ordered by occurrence', async () => {
+            tracker.on
+                .select(AiAgentReviewRemediationEventsTableName)
+                .responseOnce([
+                    {
+                        ai_agent_review_remediation_event_uuid: 'event-1',
+                        ai_agent_review_remediation_uuid: REMEDIATION_UUID,
+                        organization_uuid: ORGANIZATION_UUID,
+                        event_type: 'pr_opened',
+                        occurred_at: SEEN_AT,
+                        payload: {
+                            prUrl: 'https://github.com/acme/dbt/pull/42',
+                            prNumber: 42,
+                        },
+                        created_by_user_uuid: null,
+                        created_at: SEEN_AT,
+                    },
+                ]);
+
+            const events = await model.listRemediationEvents({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain('occurred_at');
+            expect(events).toEqual([
+                {
+                    uuid: 'event-1',
+                    remediationUuid: REMEDIATION_UUID,
+                    eventType: 'pr_opened',
+                    occurredAt: SEEN_AT,
+                    payload: {
+                        prUrl: 'https://github.com/acme/dbt/pull/42',
+                        prNumber: 42,
+                    },
+                    createdByUserUuid: null,
+                },
+            ]);
         });
     });
 

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -22,6 +22,8 @@ import type {
     AiAgentReviewItemWritebackEligibility,
     AiAgentReviewItemWritebackStatus,
     AiAgentReviewRemediation,
+    AiAgentReviewRemediationEvent,
+    AiAgentReviewRemediationEventDetail,
     AiAgentReviewRemediationStatus,
     AiAgentReviewSignalSummary,
     AiAgentRootCause,
@@ -44,15 +46,18 @@ import {
 import {
     AiAgentReviewClassifierRunTableName,
     AiAgentReviewItemTableName,
+    AiAgentReviewRemediationEventsTableName,
     AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
     type AiAgentReviewClassifierRunTable,
     type AiAgentReviewItemTable,
+    type AiAgentReviewRemediationEventsTable,
     type AiAgentReviewRemediationTable,
     type AiAgentTurnSignalTable,
     type DbAiAgentReviewClassifierRun,
     type DbAiAgentReviewItem,
     type DbAiAgentReviewRemediation,
+    type DbAiAgentReviewRemediationEvent,
     type DbAiAgentTurnSignal,
 } from '../database/entities/aiAgentReviewClassifier';
 
@@ -1332,7 +1337,7 @@ export class AiAgentReviewClassifierModel {
     async updateReviewRemediationStatus(
         args: UpdateReviewRemediationStatusArgs,
     ): Promise<void> {
-        await this.database<AiAgentReviewRemediationTable>(
+        const updatedCount = await this.database<AiAgentReviewRemediationTable>(
             AiAgentReviewRemediationTableName,
         )
             .where('ai_agent_review_remediation_uuid', args.remediationUuid)
@@ -1350,6 +1355,77 @@ export class AiAgentReviewClassifierModel {
                         : null,
                 updated_at: this.database.fn.now() as never,
             });
+
+        // Terminal transitions emit activity events centrally so no call site
+        // can forget; moment events (pr_opened, preview_compiled, …) are
+        // written by the services where the moment happens.
+        if (updatedCount === 0) {
+            return;
+        }
+        if (args.status === 'resolved') {
+            await this.createRemediationEvent({
+                remediationUuid: args.remediationUuid,
+                organizationUuid: args.organizationUuid,
+                event: { eventType: 'resolved', payload: {} },
+                createdByUserUuid: args.resolvedByUserUuid ?? null,
+            });
+        } else if (args.status === 'failed') {
+            await this.createRemediationEvent({
+                remediationUuid: args.remediationUuid,
+                organizationUuid: args.organizationUuid,
+                event: {
+                    eventType: 'failed',
+                    payload: { errorMessage: args.errorMessage ?? null },
+                },
+            });
+        }
+    }
+
+    async createRemediationEvent(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+        event: AiAgentReviewRemediationEventDetail;
+        occurredAt?: Date;
+        createdByUserUuid?: string | null;
+    }): Promise<void> {
+        await this.database<AiAgentReviewRemediationEventsTable>(
+            AiAgentReviewRemediationEventsTableName,
+        ).insert({
+            ai_agent_review_remediation_uuid: args.remediationUuid,
+            organization_uuid: args.organizationUuid,
+            event_type: args.event.eventType,
+            payload: args.event.payload,
+            occurred_at: args.occurredAt ?? (this.database.fn.now() as never),
+            created_by_user_uuid: args.createdByUserUuid ?? null,
+        });
+    }
+
+    async listRemediationEvents(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+    }): Promise<AiAgentReviewRemediationEvent[]> {
+        const rows = await this.database<AiAgentReviewRemediationEventsTable>(
+            AiAgentReviewRemediationEventsTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .orderBy('occurred_at', 'asc')
+            .select('*');
+
+        return rows.map(AiAgentReviewClassifierModel.mapRemediationEvent);
+    }
+
+    private static mapRemediationEvent(
+        row: DbAiAgentReviewRemediationEvent,
+    ): AiAgentReviewRemediationEvent {
+        return {
+            uuid: row.ai_agent_review_remediation_event_uuid,
+            remediationUuid: row.ai_agent_review_remediation_uuid,
+            occurredAt: row.occurred_at,
+            createdByUserUuid: row.created_by_user_uuid,
+            eventType: row.event_type,
+            payload: row.payload,
+        } as AiAgentReviewRemediationEvent;
     }
 
     /**

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -127,6 +127,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                             await this.aiAgentService.executeReviewRemediationRun(
                                 payload,
                             );
+                            await this.aiAgentAdminService.recordReviewRemediationVerified(
+                                payload,
+                            );
                         },
                     ),
                     helpers.job,

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -190,6 +190,7 @@ const makeService = ({
             setReviewItemWritebackStatus: jest
                 .fn()
                 .mockResolvedValue(undefined),
+            createRemediationEvent: jest.fn().mockResolvedValue(undefined),
             ...aiAgentReviewClassifierModel,
         },
         featureFlagService: {
@@ -244,6 +245,9 @@ const makeService = ({
             aiAgentReviewRemediationPreview: jest
                 .fn()
                 .mockResolvedValue(undefined),
+            aiAgentReviewRemediationCompile: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
             aiAgentReviewRemediationRun: jest
                 .fn()
                 .mockResolvedValue({ jobId: 'job-1' }),
@@ -772,6 +776,144 @@ describe('AiAgentAdminService.pollReviewRemediationPreview', () => {
     });
 });
 
+describe('AiAgentAdminService.getReviewItemActivity', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const makeEvent = (eventType: string, payload = {}) => ({
+        uuid: `event-${eventType}`,
+        remediationUuid: REMEDIATION_UUID,
+        eventType,
+        occurredAt: NOW,
+        payload,
+        createdByUserUuid: null,
+    });
+
+    it('returns a writeback live state with the live progress message', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest.fn().mockResolvedValue(
+                makeReviewItem({
+                    prWritebackMessage: 'Reading payments.yml',
+                    remediation: makeRemediation({ status: 'running' }),
+                }),
+            ),
+            listRemediationEvents: jest
+                .fn()
+                .mockResolvedValue([makeEvent('finding_opened')]),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.liveState).toBe('writeback');
+        expect(activity.liveMessage).toBe('Reading payments.yml');
+    });
+
+    it('returns events with a compiling live state before the preview compiles', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest.fn().mockResolvedValue(
+                makeReviewItem({
+                    remediation: makeRemediation({ status: 'pr_open' }),
+                }),
+            ),
+            listRemediationEvents: jest
+                .fn()
+                .mockResolvedValue([
+                    makeEvent('finding_opened'),
+                    makeEvent('pr_opened'),
+                ]),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.events).toHaveLength(2);
+        expect(activity.liveState).toBe('compiling');
+    });
+
+    it('returns a verifying live state after the preview compiles', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest.fn().mockResolvedValue(
+                makeReviewItem({
+                    remediation: makeRemediation({ status: 'preview_ready' }),
+                }),
+            ),
+            listRemediationEvents: jest
+                .fn()
+                .mockResolvedValue([
+                    makeEvent('finding_opened'),
+                    makeEvent('pr_opened'),
+                    makeEvent('preview_compiled'),
+                ]),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.liveState).toBe('verifying');
+    });
+
+    it('returns no live state once verification completed or remediation is terminal', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest.fn().mockResolvedValue(
+                makeReviewItem({
+                    remediation: makeRemediation({ status: 'resolved' }),
+                }),
+            ),
+            listRemediationEvents: jest
+                .fn()
+                .mockResolvedValue([
+                    makeEvent('pr_opened'),
+                    makeEvent('preview_compiled'),
+                    makeEvent('verification_completed'),
+                    makeEvent('resolved'),
+                ]),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.liveState).toBeNull();
+    });
+
+    it('returns an empty feed when the item has no remediation', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest
+                .fn()
+                .mockResolvedValue(makeReviewItem({ remediation: null })),
+            listRemediationEvents: jest.fn(),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity).toEqual({
+            events: [],
+            liveState: null,
+            liveMessage: null,
+        });
+        expect(
+            aiAgentReviewClassifierModel.listRemediationEvents,
+        ).not.toHaveBeenCalled();
+    });
+});
+
 describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
     const payload = {
         fingerprint: 'fingerprint-1',
@@ -822,6 +964,56 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
         expect(
             schedulerClient.aiAgentReviewRemediationRun,
         ).not.toHaveBeenCalled();
+    });
+
+    it('records writeback_completed and pr_opened activity events', async () => {
+        const aiAgentReviewClassifierModel = {
+            createRemediationEvent: jest.fn().mockResolvedValue(undefined),
+        };
+        const aiWritebackService = {
+            run: jest.fn().mockResolvedValue({
+                prUrl: PR_URL,
+                additions: 9,
+                deletions: 1,
+                steps: [
+                    { kind: 'read', label: 'schema.yml' },
+                    { kind: 'edit', label: 'accounts.yml' },
+                ],
+            }),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            aiWritebackService,
+        });
+
+        await service.runReviewItemWritebackJob(payload);
+
+        expect(
+            aiAgentReviewClassifierModel.createRemediationEvent,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                remediationUuid: REMEDIATION_UUID,
+                organizationUuid: ORGANIZATION_UUID,
+                event: {
+                    eventType: 'writeback_completed',
+                    payload: {
+                        files: ['accounts.yml'],
+                        additions: 9,
+                        deletions: 1,
+                    },
+                },
+            }),
+        );
+        expect(
+            aiAgentReviewClassifierModel.createRemediationEvent,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: {
+                    eventType: 'pr_opened',
+                    payload: { prUrl: PR_URL, prNumber: 42 },
+                },
+            }),
+        );
     });
 });
 
@@ -887,6 +1079,32 @@ describe('AiAgentAdminService.pollReviewRemediationCompile', () => {
         expect(
             schedulerClient.aiAgentReviewRemediationCompile,
         ).not.toHaveBeenCalled();
+    });
+
+    it('records a preview_compiled activity event when the compile lands', async () => {
+        const jobModel = {
+            get: jest.fn().mockResolvedValue({ jobStatus: JobStatusType.DONE }),
+        };
+        const aiAgentReviewClassifierModel = {
+            createRemediationEvent: jest.fn().mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            jobModel,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.pollReviewRemediationCompile(payload);
+
+        expect(
+            aiAgentReviewClassifierModel.createRemediationEvent,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            event: {
+                eventType: 'preview_compiled',
+                payload: { previewProjectUuid: PREVIEW_PROJECT_UUID },
+            },
+        });
     });
 
     it('re-enqueues itself while the compile job is still running', async () => {
@@ -991,6 +1209,34 @@ describe('AiAgentAdminService.pollReviewRemediationCompile', () => {
         expect(
             schedulerClient.aiAgentReviewRemediationCompile,
         ).not.toHaveBeenCalled();
+    });
+
+    it('records a verification_completed event after the remediation run', async () => {
+        const aiAgentReviewClassifierModel = {
+            createRemediationEvent: jest.fn().mockResolvedValue(undefined),
+        };
+        const service = makeService({ aiAgentReviewClassifierModel });
+
+        await service.recordReviewRemediationVerified({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PREVIEW_PROJECT_UUID,
+            userUuid: USER_UUID,
+            fingerprint: 'fingerprint-1',
+            remediationUuid: REMEDIATION_UUID,
+            agentUuid: PREVIEW_AGENT_UUID,
+            threadUuid: PREVIEW_THREAD_UUID,
+        });
+
+        expect(
+            aiAgentReviewClassifierModel.createRemediationEvent,
+        ).toHaveBeenCalledWith({
+            remediationUuid: REMEDIATION_UUID,
+            organizationUuid: ORGANIZATION_UUID,
+            event: {
+                eventType: 'verification_completed',
+                payload: { previewThreadUuid: PREVIEW_THREAD_UUID },
+            },
+        });
     });
 
     it('does nothing when the remediation is no longer pr_open', async () => {

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -3,11 +3,13 @@ import {
     AiAgentAdminConversationsSummary,
     AiAgentAdminFilters,
     AiAgentAdminSort,
+    AiAgentReviewItemActivity,
     AiAgentReviewItemPrDiff,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
     AiAgentReviewRemediationCompileJobPayload,
     AiAgentReviewRemediationPreviewJobPayload,
+    AiAgentReviewRemediationRunJobPayload,
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
@@ -33,6 +35,10 @@ import {
     type AiAgentReviewItemWritebackPreview,
     type AiAgentReviewItemWritebackStrategy,
     type AiAgentReviewRemediation,
+    type AiAgentReviewRemediationEvent,
+    type AiAgentReviewRemediationEventType,
+    type AiAgentReviewRemediationLiveState,
+    type AiAgentReviewRemediationStatus,
     type PullRequest,
     type SessionUser,
 } from '@lightdash/common';
@@ -727,6 +733,20 @@ export class AiAgentAdminService extends BaseService {
                             prState,
                         },
                     );
+                    if (item.remediation) {
+                        await this.aiAgentReviewClassifierModel.createRemediationEvent(
+                            {
+                                remediationUuid: item.remediation.uuid,
+                                organizationUuid,
+                                event: {
+                                    eventType: pr.merged
+                                        ? 'pr_merged'
+                                        : 'pr_closed',
+                                    payload: { prUrl: item.linkedPrUrl! },
+                                },
+                            },
+                        );
+                    }
                     overrides.set(item.fingerprint, { status, prState });
                     // Loop closure: a merged project_context PR changed the file,
                     // so re-ingest to refresh the cache for future agent turns.
@@ -975,6 +995,22 @@ export class AiAgentAdminService extends BaseService {
             throw error;
         }
 
+        // Anchor the feed at the finding itself, backdated to when it was
+        // first seen — the remediation row is created much later.
+        await this.aiAgentReviewClassifierModel.createRemediationEvent({
+            remediationUuid: remediation.uuid,
+            organizationUuid,
+            event: {
+                eventType: 'finding_opened',
+                payload: {
+                    excerpt: retryPrompt,
+                    sourceThreadUuid: finding.threadUuid,
+                    sourcePromptUuid: finding.promptUuid,
+                },
+            },
+            occurredAt: reviewItem.firstSeenAt,
+        });
+
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
             fingerprint,
             organizationUuid,
@@ -1140,6 +1176,24 @@ export class AiAgentAdminService extends BaseService {
                     },
                 });
                 prUrl = result.prUrl;
+                if (remediationUuid) {
+                    await this.aiAgentReviewClassifierModel.createRemediationEvent(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            event: {
+                                eventType: 'writeback_completed',
+                                payload: {
+                                    files: (result.steps ?? [])
+                                        .filter((step) => step.kind === 'edit')
+                                        .map((step) => step.label),
+                                    additions: result.additions ?? null,
+                                    deletions: result.deletions ?? null,
+                                },
+                            },
+                        },
+                    );
+                }
                 pullRequest = prUrl
                     ? await this.pullRequestsModel.findByProjectAndUrl(
                           projectUuid,
@@ -1182,6 +1236,21 @@ export class AiAgentAdminService extends BaseService {
                             remediationUuid,
                             organizationUuid,
                             pullRequestUuid: pullRequest.pullRequestUuid,
+                        },
+                    );
+                    await this.aiAgentReviewClassifierModel.createRemediationEvent(
+                        {
+                            remediationUuid,
+                            organizationUuid,
+                            event: {
+                                eventType: 'pr_opened',
+                                payload: {
+                                    prUrl,
+                                    prNumber:
+                                        parsePullRequestUrl(prUrl)
+                                            ?.pullNumber ?? null,
+                                },
+                            },
                         },
                     );
                 } else if (remediationUuid) {
@@ -1319,6 +1388,85 @@ export class AiAgentAdminService extends BaseService {
     }
 
     /**
+     * The per-PR activity feed for a review finding: stored lifecycle events
+     * plus a derived in-flight state (never stored) for the accented live row.
+     */
+    async getReviewItemActivity(
+        user: SessionUser,
+        fingerprint: string,
+    ): Promise<AiAgentReviewItemActivity> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!reviewItem?.remediation) {
+            return { events: [], liveState: null, liveMessage: null };
+        }
+
+        const events =
+            await this.aiAgentReviewClassifierModel.listRemediationEvents({
+                remediationUuid: reviewItem.remediation.uuid,
+                organizationUuid,
+            });
+
+        const liveState = AiAgentAdminService.deriveRemediationLiveState(
+            reviewItem.remediation.status,
+            events,
+        );
+        return {
+            events,
+            liveState,
+            liveMessage:
+                liveState === 'writeback'
+                    ? reviewItem.prWritebackMessage
+                    : null,
+        };
+    }
+
+    private static deriveRemediationLiveState(
+        status: AiAgentReviewRemediationStatus,
+        events: AiAgentReviewRemediationEvent[],
+    ): AiAgentReviewRemediationLiveState | null {
+        if (status === 'queued' || status === 'running') {
+            return 'writeback';
+        }
+        if (status !== 'pr_open' && status !== 'preview_ready') {
+            return null;
+        }
+        const has = (eventType: AiAgentReviewRemediationEventType) =>
+            events.some((event) => event.eventType === eventType);
+        if (!has('pr_opened') || has('verification_completed')) {
+            return null;
+        }
+        return has('preview_compiled') ? 'verifying' : 'compiling';
+    }
+
+    /**
+     * Called by the worker after the remediation verification run finishes —
+     * the run itself lives in AiAgentService, which doesn't own remediation
+     * lifecycle state.
+     */
+    async recordReviewRemediationVerified(
+        payload: AiAgentReviewRemediationRunJobPayload,
+    ): Promise<void> {
+        await this.aiAgentReviewClassifierModel.createRemediationEvent({
+            remediationUuid: payload.remediationUuid,
+            organizationUuid: payload.organizationUuid,
+            event: {
+                eventType: 'verification_completed',
+                payload: { previewThreadUuid: payload.threadUuid },
+            },
+        });
+    }
+
+    /**
      * Self-rescheduling poll: checks the preview's compile job and only seeds
      * the verification thread once the explores exist — the verification agent
      * snapshots explores at run start, so prompting earlier produces a false
@@ -1364,6 +1512,14 @@ export class AiAgentAdminService extends BaseService {
         const job = await this.jobModel.get(compileJobUuid);
         switch (job.jobStatus) {
             case JobStatusType.DONE:
+                await this.aiAgentReviewClassifierModel.createRemediationEvent({
+                    remediationUuid,
+                    organizationUuid,
+                    event: {
+                        eventType: 'preview_compiled',
+                        payload: { previewProjectUuid },
+                    },
+                });
                 await this.setReviewRemediationPreviewFromProject({
                     organizationUuid,
                     remediationUuid,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -14,6 +14,7 @@ import {
     AiAgentSummary,
     AiAgentThread,
     AiAgentThreadFilters,
+    AiAgentThreadPullRequest,
     AiAgentThreadSummary,
     AiAgentUser,
     AiAgentUserPreferences,
@@ -72,6 +73,7 @@ import {
     ParameterError,
     parseVizConfig,
     ProjectType,
+    PullRequestProvider,
     QueryExecutionContext,
     ReadinessScore,
     ShareUrl,
@@ -131,7 +133,10 @@ import {
     LightdashAnalytics,
 } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
-import { getInstallationToken } from '../../../clients/github/Github';
+import {
+    getInstallationToken,
+    getPullRequest,
+} from '../../../clients/github/Github';
 import { type SlackClient } from '../../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
@@ -145,6 +150,7 @@ import { GithubAppInstallationsModel } from '../../../models/GithubAppInstallati
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { PullRequestsModel } from '../../../models/PullRequestsModel';
 import { SearchModel } from '../../../models/SearchModel';
 import { SpaceModel } from '../../../models/SpaceModel';
 import { UserAttributesModel } from '../../../models/UserAttributesModel';
@@ -174,6 +180,7 @@ import {
     type AiMcpCredential,
     type AiMcpServerWithSensitiveData,
 } from '../../models/AiAgentModel';
+import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -308,6 +315,11 @@ type AiAgentServiceDependencies = {
     writebackPreviewService: WritebackPreviewService;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     aiAgentToolsService: AiAgentToolsService;
+    pullRequestsModel: Pick<PullRequestsModel, 'findByAiThreadUuid' | 'find'>;
+    aiAgentReviewClassifierModel: Pick<
+        AiAgentReviewClassifierModel,
+        'findReviewRemediationByPreviewThread'
+    >;
     prometheusMetrics?: PrometheusMetrics;
 };
 
@@ -528,6 +540,16 @@ export class AiAgentService extends BaseService {
 
     private readonly aiAgentToolsService: AiAgentToolsService;
 
+    private readonly pullRequestsModel: Pick<
+        PullRequestsModel,
+        'findByAiThreadUuid' | 'find'
+    >;
+
+    private readonly aiAgentReviewClassifierModel: Pick<
+        AiAgentReviewClassifierModel,
+        'findReviewRemediationByPreviewThread'
+    >;
+
     private readonly aiAgentMcpRuntimeClient: AiAgentMcpRuntimeClient;
 
     private static getPinnedContextAnalyticsProperties(
@@ -696,6 +718,9 @@ export class AiAgentService extends BaseService {
         this.githubAppInstallationsModel =
             dependencies.githubAppInstallationsModel;
         this.aiAgentToolsService = dependencies.aiAgentToolsService;
+        this.pullRequestsModel = dependencies.pullRequestsModel;
+        this.aiAgentReviewClassifierModel =
+            dependencies.aiAgentReviewClassifierModel;
         this.aiAgentMcpRuntimeClient = new AiAgentMcpRuntimeClient({
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
@@ -845,6 +870,106 @@ export class AiAgentService extends BaseService {
      * 2. The user is the thread owner
      * 3. The user has manage permissions for the agent
      */
+    /**
+     * The writeback PR a thread is associated with — the PR the agent opened
+     * in this thread, or (for remediation verification threads) the PR being
+     * verified. Live fields (title/state/counts) are best-effort from GitHub;
+     * the stored summary renders without them. Null when the thread has no PR.
+     */
+    async getThreadPullRequest(
+        user: SessionUser,
+        agentUuid: string,
+        threadUuid: string,
+    ): Promise<AiAgentThreadPullRequest | null> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid,
+            agentUuid,
+        });
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to view this thread',
+            );
+        }
+
+        let pullRequest =
+            await this.pullRequestsModel.findByAiThreadUuid(threadUuid);
+        if (!pullRequest) {
+            const remediation =
+                await this.aiAgentReviewClassifierModel.findReviewRemediationByPreviewThread(
+                    { organizationUuid, previewThreadUuid: threadUuid },
+                );
+            if (remediation?.pullRequestUuid) {
+                pullRequest = await this.pullRequestsModel.find(
+                    remediation.pullRequestUuid,
+                );
+            }
+        }
+        if (!pullRequest) {
+            return null;
+        }
+
+        const result: AiAgentThreadPullRequest = {
+            prUrl: pullRequest.prUrl,
+            repo: `${pullRequest.owner}/${pullRequest.repo}`,
+            prNumber: pullRequest.prNumber,
+            title: null,
+            summary: pullRequest.summary,
+            state: null,
+            additions: null,
+            deletions: null,
+            changedFiles: null,
+            commitSha: null,
+        };
+
+        try {
+            if (pullRequest.provider === PullRequestProvider.GITHUB) {
+                const installationId =
+                    await this.githubAppInstallationsModel.findInstallationId(
+                        organizationUuid,
+                    );
+                if (installationId) {
+                    const pr = await getPullRequest({
+                        owner: pullRequest.owner,
+                        repo: pullRequest.repo,
+                        pullNumber: pullRequest.prNumber,
+                        installationId,
+                    });
+                    result.title = pr.title;
+                    result.state = pr.merged ? 'merged' : pr.state;
+                    result.additions = pr.additions;
+                    result.deletions = pr.deletions;
+                    result.changedFiles = pr.changedFiles;
+                }
+            }
+        } catch (error) {
+            this.logger.warn(
+                `Failed to resolve live PR state for thread ${threadUuid}: ${getErrorMessage(error)}`,
+            );
+        }
+
+        return { ...result, summary: result.summary ?? result.title };
+    }
+
     private async checkAgentThreadAccess(
         user: SessionUser,
         agent: AiAgent,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -665,6 +665,7 @@ export class AiWritebackService extends BaseService {
             const {
                 title: prTitle,
                 description: prDescription,
+                summary: prSummary,
                 sanitizedStdout,
             } = extractPrMetadata(agent.stdout);
             this.logger.info(
@@ -732,6 +733,7 @@ export class AiWritebackService extends BaseService {
                 setStage,
                 prTitle,
                 prDescription,
+                prSummary,
             });
             pauseOnExit = applied.pauseOnExit;
 
@@ -1476,6 +1478,7 @@ export class AiWritebackService extends BaseService {
         setStage,
         prTitle,
         prDescription,
+        prSummary,
     }: {
         sandbox: Sandbox;
         installation: GitInstallation;
@@ -1488,6 +1491,7 @@ export class AiWritebackService extends BaseService {
         setStage: SetStage;
         prTitle: string | null;
         prDescription: string | null;
+        prSummary: string | null;
     }): Promise<AppliedChanges> {
         if (!hasChanges) {
             this.logger.info(
@@ -1542,6 +1546,7 @@ export class AiWritebackService extends BaseService {
                     aiThreadUuid,
                     sandbox,
                     prUrl: targetPrUrl,
+                    summary: prSummary,
                 });
             }
 
@@ -1582,6 +1587,7 @@ export class AiWritebackService extends BaseService {
             aiThreadUuid,
             sandbox,
             prUrl,
+            summary: prSummary,
         });
 
         return {
@@ -1637,6 +1643,7 @@ export class AiWritebackService extends BaseService {
         aiThreadUuid,
         sandbox,
         prUrl,
+        summary,
     }: {
         turn: TurnContext;
         projectUuid: string;
@@ -1644,6 +1651,7 @@ export class AiWritebackService extends BaseService {
         aiThreadUuid: string | undefined;
         sandbox: Sandbox;
         prUrl: string;
+        summary: string | null;
     }): Promise<void> {
         const pullRequest = await this.pullRequestsModel.findOrCreate({
             organizationUuid: turn.organizationUuid,
@@ -1655,6 +1663,7 @@ export class AiWritebackService extends BaseService {
             repo: turn.gitConnection.repo,
             prNumber: parsePullNumber(prUrl),
             prUrl,
+            summary,
         });
 
         if (aiThreadUuid) {

--- a/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/WritebackPreviewService.test.ts
@@ -23,6 +23,10 @@ const openPullRequest = () => ({
     mergeable: true,
     mergeableState: 'clean',
     draft: false,
+    title: 'Add metric',
+    additions: 9,
+    deletions: 1,
+    changedFiles: 1,
 });
 
 const userWithSourceCodeAccess = (canViewSourceCode: boolean): SessionUser => {

--- a/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
+++ b/packages/backend/src/ee/services/AiWritebackService/__snapshots__/templates.test.ts.snap
@@ -52,8 +52,8 @@ If you made any file changes, perform these follow-up steps before you finish:
 
 6. End your final reply with the two structured-output blocks below.
 
-The two structured-output blocks let the host pick up the PR metadata reliably.
-The host strips both blocks before showing your reply to the user, so they will
+The structured-output blocks let the host pick up the PR metadata reliably.
+The host strips the blocks before showing your reply to the user, so they will
 not appear in Slack. Emit them verbatim, on their own lines, each opening and
 closing tag exactly as shown:
 
@@ -64,6 +64,11 @@ closing tag exactly as shown:
    <lightdash-writeback-pr-description>
    PR description in plain markdown, no emojis
    </lightdash-writeback-pr-description>
+
+   <lightdash-writeback-pr-summary>
+   one or two short sentences, plain text, written for a business user:
+   what this change lets them do, not how the files changed
+   </lightdash-writeback-pr-summary>
 
 If you did not change any files, skip these steps entirely and do not emit the
 blocks."
@@ -121,8 +126,8 @@ If you made any file changes, perform these follow-up steps before you finish:
 
 6. End your final reply with the two structured-output blocks below.
 
-The two structured-output blocks let the host pick up the PR metadata reliably.
-The host strips both blocks before showing your reply to the user, so they will
+The structured-output blocks let the host pick up the PR metadata reliably.
+The host strips the blocks before showing your reply to the user, so they will
 not appear in Slack. Emit them verbatim, on their own lines, each opening and
 closing tag exactly as shown:
 
@@ -133,6 +138,11 @@ closing tag exactly as shown:
    <lightdash-writeback-pr-description>
    PR description in plain markdown, no emojis
    </lightdash-writeback-pr-description>
+
+   <lightdash-writeback-pr-summary>
+   one or two short sentences, plain text, written for a business user:
+   what this change lets them do, not how the files changed
+   </lightdash-writeback-pr-summary>
 
 If you did not change any files, skip these steps entirely and do not emit the
 blocks."

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -42,6 +42,8 @@ export const PR_TITLE_OPEN = '<lightdash-writeback-pr-title>';
 export const PR_TITLE_CLOSE = '</lightdash-writeback-pr-title>';
 export const PR_DESCRIPTION_OPEN = '<lightdash-writeback-pr-description>';
 export const PR_DESCRIPTION_CLOSE = '</lightdash-writeback-pr-description>';
+export const PR_SUMMARY_OPEN = '<lightdash-writeback-pr-summary>';
+export const PR_SUMMARY_CLOSE = '</lightdash-writeback-pr-summary>';
 
 // Installation tokens authenticate over HTTPS with a fixed username.
 export const GIT_USERNAME = 'x-access-token';

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GithubProvider.test.ts
@@ -44,6 +44,10 @@ const openPr = {
     mergeable: true,
     mergeableState: 'clean',
     draft: false,
+    title: 'Add metric',
+    additions: 9,
+    deletions: 1,
+    changedFiles: 1,
 };
 
 const adopt = (prUrl: string) =>

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -3,6 +3,8 @@ import {
     COMPILE_WRAPPER_PATH,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
+    PR_SUMMARY_CLOSE,
+    PR_SUMMARY_OPEN,
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
     SHARED_SKILL_PATH,
@@ -153,8 +155,8 @@ ${
 6. End your final reply with the two structured-output blocks below.`
 }
 
-The two structured-output blocks let the host pick up the PR metadata reliably.
-The host strips both blocks before showing your reply to the user, so they will
+The structured-output blocks let the host pick up the PR metadata reliably.
+The host strips the blocks before showing your reply to the user, so they will
 not appear in Slack. Emit them verbatim, on their own lines, each opening and
 closing tag exactly as shown:
 
@@ -165,6 +167,11 @@ closing tag exactly as shown:
    ${PR_DESCRIPTION_OPEN}
    PR description in plain markdown, no emojis
    ${PR_DESCRIPTION_CLOSE}
+
+   ${PR_SUMMARY_OPEN}
+   one or two short sentences, plain text, written for a business user:
+   what this change lets them do, not how the files changed
+   ${PR_SUMMARY_CLOSE}
 
 If you did not change any files, skip these steps entirely and do not emit the
 blocks.

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -170,10 +170,11 @@ export type AgentStreamEvent =
       }
     | { type: 'ignored' };
 
-/** Title/description parsed out of the agent's final stdout. */
+/** Title/description/summary parsed out of the agent's final stdout. */
 export type PrMetadata = {
     title: string | null;
     description: string | null;
+    summary: string | null;
     sanitizedStdout: string;
 };
 

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -13,6 +13,8 @@ import {
     COMPILE_WRAPPER_PATH,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
+    PR_SUMMARY_CLOSE,
+    PR_SUMMARY_OPEN,
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
 } from './constants';
@@ -255,6 +257,7 @@ describe('extractPrMetadata', () => {
         expect(extractPrMetadata(stdout)).toEqual({
             title: 'Add metric',
             description: 'Adds a revenue metric.',
+            summary: null,
             sanitizedStdout: 'Here is the change.',
         });
     });
@@ -263,6 +266,7 @@ describe('extractPrMetadata', () => {
         expect(extractPrMetadata('just a reply')).toEqual({
             title: null,
             description: null,
+            summary: null,
             sanitizedStdout: 'just a reply',
         });
     });
@@ -270,6 +274,16 @@ describe('extractPrMetadata', () => {
     it('collapses the gap left behind into a single blank line', () => {
         const stdout = `Top\n\n${PR_TITLE_OPEN}T${PR_TITLE_CLOSE}\n\n\nBottom`;
         expect(extractPrMetadata(stdout).sanitizedStdout).toBe('Top\n\nBottom');
+    });
+
+    it('parses the user-facing summary block and strips it from stdout', () => {
+        const stdout = `Reply.\n\n${PR_SUMMARY_OPEN}Adds a governed Avg ARR metric.${PR_SUMMARY_CLOSE}`;
+        expect(extractPrMetadata(stdout)).toEqual(
+            expect.objectContaining({
+                summary: 'Adds a governed Avg ARR metric.',
+                sanitizedStdout: 'Reply.',
+            }),
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -15,6 +15,8 @@ import {
     DBT_VENV_BIN_PREFIX,
     PR_DESCRIPTION_CLOSE,
     PR_DESCRIPTION_OPEN,
+    PR_SUMMARY_CLOSE,
+    PR_SUMMARY_OPEN,
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
 } from './constants';
@@ -251,13 +253,21 @@ export const extractPrMetadata = (stdout: string): PrMetadata => {
             PR_DESCRIPTION_CLOSE,
         )}`,
     );
+    const summaryRe = new RegExp(
+        `${escapeRegExp(PR_SUMMARY_OPEN)}([\\s\\S]*?)${escapeRegExp(
+            PR_SUMMARY_CLOSE,
+        )}`,
+    );
     const title = stdout.match(titleRe)?.[1].trim() || null;
     const description = stdout.match(descRe)?.[1].trim() || null;
+    const summary = stdout.match(summaryRe)?.[1].trim() || null;
     const stripRe = new RegExp(
         `${escapeRegExp(PR_TITLE_OPEN)}[\\s\\S]*?${escapeRegExp(
             PR_TITLE_CLOSE,
         )}|${escapeRegExp(PR_DESCRIPTION_OPEN)}[\\s\\S]*?${escapeRegExp(
             PR_DESCRIPTION_CLOSE,
+        )}|${escapeRegExp(PR_SUMMARY_OPEN)}[\\s\\S]*?${escapeRegExp(
+            PR_SUMMARY_CLOSE,
         )}`,
         'g',
     );
@@ -265,7 +275,7 @@ export const extractPrMetadata = (stdout: string): PrMetadata => {
         .replace(stripRe, '')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
-    return { title, description, sanitizedStdout };
+    return { title, description, summary, sanitizedStdout };
 };
 
 /**

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12475,11 +12475,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12537,11 +12537,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -12578,11 +12578,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12597,11 +12597,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12745,17 +12745,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -13026,17 +13026,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13124,13 +13124,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13157,13 +13157,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
                                                                 'not_found',
                                                             ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13223,6 +13223,26 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -13239,13 +13259,6 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
                                                                                                         'false',
                                                                                                     ],
                                                                                                 },
@@ -13256,16 +13269,23 @@ const models: TsoaRoute.Models = {
                                                                                                         'not_applicable',
                                                                                                     ],
                                                                                                 },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -13294,27 +13314,17 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -13325,16 +13335,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -13344,12 +13344,6 @@ const models: TsoaRoute.Models = {
                                                                         'nestedObjectLiteral',
                                                                     nestedProperties:
                                                                         {
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -13358,6 +13352,12 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'string',
                                                                                     },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
                                                                                     required: true,
                                                                                 },
                                                                             label: {
@@ -13525,10 +13525,6 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 warnings: {
                                                     dataType: 'array',
                                                     array: {
@@ -13536,12 +13532,7 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
-                                                slug: {
+                                                href: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -13551,6 +13542,15 @@ const models: TsoaRoute.Models = {
                                                 },
                                                 name: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13868,17 +13868,17 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
                                                     required: true,
                                                 },
                                             },
@@ -13891,11 +13891,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13930,14 +13930,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13956,11 +13956,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14031,13 +14031,13 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -14055,25 +14055,6 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -14105,6 +14086,25 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                             },
                                                         },
                                                         {
@@ -14118,25 +14118,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -14156,11 +14137,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14175,11 +14156,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14509,6 +14509,118 @@ const models: TsoaRoute.Models = {
                 results: { ref: 'AiAgentThread', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentThreadPullRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                commitSha: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                changedFiles: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                additions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                state: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'enum', enums: ['open'] },
+                        { dataType: 'enum', enums: ['merged'] },
+                        { dataType: 'enum', enums: ['closed'] },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                summary: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                prNumber: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                repo: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                prUrl: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiAgentThreadPullRequest-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentThreadPullRequest' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadPullRequestResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiAgentThreadPullRequest-or-null_',
             validators: {},
         },
     },
@@ -20883,6 +20995,313 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiAgentReviewItemSummary_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewRemediationEventDetail: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                sourcePromptUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                sourceThreadUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                excerpt: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['finding_opened'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                deletions: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'double' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                additions: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'double' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                files: {
+                                    dataType: 'array',
+                                    array: { dataType: 'string' },
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['writeback_completed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                prNumber: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'double' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                prUrl: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['pr_opened'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                previewProjectUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['preview_compiled'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                previewThreadUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['verification_completed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                prUrl: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['pr_merged'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                prUrl: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['pr_closed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            ref: 'Record_string.never_',
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['resolved'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                errorMessage: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['failed'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewRemediationEvent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdByUserUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        occurredAt: { dataType: 'datetime', required: true },
+                        remediationUuid: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                { ref: 'AiAgentReviewRemediationEventDetail' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewRemediationLiveState: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['writeback'] },
+                { dataType: 'enum', enums: ['compiling'] },
+                { dataType: 'enum', enums: ['verifying'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemActivity: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                liveMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                liveState: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentReviewRemediationLiveState' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                events: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiAgentReviewRemediationEvent',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiAgentReviewItemActivity_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'AiAgentReviewItemActivity', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentReviewItemActivityResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiAgentReviewItemActivity_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewItemPrDiffFile: {
         dataType: 'refAlias',
         type: {
@@ -26611,6 +27030,14 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                summary: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 prUrl: { dataType: 'string', required: true },
                 prNumber: { dataType: 'double', required: true },
                 repo: { dataType: 'string', required: true },
@@ -28635,7 +29062,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28645,7 +29072,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -28655,7 +29082,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -28668,7 +29095,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -29323,7 +29750,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29333,7 +29760,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29343,7 +29770,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29356,7 +29783,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -46181,6 +46608,77 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_getAgentThreadPullRequest: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/pull-request',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.getAgentThreadPullRequest,
+        ),
+
+        async function AiAgentController_getAgentThreadPullRequest(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_getAgentThreadPullRequest,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getAgentThreadPullRequest',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentController_createAgentThread: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -51242,6 +51740,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getReviewItem',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewItemActivity: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/activity',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewItemActivity,
+        ),
+
+        async function AiAgentAdminController_getReviewItemActivity(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewItemActivity,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewItemActivity',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14044,8 +14044,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14103,8 +14103,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14138,8 +14138,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14151,8 +14151,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14184,10 +14184,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -14196,8 +14196,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -14309,10 +14309,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -14321,8 +14321,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -14364,19 +14364,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14386,8 +14386,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
-                                                            "not_found"
+                                                            "not_found",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -14420,21 +14420,25 @@
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
                                                                                 "isFromJoinedTable": {
                                                                                     "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "true",
                                                                                         "false",
-                                                                                        "not_applicable"
+                                                                                        "not_applicable",
+                                                                                        "true"
                                                                                     ]
                                                                                 },
-                                                                                "fieldValueType": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldFilterType": {
+                                                                                "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -14444,34 +14448,30 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "table": {
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
+                                                                                "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldValueType",
                                                                                 "fieldFilterType",
+                                                                                "fieldValueType",
                                                                                 "fieldType",
-                                                                                "description",
+                                                                                "table",
                                                                                 "label",
-                                                                                "fieldId",
                                                                                 "name",
-                                                                                "table"
+                                                                                "fieldId"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -14479,14 +14479,14 @@
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -14496,8 +14496,8 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
@@ -14613,21 +14613,13 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "href": {
-                                                        "type": "string"
-                                                    },
                                                     "warnings": {
                                                         "items": {
                                                             "type": "string"
                                                         },
                                                         "type": "array"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
-                                                    },
-                                                    "slug": {
+                                                    "href": {
                                                         "type": "string"
                                                     },
                                                     "uuid": {
@@ -14635,16 +14627,24 @@
                                                     },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "href",
                                                     "warnings",
-                                                    "status",
-                                                    "slug",
+                                                    "href",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "slug",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14744,23 +14744,23 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
+                                                    "name": {
+                                                        "type": "string"
                                                     },
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "status",
+                                                    "name",
                                                     "slug",
-                                                    "name"
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14770,8 +14770,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14796,10 +14796,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -14810,18 +14810,14 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
                                                                         "fieldType",
+                                                                        "tableName",
                                                                         "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -14831,20 +14827,24 @@
                                                                     null
                                                                 ],
                                                                 "nullable": true
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             }
                                                         },
                                                         "required": [
                                                             "fields",
-                                                            "searchQuery",
-                                                            "type"
+                                                            "type",
+                                                            "searchQuery"
                                                         ],
                                                         "type": "object"
                                                     },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -15169,6 +15169,90 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
+            },
+            "AiAgentThreadPullRequest": {
+                "properties": {
+                    "commitSha": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "changedFiles": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "deletions": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "additions": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": ["open", "merged", "closed", null],
+                        "nullable": true
+                    },
+                    "summary": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "prNumber": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "repo": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "prUrl": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "commitSha",
+                    "changedFiles",
+                    "deletions",
+                    "additions",
+                    "state",
+                    "summary",
+                    "title",
+                    "prNumber",
+                    "repo",
+                    "prUrl"
+                ],
+                "type": "object",
+                "description": "Overview of the writeback PR a thread is associated with — either the PR the\nagent opened in this thread, or the PR a remediation verification thread is\nverifying. Live GitHub fields (state, counts) are null when the fetch fails;\n`summary` falls back to the PR title when no stored summary exists."
+            },
+            "ApiSuccess_AiAgentThreadPullRequest-or-null_": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentThreadPullRequest"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadPullRequestResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentThreadPullRequest-or-null_"
             },
             "ApiSuccess_AiAgentThreadSummary_": {
                 "properties": {
@@ -21349,6 +21433,293 @@
             "ApiAiAgentReviewItemResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemSummary_"
             },
+            "AiAgentReviewRemediationEventDetail": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "sourcePromptUuid": {
+                                        "type": "string"
+                                    },
+                                    "sourceThreadUuid": {
+                                        "type": "string"
+                                    },
+                                    "excerpt": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": [
+                                    "sourcePromptUuid",
+                                    "sourceThreadUuid",
+                                    "excerpt"
+                                ],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["finding_opened"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "deletions": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "nullable": true
+                                    },
+                                    "additions": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "nullable": true
+                                    },
+                                    "files": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["deletions", "additions", "files"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["writeback_completed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "prNumber": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "nullable": true
+                                    },
+                                    "prUrl": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["prNumber", "prUrl"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["pr_opened"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "previewProjectUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["previewProjectUuid"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["preview_compiled"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "previewThreadUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["previewThreadUuid"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["verification_completed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "prUrl": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["prUrl"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["pr_merged"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "prUrl": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["prUrl"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["pr_closed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "$ref": "#/components/schemas/Record_string.never_"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["resolved"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "errorMessage": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["errorMessage"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["failed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentReviewRemediationEvent": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "createdByUserUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "occurredAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "remediationUuid": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "createdByUserUuid",
+                            "occurredAt",
+                            "remediationUuid",
+                            "uuid"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AiAgentReviewRemediationEventDetail"
+                    }
+                ]
+            },
+            "AiAgentReviewRemediationLiveState": {
+                "type": "string",
+                "enum": ["writeback", "compiling", "verifying"],
+                "description": "The in-flight step of a remediation, derived from current status + which\nevents exist — never stored. Renders as the single accented \"live\" row."
+            },
+            "AiAgentReviewItemActivity": {
+                "properties": {
+                    "liveMessage": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Streaming progress text for the live row (writeback step messages)."
+                    },
+                    "liveState": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentReviewRemediationLiveState"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "events": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentReviewRemediationEvent"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["liveMessage", "liveState", "events"],
+                "type": "object"
+            },
+            "ApiSuccess_AiAgentReviewItemActivity_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemActivity"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentReviewItemActivityResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemActivity_"
+            },
             "AiAgentReviewItemPrDiffFile": {
                 "properties": {
                     "after": {
@@ -27277,6 +27648,11 @@
                         "nullable": true,
                         "description": "The AI thread that produced this PR, when it originated from an AI\nwrite-back (source `ai_agent`). Null for non-AI PRs, or in deployments\nwithout the enterprise AI write-back feature."
                     },
+                    "summary": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Two-line user-facing \"what this PR does\", written by the AI write-back\nagent at PR creation. Null for non-AI PRs and PRs predating the field —\nconsumers fall back to the live PR title."
+                    },
                     "prUrl": {
                         "type": "string"
                     },
@@ -27315,6 +27691,7 @@
                     "reviewContext",
                     "aiAgentUuid",
                     "aiThreadUuid",
+                    "summary",
                     "prUrl",
                     "prNumber",
                     "repo",
@@ -29446,22 +29823,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30021,22 +30398,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -38984,7 +39361,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3152.1",
+        "version": "0.3156.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -42180,6 +42557,62 @@
                         }
                     }
                 },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "threadUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}/pull-request": {
+            "get": {
+                "operationId": "getAgentThreadPullRequest",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentThreadPullRequestResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the writeback pull request associated with a thread — the PR the\nagent opened in this thread, or the PR a verification thread verifies.",
+                "summary": "Get AI agent thread pull request",
                 "security": [],
                 "parameters": [
                     {
@@ -45832,6 +46265,46 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/activity": {
+            "get": {
+                "operationId": "getAiAgentReviewItemActivity",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the remediation activity feed for a review item",
+                "summary": "Get AI agent review item activity",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}/pr-diff": {

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -39,6 +39,7 @@ type CreatePullRequest = {
     repo: string;
     prNumber: number;
     prUrl: string;
+    summary?: string | null;
 };
 
 type AiThreadInfo = { aiThreadUuid: string; aiAgentUuid: string | null };
@@ -76,6 +77,7 @@ const mapDbPullRequest = (
     repo: row.repo,
     prNumber: row.pr_number,
     prUrl: row.pr_url,
+    summary: row.summary,
     aiThreadUuid: aiThread?.aiThreadUuid ?? null,
     aiAgentUuid: aiThread?.aiAgentUuid ?? null,
     reviewContext,
@@ -377,6 +379,7 @@ export class PullRequestsModel {
                 repo: data.repo,
                 pr_number: data.prNumber,
                 pr_url: data.prUrl,
+                summary: data.summary ?? null,
             })
             .returning('*');
 
@@ -406,6 +409,7 @@ export class PullRequestsModel {
                 repo: data.repo,
                 pr_number: data.prNumber,
                 pr_url: data.prUrl,
+                summary: data.summary ?? null,
             })
             .onConflict(['provider', 'owner', 'repo', 'pr_number'])
             .ignore()
@@ -413,6 +417,19 @@ export class PullRequestsModel {
 
         if (inserted.length > 0) {
             return mapDbPullRequest(inserted[0], null, null);
+        }
+
+        // A follow-up turn carries a fresher description of what the PR now
+        // does — refresh the stored summary while preserving attribution.
+        if (data.summary) {
+            await this.database(PullRequestsTableName)
+                .where({
+                    provider: data.provider,
+                    owner: data.owner,
+                    repo: data.repo,
+                    pr_number: data.prNumber,
+                })
+                .update({ summary: data.summary });
         }
 
         // The insert was ignored because a row already exists — return it.
@@ -494,6 +511,36 @@ export class PullRequestsModel {
                 reviewContext.byPrUrl.get(row.pr_url) ??
                 null,
         );
+    }
+
+    /**
+     * The PR an AI thread produced, via the enterprise `ai_writeback_thread`
+     * link. Null in deployments without that table or when the thread never
+     * opened a PR.
+     */
+    async findByAiThreadUuid(
+        aiThreadUuid: string,
+    ): Promise<PullRequest | null> {
+        if (this.aiWritebackTableExists === undefined) {
+            this.aiWritebackTableExists = await this.database.schema.hasTable(
+                AiWritebackThreadTableName,
+            );
+        }
+        if (!this.aiWritebackTableExists) {
+            return null;
+        }
+
+        const row = await this.database(PullRequestsTableName)
+            .innerJoin(
+                AiWritebackThreadTableName,
+                `${AiWritebackThreadTableName}.pull_request_uuid`,
+                `${PullRequestsTableName}.pull_request_uuid`,
+            )
+            .where(`${AiWritebackThreadTableName}.ai_thread_uuid`, aiThreadUuid)
+            .select(`${PullRequestsTableName}.*`)
+            .first();
+
+        return row ? mapDbPullRequest(row, null, null) : null;
     }
 
     /**

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -688,6 +688,66 @@ export type AiAgentReviewItemPrDiff = {
 export type ApiAiAgentReviewItemPrDiffResponse =
     ApiSuccess<AiAgentReviewItemPrDiff>;
 
+export type AiAgentReviewRemediationEventDetail =
+    | {
+          eventType: 'finding_opened';
+          payload: {
+              excerpt: string | null;
+              sourceThreadUuid: string;
+              sourcePromptUuid: string;
+          };
+      }
+    | {
+          eventType: 'writeback_completed';
+          payload: {
+              files: string[];
+              additions: number | null;
+              deletions: number | null;
+          };
+      }
+    | {
+          eventType: 'pr_opened';
+          payload: { prUrl: string; prNumber: number | null };
+      }
+    | { eventType: 'preview_compiled'; payload: { previewProjectUuid: string } }
+    | {
+          eventType: 'verification_completed';
+          payload: { previewThreadUuid: string };
+      }
+    | { eventType: 'pr_merged'; payload: { prUrl: string } }
+    | { eventType: 'pr_closed'; payload: { prUrl: string } }
+    | { eventType: 'resolved'; payload: Record<string, never> }
+    | { eventType: 'failed'; payload: { errorMessage: string | null } };
+
+export type AiAgentReviewRemediationEventType =
+    AiAgentReviewRemediationEventDetail['eventType'];
+
+export type AiAgentReviewRemediationEvent = {
+    uuid: string;
+    remediationUuid: string;
+    occurredAt: Date;
+    createdByUserUuid: string | null;
+} & AiAgentReviewRemediationEventDetail;
+
+/**
+ * The in-flight step of a remediation, derived from current status + which
+ * events exist — never stored. Renders as the single accented "live" row.
+ */
+export type AiAgentReviewRemediationLiveState =
+    | 'writeback'
+    | 'compiling'
+    | 'verifying';
+
+export type AiAgentReviewItemActivity = {
+    events: AiAgentReviewRemediationEvent[];
+    liveState: AiAgentReviewRemediationLiveState | null;
+    /** Streaming progress text for the live row (writeback step messages). */
+    liveMessage: string | null;
+};
+
+export type ApiAiAgentReviewItemActivityResponse =
+    ApiSuccess<AiAgentReviewItemActivity>;
+
 export type AiAgentReviewSignalSummary = {
     uuid: string;
     runUuid: string;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -430,6 +430,28 @@ export type ApiAiAgentThreadResponse = {
     results: AiAgentThread;
 };
 
+/**
+ * Overview of the writeback PR a thread is associated with — either the PR the
+ * agent opened in this thread, or the PR a remediation verification thread is
+ * verifying. Live GitHub fields (state, counts) are null when the fetch fails;
+ * `summary` falls back to the PR title when no stored summary exists.
+ */
+export type AiAgentThreadPullRequest = {
+    prUrl: string;
+    repo: string | null;
+    prNumber: number | null;
+    title: string | null;
+    summary: string | null;
+    state: 'open' | 'merged' | 'closed' | null;
+    additions: number | null;
+    deletions: number | null;
+    changedFiles: number | null;
+    commitSha: string | null;
+};
+
+export type ApiAiAgentThreadPullRequestResponse =
+    ApiSuccess<AiAgentThreadPullRequest | null>;
+
 export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
     context?: AiPromptContextInput;

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -11,6 +11,7 @@ import type {
     ApiAiAgentEvaluationRunSummaryListResponse,
     ApiAiAgentEvaluationSummaryListResponse,
     ApiAiAgentProjectThreadSummaryListResponse,
+    ApiAiAgentReviewItemActivityResponse,
     ApiAiAgentReviewItemPrDiffResponse,
     ApiAiAgentReviewItemWritebackPreviewResponse,
     ApiAiAgentThreadCreateResponse,
@@ -18,6 +19,7 @@ import type {
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
+    ApiAiAgentThreadPullRequestResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadShareResponse,
     ApiAiAgentThreadSummaryListResponse,
@@ -1100,6 +1102,8 @@ type ApiResults =
     | ApiAiAgentAdminConversationsResponse['results']
     | ApiAiAgentReviewItemWritebackPreviewResponse['results']
     | ApiAiAgentReviewItemPrDiffResponse['results']
+    | ApiAiAgentReviewItemActivityResponse['results']
+    | ApiAiAgentThreadPullRequestResponse['results']
     | ApiAiAgentEvaluationSummaryListResponse['results']
     | ApiAiAgentEvaluationResponse['results']
     | ApiAiAgentEvaluationRunResponse['results']

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -62,6 +62,12 @@ export type PullRequest = {
     prNumber: number;
     prUrl: string;
     /**
+     * Two-line user-facing "what this PR does", written by the AI write-back
+     * agent at PR creation. Null for non-AI PRs and PRs predating the field —
+     * consumers fall back to the live PR title.
+     */
+    summary: string | null;
+    /**
      * The AI thread that produced this PR, when it originated from an AI
      * write-back (source `ai_agent`). Null for non-AI PRs, or in deployments
      * without the enterprise AI write-back feature.

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
@@ -1,0 +1,91 @@
+/* ldGray's dark-mode tuple is inverted (index 0 = darkest in dark), so the
+   same index reads as the same semantic shade in both schemes — no
+   light-dark() needed for grays here. */
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 5px;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: var(--mantine-color-ldGray-2);
+}
+
+.item {
+    position: relative;
+    padding: 0 0 14px 24px;
+}
+
+.item:last-child {
+    padding-bottom: 0;
+}
+
+.node {
+    position: absolute;
+    left: 0;
+    top: 4px;
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: var(--mantine-color-body);
+    border: 1.5px solid var(--mantine-color-ldGray-4);
+    z-index: 1;
+}
+
+.item[data-done] .node {
+    background: var(--mantine-color-ldGray-9);
+    border-color: var(--mantine-color-ldGray-9);
+}
+
+.item[data-live] .node {
+    border-color: light-dark(
+        var(--mantine-color-teal-8),
+        var(--mantine-color-teal-4)
+    );
+    box-shadow: 0 0 0 3px
+        light-dark(rgba(12, 133, 99, 0.12), rgba(56, 217, 169, 0.16));
+}
+
+.event {
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--mantine-color-ldGray-9);
+}
+
+.item[data-live] .event,
+.item[data-live] .when {
+    color: light-dark(var(--mantine-color-teal-8), var(--mantine-color-teal-4));
+}
+
+.when {
+    float: right;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--mantine-color-ldGray-5);
+    margin-left: var(--mantine-spacing-xs);
+}
+
+.meta {
+    font-size: 12px;
+    line-height: 1.45;
+    margin-top: 2px;
+    color: var(--mantine-color-ldGray-6);
+    overflow-wrap: anywhere;
+}
+
+.meta a,
+.metaLink {
+    color: var(--mantine-color-ldGray-9);
+    text-decoration: none;
+    border-bottom: 1px solid var(--mantine-color-ldGray-3);
+    cursor: pointer;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -1,0 +1,231 @@
+import {
+    type AiAgentReviewItemSummary,
+    type AiAgentReviewRemediationEvent,
+    type AiAgentReviewRemediationLiveState,
+} from '@lightdash/common';
+import { Anchor, Box } from '@mantine-8/core';
+import dayjs from 'dayjs';
+import { useMemo, type FC, type ReactNode } from 'react';
+import { Link } from 'react-router';
+import { useAiAgentReviewItemActivity } from '../../hooks/useAiAgentAdmin';
+import styles from './RemediationActivityTimeline.module.css';
+
+const LIVE_POLL_INTERVAL_MS = 5_000;
+// Writeback streams step messages, so poll faster while it runs.
+const WRITEBACK_POLL_INTERVAL_MS = 2_500;
+
+const formatWhen = (occurredAt: Date | string, previous: Date | null) => {
+    const date = dayjs(occurredAt);
+    // First event (or a new day) carries the day; same-day follow-ups are
+    // time-only, so the column stays quiet.
+    if (previous && date.isSame(previous, 'day')) {
+        return date.format('HH:mm');
+    }
+    return date.format('ddd HH:mm');
+};
+
+const truncate = (text: string, max = 90) =>
+    text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+
+type TimelineRow = {
+    key: string;
+    label: string;
+    meta: ReactNode;
+    when: string;
+    state: 'done' | 'live';
+};
+
+const buildThreadPath = (
+    projectUuid: string | null,
+    agentUuid: string | null,
+    threadUuid: string,
+) =>
+    projectUuid && agentUuid
+        ? `/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`
+        : null;
+
+const eventRow = (
+    event: AiAgentReviewRemediationEvent,
+    reviewItem: AiAgentReviewItemSummary,
+): Pick<TimelineRow, 'label' | 'meta'> => {
+    const remediation = reviewItem.remediation;
+    switch (event.eventType) {
+        case 'finding_opened': {
+            const threadPath = buildThreadPath(
+                reviewItem.projectUuid,
+                reviewItem.agentUuid,
+                event.payload.sourceThreadUuid,
+            );
+            return {
+                label: 'Finding opened',
+                meta: (
+                    <>
+                        {event.payload.excerpt
+                            ? `“${truncate(event.payload.excerpt)}”`
+                            : null}
+                        {event.payload.excerpt ? ' — from the ' : 'From the '}
+                        {threadPath ? (
+                            <Anchor
+                                component={Link}
+                                to={threadPath}
+                                className={styles.metaLink}
+                                inherit
+                            >
+                                source thread
+                            </Anchor>
+                        ) : (
+                            'source thread'
+                        )}
+                    </>
+                ),
+            };
+        }
+        case 'writeback_completed': {
+            const files = event.payload.files.join(', ');
+            const counts =
+                event.payload.additions !== null ||
+                event.payload.deletions !== null
+                    ? ` · +${event.payload.additions ?? 0} −${
+                          event.payload.deletions ?? 0
+                      }`
+                    : '';
+            return {
+                label: 'Writeback ran',
+                meta: files ? `Edited ${files}${counts}` : null,
+            };
+        }
+        case 'pr_opened':
+            return {
+                label: 'Pull request opened',
+                meta: (
+                    <Anchor
+                        href={event.payload.prUrl}
+                        target="_blank"
+                        className={styles.metaLink}
+                        inherit
+                    >
+                        {event.payload.prNumber
+                            ? `View PR #${event.payload.prNumber}`
+                            : 'View PR'}
+                    </Anchor>
+                ),
+            };
+        case 'preview_compiled':
+            return { label: 'Preview compiled', meta: null };
+        case 'verification_completed': {
+            const threadPath = buildThreadPath(
+                remediation?.previewProjectUuid ?? null,
+                remediation?.previewAgentUuid ?? null,
+                event.payload.previewThreadUuid,
+            );
+            return {
+                label: 'Fix verified',
+                meta: threadPath ? (
+                    <Anchor
+                        component={Link}
+                        to={threadPath}
+                        className={styles.metaLink}
+                        inherit
+                    >
+                        Open verification thread
+                    </Anchor>
+                ) : null,
+            };
+        }
+        case 'pr_merged':
+            return { label: 'Pull request merged', meta: null };
+        case 'pr_closed':
+            return { label: 'Pull request closed', meta: null };
+        case 'resolved':
+            return { label: 'Resolved', meta: null };
+        case 'failed':
+            return {
+                label: 'Failed',
+                meta: event.payload.errorMessage,
+            };
+        default:
+            return { label: 'Activity', meta: null };
+    }
+};
+
+const liveRow = (
+    liveState: AiAgentReviewRemediationLiveState,
+    writebackProgress: string | null,
+): TimelineRow => ({
+    key: `live-${liveState}`,
+    label:
+        liveState === 'writeback'
+            ? 'Writeback running'
+            : liveState === 'compiling'
+              ? 'Compiling preview'
+              : 'Verifying fix',
+    meta:
+        liveState === 'writeback'
+            ? (writebackProgress ?? 'Editing the dbt project…')
+            : liveState === 'compiling'
+              ? 'Building the preview project from the PR branch…'
+              : 'Re-running the original question in the preview…',
+    when: 'now',
+    state: 'live',
+});
+
+type Props = {
+    reviewItem: AiAgentReviewItemSummary;
+};
+
+export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
+    const { data } = useAiAgentReviewItemActivity(reviewItem.fingerprint, {
+        enabled: !!reviewItem.remediation,
+        // Poll only while a step is in flight — settled feeds are static.
+        refetchInterval: (latest) =>
+            latest?.liveState === 'writeback'
+                ? WRITEBACK_POLL_INTERVAL_MS
+                : latest?.liveState
+                  ? LIVE_POLL_INTERVAL_MS
+                  : false,
+    });
+
+    const rows = useMemo<TimelineRow[]>(() => {
+        if (!data || data.events.length === 0) {
+            return [];
+        }
+        let previous: Date | null = null;
+        const eventRows = data.events.map((event) => {
+            const when = formatWhen(event.occurredAt, previous);
+            previous = dayjs(event.occurredAt).toDate();
+            return {
+                key: event.uuid,
+                when,
+                state: 'done' as const,
+                ...eventRow(event, reviewItem),
+            };
+        });
+        return data.liveState
+            ? [...eventRows, liveRow(data.liveState, data.liveMessage)]
+            : eventRows;
+    }, [data, reviewItem]);
+
+    if (rows.length === 0) {
+        return null;
+    }
+
+    return (
+        <Box component="ul" className={styles.timeline}>
+            {rows.map((row) => (
+                <li
+                    key={row.key}
+                    className={styles.item}
+                    data-done={row.state === 'done' || undefined}
+                    data-live={row.state === 'live' || undefined}
+                >
+                    <span className={styles.when}>{row.when}</span>
+                    <div className={styles.node} />
+                    <div className={styles.event}>{row.label}</div>
+                    {row.meta ? (
+                        <div className={styles.meta}>{row.meta}</div>
+                    ) : null}
+                </li>
+            ))}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -79,22 +79,18 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     return (
         <>
             {isWritebackInFlight ? (
-                <Tooltip label={phase} withArrow openDelay={300}>
-                    <Group
-                        gap={8}
-                        wrap="nowrap"
-                        maw={mode === 'drawer' ? 320 : 180}
-                    >
-                        <Loader size={12} color="ldGray.5" />
-                        <Text
-                            fz="xs"
-                            c="ldGray.6"
-                            lineClamp={mode === 'drawer' ? 2 : 1}
-                        >
-                            {phase}
-                        </Text>
-                    </Group>
-                </Tooltip>
+                // The drawer's Activity timeline owns the live progress row —
+                // a second spinner in the corner would duplicate it.
+                mode === 'drawer' ? null : (
+                    <Tooltip label={phase} withArrow openDelay={300}>
+                        <Group gap={8} wrap="nowrap" maw={180}>
+                            <Loader size={12} color="ldGray.5" />
+                            <Text fz="xs" c="ldGray.6" lineClamp={1}>
+                                {phase}
+                            </Text>
+                        </Group>
+                    </Tooltip>
+                )
             ) : (
                 <Stack gap={mode === 'drawer' ? 'xs' : 6} align="flex-start">
                     <Group gap={4} wrap="wrap">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -36,6 +36,7 @@ import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
 import { AgentNamePill } from '../AgentNamePill';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { EvalAssessmentDisplay } from '../Evals/EvalAssessmentDisplay';
+import { RemediationActivityTimeline } from './RemediationActivityTimeline';
 import { ReviewItemActions } from './ReviewItemActions';
 import {
     formatReviewDate,
@@ -462,6 +463,23 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                 }
                                             />
                                         </Collapse>
+                                    )}
+
+                                    {selectedReviewItem.remediation && (
+                                        <Stack gap={6} pt="xs">
+                                            <Text
+                                                size="10px"
+                                                fw={700}
+                                                tt="uppercase"
+                                                lts={0.4}
+                                                c="ldGray.7"
+                                            >
+                                                Activity
+                                            </Text>
+                                            <RemediationActivityTimeline
+                                                reviewItem={selectedReviewItem}
+                                            />
+                                        </Stack>
                                     )}
                                 </Stack>
                             </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadPullRequestCard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadPullRequestCard.module.css
@@ -1,0 +1,79 @@
+.gutter {
+    width: 19.5rem;
+    flex-shrink: 0;
+    height: 100%;
+    overflow-y: auto;
+    padding: var(--mantine-spacing-md);
+}
+
+.card {
+    border-radius: var(--mantine-radius-lg);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldGray-3));
+    box-shadow: var(--mantine-shadow-sm);
+    padding: var(--mantine-spacing-md);
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldGray-0)
+    );
+}
+
+.label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--mantine-color-ldGray-5);
+}
+
+.title {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.35;
+}
+
+.ref {
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.summary {
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.statRow {
+    display: flex;
+    gap: var(--mantine-spacing-md);
+    align-items: center;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    padding-top: var(--mantine-spacing-xs);
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-ldGray-6);
+}
+
+.additions {
+    color: light-dark(var(--mantine-color-teal-8), var(--mantine-color-teal-4));
+    font-weight: 600;
+}
+
+.deletions {
+    font-weight: 600;
+}
+
+.stateMerged {
+    color: light-dark(
+        var(--mantine-color-violet-7),
+        var(--mantine-color-violet-4)
+    );
+    font-weight: 600;
+}
+
+.stateClosed {
+    color: var(--mantine-color-ldGray-6);
+    font-weight: 600;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadPullRequestCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadPullRequestCard.tsx
@@ -1,0 +1,157 @@
+import { Anchor, Button, Group, Stack, Text } from '@mantine-8/core';
+import { IconArrowUpRight, IconFileDiff } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useAiAgentThreadPullRequest } from '../hooks/useProjectAiAgents';
+import { usePullRequestCiChecks } from '../hooks/usePullRequestCiChecks';
+import { PullRequestCiChecks } from './ChatElements/ToolCalls/PullRequestCiChecks';
+import styles from './ThreadPullRequestCard.module.css';
+
+type Props = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+};
+
+/**
+ * Right-panel overview of the writeback PR a thread is associated with: what
+ * the PR does (the AI-written summary), live state and diff stats, CI checks.
+ * Renders nothing for threads without a PR.
+ */
+export const ThreadPullRequestCard: FC<Props> = ({
+    projectUuid,
+    agentUuid,
+    threadUuid,
+}) => {
+    const { data: pullRequest } = useAiAgentThreadPullRequest(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
+    const { data: ciChecks } = usePullRequestCiChecks(
+        pullRequest ? projectUuid : undefined,
+        pullRequest?.prUrl,
+        pullRequest?.commitSha ?? null,
+    );
+
+    if (!pullRequest) {
+        return null;
+    }
+
+    const stateLabel =
+        pullRequest.state === 'merged'
+            ? 'merged'
+            : pullRequest.state === 'closed'
+              ? 'closed'
+              : pullRequest.state === 'open'
+                ? 'open'
+                : null;
+
+    return (
+        <div className={styles.gutter}>
+            <Stack gap="xs" className={styles.card}>
+                <Text className={styles.label}>Pull request</Text>
+
+                <Stack gap={2}>
+                    <Text className={styles.title} lineClamp={2}>
+                        {pullRequest.title ??
+                            pullRequest.summary ??
+                            'Writeback pull request'}
+                    </Text>
+                    <Text className={styles.ref}>
+                        {pullRequest.repo}
+                        {pullRequest.prNumber
+                            ? ` #${pullRequest.prNumber}`
+                            : ''}
+                        {stateLabel ? (
+                            <>
+                                {' · '}
+                                <span
+                                    className={
+                                        pullRequest.state === 'merged'
+                                            ? styles.stateMerged
+                                            : pullRequest.state === 'closed'
+                                              ? styles.stateClosed
+                                              : undefined
+                                    }
+                                >
+                                    {stateLabel}
+                                </span>
+                            </>
+                        ) : null}
+                    </Text>
+                </Stack>
+
+                {pullRequest.summary &&
+                    pullRequest.summary !== pullRequest.title && (
+                        <Text className={styles.summary}>
+                            {pullRequest.summary}
+                        </Text>
+                    )}
+
+                {(pullRequest.changedFiles !== null ||
+                    pullRequest.additions !== null) && (
+                    <div className={styles.statRow}>
+                        {pullRequest.changedFiles !== null && (
+                            <span>
+                                {pullRequest.changedFiles}{' '}
+                                {pullRequest.changedFiles === 1
+                                    ? 'file'
+                                    : 'files'}
+                            </span>
+                        )}
+                        {pullRequest.additions !== null && (
+                            <span>
+                                <span className={styles.additions}>
+                                    +{pullRequest.additions}
+                                </span>{' '}
+                                <span className={styles.deletions}>
+                                    −{pullRequest.deletions ?? 0}
+                                </span>
+                            </span>
+                        )}
+                    </div>
+                )}
+
+                <PullRequestCiChecks
+                    prUrl={pullRequest.prUrl}
+                    ciChecks={ciChecks ?? null}
+                />
+
+                <Group gap="xs" grow>
+                    <Button
+                        component="a"
+                        href={pullRequest.prUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="compact-sm"
+                        variant="filled"
+                        color="dark"
+                        rightSection={
+                            <MantineIcon icon={IconArrowUpRight} size="sm" />
+                        }
+                    >
+                        View PR
+                    </Button>
+                    <Anchor
+                        href={`${pullRequest.prUrl}/files`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="never"
+                    >
+                        <Button
+                            size="compact-sm"
+                            variant="default"
+                            fullWidth
+                            leftSection={
+                                <MantineIcon icon={IconFileDiff} size="sm" />
+                            }
+                        >
+                            View diff
+                        </Button>
+                    </Anchor>
+                </Group>
+            </Stack>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -4,6 +4,7 @@ import {
     type AiAgentReviewItemSummary,
     type AiAgentReviewItemStatus,
     type ApiAiAgentAdminConversationsResponse,
+    type ApiAiAgentReviewItemActivityResponse,
     type ApiAiAgentReviewItemPrDiffResponse,
     type ApiAiAgentReviewItemResponse,
     type ApiAiAgentReviewItemsResponse,
@@ -23,6 +24,7 @@ import {
     useQueryClient,
     type QueryClient,
     type UseInfiniteQueryOptions,
+    type UseQueryOptions,
 } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 import useToaster from '../../../../hooks/toaster/useToaster';
@@ -214,6 +216,35 @@ export const useAiAgentAdminReviewItem = (
     return useQuery<ApiAiAgentReviewItemResponse['results'], ApiError>({
         queryKey: ['ai-agent-admin-review-item', fingerprint],
         queryFn: () => getAiAgentAdminReviewItem(fingerprint),
+        enabled: options?.enabled ?? true,
+        refetchInterval: options?.refetchInterval,
+    });
+};
+
+const getAiAgentReviewItemActivity = async (fingerprint: string) => {
+    return lightdashApi<ApiAiAgentReviewItemActivityResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(
+            fingerprint,
+        )}/activity`,
+        method: 'GET',
+        body: undefined,
+    });
+};
+
+export const useAiAgentReviewItemActivity = (
+    fingerprint: string,
+    options?: {
+        enabled?: boolean;
+        refetchInterval?: UseQueryOptions<
+            ApiAiAgentReviewItemActivityResponse['results'],
+            ApiError
+        >['refetchInterval'];
+    },
+) => {
+    return useQuery<ApiAiAgentReviewItemActivityResponse['results'], ApiError>({
+        queryKey: ['ai-agent-admin-review-item-activity', fingerprint],
+        queryFn: () => getAiAgentReviewItemActivity(fingerprint),
         enabled: options?.enabled ?? true,
         refetchInterval: options?.refetchInterval,
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -10,6 +10,7 @@ import type {
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageVizQuery,
+    ApiAiAgentThreadPullRequestResponse,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadShareResponse,
     ApiAiAgentVerifiedQuestionsResponse,
@@ -337,6 +338,37 @@ const getAgentThread = async (
         url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}`,
         method: 'GET',
         body: undefined,
+    });
+
+const getAgentThreadPullRequest = async (
+    projectUuid: string,
+    agentUuid: string,
+    threadUuid: string,
+) =>
+    lightdashApi<ApiAiAgentThreadPullRequestResponse['results']>({
+        url: `/projects/${projectUuid}/aiAgents/${agentUuid}/threads/${threadUuid}/pull-request`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAiAgentThreadPullRequest = (
+    projectUuid: string,
+    agentUuid: string | undefined,
+    threadUuid: string | null | undefined,
+) =>
+    useQuery<ApiAiAgentThreadPullRequestResponse['results'], ApiError>({
+        queryKey: [
+            AI_AGENTS_KEY,
+            projectUuid,
+            agentUuid,
+            'threads',
+            threadUuid,
+            'pull-request',
+        ],
+        queryFn: () =>
+            getAgentThreadPullRequest(projectUuid, agentUuid!, threadUuid!),
+        enabled: !!agentUuid && !!threadUuid,
+        retry: false,
     });
 
 const createAgentThreadShare = async (

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -10,6 +10,7 @@ import {
     contextItemsToContentMentionSuggestions,
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
+import { ThreadPullRequestCard } from '../../features/aiCopilot/components/ThreadPullRequestCard';
 import {
     useAiAgentReviewItemByPreviewThread,
     useUpdateAiAgentReviewItemStatus,
@@ -309,7 +310,7 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     />
                 </AgentChatDisplay>
             </Box>
-            {reviewItem && (
+            {reviewItem ? (
                 <ReviewVerificationPanel
                     reviewItem={reviewItem}
                     canRetry={!!retryPrompt && !inputDisabled}
@@ -318,6 +319,16 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
                     onRetry={handleRetryOriginalQuestion}
                     onMarkDone={handleMarkFixed}
                 />
+            ) : (
+                agentUuid &&
+                threadUuid &&
+                projectUuid && (
+                    <ThreadPullRequestCard
+                        projectUuid={projectUuid}
+                        agentUuid={agentUuid}
+                        threadUuid={threadUuid}
+                    />
+                )
             )}
         </Flex>
     );

--- a/packages/frontend/src/features/pullRequests/utils.test.ts
+++ b/packages/frontend/src/features/pullRequests/utils.test.ts
@@ -14,6 +14,7 @@ const makeRow = (overrides: Partial<PullRequestRow> = {}): PullRequestRow => ({
     repo: 'dbt',
     prNumber: 42,
     prUrl: 'https://github.com/acme/dbt/pull/42',
+    summary: null,
     aiThreadUuid: 'thread-1',
     aiAgentUuid: 'agent-1',
     reviewContext: null,


### PR DESCRIPTION
Closes: ZAP-484

## What this builds

Two polished surfaces for PRs created from Ask AI reviews:

**1. Activity timeline in the finding detail drawer.** The per-PR lifecycle story — finding opened → writeback running → PR opened → preview compiled → verifying → fix verified → merged/resolved — as a monochrome timeline with a single living teal accent on the in-flight step. The live row streams the writeback's step messages (replacing the old corner spinner in the drawer; the table keeps its compact spinner). Polls at 2.5s while the writeback streams, 5s while compiling/verifying, and stops once settled.

**2. PR overview card in the AI thread right panel.** Any thread that resolves to a writeback PR (the PR the agent opened mid-conversation, which previously only surfaced as an inline chat button that scrolls away) gets a card with the PR title, an AI-written two-line "what this PR does" summary, live state and ± stats from GitHub, CI checks, and View PR / View diff actions. Remediation verification threads keep their existing verification panel.

## How it works

**Event log.** New `ai_agent_review_remediation_events` table (event_type, occurred_at, jsonb payload, nullable actor; cascade-deleted with the remediation). Terminal transitions (`resolved`/`failed`) are emitted centrally inside `updateReviewRemediationStatus` so no call site can forget; moment events are written where the moment happens — remediation creation (`finding_opened`, backdated to the finding's first-seen), the writeback job (`writeback_completed` with files/±, `pr_opened`), the compile poll task (`preview_compiled`), the remediation run worker (`verification_completed`), and the existing PR reconcile pass (`pr_merged`/`pr_closed`).

**Live state is derived, never stored.** `GET …/review-items/{fingerprint}/activity` returns the events plus `liveState` (`writeback`/`compiling`/`verifying`) computed from the remediation status and which events exist, and `liveMessage` (the streaming writeback progress text).

**PR summary.** The writeback agent now emits a third structured-output block (`<lightdash-writeback-pr-summary>`) alongside the existing title/description blocks — one or two sentences written for a business user, stored on the new `pull_requests.summary` column at PR creation and refreshed on follow-up turns. Falls back to the live PR title for PRs predating the field.

**Thread → PR resolution.** `GET …/threads/{threadUuid}/pull-request` resolves via the `ai_writeback_thread` link first, then via the remediation whose preview thread matches; live title/state/± come from a single GitHub PR GET (best-effort — the stored card renders without them).

## Regression analysis

- **Non-AI / existing PRs:** `pull_requests.summary` is nullable; all existing rows and consumers are unaffected. `getPullRequest` (GitHub client) gained additive return fields only.
- **Review drawer:** the in-flight corner spinner is removed from drawer mode only (the feed owns live progress there); table rows keep it. Findings without a remediation, or predating the events table, show no Activity section at all.
- **Threads without a writeback PR:** the new endpoint returns null and no card renders; thread permissions reuse the same agent/thread access checks as `getAgentThread`.
- **Writeback prompt change:** agents that don't emit the new summary block degrade to title fallback — the block parser tolerates absence, same as title/description.
- **Deployments without EE tables:** `PullRequestsModel.findByAiThreadUuid` guards on table existence like the existing `getAiThreadInfo`.

## Testing

- TDD across the stack: model event emission (central terminal events, explicit occurred_at, no-emit when no row matched), activity assembly and live-state derivation (writeback/compiling/verifying/settled/empty), compile-poll and worker event writes, summary block parsing/stripping. 344 backend tests green across the touched suites; 2,286 common tests green.
- Exercised live on local dev end-to-end: finding → Create PR → writeback streaming in the feed → PR opened → preview compiled → verification, in light and dark mode (ldGray's inverted dark tuple respected — plain semantic indexes for grays, theme teal for the living accent).

Relates: ZAP-480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
