### PR TITLE
feat: increase maximum table group nesting depth to 5 levels

### DIFF
--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8050,7 +8050,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "groupLabel": {
                         "type": "string",
@@ -30587,7 +30587,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "baseTable": {
                         "type": "string"
@@ -30708,7 +30708,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     }
                 },
                 "required": ["name", "label"],
@@ -33963,7 +33963,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "aiHint": {
                         "anyOf": [
@@ -34034,7 +34034,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "aiHint": {
                         "anyOf": [
@@ -34159,7 +34159,7 @@
                             "type": "string"
                         },
                         "type": "array",
-                        "description": "Nested groups for the sidebar (max 3 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
+                        "description": "Nested groups for the sidebar (max 5 levels). Group keys resolve to\nlabels/descriptions via the project-level `table_groups` config\n(fetched separately); missing keys fall back to using the key as\nthe label."
                     },
                     "baseTable": {
                         "type": "string"

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -479,12 +479,12 @@
                 },
                 "groups": {
                     "type": "array",
-                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 5 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
                     "items": {
                         "type": "string",
                         "minLength": 1
                     },
-                    "maxItems": 3
+                    "maxItems": 5
                 },
                 "required_attributes": {
                     "$ref": "#/definitions/RequiredAttributes"

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -505,16 +505,16 @@
                 },
                 "groups": {
                     "type": "array",
-                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 5 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
                     "items": {
                         "type": "string",
                         "minLength": 1
                     },
-                    "maxItems": 3
+                    "maxItems": 5
                 },
                 "group_details": {
                     "type": "object",
-                    "description": "Set up group_details so you can group your dimensions and metrics in the sidebar using the groups parameter. You can create nested groups up to 3 levels",
+                    "description": "Set up group_details so you can group your dimensions and metrics in the sidebar using the groups parameter. You can create nested groups up to 5 levels",
                     "patternProperties": {
                         "^[a-zA-Z0-9_]+$": {
                             "type": "object",
@@ -704,12 +704,12 @@
                                 },
                                 "groups": {
                                     "type": "array",
-                                    "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 3 levels",
+                                    "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 5 levels",
                                     "items": {
                                         "type": "string",
                                         "minLength": 1
                                     },
-                                    "maxItems": 3
+                                    "maxItems": 5
                                 },
                                 "default_time_dimension": {
                                     "type": "object",
@@ -1127,12 +1127,12 @@
                                 },
                                 "groups": {
                                     "type": "array",
-                                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 5 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
                                     "items": {
                                         "type": "string",
                                         "minLength": 1
                                     },
-                                    "maxItems": 3
+                                    "maxItems": 5
                                 }
                             }
                         }
@@ -1306,12 +1306,12 @@
                                 },
                                 "groups": {
                                     "type": "array",
-                                    "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 3 levels",
+                                    "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 5 levels",
                                     "items": {
                                         "type": "string",
                                         "minLength": 1
                                     },
-                                    "maxItems": 3
+                                    "maxItems": 5
                                 },
                                 "default_time_dimension": {
                                     "type": "object",
@@ -1497,12 +1497,12 @@
                         },
                         "groups": {
                             "type": "array",
-                            "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 3 levels",
+                            "description": "Groups are used to group dimensions and metrics in the sidebar. You can create nested groups up to 5 levels",
                             "items": {
                                 "type": "string",
                                 "minLength": 1
                             },
-                            "maxItems": 3
+                            "maxItems": 5
                         },
                         "compact": {
                             "type": "string",

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -59,12 +59,12 @@
                 },
                 "groups": {
                     "type": "array",
-                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 3 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
+                    "description": "Groups are used to group tables in the sidebar. You can create nested groups up to 5 levels. Define labels & descriptions for the group keys in lightdash.config.yml under table_groups.",
                     "items": {
                         "type": "string",
                         "minLength": 1
                     },
-                    "maxItems": 3
+                    "maxItems": 5
                 },
                 "sql_filter": {
                     "type": "string",

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -105,7 +105,7 @@ type ExploreConfig = {
     /** @deprecated Use groups instead */
     group_label?: string;
     /**
-     * Nested groups for tables in the sidebar (max 3 levels). Group keys
+     * Nested groups for tables in the sidebar (max 5 levels). Group keys
      * resolve to labels via `table_groups` in lightdash.config.yml; missing
      * keys fall back to using the key as the label.
      */

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -92,7 +92,7 @@ export type Explore = {
     /** @deprecated Use `groups` instead */
     groupLabel?: string;
     /**
-     * Nested groups for the sidebar (max 3 levels). Group keys resolve to
+     * Nested groups for the sidebar (max 5 levels). Group keys resolve to
      * labels/descriptions via the project-level `table_groups` config
      * (fetched separately); missing keys fall back to using the key as
      * the label.

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.test.ts
@@ -82,9 +82,9 @@ describe('buildExploreTree', () => {
         expect(mktg.label).toBe('Marketing');
     });
 
-    it('caps nesting at 3 levels', () => {
+    it('caps nesting at 5 levels', () => {
         const tree = buildExploreTree([
-            explore('orders', { groups: ['a', 'b', 'c', 'd'] }),
+            explore('orders', { groups: ['a', 'b', 'c', 'd', 'e', 'f'] }),
         ]);
         let depth = 0;
         let cursor: ReturnType<typeof sortExploreTree>[number] | undefined =
@@ -93,7 +93,7 @@ describe('buildExploreTree', () => {
             depth += 1;
             cursor = sortExploreTree(cursor.children)[0];
         }
-        expect(depth).toBe(3);
+        expect(depth).toBe(5);
     });
 });
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/exploreTree.ts
@@ -1,6 +1,6 @@
 import { type GroupType, type SummaryExplore } from '@lightdash/common';
 
-const MAX_EXPLORE_GROUP_DEPTH = 3;
+const MAX_EXPLORE_GROUP_DEPTH = 5;
 
 export type ExploreLeafNode = {
     type: 'explore';


### PR DESCRIPTION
## Summary

Large organizations with many tables need more than 3 levels of hierarchy to organize tables meaningfully in the sidebar (for example, mirroring a dbt monorepo structure such as `repo > product > sub-product > core`, which needs 4+ levels).

This raises the maximum **table group** nesting depth in the sidebar from 3 to 5, matching the field-level group tree which already uses `MAX_GROUP_DEPTH = 5`.

## Changes

- `MAX_EXPLORE_GROUP_DEPTH`: `3` → `5` in the sidebar explore tree (`exploreTree.ts`)
- JSON schema `maxItems` for `groups`: `3` → `5`, with matching description copy ("up to 5 levels"), across:
  - `lightdash-dbt-2.0.json` (CLI `lightdash generate`)
  - `lightdashMetadata.json` (compile-time validation)
  - `model-as-code-1.0.json`
- Updated the `groups` JSDoc on the `explore`/`dbt` types and regenerated the OpenAPI description (`swagger.json`)
- Updated the sidebar tree unit test to assert the new 5-level cap

Backend has no separate depth enforcement (the compiler passes `groups` through unchanged), so the schema + sidebar tree were the only constraints.

## Test plan

- [x] `pnpm -F frontend test exploreTree` passes (cap now 5 levels)
- [x] `pnpm -F common typecheck:fast`
- [x] `pnpm check:chart-as-code-schema`

Closes: PROD-8229
Closes: #24119

🤖 Generated with [Claude Code](https://claude.com/claude-code)