### PR TITLE
docs: update CLI skill deploy guidance

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -27,7 +27,7 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 | Build dashboards | `lightdash download`, edit YAML, `lightdash upload` | [Dashboard Reference](./resources/dashboard-reference.md) |
 | Lint yaml files | `lightdash lint` | [CLI Reference](./resources/cli-reference.md) |
 | Set warehouse connection | `lightdash set-warehouse` from profiles.yml | [CLI Reference](./resources/cli-reference.md) |
-| Deploy changes | `lightdash deploy` (semantic layer), `lightdash upload` (content) | [CLI Reference](./resources/cli-reference.md) |
+| Deploy changes | Prefer CI/CD or UI refresh for production; use `lightdash deploy` only when explicitly appropriate | [CLI Reference](./resources/cli-reference.md) |
 | Test changes | `lightdash preview` | [Workflows](./resources/workflows-reference.md) |
 
 ## Common Mistakes
@@ -38,20 +38,23 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 | **Not updating dashboard tiles after renaming a chart** | Dashboard tile still shows old title — `title` and `chartName` are independent overrides that do NOT auto-update | Download the dashboard, find tiles with matching `chartSlug`, update `title` and `chartName` to match |
 | **Including unused dimensions in metricQuery** | "Results may be incorrect" warning — extra dimensions change SQL grouping and produce wrong numbers | Every dimension in `metricQuery.dimensions` must appear in the chart config. For cartesian: `layout.xField`, `layout.yField`, or `pivotConfig.columns` |
 | **Unsorted YAML keys** | `lightdash upload` warns "unsorted YAML keys" and diffs become noisy | Always sort keys alphabetically at every nesting level — the CLI writes with `sortKeys: true` |
-| **Deploying to wrong project** | Overwrites production content | Always run `lightdash config get-project` before deploying |
+| **Running `lightdash deploy` ad hoc against production** | Bypasses the team's release process and can overwrite the production semantic layer | Avoid direct production deploys. Remind the user to use CI/CD (for example GitHub Actions) or refresh dbt from the Lightdash UI unless they explicitly confirm a rare direct-deploy reason |
+| **Deploying to wrong project** | Overwrites project content | Always run `lightdash config get-project` before any deploy or upload |
 | **Missing `contentType` field** | Content type can't be determined without relying on directory structure | Always include `contentType: chart`, `contentType: dashboard`, or `contentType: sql_chart` at the top level |
 
 ## Before You Start
 
 ### Check Your Target Project
 
-**Always verify which project you're deploying to.** Deploying to the wrong project can overwrite production content.
+**Always verify which project you're targeting.** Deploying or uploading to the wrong project can overwrite production content.
 
 ```bash
 lightdash config get-project        # Show current project
 lightdash config list-projects      # List available projects
 lightdash config set-project --name "My Project"  # Switch project
 ```
+
+**Production deploys:** Do not run `lightdash deploy` against production as a default agent action. Production updates should almost always happen through the project's CI/CD pipeline (for example GitHub Actions after merge) or by refreshing dbt from the Lightdash UI. Only run a direct production deploy when the user explicitly asks for it and confirms why the normal release path is not appropriate.
 
 ### Detect Your Project Type
 
