### PR TITLE
fix: show pivot row totals without index dims

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1359,7 +1359,7 @@ export class AsyncQueryService extends ProjectService {
                   (col) => col.reference,
               )
             : [];
-        if (pivotConfig.rowTotals && indexFieldIds.length > 0) {
+        if (pivotConfig.rowTotals) {
             try {
                 const { rows, fields } =
                     await this.executeCalculateTotalAndGetResults({

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
@@ -716,6 +716,27 @@ describe('getRowTotalQueryFromSource', () => {
                 result.pivotConfiguration?.passthroughDimensions,
             ).toBeUndefined();
         });
+
+        it('supports metrics-as-rows pivots with no index column', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: baseMetricQuery,
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    indexColumn: undefined,
+                    sortBy: [
+                        {
+                            reference: 'orders_payment_method',
+                            direction: SortByDirection.ASC,
+                        },
+                    ],
+                },
+            });
+
+            expect(result.metricQuery.dimensions).toEqual([]);
+            expect(result.metricQuery.sorts).toEqual([]);
+            expect(result.metricQuery.limit).toBe(1);
+            expect(result.pivotConfiguration).toBeUndefined();
+        });
     });
 
     describe('non-pivoted source', () => {
@@ -735,18 +756,6 @@ describe('getRowTotalQueryFromSource', () => {
                     pivotConfiguration: {
                         ...pivotConfiguration,
                         groupByColumns: [],
-                    },
-                }),
-            ).toThrow(NotSupportedError);
-        });
-
-        it('throws when the pivot configuration has no index column', () => {
-            expect(() =>
-                getRowTotalQueryFromSource({
-                    metricQuery: baseMetricQuery,
-                    pivotConfiguration: {
-                        ...pivotConfiguration,
-                        indexColumn: undefined,
                     },
                 }),
             ).toThrow(NotSupportedError);

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
@@ -308,9 +308,10 @@ export const getRowTotalQueryFromSource = (
         source.pivotConfiguration!.indexColumn,
     );
     if (indexFieldIds.length === 0) {
-        throw new NotSupportedError(
-            'Row totals require a pivot index column on the source query',
-        );
+        return {
+            metricQuery: getGrandTotalMetricQuery(source.metricQuery),
+            pivotConfiguration: undefined,
+        };
     }
 
     const sourceDimensionIds = new Set(source.metricQuery.dimensions);

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -316,6 +316,45 @@ describe('convertSqlPivotedRowsToPivotData', () => {
         expect(result).toStrictEqual(EXPECTED_PIVOT_DATA_METRICS_AS_ROWS);
     });
 
+    it('uses warehouse row totals for metrics-as-rows pivots with no index dimensions', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows: [SQL_PIVOTED_ROWS[0]],
+            pivotDetails: {
+                ...SQL_PIVOT_DETAILS,
+                indexColumn: undefined,
+            },
+            pivotConfig: {
+                rowTotals: true,
+                columnTotals: false,
+                metricsAsRows: true,
+                columnOrder: [
+                    'payments_payment_method',
+                    'orders_order_date_year',
+                    'payments_total_revenue',
+                ],
+            },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+            warehouseRowTotals: {
+                [buildPivotRowTotalKey([])]: {
+                    payments_total_revenue_any: 999,
+                },
+            },
+        });
+
+        expect(result.indexValues).toStrictEqual([
+            [{ type: 'label', fieldId: 'payments_total_revenue' }],
+        ]);
+        expect(result.rowTotals).toStrictEqual([[999]]);
+        expect(result.retrofitData.allCombinedData[0]['row-total-0']).toEqual({
+            value: {
+                raw: 999,
+                formatted: '999',
+            },
+        });
+    });
+
     it('should convert complex SQL-pivoted rows to PivotData format', () => {
         // Convert SQL Pivoted rows to PivotData with metricsAsRows: true
         const result = convertSqlPivotedRowsToPivotData({

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -204,11 +204,7 @@ export const useAsyncCalculateRowTotal = ({
                 invalidateCache,
             });
         },
-        enabled:
-            enabled &&
-            !!projectUuid &&
-            !!sourceQueryUuid &&
-            indexFieldIds.length > 0,
+        enabled: enabled && !!projectUuid && !!sourceQueryUuid,
         retry: false,
     });
 


### PR DESCRIPTION
## Summary
- Fetch row totals for pivot tables even when there are no index dimensions
- Use the grand-total query path for no-index row totals to avoid malformed pivot SQL
- Cover the metrics-as-rows/no-index case in backend and pivot result tests

## Tests
- `pnpm --dir packages/backend test getTotalsQueryFromSource.test.ts --runInBand`
- `pnpm --dir packages/common test pivotQueryResults.test.ts --runInBand`

Closes: https://linear.app/lightdash/issue/PROD-8313
Closes: #24274
