### PR TITLE
fix: do not require warehouse catalog entry for columns with explicit dimension type

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -141,6 +141,24 @@ describe('attachTypesToModels', () => {
             'Column "myColumnName" from model "myTable" does not exist.\n "myTable.myColumnName" was not found in your target warehouse at myDatabase.mySchema.myTable. Try rerunning dbt to update your warehouse.',
         );
     });
+    it('should not throw for a missing column with an explicit dimension type', async () => {
+        const modelWithExplicitType = {
+            ...model,
+            columns: {
+                myColumnName: {
+                    name: 'myColumnName',
+                    meta: { dimension: { type: DimensionType.STRING } },
+                },
+            },
+        };
+        expect(
+            attachTypesToModels(
+                [modelWithExplicitType],
+                warehouseSchemaWithMissingColumn,
+                true,
+            )[0].columns.myColumnName.data_type,
+        ).toBeUndefined();
+    });
     it('should match uppercase column names when case-sensitive is false', async () => {
         expect(
             attachTypesToModels(

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1466,7 +1466,14 @@ export const attachTypesToModels = (
     const getType = (
         { database, schema, name, alias }: DbtModelNode,
         columnName: string,
+        column: DbtModelColumn,
     ): DimensionType | undefined => {
+        // Columns with an explicit dimension type don't need a catalog entry
+        // (the explicit type wins in convertDimension) and may not exist as
+        // physical columns, e.g. expr-based dbt semantic layer dimensions.
+        const explicitDimensionType =
+            column.config?.meta?.dimension?.type ??
+            column.meta?.dimension?.type;
         const tableName = alias || name;
         const databaseMatch = Object.keys(warehouseCatalog).find((db) =>
             caseSensitiveMatching
@@ -1505,7 +1512,7 @@ export const attachTypesToModels = (
                 columnMatch
             ];
         }
-        if (throwOnMissingCatalogEntry) {
+        if (throwOnMissingCatalogEntry && !explicitDimensionType) {
             throw new MissingCatalogEntryError(
                 `Column "${columnName}" from model "${tableName}" does not exist.\n "${tableName}.${columnName}" was not found in your target warehouse at ${database}.${schema}.${tableName}. Try rerunning dbt to update your warehouse.`,
                 {},
@@ -1520,7 +1527,7 @@ export const attachTypesToModels = (
         columns: Object.fromEntries(
             Object.entries(model.columns).map(([column_name, column]) => [
                 column_name,
-                { ...column, data_type: getType(model, column_name) },
+                { ...column, data_type: getType(model, column_name, column) },
             ]),
         ),
     }));


### PR DESCRIPTION
## Summary

`attachTypesToModels` throws `MissingCatalogEntryError` for any declared column that doesn't exist in the warehouse catalog. On the backend this triggers a full warehouse catalog refresh on **every** compile when a model declares a column that isn't a physical warehouse column (e.g. a dimension backed by a SQL expression with an explicit `dimension.type`).

This change skips the throw when the column has an explicit dimension type in its `meta`/`config.meta` — the explicit type already wins over the catalog type in `convertDimension`, so the catalog entry is never needed for these columns.

This also unblocks dbt-semantic-layer-synthesized expression dimensions (see related ticket) from causing catalog thrash.

## Testing

- New unit test in `translator.test.ts`: a column missing from the catalog with an explicit dimension type no longer throws with `throwOnMissingCatalogEntry=true`.

Relates: PROD-2191