### PR TITLE
refactor(timezone): combine EnableUserTimezones into EnableTimezoneSupport

### DIFF
--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -73,9 +73,9 @@ services:
             S3_BUCKET: ${S3_BUCKET}
             MCP_ENABLED: true
             CUSTOM_ROLES_ENABLED: true
+            # Enables the combined timezone feature (incl. user-level timezone
+            # resolution) so the timezone api-tests pass.
             LIGHTDASH_ENABLE_TIMEZONE_SUPPORT: true
-            # Gates user-level timezone resolution; on so the userTimezone api-tests pass.
-            LIGHTDASH_ENABLE_FEATURE_FLAGS: enable-user-timezones
 
             # Force-enable embedding flag in preview envs so e2e tests work.
             # Picked up via LEGACY_ENABLE_ENV_VARS in parseConfig.ts → unified

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -23,14 +23,13 @@ In addition, three overrides sit on top of the project timezone (the session tim
 
 Resolution order: `session (embed URL) → chart → user → project → server default ('UTC')`. A viewer with no profile preference falls through to the project. A viewer with a profile timezone sees their zone on charts that don't pin one. An embedding host can pin a single session to a zone via the `?timezone=` URL param, which outranks even the chart pin. See [User-level timezone](#user-level-timezone) below.
 
-Two flags gate timezone behavior:
+A single flag gates timezone behavior:
 
-| Flag                    | Env var                               | Gates                                                                                                                  |
-| ----------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | Data timezone feature: warehouse UI field, session-TZ setup, and the project-level "filter inputs in project TZ" toggle |
-| `EnableUserTimezones`   | `enable-user-timezones` (flag only)   | UI surface for user-facing timezone pickers: Profile panel picker and Explorer chart-level picker                       |
+| Flag                    | Env var                               | Gates                                                                                                                                                  |
+| ----------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `EnableTimezoneSupport` | `LIGHTDASH_ENABLE_TIMEZONE_SUPPORT`   | The whole timezone feature: data-timezone warehouse field + session-TZ setup, the "filter inputs in project TZ" toggle, the user-facing timezone pickers (Profile panel, Explorer chart-level), and per-viewer (user-profile) timezone resolution |
 
-The project timezone setting itself is always available. Server-side resolution honors a user's profile timezone only when `EnableUserTimezones` is on: each call site resolves the flag and passes it into `getAccountUserTimezone(account, isUserTimezoneEnabled)`, which returns `null` when the flag is off so stored `users.timezone` values fall back to the project timezone. Both flags can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
+The project timezone setting itself is always available. `resolveQueryTimezone` always honors a chart pinned to `user_timezone` — falling back to the project timezone only when the viewer has no stored profile preference. The `EnableTimezoneSupport` flag gates the surrounding pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`), so when the flag is off the resolved zone simply isn't applied to the query. The flag can be toggled per-organization (or per-user) via `feature_flag_overrides` in the database, which takes precedence over the env var, so we can roll out gradually without flipping the global switch.
 
 ### Data timezone (`dataTimezone`)
 
@@ -244,7 +243,7 @@ Absolute-date filter pickers (`FilterDateTimePicker`, `FilterDateTimeRangePicker
 - Subtext flips to a local-time translation; side label shows the project TZ
 - Per-chart overrides via `metricQuery.timezone` are respected — the picker reads the resolved chart > user > project value rather than the project setting directly
 
-The toggle is independent of `EnableUserTimezones`: it controls picker rendering for absolute boundaries, not the chain that resolves which zone applies.
+The toggle controls picker rendering for absolute boundaries, not the chain that resolves which zone applies.
 
 **Files:** `packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx`, `packages/frontend/src/components/SettingsQueryTimezone/index.tsx`, `packages/backend/src/database/migrations/20260511132608_add_use_project_timezone_in_filters_to_projects.ts`, `packages/backend/src/models/ProjectModel/ProjectModel.ts`.
 

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -101,17 +101,17 @@ This is the same order documented in [`timezone-handling.md:23`](./timezone-hand
 
 ### Per-content choice between a pinned TZ and a viewer TZ?
 
-**Partially.** The per-chart pin in Explorer (chart-level `metricQuery.timezone`) gives an **author-pinned** mode — once set, every viewer sees that zone. An unpinned chart with `EnableUserTimezones=on` gives a **viewer-TZ** mode — each viewer's profile drives the resolution.
+**Partially.** The per-chart pin in Explorer (chart-level `metricQuery.timezone`) gives an **author-pinned** mode — once set, every viewer sees that zone. A chart pinned to `user_timezone` with `EnableTimezoneSupport=on` gives a **viewer-TZ** mode — each viewer's profile drives the resolution.
 
 **What we don't have**: an *author-saved-at-save-time* default that silently inherits the author's zone. We require the author to explicitly pin if they want viewer-stable behavior. This is more honest, slightly less ergonomic.
 
 ### Is there a user-TZ concept at all? What's the roadmap?
 
-**Yes, today.** `users.timezone` (IANA string) is settable in Profile Settings → Default timezone, gated behind the `EnableUserTimezones` feature flag (`featureFlags.ts:12`). Stored in the database, validated server-side in `UserService.ts`, threaded through every authenticated query.
+**Yes, today.** `users.timezone` (IANA string) is settable in Profile Settings → Default timezone, gated behind the `EnableTimezoneSupport` feature flag. Stored in the database, validated server-side in `UserService.ts`, threaded through every authenticated query.
 
-**Admin opt-in**: yes — `EnableUserTimezones` defaults off and can be toggled per-org via `feature_flag_overrides`.
+**Admin opt-in**: yes — `EnableTimezoneSupport` defaults off and can be toggled per-org via `feature_flag_overrides`.
 
-**Flag-off behavior**: turning the flag off does NOT clear stored `users.timezone` values, but they are no longer applied — `getAccountUserTimezone(account, isUserTimezoneEnabled)` returns `null` when `EnableUserTimezones` is off, so resolution falls back to the project timezone for every user. The stored preference is preserved (non-destructive) and re-applies when the flag is turned back on.
+**Flag-off behavior**: turning the flag off does NOT clear stored `users.timezone` values, but they are no longer applied — when `EnableTimezoneSupport` is off, the surrounding query pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`) is short-circuited, so the resolved zone is not applied to the query. The stored preference is preserved (non-destructive) and re-applies when the flag is turned back on.
 
 ### Scheduled deliveries & embeds — which TZ wins?
 
@@ -163,11 +163,12 @@ The DATE-base bypass at `filtersCompiler.ts` is the same logic as the SELECT-sid
 
 | Configuration | Alice's SQL == Bob's SQL? |
 |---|---|
-| `EnableUserTimezones=off`, no chart pin | ✅ Yes — both get project TZ |
-| `EnableUserTimezones=off`, chart pinned to Pacific | ✅ Yes — pin wins |
-| `EnableUserTimezones=on`, no chart pin, neither has profile TZ | ✅ Yes — both fall through to project |
-| `EnableUserTimezones=on`, no chart pin, both have profile TZs | ❌ No — Alice's WHERE uses Tokyo bounds, Bob's uses LA bounds |
-| `EnableUserTimezones=on`, chart pinned to Pacific | ✅ Yes — pin wins over profile |
+| `EnableTimezoneSupport=off`, no chart pin | ✅ Yes — both get project TZ |
+| `EnableTimezoneSupport=off`, chart pinned to `user_timezone` | ✅ Yes — flag off, both fall back to project TZ |
+| `EnableTimezoneSupport=on`, no chart pin | ✅ Yes — both get project TZ |
+| `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, neither has profile TZ | ✅ Yes — both fall through to project |
+| `EnableTimezoneSupport=on`, chart pinned to `user_timezone`, both have profile TZs | ❌ No — Alice's WHERE uses Tokyo bounds, Bob's uses LA bounds |
+| `EnableTimezoneSupport=on`, chart pinned to Pacific | ✅ Yes — pin wins over profile |
 | Dashboard date filter (absolute range) | ✅ Yes — absolute filters are UTC instants regardless of viewer |
 | Dashboard date filter (relative — "last 7 days") | depends on the chart settings as above |
 
@@ -379,12 +380,12 @@ Verified on Snowflake too: `CONVERT_TIMEZONE('America/New_York', '2026-06-09 12:
 
 ### What's the declared design intent — "consistent shape" or "viewer-local"?
 
-**Both, depending on configuration.** Off the rack with `EnableUserTimezones=off`:
-- Every viewer of a non-pinned chart sees project-TZ buckets → **consistent chart shape**.
+**Both, depending on configuration.** Off the rack with `EnableTimezoneSupport=off`:
+- Every viewer sees project-TZ buckets → **consistent chart shape**.
 
-With `EnableUserTimezones=on`:
-- Non-pinned charts shift per viewer → **viewer-local boundaries**.
-- Pinned charts override per viewer → **per-content choice**.
+With `EnableTimezoneSupport=on`:
+- Charts pinned to `user_timezone` shift per viewer → **viewer-local boundaries**.
+- Charts pinned to a specific zone override per viewer → **per-content choice**.
 
 So the architectural intent is "support both, default to consistent." **This is not documented anywhere a customer can find.** Customers discover it via:
 - The Profile Settings picker appearing or not appearing (depending on flag).
@@ -400,7 +401,7 @@ So the architectural intent is "support both, default to consistent." **This is 
 | Issue | Severity | Effort | Location |
 |---|---|---|---|
 | ECharts DST shift bug | Correctness | 1d test + 2d fix | `packages/frontend/src/hooks/echarts/timezoneShift.ts` |
-| ~~`EnableUserTimezones=off` doesn't gate stored profile TZs~~ ✅ fixed | Correctness | 1d | `resolveQueryTimezone.ts` |
+| ~~`EnableTimezoneSupport=off` doesn't gate stored profile TZs~~ ✅ fixed | Correctness | 1d | `resolveQueryTimezone.ts` |
 | Scheduled deliveries TZ interaction undocumented | Docs | 0.5d | `timezone-handling.md` |
 | Per-column wall-clock TZ annotation | Feature | 2d | `translator.ts` + `getColumnTimezone` |
 | ~~BigQuery half-hour offset bare-literal hole~~ ✅ not a bug (literal is a pre-converted UTC instant) | Correctness | 1d | `filtersCompiler.ts` |

--- a/docs/timezones/timezones-v2-design.md
+++ b/docs/timezones/timezones-v2-design.md
@@ -39,10 +39,11 @@ Tags combine (e.g., `bug + breaking` for a correctness fix that, shipped without
    ✅ Implemented in `resolveQueryTimezone.ts`.
 
 6. **User-level TZ is an admin opt-in (org-wide feature flag).**
-   ✅ `EnableUserTimezones`.
+   ✅ `EnableTimezoneSupport` — the single timezone feature flag (the former
+   `EnableUserTimezones` flag was merged into it).
 
 7. **Disabling the user-TZ feature must actually disable it, not just hide the picker.**
-   ✅ `gap-flag-off-leak` fixed — `getAccountUserTimezone(account, isUserTimezoneEnabled)` returns `null` when `EnableUserTimezones` is off, so stored `users.timezone` values are ignored and resolution falls back to the project timezone. Non-destructive (values are kept, just not applied).
+   ✅ When `EnableTimezoneSupport` is off, the surrounding query pipeline (warehouse session setup, timezone-aware `DATE_TRUNC`, returning `displayTimezone`) is short-circuited, so the resolved zone is not applied to the query. The stored `users.timezone` is preserved (non-destructive) and re-applies when the flag is turned back on.
 
 8. **Resolved TZ persists with the query record; downstream paths read it back, never re-resolve.**
    ✅ Stamped onto `metricQuery.timezone` in `executePreparedAsyncQuery`.

--- a/packages/api-tests/tests/userTimezone.test.ts
+++ b/packages/api-tests/tests/userTimezone.test.ts
@@ -18,9 +18,8 @@ import {
  * (+9) shifts events into Jan 15/16/17 — distinct from the UTC layout
  * (Jan 15/16), so a wrong grouping is immediately visible.
  *
- * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true and the EnableUserTimezones
- * flag enabled (LIGHTDASH_ENABLE_FEATURE_FLAGS=enable-user-timezones) in the
- * environment — `user_timezone` resolution is gated on the latter.
+ * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment —
+ * `user_timezone` resolution is gated on the EnableTimezoneSupport flag.
  */
 
 const DIMENSION_KEY = 'timezone_test_event_timestamp_day';

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1486,7 +1486,6 @@ export class EmbedService extends BaseService {
             metricQuery: metricQueryWithDashboardOverrides,
             projectTimezone,
             userTimezone: null,
-            isUserTimezoneEnabled: false,
         });
         const isTimezoneSupportEnabled =
             await this.projectService.isTimezoneSupportEnabled({
@@ -2133,7 +2132,6 @@ export class EmbedService extends BaseService {
             metricQuery,
             projectTimezone,
             userTimezone: null,
-            isUserTimezoneEnabled: false,
         });
 
         const { rows, cacheMetadata } = await this._runEmbedQuery({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2826,16 +2826,11 @@ export class AsyncQueryService extends ProjectService {
         const projectTimezone = projectUuid
             ? await this.getQueryTimezoneForProject(projectUuid)
             : 'UTC';
-        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
-            userUuid,
-            organizationUuid,
-        });
         const resolvedTimezone = resolveQueryTimezone({
             sessionTimezone,
             metricQuery,
             projectTimezone,
             userTimezone,
-            isUserTimezoneEnabled,
         });
         const enabled = await this.isTimezoneSupportEnabled({
             userUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3862,16 +3862,11 @@ export class ProjectService extends BaseService {
 
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
-        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
-            userUuid: account.user.id,
-            organizationUuid: account.organization.organizationUuid,
-        });
         const timezone = resolveQueryTimezone({
             sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: getAccountUserTimezone(account),
-            isUserTimezoneEnabled,
         });
         const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
             userUuid: account.user.id,
@@ -4552,22 +4547,18 @@ export class ProjectService extends BaseService {
 
                 const projectTimezone =
                     await this.getQueryTimezoneForProject(projectUuid);
-                const isUserTimezoneEnabled = await this.isUserTimezoneEnabled({
-                    userUuid: account.user.id,
-                    organizationUuid: account.organization.organizationUuid,
-                });
                 const resolvedTimezone = resolveQueryTimezone({
                     sessionTimezone: null,
                     metricQuery,
                     projectTimezone,
                     userTimezone: getAccountUserTimezone(account),
-                    isUserTimezoneEnabled,
                 });
-                const isTimezoneEnabled = await this.isTimezoneSupportEnabled({
-                    userUuid: account.user.id,
-                    organizationUuid: account.organization.organizationUuid,
-                });
-                const displayTimezone = isTimezoneEnabled
+                const isTimezoneSupportEnabled =
+                    await this.isTimezoneSupportEnabled({
+                        userUuid: account.user.id,
+                        organizationUuid: account.organization.organizationUuid,
+                    });
+                const displayTimezone = isTimezoneSupportEnabled
                     ? resolvedTimezone
                     : undefined;
 
@@ -4908,18 +4899,11 @@ export class ProjectService extends BaseService {
 
                     const projectTimezone =
                         await this.getQueryTimezoneForProject(projectUuid);
-                    const isUserTimezoneEnabled =
-                        await this.isUserTimezoneEnabled({
-                            userUuid: account.user.id,
-                            organizationUuid:
-                                account.organization.organizationUuid,
-                        });
                     const timezone = resolveQueryTimezone({
                         sessionTimezone: null,
                         metricQuery: metricQueryWithLimit,
                         projectTimezone,
                         userTimezone: getAccountUserTimezone(account),
-                        isUserTimezoneEnabled,
                     });
                     const useTimezoneAwareDateTrunc =
                         await this.isTimezoneSupportEnabled({
@@ -5522,13 +5506,11 @@ export class ProjectService extends BaseService {
 
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
-        const isUserTimezoneEnabled = await this.isUserTimezoneEnabled(user);
         const timezone = resolveQueryTimezone({
             sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: user.timezone,
-            isUserTimezoneEnabled,
         });
         const useTimezoneAwareDateTrunc =
             await this.isTimezoneSupportEnabled(user);
@@ -8562,18 +8544,6 @@ export class ProjectService extends BaseService {
     }): Promise<boolean> {
         const { enabled } = await this.featureFlagModel.get({
             featureFlagId: FeatureFlags.EnableTimezoneSupport,
-            user,
-        });
-
-        return enabled;
-    }
-
-    protected async isUserTimezoneEnabled(user: {
-        userUuid: string;
-        organizationUuid?: string;
-    }): Promise<boolean> {
-        const { enabled } = await this.featureFlagModel.get({
-            featureFlagId: FeatureFlags.EnableUserTimezones,
             user,
         });
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -8,11 +8,9 @@ export enum FeatureFlags {
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 
-    /* Send local timezone to the warehouse session */
-    EnableUserTimezones = 'enable-user-timezones',
-
     /* Gate new timezone features: warehouse session timezone, timezone-aware
-       DATE_TRUNC, result formatting, etc. Temporary — remove once stable. */
+       DATE_TRUNC, per-viewer (user-profile) timezone resolution, result
+       formatting, etc. Temporary — remove once stable. */
     EnableTimezoneSupport = 'enable-timezone-support',
 
     /**

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -20,7 +20,6 @@ describe('resolveQueryTimezone', () => {
             sessionTimezone: null,
             metricQuery: { timezone: 'project_timezone' },
             projectTimezone: 'Australia/Brisbane',
-            isUserTimezoneEnabled: true,
         };
         expect(
             resolveQueryTimezone({ ...args, userTimezone: 'Asia/Tokyo' }),
@@ -39,7 +38,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: {},
                 projectTimezone: 'Europe/London',
                 userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
             }),
         ).toBe('Europe/London');
     });
@@ -51,33 +49,19 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: {},
                 projectTimezone: 'UTC',
                 userTimezone: null,
-                isUserTimezoneEnabled: true,
             }),
         ).toBe('UTC');
     });
 
-    it('user_timezone resolves to the viewer profile when EnableUserTimezones is on', () => {
+    it('user_timezone resolves to the viewer profile', () => {
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
                 metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
             }),
         ).toBe('Asia/Tokyo');
-    });
-
-    it('user_timezone falls through to project when EnableUserTimezones is off', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: 'user_timezone' },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: false,
-            }),
-        ).toBe('Australia/Brisbane');
     });
 
     it('user_timezone falls through to project when the viewer has no profile', () => {
@@ -87,7 +71,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: null,
-                isUserTimezoneEnabled: true,
             }),
         ).toBe('Australia/Brisbane');
     });
@@ -99,19 +82,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: 'America/New_York' },
                 projectTimezone: 'Australia/Brisbane',
                 userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
-            }),
-        ).toBe('America/New_York');
-    });
-
-    it('an override zone applies even when the user-timezone flag is off', () => {
-        expect(
-            resolveQueryTimezone({
-                sessionTimezone: null,
-                metricQuery: { timezone: 'America/New_York' },
-                projectTimezone: 'Australia/Brisbane',
-                userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: false,
             }),
         ).toBe('America/New_York');
     });
@@ -123,7 +93,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: 'Europe/London' },
                 projectTimezone: 'UTC',
                 userTimezone: 'Asia/Tokyo',
-                isUserTimezoneEnabled: true,
             }),
         ).toBe('America/Los_Angeles');
     });
@@ -135,7 +104,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: 'Europe/London' },
                 projectTimezone: 'UTC',
                 userTimezone: null,
-                isUserTimezoneEnabled: false,
             }),
         ).toBe('Europe/London');
     });
@@ -147,7 +115,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: {},
                 projectTimezone: 'America/New_York',
                 userTimezone: null,
-                isUserTimezoneEnabled: false,
             }),
         ).toBe('America/New_York');
     });
@@ -159,7 +126,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: "'; DROP TABLE users; --" },
                 projectTimezone: 'UTC',
                 userTimezone: null,
-                isUserTimezoneEnabled: true,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -171,7 +137,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: {},
                 projectTimezone: 'Not/A/Timezone',
                 userTimezone: null,
-                isUserTimezoneEnabled: true,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -183,7 +148,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: 'user_timezone' },
                 projectTimezone: 'UTC',
                 userTimezone: "UTC'; DROP TABLE users; --",
-                isUserTimezoneEnabled: true,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -195,7 +159,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: { timezone: "UTC' OR '1'='1" },
                 projectTimezone: 'UTC',
                 userTimezone: null,
-                isUserTimezoneEnabled: true,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -207,7 +170,6 @@ describe('resolveQueryTimezone', () => {
                 metricQuery: {},
                 projectTimezone: 'UTC',
                 userTimezone: null,
-                isUserTimezoneEnabled: false,
             }),
         ).toThrow('Invalid timezone');
     });
@@ -228,8 +190,7 @@ describe('getAccountUserTimezone', () => {
         expect(getAccountUserTimezone(anonymousAccount())).toBeNull();
     });
 
-    it('feeds user_timezone resolution: project when the flag is off, profile when on', () => {
-        const account = registeredAccount('Asia/Tokyo');
+    it('feeds user_timezone resolution: viewer profile when set, project otherwise', () => {
         const projectTimezone = 'Australia/Brisbane';
 
         expect(
@@ -237,19 +198,19 @@ describe('getAccountUserTimezone', () => {
                 sessionTimezone: null,
                 metricQuery: { timezone: 'user_timezone' },
                 projectTimezone,
-                userTimezone: getAccountUserTimezone(account),
-                isUserTimezoneEnabled: false,
+                userTimezone: getAccountUserTimezone(
+                    registeredAccount('Asia/Tokyo'),
+                ),
             }),
-        ).toBe('Australia/Brisbane');
+        ).toBe('Asia/Tokyo');
 
         expect(
             resolveQueryTimezone({
                 sessionTimezone: null,
                 metricQuery: { timezone: 'user_timezone' },
                 projectTimezone,
-                userTimezone: getAccountUserTimezone(account),
-                isUserTimezoneEnabled: true,
+                userTimezone: getAccountUserTimezone(anonymousAccount()),
             }),
-        ).toBe('Asia/Tokyo');
+        ).toBe('Australia/Brisbane');
     });
 });

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -9,8 +9,7 @@ import { isValidTimezone } from './scheduler';
 
 /**
  * Returns the account's stored user-level timezone preference, or null for
- * anonymous viewers (embeds / JWT) who have no profile. The EnableUserTimezones
- * gate is applied downstream in resolveQueryTimezone, the single chokepoint.
+ * anonymous viewers (embeds / JWT) who have no profile.
  */
 export function getAccountUserTimezone(account: Account): string | null {
     if (account.user.type !== 'registered') {
@@ -29,8 +28,9 @@ export function getAccountUserTimezone(account: Account): string | null {
  *     project TZ for every viewer, tracking project-TZ changes, so the chart is
  *     deterministic across its audience. This replaces the old "unpinned charts
  *     fall through to the viewer's profile" behaviour.
- *   - `user_timezone` → the viewer's profile TZ when `isUserTimezoneEnabled`,
- *     else the project TZ.
+ *   - `user_timezone` → the viewer's profile TZ, falling back to the project
+ *     TZ when the viewer has no profile (anonymous embeds/JWT, or no stored
+ *     preference).
  *   - any other value → an override IANA zone, frozen regardless of viewer/project.
  *
  * Whether the resolved zone is actually applied to the query is gated by the
@@ -42,13 +42,11 @@ export function resolveQueryTimezone({
     metricQuery,
     projectTimezone,
     userTimezone,
-    isUserTimezoneEnabled,
 }: {
     sessionTimezone: string | null;
     metricQuery: Pick<MetricQuery, 'timezone'>;
     projectTimezone: string;
     userTimezone: string | null;
-    isUserTimezoneEnabled: boolean;
 }): string {
     const setting = metricQuery.timezone;
 
@@ -58,8 +56,7 @@ export function resolveQueryTimezone({
         timezone = sessionTimezone;
     } else if (setting === USER_TIMEZONE_SETTING) {
         // userTimezone may be null (no profile) → fall back to project.
-        timezone =
-            (isUserTimezoneEnabled ? userTimezone : null) ?? projectTimezone;
+        timezone = userTimezone ?? projectTimezone;
     } else if (!setting || setting === PROJECT_TIMEZONE_SETTING) {
         timezone = projectTimezone;
     } else {

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -1,8 +1,7 @@
-import { FeatureFlags, getTimezoneLabel, isTimeZone } from '@lightdash/common';
+import { getTimezoneLabel } from '@lightdash/common';
 import { Badge, Tooltip } from '@mantine-8/core';
 import { IconClock } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { getTimezoneSourceLabel } from '../../../utils/timezoneSourceLabel';
 import MantineIcon from '../../common/MantineIcon';
 
@@ -17,21 +16,11 @@ const VisualizationTimezone: FC<Props> = ({
     resolvedTimezone,
     timezoneSetting,
 }) => {
-    const { data: enableUserTimezonesFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableUserTimezones,
-    );
-    const userTimeZonesEnabled = enableUserTimezonesFlag?.enabled ?? false;
-    // Backwards-compat fallback: before `EnableTimezoneSupport`, the only
-    // timezone signal is an explicit override zone on the query.
-    const overrideFallback =
-        timezoneSetting && isTimeZone(timezoneSetting) ? timezoneSetting : null;
-    const timezone =
-        resolvedTimezone ?? (userTimeZonesEnabled ? overrideFallback : null);
-    if (!timezone) return null;
+    if (!resolvedTimezone) return null;
 
     return (
         <Tooltip
-            label={getTimezoneSourceLabel(timezoneSetting, timezone)}
+            label={getTimezoneSourceLabel(timezoneSetting, resolvedTimezone)}
             position="bottom"
             multiline
             w={260}
@@ -43,7 +32,7 @@ const VisualizationTimezone: FC<Props> = ({
                 size="sm"
                 tt="none"
             >
-                {getTimezoneLabel(timezone)}
+                {getTimezoneLabel(resolvedTimezone)}
             </Badge>
         </Tooltip>
     );

--- a/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProfilePanel/index.tsx
@@ -51,10 +51,10 @@ const ProfilePanel: FC = () => {
     } = useApp();
     const { showToastSuccess, showToastApiError } = useToaster();
 
-    const { data: userTimezonesFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableUserTimezones,
+    const { data: timezoneSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
     );
-    const userTimezonesEnabled = userTimezonesFlag?.enabled === true;
+    const timezoneSupportEnabled = timezoneSupportFlag?.enabled === true;
 
     const form = useForm<FormValues>({
         validate: zodResolver(validationSchema),
@@ -198,10 +198,10 @@ const ProfilePanel: FC = () => {
                     }
                 />
 
-                {userTimezonesEnabled && (
+                {timezoneSupportEnabled && (
                     <TimeZonePicker
                         label="Default timezone"
-                        description="Used to render query results when a chart hasn't pinned its own timezone. Leave empty to use the project default."
+                        description="Used to render query results for charts pinned to the viewer timezone. Leave empty to fall back to the project timezone."
                         variant="default"
                         maw="100%"
                         size="sm"

--- a/packages/frontend/src/components/common/ChartTimezoneSelect/getChartTimezoneSelectData.ts
+++ b/packages/frontend/src/components/common/ChartTimezoneSelect/getChartTimezoneSelectData.ts
@@ -11,11 +11,9 @@ export type ChartTimezoneSelectGroup = {
 
 // Grouped options for the chart timezone dropdown. Labels here are the compact
 // form shown in the closed control; the open list adds the UTC offset and the
-// resolved project zone via the Select's renderOption. The per-viewer option is
-// only offered when user timezones are enabled.
+// resolved project zone via the Select's renderOption.
 export const getChartTimezoneSelectData = (
     localTimezone: string | undefined,
-    includeUserTimezone: boolean,
 ): ChartTimezoneSelectGroup[] => {
     const specificZones = Object.keys(TimeZone)
         .filter((key) => isNaN(Number(key)))
@@ -30,9 +28,7 @@ export const getChartTimezoneSelectData = (
             group: 'Default',
             items: [
                 { value: PROJECT_TIMEZONE_SETTING, label: 'Project timezone' },
-                ...(includeUserTimezone
-                    ? [{ value: USER_TIMEZONE_SETTING, label: 'User timezone' }]
-                    : []),
+                { value: USER_TIMEZONE_SETTING, label: 'User timezone' },
             ],
         },
         {

--- a/packages/frontend/src/components/common/ChartTimezoneSelect/index.tsx
+++ b/packages/frontend/src/components/common/ChartTimezoneSelect/index.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     getTimezoneLabel,
     isTimeZone,
     PROJECT_TIMEZONE_SETTING,
@@ -20,7 +19,6 @@ import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
 import { useProject } from '../../../hooks/useProject';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../MantineIcon';
 import classes from './ChartTimezoneSelect.module.css';
 import { getChartTimezoneSelectData } from './getChartTimezoneSelectData';
@@ -41,21 +39,12 @@ const ChartTimezoneSelect: FC<Props> = ({ value, onChange, ...rest }) => {
     const { data: project } = useProject(projectUuid);
     const projectTimezone = project?.queryTimezone ?? undefined;
 
-    const { data: userTimezonesFlag } = useServerFeatureFlag(
-        FeatureFlags.EnableUserTimezones,
-    );
-
     const normalizedValue = toTimezoneSetting(value);
-    // Only offer the per-viewer option when user timezones are enabled, but keep
-    // it available if a chart is already pinned to it so the value still renders.
-    const includeUserTimezone =
-        (userTimezonesFlag?.enabled ?? false) ||
-        normalizedValue === USER_TIMEZONE_SETTING;
 
     const localTimezone = dayjs.tz.guess();
     const data = useMemo(
-        () => getChartTimezoneSelectData(localTimezone, includeUserTimezone),
-        [localTimezone, includeUserTimezone],
+        () => getChartTimezoneSelectData(localTimezone),
+        [localTimezone],
     );
 
     // The closed control shows the compact label; specific zones gain their UTC


### PR DESCRIPTION
Closes: GLITCH-494

### Description

Collapses the two timezone feature flags into one. \`EnableUserTimezones\` is removed entirely — \`EnableTimezoneSupport\` is now the single gate for the whole pipeline (warehouse session, timezone-aware DATE_TRUNC, returned \`displayTimezone\`, profile picker visibility). \`resolveQueryTimezone\` no longer takes the user-timezone arg: a chart pinned to \`user_timezone\` always resolves to the viewer's profile (falling back to project when none is set), and the surrounding pipeline short-circuits the resolved zone when \`EnableTimezoneSupport\` is off, so disabling the feature keeps behaviour project-deterministic. The chart-level timezone picker now always offers the user-timezone option; the profile picker stays gated on \`EnableTimezoneSupport\` so admins can hide the user-preference UI. No DB migration needed — feature flags are referenced by string id, so stale \`enable-user-timezones\` rows just go inert.