### PR TITLE
fix(ai-agents): keep web agent streams warm to prevent idle-timeout drops

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -278,6 +278,15 @@ type AgentResponseStream = {
 
 const MAX_AI_PROMPT_CONTEXT_ITEMS = 10;
 
+// Web (SSE) agent streams are kept warm with a transient keepalive chunk on
+// this interval. A long, output-silent tool call — notably AI writeback, whose
+// sandbox/agent stage can run for minutes with no streamed tokens — otherwise
+// lets the connection idle long enough for an intermediary (the GCP HTTPS load
+// balancer) to drop it, which the client surfaces as a spurious "something went
+// wrong" even though the backend job completes and opens the PR. 15s sits
+// comfortably under the usual 30-60s idle timeouts.
+const STREAM_KEEPALIVE_INTERVAL_MS = 15_000;
+
 type AiAgentServiceDependencies = {
     aiAgentModel: AiAgentModel;
     aiAgentDocumentModel: AiAgentDocumentModel;
@@ -5811,6 +5820,16 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             dependencies,
             mcpToolSetup,
         });
+        // Heartbeat handle for the SSE keepalive (see STREAM_KEEPALIVE_INTERVAL_MS).
+        // Cleared in onFinish, and defensively if a write lands after the stream
+        // has closed.
+        let keepaliveInterval: ReturnType<typeof setInterval> | undefined;
+        const clearKeepalive = () => {
+            if (keepaliveInterval) {
+                clearInterval(keepaliveInterval);
+                keepaliveInterval = undefined;
+            }
+        };
         const streamWithMcpNotices = createUIMessageStream({
             execute: ({ writer }) => {
                 for (const unavailableMcpServer of mcpToolSetup.unavailableMcpServers) {
@@ -5820,6 +5839,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         transient: true,
                     });
                 }
+
+                // Keep the connection warm during long, output-silent tool
+                // calls so an idle-timeout proxy can't cut the stream (see
+                // STREAM_KEEPALIVE_INTERVAL_MS). `transient: true` → never
+                // persisted; the client drops unknown transient data parts, so
+                // this is invisible. Best-effort: a write after close throws,
+                // which just tears the heartbeat down.
+                keepaliveInterval = setInterval(() => {
+                    try {
+                        writer.write({
+                            type: 'data-keepalive',
+                            data: { ts: Date.now() },
+                            transient: true,
+                        });
+                    } catch {
+                        clearKeepalive();
+                    }
+                }, STREAM_KEEPALIVE_INTERVAL_MS);
 
                 // Forward step-progress events from tools (`updateProgress`,
                 // `editDbtProject`) to the client. `transient: true` so
@@ -5846,6 +5883,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 }
 
                 writer.merge(result.toUIMessageStream());
+            },
+            onFinish: () => {
+                clearKeepalive();
             },
         });
 


### PR DESCRIPTION
## Problem

Long, output-silent agent tool calls could leave the web (SSE) agent stream idle long enough for an intermediary load balancer to drop the connection. The frontend reports a dropped stream as a generic **"something went wrong"** error.

The worst offender is **AI writeback**: its sandbox/agent stage routinely runs for **several minutes** while the agent works in the sandbox, emitting no streamed tokens. The writeback worker job is fully decoupled from the stream (graphile-worker), so it runs to completion and **opens the pull request anyway** — but the user has already been shown a failure. This is misleading and drives needless retries.

Diagnosed from production: the stream drop shows up as `AiAgentStreamError` / `TypeError: network error` on the frontend, with **no** corresponding backend 4xx/5xx (it's a client-side stream interruption), while the writeback run completes and creates the PR seconds later.

## Fix

Write a `transient` `data-keepalive` chunk every 15s for the lifetime of the web stream, cleared on `onFinish` (and defensively if a write lands after the stream has closed).

- **Reuses the existing transient data-chunk pattern** already used right beside it (`data-step-progress`, `data-mcp-unavailable`) — concurrent writes during `writer.merge(...)` are already proven safe.
- **Invisible client-side**: transient parts are never persisted into the message, and the client drops unknown transient `data-*` chunks — nothing renders, no frontend change required.
- **Web-only**: lives at the SSE layer, so it leaves the rate-limited Slack progress path (`chat.update`) untouched.
- **General**: covers any long tool call, not just writeback.

15s sits comfortably under the usual 30–60s idle timeouts.

## Scope / follow-up

This prevents the *drop*. It does not add client-side *recovery* if a stream dies for some other reason (hard connection reset, etc.). A complementary frontend change — on a stream error with a tool call in flight, show "still working…" and reconcile via job status instead of a hard error — is worth doing as a follow-up.

## Testing

- `tsgo` backend typecheck: clean
- ESLint + oxfmt on the changed file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)