### PR TITLE
feat(explorer): show TZ-sensitivity icons on datetime dimensions in picker

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -1,4 +1,6 @@
 import {
+    DimensionType,
+    FeatureFlags,
     getItemId,
     isAdditionalMetric,
     isCompiledMetric,
@@ -8,6 +10,7 @@ import {
     isFilterableField,
     isTimeInterval,
     MetricType,
+    shouldShiftItemTimezone,
     timeFrameConfigs,
     type AdditionalMetric,
     type Dimension,
@@ -25,6 +28,8 @@ import {
 } from '@mantine/core';
 import {
     IconAlertTriangle,
+    IconCalendarPin,
+    IconClockPin,
     IconFilter,
     IconHierarchyOff,
     IconInfoCircle,
@@ -42,6 +47,7 @@ import {
 } from '../../../../../features/explorer/store';
 import { useExplore } from '../../../../../hooks/useExplore';
 import { useAddFilter } from '../../../../../hooks/useFilters';
+import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import {
@@ -63,11 +69,67 @@ const NavItemIcon = ({
     isMissing?: boolean;
     item: Item | AdditionalMetric;
 }) => {
-    return isMissing ? (
-        <MantineIcon icon={IconAlertTriangle} color="ldGray.7" />
-    ) : (
-        <FieldIcon item={item} color={getFieldColor(item)} size="md" />
+    const { data: tzSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
     );
+    const tzSupportEnabled = tzSupportFlag?.enabled ?? false;
+
+    const tzAffordance = useMemo(() => {
+        if (isMissing || !tzSupportEnabled || !isField(item)) return null;
+        const isDate = item.type === DimensionType.DATE;
+        const isTimestamp = item.type === DimensionType.TIMESTAMP;
+        if (!isDate && !isTimestamp) return null;
+        // TZ-sensitive dims keep the default glyph; only the tooltip flags them.
+        if (shouldShiftItemTimezone(item)) {
+            return {
+                pinIcon: null,
+                tooltip: isDate
+                    ? "Calendar date, shifts with the chart's timezone"
+                    : "Timestamp, shifts with the chart's timezone",
+            };
+        }
+        // TZ-immune dims are "pinned" — a calendar/clock-pin by display type.
+        return isDate
+            ? {
+                  pinIcon: IconCalendarPin,
+                  tooltip:
+                      "Calendar date, not affected by the chart's timezone",
+              }
+            : {
+                  pinIcon: IconClockPin,
+                  tooltip:
+                      "Timestamp shown as stored, not affected by the chart's timezone",
+              };
+    }, [isMissing, tzSupportEnabled, item]);
+
+    if (isMissing) {
+        return <MantineIcon icon={IconAlertTriangle} color="ldGray.7" />;
+    }
+    if (tzAffordance) {
+        return (
+            <Tooltip
+                withinPortal
+                maw={300}
+                multiline
+                label={tzAffordance.tooltip}
+            >
+                {tzAffordance.pinIcon ? (
+                    <MantineIcon
+                        icon={tzAffordance.pinIcon}
+                        color={getFieldColor(item)}
+                        size="md"
+                    />
+                ) : (
+                    <FieldIcon
+                        item={item}
+                        color={getFieldColor(item)}
+                        size="md"
+                    />
+                )}
+            </Tooltip>
+        );
+    }
+    return <FieldIcon item={item} color={getFieldColor(item)} size="md" />;
 };
 
 NavItemIcon.displayName = 'NavItemIcon';


### PR DESCRIPTION
Closes: GLITCH-458

### Description:

Behind the `EnableTimezoneSupport` feature flag, temporal dimensions in the Explore picker now show visual indicators of their timezone sensitivity:

- **TZ-sensitive** dimensions (plain timestamps, timestamp-base date intervals) keep their default calendar/clock icon and get a tooltip: "Timestamp/Calendar date, shifts with the chart's timezone"
- **TZ-immune** dimensions get a pinned icon variant (`IconCalendarPin` for dates, `IconClockPin` for timestamps) and a tooltip explaining they're not affected by the chart's timezone
- When the flag is **off**, the picker is completely unchanged

All classification logic delegates to existing `shouldShiftItemTimezone` / `isCalendarValueDimension` predicates — no new common exports. The change is contained to `NavItemIcon` in `TreeSingleNode.tsx`.


<img width="790" height="1266" alt="CleanShot 2026-06-15 at 09 41 47@2x" src="https://github.com/user-attachments/assets/53c1fad0-49fc-4f4f-b461-3f419424f7bd" />

<img width="786" height="608" alt="CleanShot 2026-06-15 at 09 54 45@2x" src="https://github.com/user-attachments/assets/da31afd4-8a4d-4345-8b3e-2d5516355798" />
