### PR TITLE
feat(docker-dev): profile-based setup, executable reconcile, 1Password discovery

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -5,8 +5,9 @@ Manage Docker dev environment. Args: (none) = show status & help, `start` = auto
 ## Arguments
 
 - **No arguments**: Show current status, assigned ports, and available commands. Read-only, safe to run anytime.
-- **`start`**: Bring this instance up. Runs the deterministic `scripts/dev-fast-start.sh` first (idempotent, non-interactive — no agentic step-by-step); only falls back to agentic setup + **self-repair** if the script fails. Uses the shared base snapshot to bootstrap new instances fast.
-- **`start ee`** (also `start --ee`, "start with ee enabled", "enterprise"): Same as `start`, but provisions an Enterprise Edition license (`LIGHTDASH_LICENSE_KEY`) and runs the EE migration/seed pass. See **Enterprise Edition (EE) Mode** below. Auto-enabled if `.env.development.local` already contains `LIGHTDASH_LICENSE_KEY`.
+- **`start`**: Bring this instance up. First runs **Step P: Instance profile selection** (capability multi-select → 1Password approval gate → write secrets/flags), then the deterministic `scripts/dev-fast-start.sh` (idempotent, non-interactive); only falls back to agentic setup + **self-repair** if the script fails. Bootstraps new instances fast from a shared base snapshot.
+- **`start <profiles>`**: Provision for named capabilities, comma-separated — e.g. `start ee` (turnkey EE: all AI + GitHub), `start github` (Core + dbt-over-GitHub, no AI), `start ee,slack`. Skips the menu. The AI tier is just **Core vs EE** — all AI features (agents, writeback, reviews classifier) are bundled into `ee`. See `scripts/dev-profiles.json`. `ee` requires `github` so writeback opens PRs out of the box; profiles run their GitHub/dbt-repo + classifier reconcile + verify automatically.
+- **`start ee`** (also `start --ee`, "start with ee enabled", "enterprise"): The EE profile — provisions an Enterprise Edition license (`LIGHTDASH_LICENSE_KEY`), runs the EE migration/seed pass, and **bundles all AI features** (Copilot/agents, AI writeback, reviews classifier) plus the GitHub integration so writeback is turnkey. See **Enterprise Edition (EE) Mode** below. Auto-enabled if `.env.development.local` already contains `LIGHTDASH_LICENSE_KEY`. EE instances bootstrap from a dedicated EE base snapshot (`ld-shared_postgres_base_ee`) so they skip the slow EE migrate pass.
 - **`stop`**: Stop this instance's PM2 processes and PostgreSQL. Shared services stay running. Releases port slot.
 - **`stop-all`**: Stop ALL instances — all PM2 processes, all per-instance PostgreSQL containers, shared services, and release all port slots. Use when shutting down for the day.
 - **`reset`**: Restore database from this instance's volume snapshot (fast, ~3 seconds). Fails if no snapshot exists.
@@ -279,6 +280,87 @@ Expect `Enterprise license for <site> is valid.` and no `no factory or provider`
 
 **ALWAYS try the deterministic fast path first.** Only fall back to the agentic steps when the script fails — this is what keeps worktree iteration fast.
 
+### Step P: Instance profile selection (run BEFORE the fast path)
+
+`start` provisions an instance for a set of *capabilities* (EE, AI agents, AI writeback, GitHub, reviews classifier, Slack). Each capability declares its feature flags, env, 1Password secrets, reconcile steps, and verification in `scripts/dev-profiles.json`. Resolve the selection, get the user's approval to read 1Password, write the env, **then** run the fast path. This is what removes the "re-explain the GitHub/writeback setup every time" friction — it's encoded, not recalled.
+
+**1. Determine requested profiles.**
+- If the user named them (e.g. `/docker-dev start ee`, `start ee,slack`, `start github`), use those. The AI tier is Core vs EE — `ee` bundles all AI features.
+- If the user just ran `start` with no profile, show the menu and ask (multi-select):
+  ```bash
+  ./scripts/dev-profiles.sh list
+  ```
+  Present the labels via **AskUserQuestion** (multiSelect). Selecting nothing = a plain Core instance. Selecting **EE** transitively pulls in GitHub (so writeback is turnkey) and turns on every AI feature.
+
+**2. Resolve the plan** (expands `requires` transitively, unions everything):
+```bash
+PLAN="$(./scripts/dev-profiles.sh resolve <comma,separated,names>)"   # JSON: {ee, secrets[], flags[], env{}, orgSettings{}, reconcile[], verify[]}
+```
+
+**3. Ensure the base env file exists** (ports block) so later writes don't lose the port reconciliation. If `.env.development.local` is absent, create it now from the **Create Environment File** template below (ports only — no secrets yet).
+
+**4. Discover & confirm the 1Password item for each secret, then remember it.** Item names are NOT hardcoded — find the best match in *this engineer's own* vault and confirm:
+```bash
+./scripts/dev-op-pull.sh discover <PLAN.secrets...>   # JSON per secret: {saved, savedItem, confident, top, candidates[]}
+```
+For each secret not already `saved:true`: present `top` (recommended) plus the other `candidates` via **AskUserQuestion**, defaulting to the obvious *dev/development* item.
+> ⚠️ Vaults contain other-org / customer items that fuzzy-match (license keys, API keys for clients). NEVER auto-pick, and never write a customer-named item into the env file, memory, a commit, or a PR — confirm the dev item with the user. (Confidentiality policy.)
+
+On confirmation, persist the choice two ways so it's never asked again:
+```bash
+./scripts/dev-op-pull.sh save <SECRET_KEY> "<confirmed item name>"   # -> ~/.lightdash/dev-secrets.local.json (the scripts read this)
+```
+…and **record it in Claude memory** (the dev-env 1Password-sources memory): `env var → confirmed item name`, so the preference survives a fresh machine / lost local file. On future runs, skip the ask for any secret that's `saved:true` or already in memory. Shared items (license, GitHub App) are usually one unambiguous match — confirm once.
+
+**5. Approval gate (REQUIRED before reading 1Password).** With items confirmed, show the final read+apply summary and get explicit approval:
+```bash
+./scripts/dev-op-pull.sh list <PLAN.secrets...>     # prints the confirmed 1Password items + the env vars they populate
+```
+Present that list plus `PLAN.flags`, `PLAN.env`, and `PLAN.orgSettings` (AskUserQuestion or inline "Read these N items and apply these flags/env? [y/N]"). Do not proceed without a yes.
+
+**6. Apply the plan** (only after approval). Pull ALL secrets in **one** `pull` call — it signs in (Touch ID via desktop integration) and reads in the same invocation, because the `op` session does NOT carry across separate Bash calls. Run it yourself; only fall back to asking the user if it returns `FAIL: could not establish a 1Password session` (integration disabled).
+```bash
+./scripts/dev-op-pull.sh pull <PLAN.secrets...>          # self-signs-in, pulls into .env.development.local, verifies prefixes, never echoes values
+# write PLAN.env (static, non-secret) — e.g. AI_COPILOT_ENABLED=true, AI_DEFAULT_PROVIDER=anthropic
+./scripts/dev-feature-flags.sh enable <PLAN.flags joined by comma>   # merges into LIGHTDASH_ENABLE_FEATURE_FLAGS
+```
+> Do NOT split sign-in and pull across two Bash calls (the session is per-shell — the second call would report "not signed in"). `pull` handles both internally; if you must run `op` manually, chain it in one line: `op signin --account lightdash.1password.com && ./scripts/dev-op-pull.sh pull ...`.
+
+**7. Feature-flag opt-in (scan + pick extras).** Beyond the profile's flags, let the user turn on any other flag that isn't already enabled:
+```bash
+./scripts/dev-feature-flags.sh scan          # TSV: value, ON/off, EnumName, description
+```
+Present the **disabled** flags (`./scripts/dev-feature-flags.sh list-disabled`) with their descriptions via **AskUserQuestion** (multiSelect, "which additional feature flags to enable?"). Then:
+```bash
+./scripts/dev-feature-flags.sh enable <selected,flags>
+```
+("Enabled" here means present in `LIGHTDASH_ENABLE_FEATURE_FLAGS` — that's what `FeatureFlagModel` resolves against. Code-level per-org/PostHog defaults aren't machine-readable, so the scan reports the local env state.)
+
+**8. Run the fast path** (now the env has the license + secrets + flags, so EE auto-detects and the EE base is used):
+```bash
+./scripts/dev-fast-start.sh $( [ "$(echo "$PLAN" | python3 -c 'import sys,json;print(json.load(sys.stdin)["ee"])')" = "True" ] && echo --ee )
+```
+
+**9. Post-start reconcile + verify** (after `READY:`) — **executable**, not hand-run crypto. First, if the GitHub account isn't known yet (first EE+github run), discover and remember it (same pattern as the secrets):
+```bash
+./scripts/dev-reconcile.sh list-accounts            # JSON of [{login, repos}] this App is installed on
+# ask the user which login is theirs (AskUserQuestion), then:
+./scripts/dev-reconcile.sh save-github-account <login>   # -> ~/.lightdash/dev-secrets.local.json
+# and record it in Claude memory alongside the 1Password item prefs.
+```
+Then the reconcile steps:
+```bash
+./scripts/dev-reconcile.sh github-app-installation     # ensure github_app_installations decrypts with the running secret + points at a LIVE install (mints JWT, lists installs, re-encrypts, UPSERTs)
+./scripts/dev-reconcile.sh github-dbt-repo             # check the project dbt_connection is github (repoint is guided if NEED)
+./scripts/dev-reconcile.sh org-settings ai_agent_reviews_enabled=true   # PLAN.orgSettings
+./scripts/dev-reconcile.sh verify-token               # PLAN.verify — mints an installation token (HTTP 201)
+# or in one shot:
+./scripts/dev-reconcile.sh all                        # installation -> dbt-repo-check -> verify-token
+```
+`dev-reconcile.sh` supplies the environment truths itself: the **running pm2 api's `LIGHTDASH_SECRET`** (the one the backend decrypts with — differs from the quote-wrapped env-file value), the PG connection from the claimed slot, and `pg`/crypto from the backend package (pnpm doesn't hoist `pg` to repo root). Map each `PLAN.reconcile` entry / `PLAN.orgSettings` / `PLAN.verify` to the calls above, then print a profile-aware **READY (writeback ✓ github ✓ reviews ✓ …)**. The *GitHub Integration & dbt Repo Setup* section explains each step and is the fallback when one reports `NEED` (e.g. a non-github dbt project to repoint).
+
+> Fast path for a known profile: `/docker-dev start ee` does steps 1–9 with no menu (and skips the discover/ask for any secret already confirmed). The multi-select is only for discovery when no profile is named.
+
 ### Fast path (do this first, every time)
 
 `scripts/dev-fast-start.sh` encodes the entire happy path of this section as one idempotent, non-interactive run. Run it directly instead of executing the steps below one at a time:
@@ -542,11 +624,16 @@ If `sfw pnpm install` fails with canvas errors: https://github.com/Automattic/no
 
 ### Set Up Python/dbt
 
+The dbt venv is identical across worktrees, so `dev-fast-start.sh` builds it **once** in a shared cache (`~/.lightdash/dev-venv`) and symlinks each worktree's `./venv` at it — saving the pip install per worktree. Manual equivalent:
+
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install dbt-core==1.7.0 dbt-postgres==1.7.0 'protobuf>=4.0.0,<5.0.0'
-ln -sf dbt venv/bin/dbt1.7
+SHARED_VENV="$HOME/.lightdash/dev-venv"
+if [ ! -f "$SHARED_VENV/bin/dbt" ]; then
+  python3 -m venv "$SHARED_VENV"
+  "$SHARED_VENV/bin/pip" install dbt-core==1.7.0 dbt-postgres==1.7.0 'protobuf>=4.0.0,<5.0.0'
+  ln -sf dbt "$SHARED_VENV/bin/dbt1.7"
+fi
+ln -s "$SHARED_VENV" venv   # only if ./venv doesn't already exist as a real venv
 ```
 
 ### Run Migrations (skip if bootstrapped)
@@ -679,6 +766,72 @@ If a monitor fires, investigate the error. Common responses:
 - **Demo login**: `demo@lightdash.com` / `demo_password!`
 
 ---
+
+## GitHub Integration & dbt Repo Setup
+
+The common cases are **scripted** — `./scripts/dev-reconcile.sh {github-app-installation|github-dbt-repo|verify-token|all}` (called by Step P9). This section explains what those steps do and is the fallback when one reports `NEED` (e.g. a brand-new repo, or a non-github dbt project to repoint). Goal: a project whose dbt is connected over the dev GitHub App, so the agent can read the repo and writeback can open real PRs. The reconcile targets **your** GitHub account — set `githubAccount` in `~/.lightdash/dev-secrets.local.json` (or `GH_ACCOUNT`); without it the script picks the first `repos=all` installation and warns, which is wrong on the shared multi-install App.
+
+**Environment truths the script encodes (don't relearn them by hand):**
+- The decrypt secret is the **running pm2 api's `LIGHTDASH_SECRET`** (`pm2 jlist` → `pm2_env.LIGHTDASH_SECRET`), NOT the `.env.development` line — the file value is quote-wrapped, so dotenv's dequoted value differs by two `"` chars.
+- `pg` is **not hoisted** to repo root under pnpm — require it from `packages/backend/node_modules` (or set `NODE_PATH`).
+- `projects` is keyed by `organization_id` (int), not `organization_uuid`; `github_app_installations` and `ai_organization_settings` are keyed by `organization_uuid`.
+- The `github/repos/list` and writeback routes need a **browser session cookie**, not the seeded PAT (its bcrypt hash ≠ the env placeholder) — so the script verifies via `verify-token` (mint an installation token) instead of `repos/list`.
+
+**Preconditions.** The `GITHUB_*` env vars are set (Step P pulled them) and `GET /api/v1/health` shows `hasGithub:true` (it gates purely on `GITHUB_PRIVATE_KEY`). If false, the App creds didn't load — re-pull `GITHUB_APP` and restart the API.
+
+**Step G1 — Ensure an installation row that decrypts with the RUNNING secret.**
+`github_app_installations.encrypted_installation_id` is AES-256-GCM (salt[64]|tag[16]|iv[12]|msg; pbkdf2 sha512/2000/32) keyed by `LIGHTDASH_SECRET`. Two failure modes both surface as writeback errors:
+- **Stale id** (decrypts, but the install no longer exists) → minting the token 404s (`Not Found — create-an-installation-access-token-for-an-app`).
+- **Won't decrypt** (`Unsupported state or unable to authenticate data`) → the row was sealed with a *different* instance's secret (common after restoring another worktree's snapshot). Backend throws `Failed to decrypt installation id`.
+
+Reconcile (idempotent):
+1. Read the org uuid and whether a row exists/decrypts. **Use the secret the running API actually uses** — read `LIGHTDASH_SECRET` from `pm2 jlist` (`pm2_env.LIGHTDASH_SECRET`), NOT the raw `.env.development` line (the file value is quote-wrapped; dotenv strips the quotes, so they differ by the two `"` chars).
+2. Mint a GitHub **App JWT** (RS256, `iss`=`GITHUB_APP_ID`, key = `Buffer.from(GITHUB_PRIVATE_KEY,'base64')`) and `GET https://api.github.com/app/installations` (authenticate as the *App*, not a user token). Pick the installation whose `account.login` is **your** GitHub account (`githubAccount`/`GH_ACCOUNT`) and owns the dbt repo you'll use (`repository_selection: all`). The id changes over time — never hardcode; always list.
+3. Re-encrypt that id with the running secret and **UPSERT** the row (`organization_uuid`, `encrypted_installation_id`; on a fresh INSERT also set `created_by_user_uuid`/`updated_by_user_uuid` to the demo user and placeholder `auth_token`/`refresh_token` — they're `NOT NULL` but only affect PR authorship, never the token mint). Verify it decrypts back to the id.
+
+**Step G2 — Point a project's dbt at a GitHub repo.** Writeback requires the project `dbt_connection.type` to be `github`/`gitlab`, pointing at a repo the installation covers. Check `GET /api/v1/projects/{uuid}` → `dbtConnection.{type,repository,branch,project_sub_path}`. If it isn't github (e.g. a `dbt`/local-file project), repoint it: re-encrypt a github dbt_connection (repo `<your-account>/<dbt-repo>`, e.g. a fork of the jaffle-shop dbt project, branch `main`, subpath `dbt`) with the **running** secret and UPDATE `projects.dbt_connection`. For a brand-new repo, first install the dev App (`lightdash-app-dev`) on that GitHub account/repo so an installation exists to find in G1.
+
+**Step G3 — Verify.**
+```bash
+# token mints + repos visible (needs a browser session cookie, not a PAT):
+curl -s -b <cookiejar> "http://localhost:$PORT/api/v1/github/repos/list" -o /dev/null -w "repos/list %{http_code}\n"   # expect 200
+```
+A 200 with the repo present confirms the App key works AND the installation id is correct. Then a writeback run should clone the repo, edit YAML, `lightdash compile`, and open a PR.
+
+## Statusline: live web URL
+
+While managing an instance's lifecycle, the Claude statusline shows this worktree's web app URL — **🟢 http://localhost:&lt;FE&gt;** when the frontend is up, **⚪ localhost:&lt;FE&gt;** when the slot is assigned but down, and nothing outside a Lightdash worktree. So `start`/`stop` are reflected at a glance without re-deriving the port.
+
+How it's wired (composes with claude-hud — does not replace it):
+- `scripts/dev-statusline.sh` (version-controlled) derives the instance from the cwd's git root → reads `~/.lightdash/dev-instances/<instance>.json` for `ports.frontend` → does one 0.3s TCP probe → prints claude-hud's `{"label":"…"}`.
+- A global shim `~/.lightdash/dev-statusline-hud.sh` delegates to that repo script (falling back to a global copy `~/.lightdash/dev-statusline.sh` for worktrees that predate this script), so the logic stays in the repo.
+- claude-hud runs it via `--extra-cmd`, appended to the `statusLine.command` in `~/.claude/settings.json`.
+
+First-time install on a machine (idempotent):
+```bash
+mkdir -p ~/.lightdash
+install -m755 scripts/dev-statusline.sh ~/.lightdash/dev-statusline.sh
+cat > ~/.lightdash/dev-statusline-hud.sh <<'EOF'
+#!/bin/sh
+root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$root" ] && [ -x "$root/scripts/dev-statusline.sh" ]; then exec "$root/scripts/dev-statusline.sh";
+elif [ -x "$HOME/.lightdash/dev-statusline.sh" ]; then exec "$HOME/.lightdash/dev-statusline.sh"; fi
+exit 0
+EOF
+chmod +x ~/.lightdash/dev-statusline-hud.sh
+# append --extra-cmd to the existing statusLine command WITHOUT clobbering it (claude-hud or otherwise):
+python3 - <<'PY'
+import json, os
+p = os.path.expanduser("~/.claude/settings.json")
+d = json.load(open(p)); sl = d.get("statusLine")
+if isinstance(sl, dict) and sl.get("type") == "command" and "--extra-cmd" not in sl["command"]:
+    sl["command"] += ' --extra-cmd "$HOME/.lightdash/dev-statusline-hud.sh"'
+    json.dump(d, open(p, "w"), indent=2); print("wired")
+else:
+    print("already wired or no command statusLine")
+PY
+```
+Restart Claude Code to load the new `statusLine` command. If there's no command-type statusline yet, set `statusLine` to `{"type":"command","command":"$HOME/.lightdash/dev-statusline-hud.sh"}` for a bare URL-only line.
 
 ## `stop`: Stop This Instance
 

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ credentials.json
 # dbt
 /target
 packages/backend/target/
-venv/
+venv
 .venv/
 .venvs/
 dbt_modules/

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -35,6 +35,10 @@ cd "$REPO_ROOT" || { echo "FAIL: cd -- cannot enter repo root $REPO_ROOT" >&2; e
 SHARED_COMPOSE="docker/docker-compose.dev.shared.yml"
 INSTANCE_COMPOSE="docker/docker-compose.dev.instance.yml"
 SHARED_BASE_VOLUME="ld-shared_postgres_base"
+# Dedicated EE base (core + EE migrations + EE seed) so EE/writeback instances
+# bootstrap already-migrated and skip the slow EE migrate pass. Kept SEPARATE from
+# the core base, which must stay core-only for non-EE instances.
+EE_BASE_VOLUME="ld-shared_postgres_base_ee"
 
 fail() { echo "FAIL: $1 -- $2" >&2; exit 1; }
 step() { echo "STEP: $1"; }
@@ -95,9 +99,26 @@ fi
 
 # ---------------------------------------------------------------------------
 step "Ensure Python/dbt venv"
+# The dbt venv is identical across worktrees, so build it ONCE in a shared cache
+# (~/.lightdash/dev-venv) and symlink each worktree's ./venv at it. Saves the
+# ~30-60s pip install on every new worktree. A worktree that already has a real
+# (non-symlink) venv is left untouched.
+SHARED_VENV="${HOME}/.lightdash/dev-venv"
 if test -f venv/bin/dbt && test -f venv/bin/dbt1.7; then
     echo "SKIP: venv present"
+elif [ ! -e venv ]; then
+    if ! test -f "$SHARED_VENV/bin/dbt"; then
+        mkdir -p "$(dirname "$SHARED_VENV")"
+        python3 -m venv "$SHARED_VENV" || fail "venv" "python3 -m venv (shared cache) failed"
+        "$SHARED_VENV/bin/pip" install dbt-core==1.7.0 dbt-postgres==1.7.0 'protobuf>=4.0.0,<5.0.0' >/dev/null 2>&1 \
+            || fail "venv" "pip install dbt into shared cache failed"
+        ln -sf dbt "$SHARED_VENV/bin/dbt1.7"
+    fi
+    ln -s "$SHARED_VENV" venv || fail "venv" "could not symlink venv -> $SHARED_VENV"
+    test -f venv/bin/dbt || fail "venv" "shared venv symlink is broken"
+    echo "OK: venv linked to shared cache ($SHARED_VENV)"
 else
+    # venv exists but is incomplete — rebuild in place (legacy path)
     python3 -m venv venv || fail "venv" "python3 -m venv failed"
     ./venv/bin/pip install dbt-core==1.7.0 dbt-postgres==1.7.0 'protobuf>=4.0.0,<5.0.0' >/dev/null 2>&1 \
         || fail "venv" "pip install dbt failed"
@@ -209,21 +230,32 @@ MIGRATED="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_name='se
 SEEDED="$(db_has "SELECT 1 FROM emails WHERE email='demo@lightdash.com'")"
 DBT_BUILT="$(db_has "SELECT 1 FROM information_schema.tables WHERE table_schema='jaffle' AND table_name='orders'")"
 BOOTSTRAPPED=false
+BOOTSTRAPPED_EE_BASE=false
+
+# Prefer the EE base when in EE mode and it exists — it's already EE-migrated,
+# so the EE migrate pass below becomes a fast no-pending check instead of applying
+# 70+ migrations. Otherwise fall back to the core base.
+BOOTSTRAP_VOLUME=""
+if [ "$EE_MODE" = true ] && docker volume inspect "$EE_BASE_VOLUME" >/dev/null 2>&1; then
+    BOOTSTRAP_VOLUME="$EE_BASE_VOLUME"; BOOTSTRAPPED_EE_BASE=true
+elif docker volume inspect "$SHARED_BASE_VOLUME" >/dev/null 2>&1; then
+    BOOTSTRAP_VOLUME="$SHARED_BASE_VOLUME"
+fi
 
 if [ "$MIGRATED" = yes ] && [ "$SEEDED" = yes ] && [ "$DBT_BUILT" = yes ]; then
     echo "SKIP: database already migrated, seeded, dbt built"
-elif docker volume inspect "$SHARED_BASE_VOLUME" >/dev/null 2>&1; then
-    echo "Bootstrapping from shared base snapshot..."
+elif [ -n "$BOOTSTRAP_VOLUME" ]; then
+    echo "Bootstrapping from $BOOTSTRAP_VOLUME..."
     docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" stop db-dev >/dev/null 2>&1
     docker run --rm \
-        -v "${SHARED_BASE_VOLUME}:/source:ro" \
+        -v "${BOOTSTRAP_VOLUME}:/source:ro" \
         -v "${LD_VOLUME_PREFIX}_postgres_data:/target" \
         alpine sh -c "rm -rf /target/* && cd /source && tar cf - . | (cd /target && tar xf -)" \
-        || fail "bootstrap" "failed to clone shared base volume"
+        || fail "bootstrap" "failed to clone base volume $BOOTSTRAP_VOLUME"
     docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" start db-dev >/dev/null 2>&1
     for _ in $(seq 1 30); do docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
     BOOTSTRAPPED=true
-    echo "OK: bootstrapped from shared base"
+    echo "OK: bootstrapped from $BOOTSTRAP_VOLUME"
 else
     echo "No shared base snapshot — running full setup (first instance)..."
     export PATH="$(pwd)/venv/bin:$PATH"
@@ -273,14 +305,42 @@ if [ "$EE_MODE" = true ]; then
     export PATH="$(pwd)/venv/bin:$PATH"
     # migrate is idempotent — always reconcile core+EE. A restored EE snapshot has
     # ai_agent_document yet can still lag this branch's HEAD, so never gate on it.
-    PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development.local -e .env.development -- pnpm -F backend migrate \
-        || fail "ee-migrate" "EE migrate failed"
-    if [ "$BOOTSTRAPPED" = true ]; then
+    # First run applies ~99 migrations and buffers stdout silently for minutes, so
+    # emit a heartbeat of the applied-migration count — otherwise it looks hung.
+    echo "OK: applying core+EE migrations (first run is slow — minutes; bootstrapping from the EE base is near-instant)"
+    ( while sleep 20; do
+        _n="$(docker exec "$DB_CONTAINER" psql -U postgres -tAc 'SELECT count(*) FROM knex_migrations' 2>/dev/null | tr -d '[:space:]')"
+        [ -n "$_n" ] && echo "...EE migrate working (knex_migrations=$_n applied)"
+      done ) & _HB=$!
+    PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development.local -e .env.development -- pnpm -F backend migrate
+    _MIG_RC=$?
+    kill "$_HB" 2>/dev/null; wait "$_HB" 2>/dev/null
+    [ "$_MIG_RC" -eq 0 ] || fail "ee-migrate" "EE migrate failed"
+    # The EE embed seed is already present when bootstrapped from the EE base; only
+    # run it when bootstrapped from the core base (avoids duplicate-seed errors).
+    if [ "$BOOTSTRAPPED" = true ] && [ "$BOOTSTRAPPED_EE_BASE" != true ]; then
         PGHOST=localhost PGPORT=$LD_PG_PORT pnpx dotenv-cli -e .env.development.local -e .env.development -- \
             pnpm -F backend exec knex seed:run --specific=01_embed.ts --knexfile src/knexfile.ts \
             || fail "ee-seed" "EE seed failed"
     fi
     echo "OK: EE migration pass complete"
+
+    # Seed the dedicated EE base for future EE instances (one-time). Captured here,
+    # right after a clean core+EE migrate/seed and BEFORE any profile reconcile
+    # (github seeding etc.), so the EE base stays generic. Never touches the core base.
+    if ! docker volume inspect "$EE_BASE_VOLUME" >/dev/null 2>&1; then
+        echo "Creating EE base snapshot ($EE_BASE_VOLUME) for future EE instances..."
+        docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" stop db-dev >/dev/null 2>&1
+        docker volume create "$EE_BASE_VOLUME" >/dev/null
+        docker run --rm \
+            -v "${LD_VOLUME_PREFIX}_postgres_data:/source:ro" \
+            -v "${EE_BASE_VOLUME}:/snapshot" \
+            alpine sh -c "cd /source && tar cf - . | (cd /snapshot && tar xf -)" \
+            || fail "ee-base" "failed to create EE base snapshot"
+        docker compose -p "$LD_COMPOSE_PROJECT" -f "$INSTANCE_COMPOSE" start db-dev >/dev/null 2>&1
+        for _ in $(seq 1 30); do docker exec "$DB_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+        echo "OK: EE base snapshot created"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/dev-feature-flags.sh
+++ b/scripts/dev-feature-flags.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Scan the FeatureFlags enum and report which flags are enabled for THIS instance.
+#
+# "Enabled" locally == listed in LIGHTDASH_ENABLE_FEATURE_FLAGS in the env file
+# (that's what FeatureFlagModel resolves against). Code-level defaults are prose-only
+# (per-org / PostHog) and not machine-readable, so this reports the *local* state plus
+# each flag's description, and the /docker-dev picker offers the disabled ones to enable.
+#
+# Usage:
+#   dev-feature-flags.sh scan          [--env-file PATH]   # TSV: value <TAB> ON|off <TAB> EnumName <TAB> description
+#   dev-feature-flags.sh list-disabled [--env-file PATH]   # one flag value per line, not currently enabled (for the picker)
+#   dev-feature-flags.sh enable <a,b,c> [--env-file PATH]  # merge flags into LIGHTDASH_ENABLE_FEATURE_FLAGS (creates/updates the line)
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLAGS_TS="$REPO_ROOT/packages/common/src/types/featureFlags.ts"
+ENV_FILE=".env.development.local"
+
+MODE="${1:-}"; shift || true
+ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --flags-ts) FLAGS_TS="$2"; shift 2 ;;
+        *) ARGS+=("$1"); shift ;;
+    esac
+done
+
+[ -f "$FLAGS_TS" ] || { echo "dev-feature-flags: enum not found: $FLAGS_TS" >&2; exit 1; }
+
+# enabled flags from the env file (comma-separated LIGHTDASH_ENABLE_FEATURE_FLAGS)
+current_enabled() {
+    [ -f "$ENV_FILE" ] || return 0
+    grep "^LIGHTDASH_ENABLE_FEATURE_FLAGS=" "$ENV_FILE" | head -1 | cut -d= -f2- | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -v '^$'
+}
+
+# emit TSV: value <TAB> EnumName <TAB> description(first sentence)
+parse_enum() {
+    python3 - "$FLAGS_TS" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+m = re.search(r'export enum FeatureFlags\s*\{(.*?)\n\}', src, re.S)
+body = m.group(1) if m else ''
+def clean(c):
+    c = re.sub(r'/\*\*?|\*/', '', c)
+    c = re.sub(r'^\s*\*\s?', '', c, flags=re.M)
+    c = re.sub(r'^\s*//\s?', '', c, flags=re.M)
+    c = ' '.join(c.split())
+    s = re.split(r'(?<=\.)\s', c)          # first sentence-ish
+    return (s[0] if s else c).strip()
+# capture the (optional) comment block immediately preceding each `Name = 'value'`
+pat = re.compile(r"((?:/\*[\s\S]*?\*/|//[^\n]*\n|\s)*?)(\w+)\s*=\s*'([^']+)'")
+for mm in pat.finditer(body):
+    comment, name, value = mm.group(1), mm.group(2), mm.group(3)
+    cblocks = re.findall(r'/\*[\s\S]*?\*/|//[^\n]*', comment)
+    desc = clean(cblocks[-1]) if cblocks else ''
+    print(f"{value}\t{name}\t{desc}")
+PY
+}
+
+case "$MODE" in
+  scan)
+    enabled="$(current_enabled)"
+    parse_enum | while IFS=$'\t' read -r value name desc; do
+        state="off"
+        echo "$enabled" | grep -qx "$value" && state="ON"
+        printf '%s\t%s\t%s\t%s\n' "$value" "$state" "$name" "$desc"
+    done
+    ;;
+
+  list-disabled)
+    enabled="$(current_enabled)"
+    parse_enum | while IFS=$'\t' read -r value name desc; do
+        echo "$enabled" | grep -qx "$value" || echo "$value"
+    done
+    ;;
+
+  enable)
+    SEL="${ARGS[0]:-}"
+    [ -n "$SEL" ] || { echo "dev-feature-flags enable: give flags comma-separated" >&2; exit 2; }
+    touch "$ENV_FILE"
+    existing="$(current_enabled | paste -sd, -)"
+    merged="$(printf '%s,%s' "$existing" "$SEL" | tr ',' '\n' | sed 's/[[:space:]]//g' | grep -v '^$' | awk '!seen[$0]++' | paste -sd, -)"
+    tmp="$(mktemp)"
+    MERGED="$merged" python3 - "$ENV_FILE" > "$tmp" <<'PY'
+import os, sys
+path = sys.argv[1]; val = os.environ['MERGED']
+lines = open(path).read().splitlines() if os.path.exists(path) else []
+out, seen = [], False
+for l in lines:
+    if l.startswith('LIGHTDASH_ENABLE_FEATURE_FLAGS='):
+        out.append(f'LIGHTDASH_ENABLE_FEATURE_FLAGS={val}'); seen = True
+    else:
+        out.append(l)
+if not seen:
+    out.append(f'LIGHTDASH_ENABLE_FEATURE_FLAGS={val}')
+sys.stdout.write('\n'.join(out) + '\n')
+PY
+    mv "$tmp" "$ENV_FILE"
+    echo "OK: LIGHTDASH_ENABLE_FEATURE_FLAGS=$merged"
+    ;;
+
+  *)
+    echo "Usage: dev-feature-flags.sh {scan|list-disabled|enable <a,b,c>} [--env-file PATH]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dev-github-reconcile.cjs
+++ b/scripts/dev-github-reconcile.cjs
@@ -1,0 +1,219 @@
+/* eslint-disable */
+// Executable GitHub reconcile for the /docker-dev EE+github profile — replaces the
+// hand-written crypto the flow used to require. Idempotent; safe to re-run.
+//
+// Reimplements the backend EncryptionUtil EXACTLY (aes-256-gcm, pbkdf2 sha512/2000/32,
+// layout salt[64]|tag[16]|iv[12]|msg) and signs the GitHub App JWT with node crypto
+// (no jsonwebtoken dep). Talks to Postgres via the backend's `pg` (resolved explicitly,
+// since pnpm doesn't hoist it to repo root — see env-truth note in the skill).
+//
+// Steps (argv[2]):
+//   installation   ensure github_app_installations has a row that DECRYPTS with the running
+//                  secret AND points at a live installation (mint App JWT -> GET /app/installations
+//                  -> pick account -> re-encrypt with running secret -> UPSERT -> verify).
+//   org-settings   UPSERT ai_organization_settings (args like ai_agent_reviews_enabled=true).
+//   dbt-repo-check report whether the org's project dbt_connection is github (repoint is guided).
+//   verify-token   mint an installation access token (201) to prove the stored id works.
+//
+// Required env: RUNNING_SECRET (the pm2 api process LIGHTDASH_SECRET), GITHUB_APP_ID,
+//   GITHUB_PRIVATE_KEY (base64 PEM), PGHOST PGPORT PGUSER PGPASSWORD PGDATABASE.
+// Optional env: ORG_UUID (default: first org), GH_ACCOUNT (default: prefer repos=all).
+
+const crypto = require('crypto');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+function reqBackend(mod) {
+  // pg isn't hoisted to repo root under pnpm; resolve from the backend package.
+  try { return require(mod); } catch (_) {}
+  return require(path.join(REPO_ROOT, 'packages/backend/node_modules', mod));
+}
+const { Client } = reqBackend('pg');
+
+const SALT = 64, TAG = 16, IV = 12, ITER = 2000, KEYLEN = 32, DIGEST = 'sha512';
+
+function need(name) {
+  const v = process.env[name];
+  if (!v) { console.error(`FAIL: reconcile -- missing env ${name}`); process.exit(1); }
+  return v;
+}
+
+function encrypt(message, secret) {
+  const iv = crypto.randomBytes(IV);
+  const salt = crypto.randomBytes(SALT);
+  const key = crypto.pbkdf2Sync(secret, salt, ITER, KEYLEN, DIGEST);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, { authTagLength: TAG });
+  const enc = Buffer.concat([cipher.update(String(message), 'utf-8'), cipher.final()]);
+  return Buffer.concat([salt, cipher.getAuthTag(), iv, enc]);
+}
+function decrypt(buf, secret) {
+  const salt = buf.subarray(0, SALT);
+  const tag = buf.subarray(SALT, SALT + TAG);
+  const iv = buf.subarray(SALT + TAG, SALT + TAG + IV);
+  const msg = buf.subarray(SALT + TAG + IV);
+  const key = crypto.pbkdf2Sync(secret, salt, ITER, KEYLEN, DIGEST);
+  const d = crypto.createDecipheriv('aes-256-gcm', key, iv, { authTagLength: TAG });
+  d.setAuthTag(tag);
+  return d.update(msg, undefined, 'utf-8') + d.final('utf-8');
+}
+
+function appJwt() {
+  const appId = need('GITHUB_APP_ID');
+  const pem = Buffer.from(need('GITHUB_PRIVATE_KEY'), 'base64').toString('utf-8');
+  const now = Math.floor(Date.now() / 1000);
+  const b64 = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  const data = b64({ alg: 'RS256', typ: 'JWT' }) + '.' + b64({ iat: now - 60, exp: now + 540, iss: String(appId) });
+  const sig = crypto.createSign('RSA-SHA256').update(data).sign(pem, 'base64url');
+  return data + '.' + sig;
+}
+async function gh(url, opts = {}) {
+  const res = await fetch(`https://api.github.com${url}`, {
+    ...opts,
+    headers: { Authorization: `Bearer ${appJwt()}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28', ...(opts.headers || {}) },
+  });
+  return res;
+}
+
+async function listInstallations() {
+  const res = await gh('/app/installations');
+  if (!res.ok) throw new Error(`GET /app/installations -> ${res.status}`);
+  return res.json();
+}
+async function pickInstallation() {
+  const list = await listInstallations();
+  if (!list.length) throw new Error('App has no installations — install the dev GitHub App on your account first');
+  const want = (process.env.GH_ACCOUNT || '').trim();
+  if (want) {
+    const chosen = list.find((i) => i.account && i.account.login === want);
+    if (!chosen) {
+      const accts = list.map((i) => i.account && i.account.login).filter(Boolean).join(', ');
+      throw new Error(`GH_ACCOUNT='${want}' has no installation of this App. Available: ${accts}`);
+    }
+    return chosen;
+  }
+  // No account configured: the shared dev App has many installs, so guessing is unsafe.
+  if (list.length === 1) return list[0];
+  const accts = list.map((i) => `${i.account && i.account.login}(${i.repository_selection})`).join(', ');
+  console.error(`WARN: GH_ACCOUNT not set and ${list.length} installations exist — guessing. Set githubAccount in ~/.lightdash/dev-secrets.local.json (or GH_ACCOUNT). Candidates: ${accts}`);
+  return list.find((i) => i.repository_selection === 'all') || list[0];
+}
+
+async function orgUuid(client) {
+  if (process.env.ORG_UUID) return process.env.ORG_UUID;
+  const r = await client.query('SELECT organization_uuid FROM organizations ORDER BY organization_id LIMIT 1');
+  if (!r.rows.length) throw new Error('no organizations in DB');
+  return r.rows[0].organization_uuid;
+}
+
+async function stepInstallation(client) {
+  const secret = need('RUNNING_SECRET');
+  const org = await orgUuid(client);
+  const live = await gh('/app/installations').then((r) => r.json());
+  const liveIds = new Set((Array.isArray(live) ? live : []).map((i) => String(i.id)));
+
+  const existing = await client.query(
+    "SELECT encode(encrypted_installation_id,'hex') AS hex FROM github_app_installations WHERE organization_uuid=$1", [org]);
+  if (existing.rows.length) {
+    try {
+      const cur = decrypt(Buffer.from(existing.rows[0].hex, 'hex'), secret);
+      if (liveIds.has(String(cur))) {
+        console.log(`OK: installation row already valid (id=${cur}, decrypts, live)`);
+        return;
+      }
+      console.log(`reconcile: stored id ${cur} is stale (not a live installation) — refreshing`);
+    } catch (_) {
+      console.log('reconcile: stored installation id will not decrypt with the running secret — refreshing');
+    }
+  } else {
+    console.log('reconcile: no installation row for this org — creating');
+  }
+
+  const inst = await pickInstallation();
+  const id = String(inst.id);
+  const enc = encrypt(id, secret);
+  if (decrypt(enc, secret) !== id) throw new Error('round-trip check failed');
+
+  if (existing.rows.length) {
+    await client.query(
+      'UPDATE github_app_installations SET encrypted_installation_id=$1, updated_at=now() WHERE organization_uuid=$2',
+      [enc, org]);
+  } else {
+    const u = await client.query(
+      "SELECT u.user_uuid FROM users u JOIN emails e ON e.user_id=u.user_id WHERE e.email='demo@lightdash.com' LIMIT 1");
+    const userUuid = u.rows[0] && u.rows[0].user_uuid;
+    if (!userUuid) throw new Error('demo user not found for created_by');
+    const placeholder = encrypt('placeholder', secret);
+    await client.query(
+      `INSERT INTO github_app_installations
+         (organization_uuid, encrypted_installation_id, auth_token, refresh_token,
+          created_by_user_uuid, updated_by_user_uuid, created_at, updated_at)
+       VALUES ($1,$2,$3,$3,$4,$4,now(),now())`,
+      [org, enc, placeholder, userUuid]);
+  }
+  console.log(`OK: installation row set to id=${id} (account=${inst.account && inst.account.login}, repos=${inst.repository_selection})`);
+}
+
+async function stepOrgSettings(client, kvs) {
+  const org = await orgUuid(client);
+  const reviews = kvs.ai_agent_reviews_enabled === 'true';
+  await client.query(
+    `INSERT INTO ai_organization_settings (organization_uuid, ai_agents_visible, ai_agent_reviews_enabled)
+     VALUES ($1, true, $2)
+     ON CONFLICT (organization_uuid) DO UPDATE SET ai_agent_reviews_enabled=$2`,
+    [org, reviews]);
+  console.log(`OK: ai_organization_settings ai_agent_reviews_enabled=${reviews} for ${org}`);
+}
+
+async function stepDbtRepoCheck(client) {
+  const secret = need('RUNNING_SECRET');
+  const org = await orgUuid(client);
+  const r = await client.query(
+    `SELECT project_uuid, encode(dbt_connection,'hex') AS hex
+       FROM projects WHERE organization_id=(SELECT organization_id FROM organizations WHERE organization_uuid=$1)
+       ORDER BY project_id LIMIT 1`, [org]);
+  if (!r.rows.length) { console.log('OK: no project to check'); return; }
+  let type = '?';
+  try { type = (JSON.parse(decrypt(Buffer.from(r.rows[0].hex, 'hex'), secret)).type) || '?'; } catch (_) {}
+  if (type === 'github' || type === 'gitlab') {
+    console.log(`OK: project ${r.rows[0].project_uuid} dbt_connection is '${type}' (writeback-capable)`);
+  } else {
+    console.log(`NEED: project ${r.rows[0].project_uuid} dbt_connection is '${type}', not github/gitlab — repoint it (guided: see the GitHub Integration section) for writeback to open PRs`);
+  }
+}
+
+async function stepVerifyToken(client) {
+  const secret = need('RUNNING_SECRET');
+  const org = await orgUuid(client);
+  const row = await client.query(
+    "SELECT encode(encrypted_installation_id,'hex') AS hex FROM github_app_installations WHERE organization_uuid=$1", [org]);
+  if (!row.rows.length) throw new Error('no installation row');
+  const id = decrypt(Buffer.from(row.rows[0].hex, 'hex'), secret);
+  const res = await gh(`/app/installations/${id}/access_tokens`, { method: 'POST' });
+  if (res.status === 201) console.log(`OK: installation token mints (id=${id}, HTTP 201)`);
+  else { console.error(`FAIL: verify-token -- POST access_tokens for id=${id} -> ${res.status}`); process.exit(1); }
+}
+
+(async () => {
+  const step = process.argv[2];
+  const kvs = {};
+  for (const a of process.argv.slice(3)) { const i = a.indexOf('='); if (i > 0) kvs[a.slice(0, i)] = a.slice(i + 1); }
+  const client = new Client({
+    host: process.env.PGHOST || 'localhost', port: parseInt(process.env.PGPORT || '5432', 10),
+    user: process.env.PGUSER || 'postgres', password: process.env.PGPASSWORD || 'password',
+    database: process.env.PGDATABASE || 'postgres',
+  });
+  await client.connect();
+  try {
+    if (step === 'list-accounts') {
+      const list = await listInstallations();
+      console.log(JSON.stringify(list.map((i) => ({ login: i.account && i.account.login, repos: i.repository_selection })), null, 2));
+    }
+    else if (step === 'installation') await stepInstallation(client);
+    else if (step === 'org-settings') await stepOrgSettings(client, kvs);
+    else if (step === 'dbt-repo-check') await stepDbtRepoCheck(client);
+    else if (step === 'verify-token') await stepVerifyToken(client);
+    else { console.error(`FAIL: reconcile -- unknown step '${step}'`); process.exit(2); }
+  } finally {
+    await client.end();
+  }
+})().catch((e) => { console.error(`FAIL: reconcile -- ${e.message}`); process.exit(1); });

--- a/scripts/dev-op-pull.sh
+++ b/scripts/dev-op-pull.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Pull local-dev secrets from 1Password into .env.development.local, driven by
+# scripts/dev-secrets.manifest.json. Used by the /docker-dev profile flow.
+#
+# Why this exists: bare `op item get` inside command-substitution is flaky until
+# the biometric session is warm, and batching calls in one subshell intermittently
+# returns empty / "unknown flag". This script warms the session once, then pulls
+# each secret in its own call with explicit --account, writes straight to the env
+# file (never echoing values), and verifies the expected prefix.
+#
+# Usage:
+#   dev-op-pull.sh list  <SECRET_KEY...>      # print the 1Password items that WILL be read (approval gate); no values
+#   dev-op-pull.sh pull  <SECRET_KEY...>      # pull + write to env file; prints only key names + verify status
+#   dev-op-pull.sh check                      # report whether `op` is signed in to the manifest account
+# Options: --env-file <path> (default .env.development.local), --manifest <path>
+#
+# SECRET_KEY is a top-level key under "secrets" in the manifest (e.g. LIGHTDASH_LICENSE_KEY, GITHUB_APP).
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$SCRIPT_DIR/dev-secrets.manifest.json"
+ENV_FILE=".env.development.local"
+
+MODE="${1:-}"; shift || true
+KEYS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --env-file) ENV_FILE="$2"; shift 2 ;;
+        --manifest) MANIFEST="$2"; shift 2 ;;
+        --*) echo "dev-op-pull: unknown option $1" >&2; exit 2 ;;
+        *) KEYS+=("$1"); shift ;;
+    esac
+done
+
+[ -f "$MANIFEST" ] || { echo "dev-op-pull: manifest not found: $MANIFEST" >&2; exit 1; }
+# Per-engineer overrides (item names, account) — deep-merged over the committed manifest
+# so nothing is hardcoded to one person. Lives in $HOME (survives worktree recreation).
+LOCAL_MANIFEST="${LD_SECRETS_LOCAL:-$HOME/.lightdash/dev-secrets.local.json}"
+
+ACCOUNT="$(MANIFEST="$MANIFEST" LOCAL="$LOCAL_MANIFEST" python3 -c "
+import json, os
+m = json.load(open(os.environ['MANIFEST']))
+acct = m.get('account', '')
+lp = os.environ.get('LOCAL', '')
+if lp and os.path.exists(lp):
+    try: acct = json.load(open(lp)).get('account', acct)
+    except Exception: pass
+print(acct)
+")"
+
+manifest_field() { # key field
+    MANIFEST="$MANIFEST" LOCAL="$LOCAL_MANIFEST" python3 - "$1" "$2" <<'PY'
+import json, os, sys
+m = json.load(open(os.environ['MANIFEST']))
+lp = os.environ.get('LOCAL', '')
+if lp and os.path.exists(lp):
+    try:
+        lm = json.load(open(lp))
+        for k, ov in (lm.get('secrets') or {}).items():
+            m['secrets'].setdefault(k, {}).update(ov)
+    except Exception:
+        pass
+s = m['secrets'].get(sys.argv[1], {})
+v = s.get(sys.argv[2], '')
+print('\n'.join(v) if isinstance(v, list) else v)
+PY
+}
+
+op_signed_in() { op whoami --account "$ACCOUNT" >/dev/null 2>&1; }
+
+# Ensure a usable session WITHOUT bouncing to the user. The `op` session does NOT
+# survive across separate shells, so callers that pull must sign in and read in the
+# SAME invocation (the `pull` mode does). `eval "$(op signin ...)"` covers both modes:
+# in manual mode it captures the printed `export OP_SESSION_...` into this shell; in
+# desktop-integration mode it triggers Touch ID and prints nothing (eval of "" is a
+# no-op). Skips entirely when already signed in, so there's no repeated prompt.
+ensure_signin() {
+    op_signed_in && return 0
+    eval "$(op signin --account "$ACCOUNT" 2>/dev/null)" || true
+    op_signed_in
+}
+
+# Parse an `export KEY=""value""` block from $RAW; args are the wanted KEY names.
+# Prints "KEY<TAB>VALUE" lines. Defined as a function so the heredoc is NOT inside
+# a $(...) — bash 3.2 mis-parses heredocs nested in command substitution.
+parse_env_block() {
+    RAW="${RAW:-}" python3 - "$@" <<'PY'
+import os, re, sys
+raw = os.environ.get('RAW', '')
+want = set(sys.argv[1:])
+for m in re.finditer(r'([A-Z][A-Z0-9_]+)\s*=\s*(.*)', raw):
+    key, v = m.group(1), m.group(2).rstrip('\r\n').strip()
+    while len(v) >= 2 and v[0] in '"\'' and v[-1] in '"\'':
+        v = v[1:-1]
+    v = v.rstrip('"').rstrip("'")
+    if not want or key in want:
+        print(f"{key}\t{v}")
+PY
+}
+
+case "$MODE" in
+  check|signin)
+    # Ensure a session, attempting a Touch ID sign-in if needed (don't bounce to the user).
+    if ensure_signin; then echo "OK: signed in to $ACCOUNT"; exit 0
+    else echo "NOT-SIGNED-IN: \`op signin --account $ACCOUNT\` did not establish a session (is 1Password CLI desktop integration enabled? Settings → Developer). Ask the user to sign in, then retry."; exit 1; fi
+    ;;
+
+  discover)
+    # Search the engineer's actual vault and rank candidates per secret by matchKeywords.
+    # Output JSON the /docker-dev flow uses to ask the user; choices are saved via `save`.
+    [ ${#KEYS[@]} -gt 0 ] || { echo "dev-op-pull discover: no secret keys given" >&2; exit 2; }
+    ensure_signin || { echo "FAIL: not signed in to $ACCOUNT" >&2; exit 1; }
+    ITEMS="$(op item list --account "$ACCOUNT" --format=json 2>/dev/null)"
+    [ -n "$ITEMS" ] || { echo "FAIL: could not list 1Password items for $ACCOUNT" >&2; exit 1; }
+    MANIFEST="$MANIFEST" LOCAL="$LOCAL_MANIFEST" ITEMS="$ITEMS" python3 - "${KEYS[@]}" <<'PY'
+import json, os, sys
+m = json.load(open(os.environ['MANIFEST']))
+lp = os.environ.get('LOCAL', ''); local = {}
+if lp and os.path.exists(lp):
+    try: local = json.load(open(lp))
+    except Exception: pass
+titles = [it.get('title', '') for it in json.loads(os.environ['ITEMS']) if it.get('title')]
+out = {}
+for key in sys.argv[1:]:
+    spec = dict(m['secrets'].get(key, {}))
+    ov = (local.get('secrets') or {}).get(key, {})
+    spec.update(ov)
+    kws = [k.lower() for k in spec.get('matchKeywords', [])]
+    scored = []
+    for t in titles:
+        tl = t.lower()
+        s = sum(1 for k in kws if k in tl)
+        if s: scored.append((s, t))
+    scored.sort(key=lambda x: (-x[0], len(x[1])))
+    cands = [{'title': t, 'score': s} for s, t in scored[:5]]
+    saved = bool(ov.get('item'))
+    confident = saved or len(cands) == 1 or (len(cands) >= 2 and cands[0]['score'] > cands[1]['score'])
+    out[key] = {'saved': saved, 'savedItem': ov.get('item'), 'confident': confident,
+                'top': cands[0]['title'] if cands else None, 'candidates': cands}
+print(json.dumps(out, indent=2))
+PY
+    ;;
+
+  save)
+    KEY="${KEYS[0]:-}"; ITEM="${KEYS[1]:-}"
+    { [ -n "$KEY" ] && [ -n "$ITEM" ]; } || { echo "usage: dev-op-pull.sh save <SECRET_KEY> \"<1Password item name>\"" >&2; exit 2; }
+    KEY="$KEY" ITEM="$ITEM" LOCAL="$LOCAL_MANIFEST" python3 - <<'PY'
+import json, os
+p = os.environ['LOCAL']; key = os.environ['KEY']; item = os.environ['ITEM']
+os.makedirs(os.path.dirname(p), exist_ok=True)
+d = {}
+if os.path.exists(p):
+    try: d = json.load(open(p))
+    except Exception: d = {}
+d.setdefault('secrets', {}).setdefault(key, {})['item'] = item
+json.dump(d, open(p, 'w'), indent=2)
+print(f"OK: saved {key} -> \"{item}\" in {p}")
+PY
+    ;;
+
+  list)
+    [ ${#KEYS[@]} -gt 0 ] || { echo "dev-op-pull list: no secret keys given" >&2; exit 2; }
+    echo "The following 1Password items (account: $ACCOUNT) will be read:"
+    for k in "${KEYS[@]}"; do
+        item="$(manifest_field "$k" item)"
+        [ -n "$item" ] || { echo "  - $k: (NOT IN MANIFEST)"; continue; }
+        provides="$(manifest_field "$k" provides | paste -sd, - 2>/dev/null)"
+        aliases="$(manifest_field "$k" aliases | paste -sd, - 2>/dev/null)"
+        target="$k"; [ -n "$provides" ] && target="$provides"; [ -n "$aliases" ] && target="$k,$aliases"
+        echo "  - \"$item\"  ->  $target"
+    done
+    ;;
+
+  pull)
+    [ ${#KEYS[@]} -gt 0 ] || { echo "dev-op-pull pull: no secret keys given" >&2; exit 2; }
+    # Sign in + read all secrets in THIS one invocation (the session won't cross shells).
+    ensure_signin || { echo "FAIL: could not establish a 1Password session for $ACCOUNT (enable CLI desktop integration in 1Password Settings → Developer, or have the user run \`! op signin --account $ACCOUNT\`)" >&2; exit 1; }
+
+    # set_env KEY VALUE  — replace-or-append in ENV_FILE without echoing VALUE
+    set_env() {
+        local key="$1" val="$2" tmp
+        touch "$ENV_FILE"
+        tmp="$(mktemp)"
+        KEY="$key" VAL="$val" python3 - "$ENV_FILE" > "$tmp" <<'PY'
+import os, sys
+path = sys.argv[1]; key = os.environ['KEY']; val = os.environ['VAL']
+lines = open(path).read().splitlines() if os.path.exists(path) else []
+out, seen = [], False
+for l in lines:
+    if l.startswith(key + "="):
+        out.append(f"{key}={val}"); seen = True
+    else:
+        out.append(l)
+if not seen:
+    out.append(f"{key}={val}")
+sys.stdout.write("\n".join(out) + "\n")
+PY
+        mv "$tmp" "$ENV_FILE"
+    }
+
+    RC=0
+    for k in "${KEYS[@]}"; do
+        item="$(manifest_field "$k" item)"
+        field="$(manifest_field "$k" field)"
+        type="$(manifest_field "$k" type)"
+        [ -n "$item" ] || { echo "  $k: SKIP (not in manifest)"; RC=1; continue; }
+
+        raw="$(op item get "$item" --account "$ACCOUNT" --fields "label=$field" --reveal 2>/dev/null)"
+        if [ -z "$raw" ]; then echo "  $k: FAIL (empty from 1Password — item \"$item\" field \"$field\")"; RC=1; continue; fi
+
+        if [ "$type" = "env-block" ]; then
+            # Parse `export KEY=""value""` block (notesPlain doubled-quote gotcha).
+            provides=()
+            while IFS= read -r _p; do [ -n "$_p" ] && provides+=("$_p"); done < <(manifest_field "$k" provides)
+            parsed="$(RAW="$raw" parse_env_block "${provides[@]}")"
+            got=()
+            while IFS=$'\t' read -r kk vv; do
+                [ -n "$kk" ] || continue
+                set_env "$kk" "$vv"; got+=("$kk")
+            done <<< "$parsed"
+            echo "  $k: OK -> ${got[*]:-(none parsed)}"
+            [ ${#got[@]} -gt 0 ] || RC=1
+        else
+            # single-value secret; strip wrapping quotes
+            val="${raw%\"}"; val="${val#\"}"
+            prefix="$(manifest_field "$k" verifyPrefix)"
+            stripped="${val#$prefix}"
+            if [ -n "$prefix" ] && [ "$stripped" = "$val" ]; then
+                echo "  $k: FAIL (value does not start with expected prefix '$prefix')"; RC=1; continue
+            fi
+            set_env "$k" "$val"
+            written="$k"
+            while IFS= read -r alias; do
+                [ -n "$alias" ] || continue
+                set_env "$alias" "$val"; written="$written,$alias"
+            done < <(manifest_field "$k" aliases)
+            echo "  $k: OK -> $written (len ${#val})"
+        fi
+    done
+    exit $RC
+    ;;
+
+  *)
+    echo "Usage: dev-op-pull.sh {list|pull|check} [SECRET_KEY...] [--env-file PATH] [--manifest PATH]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -1,0 +1,35 @@
+{
+  "$comment": "Instance capabilities for /docker-dev. The AI tier is just Core vs EE: all AI features (agents, writeback, reviews classifier) are bundled into the `ee` profile. GitHub and Slack are integrations (extra credentials / a tunnel), kept as their own toggles. EE requires `github` because AI writeback opens PRs through it, so an EE instance is turnkey for writeback. The start-time multi-select composes these; each pulls in its `requires` transitively, then the union of secrets/flags/env/orgSettings is applied, `reconcile` steps run, and `verify` checks confirm it. `secrets` are keys in scripts/dev-secrets.manifest.json. Addressable by name: `/docker-dev start ee` or `/docker-dev start ee,slack`; no profile = a plain Core instance.",
+  "profiles": {
+    "github": {
+      "label": "GitHub integration (dbt-over-GitHub)",
+      "description": "Connect a project's dbt over the dev GitHub App. Usable standalone on Core (dbt-over-GitHub without AI); also required by EE for writeback PRs.",
+      "secrets": ["GITHUB_APP"],
+      "reconcile": ["github-app-installation", "github-dbt-repo"],
+      "verify": ["github-repos-list"]
+    },
+    "ee": {
+      "label": "Enterprise Edition — license + all AI (agents, writeback, reviews)",
+      "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey.",
+      "ee": true,
+      "requires": ["github"],
+      "secrets": ["LIGHTDASH_LICENSE_KEY", "ANTHROPIC_API_KEY", "E2B_API_KEY"],
+      "env": { "AI_COPILOT_ENABLED": "true", "AI_DEFAULT_PROVIDER": "anthropic" },
+      "flags": ["ai-writeback", "github-mcp-one-click", "ai-preview-deploy-setup"],
+      "orgSettings": { "ai_agent_reviews_enabled": true },
+      "verify": ["agents-200", "writeback-token"]
+    },
+    "slack": {
+      "label": "Slack bot (optional add-on)",
+      "description": "Slack app for @mention agent chat. Needs a public tunnel; see the slack-bot-local-setup notes. Not bundled into EE because the tunnel step can't be automated.",
+      "requires": ["ee"],
+      "secrets": ["SLACK_APP"],
+      "notes": "SLACK_APP is not yet in the secrets manifest — confirm the 1Password item name before enabling."
+    }
+  },
+  "snapshots": {
+    "$comment": "Preferred base snapshot per tier, so common instances skip the migrate pass / reconcile. Maintained by dev-fast-start.sh.",
+    "core": "ld-shared_postgres_base",
+    "ee": "ld-shared_postgres_base_ee"
+  }
+}

--- a/scripts/dev-profiles.sh
+++ b/scripts/dev-profiles.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Resolve /docker-dev instance profiles from scripts/dev-profiles.json.
+#
+# Usage:
+#   dev-profiles.sh list                    # print available profiles (label + description)
+#   dev-profiles.sh resolve <name[,name...]> # expand `requires` transitively; print resolved plan as JSON
+#
+# The resolved JSON has: { ee, profiles[], secrets[], flags[], env{}, orgSettings{}, reconcile[], verify[] }
+# The /docker-dev skill consumes this to know which 1Password items to pull (via dev-op-pull.sh),
+# which feature flags + env to write, which reconcile steps (e.g. github setup) to run, and how to verify.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROFILES="$SCRIPT_DIR/dev-profiles.json"
+[ -f "$PROFILES" ] || { echo "dev-profiles: not found: $PROFILES" >&2; exit 1; }
+
+MODE="${1:-}"; shift || true
+
+case "$MODE" in
+  list)
+    python3 - "$PROFILES" <<'PY'
+import json, sys
+p = json.load(open(sys.argv[1]))["profiles"]
+for name, d in p.items():
+    print(f"{name:20s} {d.get('label','')}")
+    if d.get('description'): print(f"{'':20s}   {d['description']}")
+PY
+    ;;
+
+  resolve)
+    SEL="${1:-}"
+    [ -n "$SEL" ] || { echo "dev-profiles resolve: give profile name(s), comma-separated" >&2; exit 2; }
+    SEL="$SEL" python3 - "$PROFILES" <<'PY'
+import json, os, sys
+data = json.load(open(sys.argv[1]))
+profiles = data["profiles"]
+sel = [s.strip() for s in os.environ["SEL"].split(",") if s.strip()]
+
+order, seen = [], set()
+def visit(name):
+    if name in seen: return
+    if name not in profiles:
+        sys.stderr.write(f"unknown profile: {name}\n"); sys.exit(3)
+    seen.add(name)
+    for req in profiles[name].get("requires", []):
+        visit(req)
+    order.append(name)
+
+for s in sel: visit(s)
+
+def uniq(seq):
+    out, s = [], set()
+    for x in seq:
+        if x not in s: s.add(x); out.append(x)
+    return out
+
+plan = {"ee": False, "profiles": order, "secrets": [], "flags": [],
+        "env": {}, "orgSettings": {}, "reconcile": [], "verify": []}
+for name in order:
+    d = profiles[name]
+    if d.get("ee"): plan["ee"] = True
+    plan["secrets"] += d.get("secrets", [])
+    plan["flags"] += d.get("flags", [])
+    plan["reconcile"] += d.get("reconcile", [])
+    plan["verify"] += d.get("verify", [])
+    plan["env"].update(d.get("env", {}))
+    plan["orgSettings"].update(d.get("orgSettings", {}))
+for k in ("secrets", "flags", "reconcile", "verify", "profiles"):
+    plan[k] = uniq(plan[k])
+print(json.dumps(plan, indent=2))
+PY
+    ;;
+
+  *)
+    echo "Usage: dev-profiles.sh {list|resolve <name[,name...]>}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/dev-reconcile.sh
+++ b/scripts/dev-reconcile.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Executable post-start reconcile for /docker-dev profiles. Supplies the environment
+# truths the reconcile needs and dispatches to scripts/dev-github-reconcile.cjs:
+#   - RUNNING_SECRET: the LIGHTDASH_SECRET of the *running* pm2 api process (can differ
+#     from the env file's quoted value; that's the secret the backend decrypts with).
+#   - PG connection from the claimed slot; GitHub App creds from .env.development.local.
+#
+# Usage (step names match dev-profiles.json `reconcile` + verify):
+#   dev-reconcile.sh github-app-installation
+#   dev-reconcile.sh github-dbt-repo
+#   dev-reconcile.sh org-settings ai_agent_reviews_enabled=true
+#   dev-reconcile.sh verify-token
+#   dev-reconcile.sh all            # installation -> dbt-repo-check -> verify-token
+
+set -uo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || { echo "FAIL: reconcile -- cannot cd to repo root" >&2; exit 1; }
+
+eval "$(./scripts/dev-ports.sh env 2>/dev/null)" || { echo "FAIL: reconcile -- dev-ports.sh env failed" >&2; exit 1; }
+: "${LD_INSTANCE_ID:?}" "${LD_PG_PORT:?}"
+
+ENV_FILE=".env.development.local"
+[ -f "$ENV_FILE" ] || { echo "FAIL: reconcile -- $ENV_FILE missing (run the profile setup first)" >&2; exit 1; }
+
+# The secret the backend actually decrypts with — read from the running pm2 api process.
+RUNNING_SECRET="$(pm2 jlist 2>/dev/null | LD_INSTANCE_ID="$LD_INSTANCE_ID" python3 -c "
+import sys, json, os
+inst = os.environ['LD_INSTANCE_ID']
+try: ps = json.load(sys.stdin)
+except Exception: ps = []
+api = [p for p in ps if p.get('name') == inst + '-api']
+print(api[0]['pm2_env'].get('LIGHTDASH_SECRET', '') if api else '')
+" 2>/dev/null)"
+if [ -z "$RUNNING_SECRET" ]; then
+    # Fall back to the env-file value (dequoted) if the api isn't up yet.
+    RUNNING_SECRET="$(grep '^LIGHTDASH_SECRET=' .env.development 2>/dev/null | head -1 | cut -d= -f2-)"
+    RUNNING_SECRET="${RUNNING_SECRET%\"}"; RUNNING_SECRET="${RUNNING_SECRET#\"}"
+    [ -n "$RUNNING_SECRET" ] && echo "WARN: pm2 api not found; using .env.development secret (may differ from a running backend)"
+fi
+[ -n "$RUNNING_SECRET" ] || { echo "FAIL: reconcile -- could not determine LIGHTDASH_SECRET" >&2; exit 1; }
+
+GITHUB_APP_ID="$(grep '^GITHUB_APP_ID=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+GITHUB_PRIVATE_KEY="$(grep '^GITHUB_PRIVATE_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+
+# The dev GitHub App is shared and has many installations, so the reconcile must
+# target YOUR account. Resolve from $GH_ACCOUNT, then the per-engineer local config.
+if [ -z "${GH_ACCOUNT:-}" ]; then
+    GH_ACCOUNT="$(python3 -c "
+import json, os
+p = os.path.expanduser('${LD_SECRETS_LOCAL:-$HOME/.lightdash/dev-secrets.local.json}')
+print(json.load(open(p)).get('githubAccount', '') if os.path.exists(p) else '')
+" 2>/dev/null)"
+fi
+
+run_cjs() {
+    RUNNING_SECRET="$RUNNING_SECRET" \
+    GITHUB_APP_ID="$GITHUB_APP_ID" GITHUB_PRIVATE_KEY="$GITHUB_PRIVATE_KEY" \
+    GH_ACCOUNT="${GH_ACCOUNT:-}" \
+    PGHOST=localhost PGPORT="$LD_PG_PORT" PGUSER=postgres PGPASSWORD=password PGDATABASE=postgres \
+    NODE_PATH="$REPO_ROOT/packages/backend/node_modules" \
+    node "$REPO_ROOT/scripts/dev-github-reconcile.cjs" "$@"
+}
+
+STEP="${1:-}"; shift || true
+case "$STEP" in
+    github-app-installation) run_cjs installation ;;
+    github-dbt-repo)         run_cjs dbt-repo-check ;;
+    org-settings)            run_cjs org-settings "$@" ;;
+    verify-token|verify)     run_cjs verify-token ;;
+    list-accounts)           run_cjs list-accounts ;;
+    save-github-account)
+        ACCT="${1:-}"; [ -n "$ACCT" ] || { echo "usage: dev-reconcile.sh save-github-account <github-login>" >&2; exit 2; }
+        ACCT="$ACCT" LF="${LD_SECRETS_LOCAL:-$HOME/.lightdash/dev-secrets.local.json}" python3 -c "
+import json, os
+p = os.environ['LF']; os.makedirs(os.path.dirname(p), exist_ok=True)
+d = {}
+if os.path.exists(p):
+    try: d = json.load(open(p))
+    except Exception: d = {}
+d['githubAccount'] = os.environ['ACCT']
+json.dump(d, open(p, 'w'), indent=2)
+print(f\"OK: saved githubAccount={os.environ['ACCT']} in {p}\")
+" ;;
+    all)
+        run_cjs installation && run_cjs dbt-repo-check && run_cjs verify-token ;;
+    "")
+        echo "Usage: dev-reconcile.sh {github-app-installation|github-dbt-repo|org-settings k=v|verify-token|all}" >&2; exit 2 ;;
+    *)                       run_cjs "$STEP" "$@" ;;
+esac

--- a/scripts/dev-secrets.local.example.json
+++ b/scripts/dev-secrets.local.example.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Per-engineer local config. Copy to ~/.lightdash/dev-secrets.local.json and fill in YOUR values. dev-op-pull.sh deep-merges the `secrets` here over scripts/dev-secrets.manifest.json (so you only override what differs — your personal 1Password item names), and dev-reconcile.sh reads `githubAccount`. It lives in your home dir, so it's never committed and survives worktree recreation.",
+  "githubAccount": "your-github-username",
+  "secrets": {
+    "ANTHROPIC_API_KEY": { "item": "<your Anthropic 1Password item name>" },
+    "E2B_API_KEY": { "item": "<your e2b 1Password item name>" }
+  }
+}

--- a/scripts/dev-secrets.manifest.json
+++ b/scripts/dev-secrets.manifest.json
@@ -1,0 +1,47 @@
+{
+  "$comment": "env var -> 1Password item map for local dev, consumed by scripts/dev-op-pull.sh. Item NAMES are not hardcoded: `dev-op-pull.sh discover` searches your actual vault using `matchKeywords`, ranks candidates, and the /docker-dev flow asks you to confirm — saving your choice to ~/.lightdash/dev-secrets.local.json so it only asks once. `item` here is just a fallback default + a verification of `field`/`verifyPrefix`/`type`. All items live in the shared Lightdash 1Password account (you need access). `verifyPrefix` doubles as a safety check that the picked item holds the right kind of secret.",
+  "account": "lightdash.1password.com",
+  "secrets": {
+    "LIGHTDASH_LICENSE_KEY": {
+      "item": "Development Lightdash EE license key",
+      "field": "password",
+      "verifyPrefix": "eyJ",
+      "matchKeywords": ["lightdash", "license", "enterprise", "ee", "dev"],
+      "shared": true,
+      "description": "Shared dev Enterprise license (gates EE migrations + services)"
+    },
+    "ANTHROPIC_API_KEY": {
+      "item": "Anthropic API key (Lightdash dev)",
+      "field": "password",
+      "verifyPrefix": "sk-ant",
+      "aliases": ["AI_WRITEBACK_ANTHROPIC_API_KEY"],
+      "matchKeywords": ["anthropic", "claude"],
+      "perEngineer": true,
+      "description": "YOUR Anthropic key for AI Copilot/agents + the writeback sandbox"
+    },
+    "E2B_API_KEY": {
+      "item": "e2b API key (Lightdash dev)",
+      "field": "password",
+      "verifyPrefix": "e2b_",
+      "matchKeywords": ["e2b"],
+      "perEngineer": true,
+      "description": "YOUR E2B sandbox key for AI writeback"
+    },
+    "GITHUB_APP": {
+      "item": "lightdash-app-dev Github integration for Lightdash",
+      "field": "notesPlain",
+      "type": "env-block",
+      "matchKeywords": ["github", "lightdash-app-dev", "app", "integration"],
+      "shared": true,
+      "provides": [
+        "GITHUB_APP_ID",
+        "GITHUB_APP_NAME",
+        "GITHUB_CLIENT_ID",
+        "GITHUB_CLIENT_SECRET",
+        "GITHUB_PRIVATE_KEY",
+        "GITHUB_REDIRECT_DOMAIN"
+      ],
+      "description": "Shared dev GitHub App (lightdash-app-dev). notesPlain holds an `export KEY=\"\"value\"\"` block; GITHUB_PRIVATE_KEY is base64-encoded PEM"
+    }
+  }
+}

--- a/scripts/dev-statusline.sh
+++ b/scripts/dev-statusline.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Emit this Lightdash dev instance's web URL as a claude-hud extra-cmd segment.
+#
+# Output (stdout): {"label":"🟢 http://localhost:<FE>"} when the frontend is up,
+# a muted variant when the instance is assigned but down, and NOTHING (exit 0)
+# when the cwd isn't a Lightdash worktree with an assigned slot — so it's silent
+# everywhere else. Designed to be fast (statusline budget): a single 0.3s TCP probe.
+#
+# Wire it into claude-hud via `--extra-cmd` (see the /docker-dev "Statusline" note).
+# Run directly with `--plain` to just print the URL for humans.
+
+set -uo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+id="$(basename "$root")"
+inst="$HOME/.lightdash/dev-instances/${id}.json"
+[ -f "$inst" ] || exit 0
+
+fe="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['ports']['frontend'])" "$inst" 2>/dev/null)" || exit 0
+[ -n "$fe" ] || exit 0
+url="http://localhost:${fe}"
+
+if [ "${1:-}" = "--plain" ]; then
+    echo "$url"
+    exit 0
+fi
+
+# Fast liveness probe (instant on localhost, refused or accepted).
+if python3 -c "import socket,sys; s=socket.socket(); s.settimeout(0.3); sys.exit(0 if s.connect_ex(('127.0.0.1', int(sys.argv[1])))==0 else 1)" "$fe" 2>/dev/null; then
+    label="🟢 ${url}"
+else
+    label="⚪ localhost:${fe}"
+fi
+
+python3 -c "import json,sys; print(json.dumps({'label': sys.argv[1]}, ensure_ascii=False))" "$label"