@@ -123,7 +126,7 @@ If the project needs a different warehouse connection (e.g., switching from Post
 lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --assume-yes
 ```
 
-This reads credentials from profiles.yml, updates the warehouse connection on the currently selected project, and triggers a recompile. Run this before `lightdash deploy`.
+This reads credentials from profiles.yml, updates the warehouse connection on the currently selected project, and triggers a recompile. For production projects, prefer making this change through the established release process or UI workflow rather than following it with a direct local deploy.
 
 To target a specific project:
 
@@ -156,7 +159,7 @@ Read the CSV and use the **exact values** in your filter YAML. This applies to a
 1. **Find the model YAML file** (dbt: `models/*.yml`, pure Lightdash: `lightdash/models/*.yml`)
 2. **Edit metrics/dimensions** using the appropriate syntax for your project type
 3. **Validate**: `lightdash lint` (pure Lightdash) or `dbt compile` (dbt projects)
-4. **Deploy**: `lightdash deploy`
+4. **Ship**: open a PR and let CI/CD deploy, or ask the user to refresh dbt from the Lightdash UI. Use `lightdash deploy` only for non-production projects or a user-confirmed exceptional production deploy.
 
 See [Metrics Reference](./resources/metrics-reference.md) and [Dimensions Reference](./resources/dimensions-reference.md) for configuration options.
 
@@ -213,7 +216,7 @@ lightdash stop-preview --name "my-feature"
 
 | Command | Purpose |
 |---------|---------|
-| `lightdash deploy` | Sync semantic layer (metrics, dimensions) |
+| `lightdash deploy` | Sync semantic layer (metrics, dimensions). Avoid direct production use; prefer CI/CD or UI refresh |
 | `lightdash upload` | Upload charts/dashboards |
 | `lightdash download` | Download charts/dashboards as YAML |
 | `lightdash lint` | Validate YAML locally |
@@ -326,9 +329,9 @@ lightdash sql "SELECT SUM(amount) FROM orders" -o test.csv
 
 | Pattern | When to Use |
 |---------|-------------|
-| **Direct** (`deploy` + `upload`) | Solo dev, rapid iteration |
+| **Direct** (`deploy` + `upload`) | Non-production, solo dev, rapid iteration, or a user-confirmed exceptional production deploy |
 | **Preview-First** | Team, complex changes |
-| **CI/CD** | Automated on merge |
+| **CI/CD** | Production deploys automated on merge |
 
 See [Workflows Reference](./resources/workflows-reference.md) for detailed examples and CI/CD configurations.
 

--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -39,7 +39,7 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 | **Including unused dimensions in metricQuery** | "Results may be incorrect" warning — extra dimensions change SQL grouping and produce wrong numbers | Every dimension in `metricQuery.dimensions` must appear in the chart config. For cartesian: `layout.xField`, `layout.yField`, or `pivotConfig.columns` |
 | **Unsorted YAML keys** | `lightdash upload` warns "unsorted YAML keys" and diffs become noisy | Always sort keys alphabetically at every nesting level — the CLI writes with `sortKeys: true` |
 | **Running `lightdash deploy` ad hoc against production** | Bypasses the team's release process and can overwrite the production semantic layer | Avoid direct production deploys. Remind the user to use CI/CD (for example GitHub Actions) or refresh dbt from the Lightdash UI unless they explicitly confirm a rare direct-deploy reason |
-| **Deploying to wrong project** | Overwrites project content | Always run `lightdash config get-project` before any deploy or upload |
+| **Deploying without confirming the target** | Overwrites the wrong project's content | Before any deploy or upload, run `lightdash config get-project`, read the project name + UUID back to the user, and get explicit confirmation. Warn if it may be production |
 | **Missing `contentType` field** | Content type can't be determined without relying on directory structure | Always include `contentType: chart`, `contentType: dashboard`, or `contentType: sql_chart` at the top level |
 
 ## Before You Start
@@ -49,10 +49,16 @@ Build and deploy Lightdash analytics projects. This skill covers the **semantic 
 **Always verify which project you're targeting.** Deploying or uploading to the wrong project can overwrite production content.
 
 ```bash
-lightdash config get-project        # Show current project
-lightdash config list-projects      # List available projects
+lightdash config get-project        # Show current project (name + UUID)
+lightdash config list-projects      # List available projects (preview projects are excluded)
 lightdash config set-project --name "My Project"  # Switch project
 ```
+
+**Confirm the target with the user before every `lightdash deploy`.** Do not deploy to whichever project happens to be selected. The required steps are:
+
+1. Run `lightdash config get-project` and read back the **project name and UUID** to the user.
+2. Ask the user to explicitly confirm that this is the project they want to deploy to before you run `lightdash deploy`.
+3. **Warn the user if this looks like a production project.** Note that `get-project` reports only the name and UUID — it does **not** tell you whether the project is a preview. Previews are created by `lightdash preview` and are filtered out of `lightdash config list-projects`, so if the current project appears in `list-projects` it is a regular (non-preview) project and a direct deploy may hit production. When in doubt, treat it as production and steer the user toward CI/CD or a UI refresh.
 
 **Production deploys:** Do not run `lightdash deploy` against production as a default agent action. Production updates should almost always happen through the project's CI/CD pipeline (for example GitHub Actions after merge) or by refreshing dbt from the Lightdash UI. Only run a direct production deploy when the user explicitly asks for it and confirms why the normal release path is not appropriate.
 
@@ -159,7 +165,7 @@ Read the CSV and use the **exact values** in your filter YAML. This applies to a
 1. **Find the model YAML file** (dbt: `models/*.yml`, pure Lightdash: `lightdash/models/*.yml`)
 2. **Edit metrics/dimensions** using the appropriate syntax for your project type
 3. **Validate**: `lightdash lint` (pure Lightdash) or `dbt compile` (dbt projects)
-4. **Ship**: open a PR and let CI/CD deploy, or ask the user to refresh dbt from the Lightdash UI. Use `lightdash deploy` only for non-production projects or a user-confirmed exceptional production deploy.
+4. **Ship**: open a PR and let CI/CD deploy, or ask the user to refresh dbt from the Lightdash UI. Use `lightdash deploy` only for non-production projects or a user-confirmed exceptional production deploy — and first run `lightdash config get-project`, read the project name + UUID back to the user, and get explicit confirmation of the target.
 
 See [Metrics Reference](./resources/metrics-reference.md) and [Dimensions Reference](./resources/dimensions-reference.md) for configuration options.
 

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -26,6 +26,8 @@ lightdash config set-project --uuid abc123-def456
 
 **Production guidance for agents:** Do not run `lightdash deploy` against a production project by default. Production deployments should almost always happen through the project's CI/CD process, such as GitHub Actions after merge, or by refreshing dbt from the Lightdash UI. Use a direct production deploy only when the user explicitly confirms an exceptional reason.
 
+**Confirm the target before deploying:** Before any `lightdash deploy`, run `lightdash config get-project`, read the project **name and UUID** back to the user, and ask them to confirm it is the intended target. `get-project` reports only name and UUID, not whether the project is a preview — preview projects are created by `lightdash preview` and are excluded from `lightdash config list-projects`, so a project that shows up in `list-projects` is a regular (non-preview) project that may be production. Warn the user in that case.
+
 ```bash
 # Compile dbt models and validate
 lightdash compile --project-dir ./dbt --profiles-dir ./profiles

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -24,11 +24,13 @@ lightdash config set-project --uuid abc123-def456
 
 ## Compilation & Deployment
 
+**Production guidance for agents:** Do not run `lightdash deploy` against a production project by default. Production deployments should almost always happen through the project's CI/CD process, such as GitHub Actions after merge, or by refreshing dbt from the Lightdash UI. Use a direct production deploy only when the user explicitly confirms an exceptional reason.
+
 ```bash
 # Compile dbt models and validate
 lightdash compile --project-dir ./dbt --profiles-dir ./profiles
 
-# Deploy to Lightdash
+# Deploy to a non-production Lightdash project
 lightdash deploy --project-dir ./dbt --profiles-dir ./profiles
 
 # Create new project on deploy
@@ -201,7 +203,7 @@ lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --assume-y
 - `-y, --assume-yes` - Skip confirmation prompts
 - `--verbose` - Show detailed output
 
-**Note:** This command reads warehouse credentials from profiles.yml, updates the connection on the project, and triggers a recompile. Run this before `lightdash deploy` if the project needs a different warehouse connection.
+**Note:** This command reads warehouse credentials from profiles.yml, updates the connection on the project, and triggers a recompile. For production projects, prefer the established CI/CD or UI refresh workflow over following this with a direct local deploy.
 
 ## Command Summary
 
@@ -209,7 +211,7 @@ lightdash set-warehouse --project-dir ./dbt --profiles-dir ./profiles --assume-y
 | --------------------- | -------------------------------- |
 | `lightdash login`     | Authenticate with Lightdash      |
 | `lightdash config`    | Manage project selection         |
-| `lightdash deploy`    | Sync semantic layer to Lightdash |
+| `lightdash deploy`    | Sync semantic layer to Lightdash. Avoid direct production use; prefer CI/CD or UI refresh |
 | `lightdash upload`    | Upload charts/dashboards         |
 | `lightdash download`  | Download charts/dashboards       |
 | `lightdash preview`   | Create temporary test project    |

--- a/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -8,7 +8,12 @@ Simple and direct - deploy changes straight to a non-production project.
 
 Do not use this as the default production workflow. Production semantic-layer updates should almost always be deployed by CI/CD after review (for example GitHub Actions on merge) or refreshed from the Lightdash UI. Use direct production `lightdash deploy` only when the user explicitly confirms an exceptional reason, such as an approved emergency or a one-off setup task.
 
+**Always confirm the target project first.** Run `lightdash config get-project`, read the project name + UUID back to the user, and get explicit confirmation before deploying. `get-project` does not report whether the project is a preview, so warn the user if it may be production.
+
 ```bash
+# Confirm the target project, then read name + UUID back to the user before deploying
+lightdash config get-project
+
 # Make dbt/YAML changes locally
 lightdash deploy --target dev
 lightdash upload

--- a/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -2,21 +2,24 @@
 
 Detailed examples and CI/CD configurations for common Lightdash development patterns.
 
-## Pattern 1: Direct Deployment
+## Pattern 1: Direct Deployment (Non-Production or Exceptional)
 
-Simple and direct - deploy changes straight to your project.
+Simple and direct - deploy changes straight to a non-production project.
+
+Do not use this as the default production workflow. Production semantic-layer updates should almost always be deployed by CI/CD after review (for example GitHub Actions on merge) or refreshed from the Lightdash UI. Use direct production `lightdash deploy` only when the user explicitly confirms an exceptional reason, such as an approved emergency or a one-off setup task.
 
 ```bash
 # Make dbt/YAML changes locally
-lightdash deploy --target prod
+lightdash deploy --target dev
 lightdash upload
 ```
 
 **When to use:**
 - Solo developer or small team
-- Single environment
-- No CI/CD pipeline
+- Non-production or scratch project
+- No CI/CD pipeline for this project yet
 - Rapid iteration needed
+- User explicitly confirms a rare direct production deploy is appropriate
 
 ## Pattern 2: Preview-First Development
 
@@ -29,21 +32,22 @@ lightdash preview --name "feature-x"
 # In preview: iterate on changes
 lightdash upload --force
 
-# When ready: stop preview, deploy to main
+# When ready: stop preview, then ship through the normal production path
 lightdash stop-preview --name "feature-x"
-lightdash config set-project --name "Production"
-lightdash deploy --target prod
-lightdash upload
+# Open a PR and let CI/CD deploy after merge, or ask the user to refresh dbt from the UI.
 ```
 
 **When to use:**
 - Multiple team members
 - Want to test before pushing
 - Complex changes spanning multiple models/charts
+- Production should still be updated by CI/CD or UI refresh, not an ad hoc agent deploy
 
 ## Pattern 3: CI/CD Pipeline
 
 Automated deployment on merge to main branch.
+
+This is the preferred production path. If a user asks the agent to update production, remind them to use the existing CI/CD pipeline or refresh dbt from the Lightdash UI unless they explicitly confirm a rare reason to deploy directly.
 
 ### GitHub Actions
 
@@ -285,7 +289,9 @@ lightdash/
 
 Separate dev, staging, and production projects with promotion workflow.
 
-### Manual Promotion
+### Manual Promotion (Non-Production Only)
+
+Use manual promotion for dev and staging projects. For production, prefer CI/CD or the Lightdash UI refresh workflow unless the user explicitly confirms a rare direct deploy is required.
 
 ```bash
 # List available projects (excludes preview projects)
@@ -305,10 +311,7 @@ lightdash upload
 
 # Test in staging...
 
-# Promote to Production
-lightdash config set-project --name "Production"
-lightdash deploy --target prod
-lightdash upload
+# Promote to Production through CI/CD after merge, or refresh dbt from the UI.
 ```
 
 ### CI/CD Multi-Environment
@@ -369,6 +372,7 @@ jobs:
 - Different dbt targets for each environment
 - Formal promotion process
 - Need to test changes before production
+- Production promotion is handled by CI/CD or UI refresh
 
 ## Environment Variables Reference
 


### PR DESCRIPTION
Closes:

### Description:

Updates the `developing-in-lightdash` skill that is installed by `lightdash install-skills` so agents do not treat `lightdash deploy` as the default way to update production projects.

What changed:
- Adds explicit guidance that production semantic-layer updates should almost always go through CI/CD, such as GitHub Actions after merge, or be refreshed from the Lightdash UI.
- Reframes direct `lightdash deploy` usage as appropriate for non-production projects or rare user-confirmed exceptions.
- Updates workflow examples so manual/preview flows do not end with an ad hoc production deploy, while preserving production `lightdash deploy` examples inside CI/CD workflows.

Why:
- Agents were sometimes running `lightdash deploy` directly, which can bypass review and the team's normal production release path.

Validation:
- `git diff --check`
- Commit hooks: git-secrets and configured staged-file checks
