### PR TITLE
fix: dashboard chart totals and subtotals use active parameter value instead of default

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5081,17 +5081,6 @@ export class AsyncQueryService extends ProjectService {
             };
         }
 
-        const requestParameters: ExecuteAsyncDashboardChartRequestParams = {
-            tileUuid,
-            chartUuid,
-            context,
-            dashboardUuid: resolvedDashboardUuid,
-            dashboardFilters,
-            dashboardSorts,
-            dateZoom,
-            limit,
-        };
-
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
@@ -5147,6 +5136,18 @@ export class AsyncQueryService extends ProjectService {
             dashboardParameters,
             projectParameters,
         );
+
+        const requestParameters: ExecuteAsyncDashboardChartRequestParams = {
+            tileUuid,
+            chartUuid,
+            context,
+            dashboardUuid: resolvedDashboardUuid,
+            dashboardFilters,
+            dashboardSorts,
+            dateZoom,
+            limit,
+            parameters: combinedParameters,
+        };
 
         const { fields, dateZoomApplied } = await this.getMetricQueryFields({
             metricQuery: metricQueryWithLimit,


### PR DESCRIPTION
## What

When a dashboard has a parameter control, changing the parameter correctly updates per-row values in flat table charts, but totals and subtotals were always frozen at the default parameter value.

**Root cause:** In `executeAsyncDashboardChartQuery`, the `requestParameters` object was constructed before `combinedParameters` was resolved, so `parameters` was never persisted to query history. When `executeAsyncCalculateTotalFromQueryHistory` re-ran totals/subtotals, it read `source.requestParameters?.parameters` and got `undefined`, causing the totals query to fall back to project-default parameter values.

The explore-view path (`executeAsyncMetricQuery`) was not affected because it correctly stores `parameters: combinedParameters`.

## Fix

Move `requestParameters` construction to after `combinedParameters` is resolved and add `parameters: combinedParameters` to it.

Closes: #24149