### PR DESCRIPTION
## Problem

Standing up a local dev instance with EE + AI writeback was a ~10-step recalled procedure: pull the right secrets from 1Password, set feature flags, and hand-write crypto to fix the GitHub App installation row + repoint the dbt repo. Easy to get wrong, slow, and re-explained every time.

## What this does

Turns `/docker-dev` into a capability-**profile** flow — one approval + one script for ~90% of the work.

- **Profiles** (`scripts/dev-profiles.json`): the AI tier is just **Core vs EE** (EE bundles agents, writeback, reviews classifier); GitHub and Slack are integration toggles. Resolved transitively, so `start ee` is turnkey (pulls in GitHub so writeback opens PRs out of the box).
- **1Password secret discovery** (`scripts/dev-op-pull.sh discover`): searches the engineer's *own* vault, ranks candidates by keyword, asks to confirm, and remembers the choice in `~/.lightdash/dev-secrets.local.json`. **No item names are hardcoded** — the committed manifest holds only generic placeholders. Pull self-signs-in (the `op` session doesn't survive across shells).
- **Executable post-start reconcile** (`scripts/dev-reconcile.sh` + `scripts/dev-github-reconcile.cjs`): ensures the `github_app_installations` row decrypts with the *running* secret and points at a live installation, applies org settings, checks the dbt repo is github, and verifies by minting an installation token — replacing the hand-written crypto.
- **Feature-flag scanner + opt-in picker** (`scripts/dev-feature-flags.sh`): scans the `FeatureFlags` enum and lets you turn on extras.
- **Speed**: shared cached venv (symlinked per worktree), a dedicated EE base snapshot so EE instances skip the slow migrate, and an EE-migrate **heartbeat** so the long step can't look hung.
- **Statusline**: an app-aware segment showing the local web URL (🟢 `http://localhost:<FE>`), composed into the existing statusline via `--extra-cmd` (non-destructive).

## Genericity & safety

- Per-engineer config (1Password item names, GitHub account) lives in `~/.lightdash/dev-secrets.local.json` — never committed; an example is included. Nothing in the repo is tied to one engineer.
- Discovery never auto-picks (vaults contain other-org items); it always asks and recommends the dev item.
- Fixes the `venv` `.gitignore` (the cached-venv symlink wasn't matched by `venv/`).

## Testing

- Shell scripts `bash -n` clean; `dev-github-reconcile.cjs` `node --check` clean; JSON validated.
- Reconcile run end-to-end against a live EE instance: installation (idempotent), `verify-token` (HTTP 201), dbt-repo check, org-settings — all green.
- Discovery + save + merge verified; `list-accounts` confirms the per-engineer account is needed (shared dev App has many installations).

## Note for reviewers

The statusline wiring (a `--extra-cmd` in `~/.claude/settings.json` + a small shim in `~/.lightdash/`) is a one-time per-machine setup documented in the command; it's not part of this diff.