### PR TITLE
feat(mcp): add AI router for automatic agent selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3161.1](https://github.com/lightdash/lightdash/compare/0.3161.0...0.3161.1) (2026-06-15)
+
+
+### Bug Fixes
+
+* dashboard chart totals and subtotals use active parameter value instead of default ([#24268](https://github.com/lightdash/lightdash/issues/24268)) ([c7ce365](https://github.com/lightdash/lightdash/commit/c7ce3658573d2b15a7060ab5a9e3a238b1c54184))
+
 # [0.3161.0](https://github.com/lightdash/lightdash/compare/0.3160.0...0.3161.0) (2026-06-15)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lightdash",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "main": "index.js",
     "license": "MIT",
     "private": true,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "backend",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "private": true,
     "license": "MIT",
     "main": "dist/index",

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -653,6 +653,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentService: repository.getAiAgentService(),
                     aiAgentToolsService:
                         repository.getAiAgentToolsService<AiAgentToolsService>(),
+                    aiRouterService:
+                        repository.getAiRouterService<AiRouterService>(),
                     aiWritebackService: repository.getAiWritebackService(),
                 }),
             slackService: ({ repository, clients }) =>

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -1,0 +1,249 @@
+import type { AiAgentWithContext, RegisteredAccount } from '@lightdash/common';
+import { selectAgent } from '../ai/agents/agentSelector';
+import { getModel } from '../ai/models';
+import { AiRouterService } from './AiRouterService';
+
+jest.mock('../ai/agents/agentSelector', () => ({
+    selectAgent: jest.fn(),
+}));
+
+jest.mock('../ai/models', () => ({
+    getModel: jest.fn(),
+}));
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+const userUuid = 'user-uuid';
+
+const ability = {
+    can: jest.fn(() => true),
+    cannot: jest.fn(() => false),
+    relevantRuleFor: jest.fn(() => undefined),
+    rules: [],
+};
+
+const account = {
+    isAnonymousUser: () => false,
+    isServiceAccount: () => false,
+    isRegisteredUser: () => true,
+    isPatUser: () => true,
+    isOauthUser: () => false,
+    organization: { organizationUuid },
+    user: {
+        userUuid,
+        id: userUuid,
+        email: 'user@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        role: 'member',
+        ability,
+    },
+    authentication: { type: 'pat' },
+} as unknown as RegisteredAccount;
+
+const createCandidate = (
+    overrides: Partial<AiAgentWithContext> & { uuid: string; name: string },
+): AiAgentWithContext => ({
+    uuid: overrides.uuid,
+    projectUuid,
+    organizationUuid,
+    name: overrides.name,
+    description: overrides.description ?? null,
+    imageUrl: null,
+    tags: overrides.tags ?? null,
+    integrations: [],
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    instruction: overrides.instruction ?? null,
+    groupAccess: [],
+    userAccess: [],
+    spaceAccess: overrides.spaceAccess ?? [],
+    enableDataAccess: true,
+    enableSelfImprovement: true,
+    enableContentTools: true,
+    version: 1,
+    context: overrides.context ?? {
+        uuid: overrides.uuid,
+        projectUuid,
+        name: overrides.name,
+        description: overrides.description ?? null,
+        explores: [`${overrides.name.toLowerCase()}_explore`],
+        verifiedQuestions: [`${overrides.name} question`],
+        instruction: overrides.instruction ?? null,
+    },
+});
+
+const makeService = ({
+    candidates,
+    routerEnabled = true,
+    instruction = 'Route finance questions to @[Finance](agent-2)',
+}: {
+    candidates: AiAgentWithContext[];
+    routerEnabled?: boolean;
+    instruction?: string | null;
+}) => {
+    const analytics = { track: jest.fn() };
+    const aiRouterModel = {
+        findByOrganization: jest.fn().mockResolvedValue(
+            routerEnabled
+                ? {
+                      routerUuid: 'router-uuid',
+                      organizationUuid,
+                      enabled: true,
+                      projectUuids: [projectUuid],
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                  }
+                : null,
+        ),
+        getLatestInstruction: jest.fn().mockResolvedValue(
+            instruction
+                ? {
+                      instructionVersionUuid: 'instruction-version-uuid',
+                      routerUuid: 'router-uuid',
+                      projectUuid,
+                      instruction,
+                      taggedAgentUuids: ['agent-2'],
+                      createdAt: new Date(),
+                  }
+                : null,
+        ),
+        createDecision: jest.fn().mockResolvedValue({
+            decisionUuid: 'decision-uuid',
+        }),
+    };
+    const aiAgentService = {
+        getAvailableAgents: jest.fn().mockResolvedValue(candidates),
+    };
+
+    const service = new AiRouterService({
+        analytics: analytics as never,
+        lightdashConfig: { ai: { copilot: {} } } as never,
+        aiRouterModel: aiRouterModel as never,
+        aiAgentService: aiAgentService as never,
+    });
+
+    return { service, analytics, aiRouterModel, aiAgentService };
+};
+
+describe('AiRouterService', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        (getModel as jest.Mock).mockReturnValue({ model: 'mock-model' });
+    });
+
+    it('uses the latest routing instructions and accessible candidates', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service, aiAgentService } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-2',
+            confidence: 'high',
+            reasoning: 'Finance agent matches the request.',
+            shouldSkipForwardingQuery: false,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'show revenue by month',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(aiAgentService.getAvailableAgents).toHaveBeenCalledWith(
+            organizationUuid,
+            userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+        expect(selectAgent).toHaveBeenCalledWith({
+            model: 'mock-model',
+            candidates,
+            prompt: 'show revenue by month',
+            instructions: 'Route finance questions to @[Finance](agent-2)',
+        });
+        expect(result.candidates).toEqual(candidates);
+        expect(result.suggestedAgent.uuid).toBe('agent-2');
+    });
+
+    it('returns the sole accessible agent without router config', async () => {
+        const onlyCandidate = createCandidate({
+            uuid: 'agent-1',
+            name: 'General',
+        });
+        const { service, aiRouterModel } = makeService({
+            candidates: [onlyCandidate],
+            routerEnabled: false,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'show me recent orders',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(result.suggestedAgent.uuid).toBe('agent-1');
+        expect(result.confidence).toBe('high');
+        expect(result.reasoning).toBe('Only one agent available');
+        expect(selectAgent).not.toHaveBeenCalled();
+        expect(aiRouterModel.findByOrganization).not.toHaveBeenCalled();
+    });
+
+    it('auto-selects low-confidence routes in mcp mode', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-1',
+            confidence: 'low',
+            reasoning: 'General seems safest.',
+            shouldSkipForwardingQuery: true,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'what agents are available?',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(result.suggestedAgent.uuid).toBe('agent-1');
+        expect(result.confidence).toBe('low');
+        expect(result.nextAction).toBe('create_thread');
+        expect(result.shouldSkipForwardingQuery).toBe(true);
+    });
+
+    it('preserves web low-confidence behavior', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service, aiRouterModel } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-2',
+            confidence: 'low',
+            reasoning: 'Not fully certain.',
+            shouldSkipForwardingQuery: false,
+        });
+
+        const result = await service.route(account, {
+            prompt: 'show revenue by month',
+            projectUuid,
+        });
+
+        expect(result.nextAction).toBe('show_picker');
+        expect(result.decision.suggestedAgentUuid).toBe('agent-2');
+        expect(aiRouterModel.createDecision).toHaveBeenCalledWith(
+            expect.objectContaining({
+                suggestedAgentUuid: 'agent-2',
+                confidence: 'low',
+                candidateAgentUuids: ['agent-1', 'agent-2'],
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     NotFoundError,
     ParameterError,
+    type AiAgentWithContext,
     type AiRouter,
     type AiRouterDecision,
     type AiRouterDecisionListFilters,
@@ -31,6 +32,18 @@ type Deps = {
     lightdashConfig: LightdashConfig;
     aiRouterModel: AiRouterModel;
     aiAgentService: AiAgentService;
+};
+
+type RoutePromptMode = 'web' | 'mcp';
+
+type PromptRouteSelection = {
+    candidates: AiAgentWithContext[];
+    suggestedAgent: AiAgentWithContext;
+    routerUuid: string | null;
+    confidence: 'high' | 'medium' | 'low';
+    reasoning: string;
+    shouldSkipForwardingQuery: boolean;
+    nextAction: 'create_thread' | 'show_picker';
 };
 
 export class AiRouterService extends BaseService {
@@ -94,6 +107,81 @@ export class AiRouterService extends BaseService {
             throw new NotFoundError('AI router is not enabled');
         }
         return router;
+    }
+
+    public async routePromptToAgent(
+        account: RegisteredAccount,
+        {
+            prompt,
+            projectUuid,
+            mode,
+        }: {
+            prompt: string;
+            projectUuid: string;
+            mode: RoutePromptMode;
+        },
+    ): Promise<PromptRouteSelection> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const candidates = await this.aiAgentService.getAvailableAgents(
+            organizationUuid,
+            account.user.userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+
+        if (candidates.length === 0) {
+            throw new ParameterError(
+                'No accessible AI agents are available for this project',
+            );
+        }
+
+        if (candidates.length === 1) {
+            return {
+                candidates,
+                suggestedAgent: candidates[0],
+                routerUuid: null,
+                confidence: 'high',
+                reasoning: 'Only one agent available',
+                shouldSkipForwardingQuery: false,
+                nextAction: 'create_thread',
+            };
+        }
+
+        const router = await this.getEnabledRouter(organizationUuid);
+        const instruction = await this.aiRouterModel.getLatestInstruction({
+            routerUuid: router.routerUuid,
+            projectUuid,
+        });
+
+        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const brain = await selectAgent({
+            model,
+            candidates,
+            prompt,
+            instructions: instruction?.instruction ?? null,
+        });
+
+        const suggestedAgent =
+            candidates.find(
+                (candidate) => candidate.uuid === brain.selectedAgentUuid,
+            ) ?? candidates[0];
+
+        return {
+            candidates,
+            suggestedAgent,
+            routerUuid: router.routerUuid,
+            confidence: brain.confidence,
+            reasoning: brain.reasoning,
+            shouldSkipForwardingQuery: brain.shouldSkipForwardingQuery,
+            nextAction:
+                mode === 'mcp' ||
+                (brain.confidence === 'high' &&
+                    !brain.shouldSkipForwardingQuery)
+                    ? 'create_thread'
+                    : 'show_picker',
+        };
     }
 
     async getConfig(account: RegisteredAccount): Promise<AiRouter> {
@@ -238,48 +326,23 @@ export class AiRouterService extends BaseService {
     ): Promise<AiRouterRouteResponseResult> {
         const organizationUuid = AiRouterService.organizationUuidOf(account);
         this.assertViewAiAgent(account, organizationUuid);
-
-        const router = await this.getEnabledRouter(organizationUuid);
-
-        const candidates = await this.aiAgentService.getAvailableAgents(
-            organizationUuid,
-            account.user.userUuid,
-            { aiRequireOAuth: true },
-            { projectFilter: { projectUuid } },
-        );
-
-        if (candidates.length < 2) {
-            throw new ParameterError(
-                'AI router requires at least two accessible agents',
-            );
-        }
-
-        const instruction = await this.aiRouterModel.getLatestInstruction({
-            routerUuid: router.routerUuid,
-            projectUuid,
-        });
-
-        const { model } = getModel(this.lightdashConfig.ai.copilot);
-        const brain = await selectAgent({
-            model,
-            candidates,
+        const selection = await this.routePromptToAgent(account, {
             prompt,
-            instructions: instruction?.instruction ?? null,
+            projectUuid,
+            mode: 'web',
         });
-
-        const nextAction =
-            brain.confidence === 'high' && !brain.shouldSkipForwardingQuery
-                ? 'create_thread'
-                : 'show_picker';
+        const routerUuid =
+            selection.routerUuid ??
+            (await this.getEnabledRouter(organizationUuid)).routerUuid;
 
         const decision = await this.aiRouterModel.createDecision({
-            routerUuid: router.routerUuid,
+            routerUuid,
             userUuid: account.user.userUuid,
             prompt,
-            suggestedAgentUuid: brain.selectedAgentUuid,
-            confidence: brain.confidence,
-            reasoning: brain.reasoning,
-            candidateAgentUuids: candidates.map((c) => c.uuid),
+            suggestedAgentUuid: selection.suggestedAgent.uuid,
+            confidence: selection.confidence,
+            reasoning: selection.reasoning,
+            candidateAgentUuids: selection.candidates.map((c) => c.uuid),
         });
 
         this.analytics.track<AiRouterMessageRoutedEvent>({
@@ -288,25 +351,25 @@ export class AiRouterService extends BaseService {
             properties: {
                 organizationId: organizationUuid,
                 projectId: projectUuid,
-                confidence: brain.confidence,
-                nextAction,
-                candidatesCount: candidates.length,
+                confidence: selection.confidence,
+                nextAction: selection.nextAction,
+                candidatesCount: selection.candidates.length,
             },
         });
 
         return {
             decision: {
                 decisionUuid: decision.decisionUuid,
-                suggestedAgentUuid: brain.selectedAgentUuid,
-                confidence: brain.confidence,
-                reasoning: brain.reasoning,
-                candidates: candidates.map((c) => ({
+                suggestedAgentUuid: selection.suggestedAgent.uuid,
+                confidence: selection.confidence,
+                reasoning: selection.reasoning,
+                candidates: selection.candidates.map((c) => ({
                     agentUuid: c.uuid,
                     name: c.name,
                     description: c.description ?? null,
                 })),
             },
-            nextAction,
+            nextAction: selection.nextAction,
         };
     }
 

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -225,6 +225,7 @@ const makeMcpService = ({
         aiOrganizationSettingsService: {
             getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
         },
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: { track: jest.fn() },
         asyncQueryService: {},

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -420,6 +420,7 @@ const makeMcpService = ({
         aiOrganizationSettingsService: {
             getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
         },
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: { track: jest.fn() },
         asyncQueryService,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -1,0 +1,340 @@
+import type { AiAgentWithContext } from '@lightdash/common';
+import { McpService, McpToolName } from './McpService';
+
+type RegisteredToolCallback = (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+) => Promise<unknown>;
+
+const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
+
+jest.mock('@sentry/node', () => ({
+    captureException: jest.fn(),
+    getActiveSpan: () => undefined,
+    isEnabled: () => false,
+    startSpanManual: (_options: unknown, callback: CallableFunction) =>
+        callback({ spanContext: () => ({ spanId: 'span-id' }) }, jest.fn()),
+    wrapMcpServerWithSentry: (server: unknown) => server,
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: jest.fn().mockImplementation(() => ({
+        registerResource: jest.fn(),
+        registerPrompt: jest.fn(),
+        registerTool: jest.fn(
+            (
+                name: string,
+                _config: Record<string, unknown>,
+                callback: RegisteredToolCallback,
+            ) => {
+                mockRegisteredMcpTools.set(name, callback);
+                return {};
+            },
+        ),
+    })),
+}));
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+const userUuid = 'user-uuid';
+const allowedSpaceUuid = 'allowed-space-uuid';
+const blockedSpaceUuid = 'blocked-space-uuid';
+
+const account = {
+    user: {
+        userUuid,
+        ability: {
+            can: jest.fn(() => true),
+            cannot: jest.fn(() => false),
+            relevantRuleFor: jest.fn(() => undefined),
+            rules: [],
+        },
+    },
+    organization: { organizationUuid },
+    authentication: { type: 'pat' },
+};
+
+const user = {
+    userUuid,
+    organizationUuid,
+    ability: account.user.ability,
+};
+
+const extra = {
+    signal: new AbortController().signal,
+    requestId: 'request-id',
+    sendNotification: jest.fn(),
+    sendRequest: jest.fn(),
+    authInfo: {
+        extra: {
+            user,
+            account,
+        },
+    },
+};
+
+const selectedAgent: AiAgentWithContext = {
+    uuid: 'agent-uuid',
+    projectUuid,
+    organizationUuid,
+    name: 'Finance',
+    description: 'Finance specialist',
+    imageUrl: null,
+    tags: ['finance'],
+    integrations: [],
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    instruction: 'Prioritize revenue metrics.',
+    groupAccess: [],
+    userAccess: [],
+    spaceAccess: [allowedSpaceUuid],
+    enableDataAccess: true,
+    enableSelfImprovement: true,
+    enableContentTools: true,
+    version: 1,
+    context: {
+        uuid: 'agent-uuid',
+        projectUuid,
+        name: 'Finance',
+        description: 'Finance specialist',
+        explores: ['orders'],
+        verifiedQuestions: ['What is monthly revenue?'],
+        instruction: 'Prioritize revenue metrics.',
+    },
+};
+
+const routeCandidates = [
+    selectedAgent,
+    {
+        ...selectedAgent,
+        uuid: 'agent-2',
+        name: 'General',
+        context: {
+            ...selectedAgent.context,
+            uuid: 'agent-2',
+            name: 'General',
+        },
+    },
+];
+
+const makeMcpService = () => {
+    const storedContext = {
+        projectUuid,
+        projectName: 'Project',
+        agentUuid: null as string | null,
+        agentName: null as string | null,
+        tags: ['finance-only'],
+    };
+
+    const mcpContextModel = {
+        getContext: jest.fn().mockImplementation(async () => ({
+            context: { ...storedContext },
+        })),
+        setContext: jest.fn().mockImplementation(async ({ context }) => {
+            Object.assign(storedContext, context);
+            return { context: { ...storedContext } };
+        }),
+    };
+
+    const aiAgentService = {
+        getAgent: jest.fn().mockResolvedValue(selectedAgent),
+    };
+
+    const aiAgentToolsService = {
+        createRuntime: jest.fn(({ spaceAccess, agentUuid }) => ({
+            listContent: jest.fn(async ({ spaceSlug }: { spaceSlug: null }) => {
+                const visibleSpaceUuids =
+                    spaceAccess?.length === 0 || !spaceAccess
+                        ? [allowedSpaceUuid, blockedSpaceUuid]
+                        : [allowedSpaceUuid, blockedSpaceUuid].filter((uuid) =>
+                              spaceAccess.includes(uuid),
+                          );
+
+                return {
+                    spaceSlug,
+                    items: visibleSpaceUuids.map((uuid) => ({
+                        contentType: 'space',
+                        name:
+                            uuid === allowedSpaceUuid
+                                ? 'Allowed Space'
+                                : 'Blocked Space',
+                        slug:
+                            uuid === allowedSpaceUuid
+                                ? 'allowed-space'
+                                : 'blocked-space',
+                        chartCount: 0,
+                        dashboardCount: 0,
+                        childSpaceCount: 0,
+                        appCount: 0,
+                        directAccess: true,
+                        agentUuid,
+                    })),
+                    pagination: {
+                        page: 1,
+                        pageSize: 25,
+                        totalResults: visibleSpaceUuids.length,
+                        totalPageCount: 1,
+                    },
+                };
+            }),
+        })),
+    };
+
+    const aiRouterService = {
+        routePromptToAgent: jest.fn().mockResolvedValue({
+            candidates: routeCandidates,
+            suggestedAgent: selectedAgent,
+            routerUuid: 'router-uuid',
+            confidence: 'low',
+            reasoning: 'Finance agent is the closest fit.',
+            shouldSkipForwardingQuery: false,
+            nextAction: 'create_thread',
+        }),
+    };
+
+    const service = new McpService({
+        aiAgentService,
+        aiAgentToolsService,
+        aiOrganizationSettingsService: {
+            getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
+        },
+        aiRouterService,
+        aiWritebackService: {},
+        analytics: { track: jest.fn() },
+        asyncQueryService: {},
+        catalogService: {},
+        contentVerificationService: {},
+        featureFlagService: {},
+        lightdashConfig: {
+            ai: {
+                copilot: {
+                    maxQueryLimit: 500,
+                },
+            },
+            mcp: {
+                enabled: true,
+                runSqlMaxLimit: 500,
+            },
+            siteUrl: 'https://lightdash.example',
+        },
+        mcpContextModel,
+        projectModel: {},
+        projectService: {
+            getProject: jest
+                .fn()
+                .mockResolvedValue({ organizationUuid, name: 'Project' }),
+            getSpaces: jest.fn().mockResolvedValue([]),
+        },
+        searchModel: {},
+        shareService: {},
+        spaceService: {},
+        userAttributesModel: {},
+    } as unknown as ConstructorParameters<typeof McpService>[0]);
+
+    return {
+        service,
+        aiAgentService,
+        aiAgentToolsService,
+        aiRouterService,
+        mcpContextModel,
+        storedContext,
+    };
+};
+
+describe('McpService route_agent', () => {
+    beforeEach(() => {
+        mockRegisteredMcpTools.clear();
+    });
+
+    it('writes the routed agent into context and get_current_agent returns it', async () => {
+        const { aiRouterService, mcpContextModel } = makeMcpService();
+
+        const routeAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.ROUTE_AGENT,
+        );
+        const getCurrentAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.GET_CURRENT_AGENT,
+        );
+
+        expect(routeAgentTool).toBeDefined();
+        expect(getCurrentAgentTool).toBeDefined();
+
+        const routeResult = (await routeAgentTool!(
+            { prompt: 'show revenue by month' },
+            extra,
+        )) as {
+            content: Array<{ text: string }>;
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(aiRouterService.routePromptToAgent).toHaveBeenCalledWith(
+            account,
+            {
+                prompt: 'show revenue by month',
+                projectUuid,
+                mode: 'mcp',
+            },
+        );
+        expect(mcpContextModel.setContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                context: expect.objectContaining({
+                    projectUuid,
+                    projectName: 'Project',
+                    tags: ['finance-only'],
+                    agentUuid: 'agent-uuid',
+                    agentName: 'Finance',
+                }),
+            }),
+        );
+        expect(routeResult.structuredContent).toEqual(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                agentName: 'Finance',
+                confidence: 'low',
+                reasoning: 'Finance agent is the closest fit.',
+            }),
+        );
+
+        const currentResult = (await getCurrentAgentTool!({}, extra)) as {
+            content: Array<{ text: string }>;
+        };
+        expect(JSON.parse(currentResult.content[0].text)).toEqual(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                agentName: 'Finance',
+                explores: ['orders'],
+            }),
+        );
+    });
+
+    it('applies routed agent scope to later tool calls', async () => {
+        const { aiAgentToolsService } = makeMcpService();
+
+        const routeAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.ROUTE_AGENT,
+        );
+        const listContentTool = mockRegisteredMcpTools.get(
+            McpToolName.LIST_CONTENT,
+        );
+
+        await routeAgentTool!({ prompt: 'show revenue by month' }, extra);
+
+        const listContentResult = (await listContentTool!(
+            { spaceSlug: null, page: 1, pageSize: 25 },
+            extra,
+        )) as {
+            content: Array<{ text: string }>;
+        };
+        const rendered = listContentResult.content[0].text;
+
+        expect(aiAgentToolsService.createRuntime).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                tags: ['finance'],
+                spaceAccess: [allowedSpaceUuid],
+            }),
+        );
+        expect(rendered).toContain('slug="allowed-space"');
+        expect(rendered).not.toContain('slug="blocked-space"');
+    });
+});

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     Account,
+    AiAgentWithContext,
     AiResultType,
     ApiKeyAccount,
     assertUnreachable,
@@ -48,6 +49,7 @@ import {
     readSkillResourceToolDefinition,
     readSkillToolDefinition,
     renderChartToolDefinition,
+    routeAgentToolDefinition,
     runAiWritebackToolDefinition,
     runQueryToolDefinition,
     runSqlToolDefinition,
@@ -129,6 +131,7 @@ import {
     AiAgentToolsService,
 } from '../AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
+import { AiRouterService } from '../AiRouterService/AiRouterService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
 import { buildMcpExploreConfigState } from './buildMcpExploreConfigState';
 import {
@@ -152,6 +155,7 @@ export enum McpToolName {
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
     LIST_AGENTS = 'list_agents',
+    ROUTE_AGENT = 'route_agent',
     SET_AGENT = 'set_agent',
     CLEAR_AGENT = 'clear_agent',
     GET_CURRENT_AGENT = 'get_current_agent',
@@ -184,6 +188,7 @@ const mcpListProjectsTool = mcpListProjectsToolDefinition.for('mcp');
 const mcpSetProjectTool = setProjectToolDefinition.for('mcp');
 const mcpGetCurrentProjectTool = getCurrentProjectToolDefinition.for('mcp');
 const mcpListAgentsTool = listAgentsToolDefinition.for('mcp');
+const mcpRouteAgentTool = routeAgentToolDefinition.for('mcp');
 const mcpSetAgentTool = setAgentToolDefinition.for('mcp');
 const mcpClearAgentTool = clearAgentToolDefinition.for('mcp');
 const mcpGetCurrentAgentTool = getCurrentAgentToolDefinition.for('mcp');
@@ -214,6 +219,7 @@ type McpServiceArguments = {
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     aiAgentService: AiAgentService;
     aiAgentToolsService: AiAgentToolsService;
+    aiRouterService: AiRouterService;
     aiWritebackService: AiWritebackService;
 };
 
@@ -294,6 +300,8 @@ export class McpService extends BaseService {
 
     private aiAgentToolsService: AiAgentToolsService;
 
+    private aiRouterService: AiRouterService;
+
     private aiWritebackService: AiWritebackService;
 
     private mcpServer: McpServer;
@@ -317,6 +325,7 @@ export class McpService extends BaseService {
         aiOrganizationSettingsService,
         aiAgentService,
         aiAgentToolsService,
+        aiRouterService,
         aiWritebackService,
     }: McpServiceArguments) {
         super();
@@ -336,6 +345,7 @@ export class McpService extends BaseService {
         this.aiOrganizationSettingsService = aiOrganizationSettingsService;
         this.aiAgentService = aiAgentService;
         this.aiAgentToolsService = aiAgentToolsService;
+        this.aiRouterService = aiRouterService;
         this.aiWritebackService = aiWritebackService;
         this.mcpCompatLayer = new McpSchemaCompatLayer();
         try {
@@ -414,6 +424,53 @@ export class McpService extends BaseService {
         return structuredContent !== undefined
             ? { content, structuredContent }
             : { content };
+    }
+
+    private static buildAgentContextResponse(agent: AiAgentWithContext) {
+        return {
+            agentUuid: agent.uuid,
+            agentName: agent.name,
+            agentDescription: agent.description,
+            agentTags: agent.tags,
+            agentSpaceAccess: agent.spaceAccess,
+            agentProjectUuid: agent.projectUuid,
+            explores: agent.context.explores,
+            verifiedQuestions: agent.context.verifiedQuestions,
+            instruction: agent.context.instruction,
+        };
+    }
+
+    private async setActiveAgentContext(
+        user: SessionUser,
+        organizationUuid: string,
+        {
+            projectUuid,
+            projectName,
+            agentUuid,
+            agentName,
+        }: {
+            projectUuid: string;
+            projectName: string;
+            agentUuid: string;
+            agentName: string;
+        },
+    ) {
+        const existingContext = await this.mcpContextModel.getContext(
+            user.userUuid,
+            organizationUuid,
+        );
+
+        await this.mcpContextModel.setContext({
+            userUuid: user.userUuid,
+            organizationUuid,
+            context: {
+                projectUuid,
+                projectName,
+                tags: existingContext?.context.tags || null,
+                agentUuid,
+                agentName,
+            },
+        });
     }
 
     static async streamToolResult<T extends { result: string }>(
@@ -1728,6 +1785,85 @@ export class McpService extends BaseService {
         );
 
         this.mcpServer.registerTool(
+            mcpRouteAgentTool.name,
+            {
+                title: mcpRouteAgentTool.title,
+                description: mcpRouteAgentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpRouteAgentTool.inputSchema,
+                ),
+                annotations: mcpRouteAgentTool.annotations,
+                outputSchema: mcpRouteAgentTool.outputSchema.shape,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                const { user, organizationUuid, account } =
+                    McpService.getAccount(ctx);
+
+                await this.checkAiAgentsVisible(user);
+
+                const projectUuid =
+                    args.projectUuid ?? (await this.resolveProjectUuid(ctx));
+
+                this.trackToolCall(ctx, McpToolName.ROUTE_AGENT, projectUuid);
+
+                let selection;
+                try {
+                    selection = await this.aiRouterService.routePromptToAgent(
+                        account,
+                        {
+                            prompt: args.prompt,
+                            projectUuid,
+                            mode: 'mcp',
+                        },
+                    );
+                } catch (error) {
+                    if (error instanceof NotFoundError) {
+                        throw new ParameterError(
+                            'AI router is not enabled for this organization. Use set_agent to choose an agent manually or ask an admin to enable the AI router.',
+                        );
+                    }
+                    throw error;
+                }
+
+                const project = await this.projectService.getProject(
+                    projectUuid,
+                    account,
+                );
+
+                await this.setActiveAgentContext(user, organizationUuid, {
+                    projectUuid: selection.suggestedAgent.projectUuid,
+                    projectName: project.name,
+                    agentUuid: selection.suggestedAgent.uuid,
+                    agentName: selection.suggestedAgent.name,
+                });
+
+                const structuredContent = {
+                    ...McpService.buildAgentContextResponse(
+                        selection.suggestedAgent,
+                    ),
+                    confidence: selection.confidence,
+                    reasoning: selection.reasoning,
+                    candidates: selection.candidates.map((candidate) => ({
+                        agentUuid: candidate.uuid,
+                        name: candidate.name,
+                        description: candidate.description ?? null,
+                    })),
+                };
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(structuredContent, null, 2),
+                        },
+                    ],
+                    structuredContent,
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
             mcpSetAgentTool.name,
             {
                 title: mcpSetAgentTool.title,
@@ -1765,21 +1901,11 @@ export class McpService extends BaseService {
                     { includeSummaryContext: true },
                 );
 
-                const existingContext = await this.mcpContextModel.getContext(
-                    user.userUuid,
-                    organizationUuid,
-                );
-
-                await this.mcpContextModel.setContext({
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                    context: {
-                        projectUuid: agent.projectUuid,
-                        projectName: project.name,
-                        tags: existingContext?.context.tags || null,
-                        agentUuid: agent.uuid,
-                        agentName: agent.name,
-                    },
+                await this.setActiveAgentContext(user, organizationUuid, {
+                    projectUuid: agent.projectUuid,
+                    projectName: project.name,
+                    agentUuid: agent.uuid,
+                    agentName: agent.name,
                 });
 
                 return {
@@ -1787,18 +1913,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: JSON.stringify(
-                                {
-                                    agentUuid: agent.uuid,
-                                    agentName: agent.name,
-                                    agentDescription: agent.description,
-                                    agentTags: agent.tags,
-                                    agentSpaceAccess: agent.spaceAccess,
-                                    agentProjectUuid: agent.projectUuid,
-                                    explores: agent.context.explores,
-                                    verifiedQuestions:
-                                        agent.context.verifiedQuestions,
-                                    instruction: agent.context.instruction,
-                                },
+                                McpService.buildAgentContextResponse(agent),
                                 null,
                                 2,
                             ),
@@ -1913,18 +2028,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: JSON.stringify(
-                                {
-                                    agentUuid: agent.uuid,
-                                    agentName: agent.name,
-                                    agentDescription: agent.description,
-                                    agentTags: agent.tags,
-                                    agentSpaceAccess: agent.spaceAccess,
-                                    agentProjectUuid: agent.projectUuid,
-                                    explores: agent.context.explores,
-                                    verifiedQuestions:
-                                        agent.context.verifiedQuestions,
-                                    instruction: agent.context.instruction,
-                                },
+                                McpService.buildAgentContextResponse(agent),
                                 null,
                                 2,
                             ),
@@ -2531,7 +2635,7 @@ export class McpService extends BaseService {
             {
                 title: 'Lightdash Data Analyst',
                 description:
-                    'Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
+                    'Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
                 argsSchema: {},
             },
             async (_args, extra) => {

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -10,12 +10,13 @@ exports[`MCP tool contracts matches the current MCP tool and prompt contract sna
         "properties": {},
         "type": "object",
       },
-      "description": "Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
+      "description": "Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
       "name": "lightdash-analyst",
       "prompt": "# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
+0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean
@@ -536,7 +537,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.",
+      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -573,7 +574,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.",
+      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -589,7 +590,139 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+      "description": "Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "projectUuid": {
+            "type": "string",
+          },
+          "prompt": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "prompt",
+        ],
+        "type": "object",
+      },
+      "name": "route_agent",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "agentDescription": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "agentName": {
+            "type": "string",
+          },
+          "agentProjectUuid": {
+            "type": "string",
+          },
+          "agentSpaceAccess": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "agentTags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+          },
+          "agentUuid": {
+            "type": "string",
+          },
+          "candidates": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "agentUuid": {
+                  "type": "string",
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "agentUuid",
+                "name",
+                "description",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "confidence": {
+            "enum": [
+              "high",
+              "medium",
+              "low",
+            ],
+            "type": "string",
+          },
+          "explores": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "instruction": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "reasoning": {
+            "type": "string",
+          },
+          "verifiedQuestions": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "agentUuid",
+          "agentName",
+          "agentDescription",
+          "agentTags",
+          "agentSpaceAccess",
+          "agentProjectUuid",
+          "explores",
+          "verifiedQuestions",
+          "instruction",
+          "confidence",
+          "reasoning",
+          "candidates",
+        ],
+        "type": "object",
+      },
+      "title": "Route agent",
+    },
+    {
+      "agentName": null,
+      "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -620,7 +753,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -8089,6 +8222,7 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
   "set_project",
   "get_current_project",
   "list_agents",
+  "route_agent",
   "set_agent",
   "clear_agent",
   "get_current_agent",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -83,6 +83,7 @@ const makeMcpService = (): McpService =>
         aiAgentService: {},
         aiAgentToolsService: { createRuntime: jest.fn() },
         aiOrganizationSettingsService: {},
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: {},
         asyncQueryService: {},

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -2,6 +2,7 @@ export const MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
+0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/cli",
-  "version": "0.3161.0",
+  "version": "0.3161.1",
   "description": "Lightdash CLI tool",
   "license": "MIT",
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/common",
-  "version": "0.3161.0",
+  "version": "0.3161.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -254,6 +254,32 @@ const writeAnnotations: McpToolAnnotations = {
 
 const emptyInputSchema = z.object({});
 
+const routeAgentArgsSchema = z.object({
+    prompt: z.string(),
+    projectUuid: z.string().optional(),
+});
+
+const routeAgentStructuredOutputSchema = z.object({
+    agentUuid: z.string(),
+    agentName: z.string(),
+    agentDescription: z.string().nullable(),
+    agentTags: z.array(z.string()).nullable(),
+    agentSpaceAccess: z.array(z.string()),
+    agentProjectUuid: z.string(),
+    explores: z.array(z.string()),
+    verifiedQuestions: z.array(z.string()),
+    instruction: z.string().nullable(),
+    confidence: z.enum(['high', 'medium', 'low']),
+    reasoning: z.string(),
+    candidates: z.array(
+        z.object({
+            agentUuid: z.string(),
+            name: z.string(),
+            description: z.string().nullable(),
+        }),
+    ),
+});
+
 export const findExploresToolDefinition = defineTool({
     name: 'findExplores',
     title: 'Find explores',
@@ -758,7 +784,7 @@ export const setProjectToolDefinition = defineTool({
     name: 'setProject',
     title: 'Set project',
     description:
-        'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.',
+        'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string(),
@@ -781,7 +807,7 @@ export const listAgentsToolDefinition = defineTool({
     name: 'listAgents',
     title: 'List agents',
     description:
-        'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.',
+        'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string().optional(),
@@ -789,11 +815,24 @@ export const listAgentsToolDefinition = defineTool({
     mcp: { annotations: readOnlyAnnotations },
 });
 
+export const routeAgentToolDefinition = defineTool({
+    name: 'routeAgent',
+    title: 'Route agent',
+    description:
+        'Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.',
+    availability: ['mcp'],
+    inputSchema: routeAgentArgsSchema,
+    mcp: {
+        annotations: writeAnnotations,
+        structuredContentSchema: routeAgentStructuredOutputSchema,
+    },
+});
+
 export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
     title: 'Set agent',
     description:
-        "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+        "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
     availability: ['mcp'],
     inputSchema: z.object({
         agentUuid: z.string(),
@@ -815,7 +854,7 @@ export const getCurrentAgentToolDefinition = defineTool({
     name: 'getCurrentAgent',
     title: 'Get current agent',
     description:
-        "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+        'Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
@@ -975,6 +1014,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     setProjectToolDefinition,
     getCurrentProjectToolDefinition,
     listAgentsToolDefinition,
+    routeAgentToolDefinition,
     setAgentToolDefinition,
     clearAgentToolDefinition,
     getCurrentAgentToolDefinition,

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
     "name": "e2e",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "private": true,
     "license": "MIT",
     "main": "index.js",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/frontend",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "private": true,
     "scripts": {
         "typecheck": "tsc --project tsconfig.json --noEmit",

--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/sdk",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "private": false,
     "repository": {
         "type": "git",

--- a/packages/query-sdk/package.json
+++ b/packages/query-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lightdash/query-sdk",
-    "version": "0.3161.0",
+    "version": "0.3161.1",
     "private": false,
     "type": "module",
     "description": "SDK for building custom data apps against the Lightdash semantic layer",

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash/warehouses",
-  "version": "0.3161.0",
+  "version": "0.3161.1",
   "description": "Warehouse connectors for Lightdash",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ overrides:
   ajv@>=8.0.0 <8.18.0: 8.18.0
   postcss@<8.5.10: 8.5.10
 
-pnpmfileChecksum: sha256-eQZaSN8dBqsURx9Y0qj3HqXggTVV5DtL6B15n8AQ53E=
+pnpmfileChecksum: ljbuipupldntgfel5vaej2gdgy
 
 importers:
 
@@ -156,7 +156,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
 
   packages/backend:
     dependencies:
@@ -246,7 +246,7 @@ importers:
         version: 1.5.4(ai@6.0.71(zod@3.25.55))(zod@3.25.55)
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
-        version: 2.1.1(tslib@2.6.2)
+        version: 2.1.1(tslib@2.8.1)
       '@sentry/core':
         specifier: 9.31.0
         version: 9.31.0
@@ -522,7 +522,7 @@ importers:
         version: 8.3.2
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
       winston:
         specifier: 3.13.0
         version: 3.13.0
@@ -941,7 +941,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
 
   packages/formula-tests:
     dependencies:
@@ -2972,25 +2972,21 @@ packages:
     resolution: {integrity: sha512-PVC9feqV+bgsnzGfiCv1pe+9mNqoC8k15/3Qmwhp6+AUloTNtk1ln9wlsHMUzhRfNG2wb2fN8P9PJ5zY5t/J/w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@duckdb/node-bindings-linux-arm64@1.5.2-r.2':
     resolution: {integrity: sha512-cAEALsSxYRzSfUgxAJCNbDZcmdlVQWvEKldd7r8lYWYZ7D2mxBjeLrF0WoL34vl+ZNEgqHAuqiv3I+wMU2dOXA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@duckdb/node-bindings-linux-x64-musl@1.5.2-r.2':
     resolution: {integrity: sha512-v2AUKCIHKq9+zFWmx+UdSWyxFLaT5wsWuTNID30pGBqGvwChxLGmm1szbHNxR7nNa00y2SGp9Gxoky0RS7YCwg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@duckdb/node-bindings-linux-x64@1.5.2-r.2':
     resolution: {integrity: sha512-9SgKECgVtkDK6+HLBbDKxW41ORj+BciQjSgERFfhnuPIDYhgx08wTPZcnaU7KxvNdOmndIn5OmjzKZ6Jrvwv0g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@duckdb/node-bindings-win32-arm64@1.5.2-r.2':
     resolution: {integrity: sha512-g5ZWK07c0Qh7UFhJC37iC5y8oW8ZqxEgpNM2vTFD3ShM9Rn1NDXkxA7zjcheHRI+My5T1JpE9kNpCvhzItJrgw==}
@@ -3654,105 +3650,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -4190,28 +4170,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -4825,56 +4801,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.35.0':
     resolution: {integrity: sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
     resolution: {integrity: sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
     resolution: {integrity: sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.35.0':
     resolution: {integrity: sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.35.0':
     resolution: {integrity: sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.35.0':
     resolution: {integrity: sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.35.0':
     resolution: {integrity: sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.35.0':
     resolution: {integrity: sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==}
@@ -4977,56 +4945,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.57.0':
     resolution: {integrity: sha512-i66WyEPVEvq9bxRUCJ/MP5EBfnTDN3nhwEdFZFTO5MmLLvzngfWEG3NSdXQzTT3vk5B9i6C2XSIYBh+aG6uqyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.57.0':
     resolution: {integrity: sha512-oMZDCwz4NobclZU3pH+V1/upVlJZiZvne4jQP+zhJwt+lmio4XXr4qG47CehvrW1Lx2YZiIHuxM2D4YpkG3KVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.57.0':
     resolution: {integrity: sha512-uoBnjJ3MMEBbfnWC1jSFr7/nSCkcQYa72NYoNtLl1imshDnWSolYCjzb8LVCwYCCfLJXD+0gBLD7fyC14c0+0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.57.0':
     resolution: {integrity: sha512-BdrwD7haPZ8a9KrZhKJRSj6jwCor+Z8tHFZ3PT89Y3Jq5v3LfMfEePeAmD0LOTWpiTmzSzdmyw9ijneapiVHKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.57.0':
     resolution: {integrity: sha512-BNs+7ZNsRstVg2tpNxAXfMX/Iv5oZh204dVyb8Z37+/gCh+yZqNTlg6YwCLIMPSk5wLWIGOaQjT0GUOahKYImw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.57.0':
     resolution: {integrity: sha512-AghS18w+XcENcAX0+BQGLiqjpqpaxKJa4cWWP0OWNLacs27vHBxu7TYkv9LUSGe5w8lOJHeMxcYfZNOAPqw2bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.57.0':
     resolution: {integrity: sha512-E/FV3GB8phu/Rpkhz5T96hAiJlGzn91qX5yj5gU754P5cmVGXY1Jw/VSjDSlZBCY3VHjsVLdzgdkJaomEmcNOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.57.0':
     resolution: {integrity: sha512-xvZ2yZt0nUVfU14iuGv3V25jpr9pov5N0Wr28RXnHFxHCRxNDMtYPHV61gGLhN9IlXM96gI4pyYpLSJC5ClLCQ==}
@@ -5213,42 +5173,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -5367,79 +5321,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -6188,28 +6129,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.5':
     resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.5':
     resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.5':
     resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.5':
     resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
@@ -11830,28 +11767,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -12792,28 +12725,24 @@ packages:
     engines: {node: '>= 16'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   nodejs-polars-linux-arm64-musl@0.15.0:
     resolution: {integrity: sha512-fg/2Wo1rCH53kk260iJvqdxTSW9q++Zh3Q6Vu7q4RX2AAr4nS08yMO90JHbnhsYeeunnzzvhC8K/fjEOBsDpsA==}
     engines: {node: '>= 16'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   nodejs-polars-linux-x64-gnu@0.15.0:
     resolution: {integrity: sha512-FF0VyJAZoqpthHoCOnCVN5dYHEXimvi06dpjNHifsFBEAS1tI6GMBDT1JAM0HKlpKtPrqJwH1Tbsr58EXqia/w==}
     engines: {node: '>= 16'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   nodejs-polars-linux-x64-musl@0.15.0:
     resolution: {integrity: sha512-rjCNTzK+g+JHNBbT6pzfEoZyyCPkMEo8kcCp3M//rwPLAQijvKt8JfyoP7k2ovsOZHHKw28OZ3Sw308ufX+b/A==}
     engines: {node: '>= 16'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   nodejs-polars-win32-x64-msvc@0.15.0:
     resolution: {integrity: sha512-N9Sxke9tqb0BGe/iSleKLbgdF3V6lrcytmLP0x+8SGAkXQT/opj1Ubd41bi0o4Put9yIp+veWiG+hcnhG16S3Q==}
@@ -15622,9 +15551,6 @@ packages:
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
-  tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -16246,46 +16172,6 @@ packages:
     resolution: {integrity: sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==}
     peerDependencies:
       vite: 7.3.2
-
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vite@8.0.5:
     resolution: {integrity: sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==}
@@ -21446,7 +21332,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.6.2)':
+  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.8.1)':
     dependencies:
       axios: 1.16.0
       axios-retry: 4.5.0(axios@1.16.0)
@@ -21458,7 +21344,7 @@ snapshots:
       ms: 2.1.3
       remove-trailing-slash: 0.1.1
       serialize-javascript: 6.0.2
-      tslib: 2.6.2
+      tslib: 2.8.1
       uuid: 11.0.2
     optionalDependencies:
       bull: 4.16.4
@@ -23975,14 +23861,6 @@ snapshots:
       '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.6(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
     dependencies:
@@ -34129,8 +34007,6 @@ snapshots:
 
   tslib@2.3.0: {}
 
-  tslib@2.6.2: {}
-
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -34909,24 +34785,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.3.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      sugarss: 5.0.1(postcss@8.5.10)
-      terser: 5.46.1
-      tsx: 4.19.4
-      yaml: 2.8.3
-
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -34946,35 +34804,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
-
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 24.3.1
-      jsdom: 24.0.0(canvas@3.2.1)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.27.7)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

Enables automatic routing of user prompts to the most appropriate agent in the Lightdash MCP, matching the Ask AI experience in the product.

Users no longer need to manually select agents - the system automatically chooses the best agent based on query intent, improving answer quality and consistency.

## Changes

- Add `routePromptToAgent` method to AiRouterService for automatic agent selection
- Integrate routing into MCP service for AI agent selection
- Update tool definitions and prompts for routing support
- Add comprehensive test coverage for routing functionality

Closes: #23753

🤖 Generated with [Claude Code](https://claude.com/claude-code)