### PR TITLE
feat(mcp): add AI router for automatic agent selection

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -653,6 +653,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentService: repository.getAiAgentService(),
                     aiAgentToolsService:
                         repository.getAiAgentToolsService<AiAgentToolsService>(),
+                    aiRouterService:
+                        repository.getAiRouterService<AiRouterService>(),
                     aiWritebackService: repository.getAiWritebackService(),
                 }),
             slackService: ({ repository, clients }) =>

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -1,0 +1,249 @@
+import type { AiAgentWithContext, RegisteredAccount } from '@lightdash/common';
+import { selectAgent } from '../ai/agents/agentSelector';
+import { getModel } from '../ai/models';
+import { AiRouterService } from './AiRouterService';
+
+jest.mock('../ai/agents/agentSelector', () => ({
+    selectAgent: jest.fn(),
+}));
+
+jest.mock('../ai/models', () => ({
+    getModel: jest.fn(),
+}));
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+const userUuid = 'user-uuid';
+
+const ability = {
+    can: jest.fn(() => true),
+    cannot: jest.fn(() => false),
+    relevantRuleFor: jest.fn(() => undefined),
+    rules: [],
+};
+
+const account = {
+    isAnonymousUser: () => false,
+    isServiceAccount: () => false,
+    isRegisteredUser: () => true,
+    isPatUser: () => true,
+    isOauthUser: () => false,
+    organization: { organizationUuid },
+    user: {
+        userUuid,
+        id: userUuid,
+        email: 'user@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        role: 'member',
+        ability,
+    },
+    authentication: { type: 'pat' },
+} as unknown as RegisteredAccount;
+
+const createCandidate = (
+    overrides: Partial<AiAgentWithContext> & { uuid: string; name: string },
+): AiAgentWithContext => ({
+    uuid: overrides.uuid,
+    projectUuid,
+    organizationUuid,
+    name: overrides.name,
+    description: overrides.description ?? null,
+    imageUrl: null,
+    tags: overrides.tags ?? null,
+    integrations: [],
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    instruction: overrides.instruction ?? null,
+    groupAccess: [],
+    userAccess: [],
+    spaceAccess: overrides.spaceAccess ?? [],
+    enableDataAccess: true,
+    enableSelfImprovement: true,
+    enableContentTools: true,
+    version: 1,
+    context: overrides.context ?? {
+        uuid: overrides.uuid,
+        projectUuid,
+        name: overrides.name,
+        description: overrides.description ?? null,
+        explores: [`${overrides.name.toLowerCase()}_explore`],
+        verifiedQuestions: [`${overrides.name} question`],
+        instruction: overrides.instruction ?? null,
+    },
+});
+
+const makeService = ({
+    candidates,
+    routerEnabled = true,
+    instruction = 'Route finance questions to @[Finance](agent-2)',
+}: {
+    candidates: AiAgentWithContext[];
+    routerEnabled?: boolean;
+    instruction?: string | null;
+}) => {
+    const analytics = { track: jest.fn() };
+    const aiRouterModel = {
+        findByOrganization: jest.fn().mockResolvedValue(
+            routerEnabled
+                ? {
+                      routerUuid: 'router-uuid',
+                      organizationUuid,
+                      enabled: true,
+                      projectUuids: [projectUuid],
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                  }
+                : null,
+        ),
+        getLatestInstruction: jest.fn().mockResolvedValue(
+            instruction
+                ? {
+                      instructionVersionUuid: 'instruction-version-uuid',
+                      routerUuid: 'router-uuid',
+                      projectUuid,
+                      instruction,
+                      taggedAgentUuids: ['agent-2'],
+                      createdAt: new Date(),
+                  }
+                : null,
+        ),
+        createDecision: jest.fn().mockResolvedValue({
+            decisionUuid: 'decision-uuid',
+        }),
+    };
+    const aiAgentService = {
+        getAvailableAgents: jest.fn().mockResolvedValue(candidates),
+    };
+
+    const service = new AiRouterService({
+        analytics: analytics as never,
+        lightdashConfig: { ai: { copilot: {} } } as never,
+        aiRouterModel: aiRouterModel as never,
+        aiAgentService: aiAgentService as never,
+    });
+
+    return { service, analytics, aiRouterModel, aiAgentService };
+};
+
+describe('AiRouterService', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        (getModel as jest.Mock).mockReturnValue({ model: 'mock-model' });
+    });
+
+    it('uses the latest routing instructions and accessible candidates', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service, aiAgentService } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-2',
+            confidence: 'high',
+            reasoning: 'Finance agent matches the request.',
+            shouldSkipForwardingQuery: false,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'show revenue by month',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(aiAgentService.getAvailableAgents).toHaveBeenCalledWith(
+            organizationUuid,
+            userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+        expect(selectAgent).toHaveBeenCalledWith({
+            model: 'mock-model',
+            candidates,
+            prompt: 'show revenue by month',
+            instructions: 'Route finance questions to @[Finance](agent-2)',
+        });
+        expect(result.candidates).toEqual(candidates);
+        expect(result.suggestedAgent.uuid).toBe('agent-2');
+    });
+
+    it('returns the sole accessible agent without router config', async () => {
+        const onlyCandidate = createCandidate({
+            uuid: 'agent-1',
+            name: 'General',
+        });
+        const { service, aiRouterModel } = makeService({
+            candidates: [onlyCandidate],
+            routerEnabled: false,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'show me recent orders',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(result.suggestedAgent.uuid).toBe('agent-1');
+        expect(result.confidence).toBe('high');
+        expect(result.reasoning).toBe('Only one agent available');
+        expect(selectAgent).not.toHaveBeenCalled();
+        expect(aiRouterModel.findByOrganization).not.toHaveBeenCalled();
+    });
+
+    it('auto-selects low-confidence routes in mcp mode', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-1',
+            confidence: 'low',
+            reasoning: 'General seems safest.',
+            shouldSkipForwardingQuery: true,
+        });
+
+        const result = await service.routePromptToAgent(account, {
+            prompt: 'what agents are available?',
+            projectUuid,
+            mode: 'mcp',
+        });
+
+        expect(result.suggestedAgent.uuid).toBe('agent-1');
+        expect(result.confidence).toBe('low');
+        expect(result.nextAction).toBe('create_thread');
+        expect(result.shouldSkipForwardingQuery).toBe(true);
+    });
+
+    it('preserves web low-confidence behavior', async () => {
+        const candidates = [
+            createCandidate({ uuid: 'agent-1', name: 'General' }),
+            createCandidate({ uuid: 'agent-2', name: 'Finance' }),
+        ];
+        const { service, aiRouterModel } = makeService({ candidates });
+
+        (selectAgent as jest.Mock).mockResolvedValue({
+            selectedAgentUuid: 'agent-2',
+            confidence: 'low',
+            reasoning: 'Not fully certain.',
+            shouldSkipForwardingQuery: false,
+        });
+
+        const result = await service.route(account, {
+            prompt: 'show revenue by month',
+            projectUuid,
+        });
+
+        expect(result.nextAction).toBe('show_picker');
+        expect(result.decision.suggestedAgentUuid).toBe('agent-2');
+        expect(aiRouterModel.createDecision).toHaveBeenCalledWith(
+            expect.objectContaining({
+                suggestedAgentUuid: 'agent-2',
+                confidence: 'low',
+                candidateAgentUuids: ['agent-1', 'agent-2'],
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -246,4 +246,19 @@ describe('AiRouterService', () => {
             }),
         );
     });
+
+    it('requires at least two agents on the web route', async () => {
+        const { service, aiRouterModel } = makeService({
+            candidates: [createCandidate({ uuid: 'agent-1', name: 'General' })],
+        });
+
+        await expect(
+            service.route(account, {
+                prompt: 'show revenue by month',
+                projectUuid,
+            }),
+        ).rejects.toThrow('AI router requires at least two accessible agents');
+        expect(selectAgent).not.toHaveBeenCalled();
+        expect(aiRouterModel.createDecision).not.toHaveBeenCalled();
+    });
 });

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -137,6 +137,15 @@ export class AiRouterService extends BaseService {
             );
         }
 
+        // The web routing UI is short-circuited when fewer than two agents are
+        // accessible, so the web endpoint keeps requiring at least two. MCP has
+        // no such picker, so a sole agent is routed to directly.
+        if (mode === 'web' && candidates.length < 2) {
+            throw new ParameterError(
+                'AI router requires at least two accessible agents',
+            );
+        }
+
         if (candidates.length === 1) {
             return {
                 candidates,

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -3,6 +3,7 @@ import {
     ForbiddenError,
     NotFoundError,
     ParameterError,
+    type AiAgentWithContext,
     type AiRouter,
     type AiRouterDecision,
     type AiRouterDecisionListFilters,
@@ -31,6 +32,18 @@ type Deps = {
     lightdashConfig: LightdashConfig;
     aiRouterModel: AiRouterModel;
     aiAgentService: AiAgentService;
+};
+
+type RoutePromptMode = 'web' | 'mcp';
+
+type PromptRouteSelection = {
+    candidates: AiAgentWithContext[];
+    suggestedAgent: AiAgentWithContext;
+    routerUuid: string | null;
+    confidence: 'high' | 'medium' | 'low';
+    reasoning: string;
+    shouldSkipForwardingQuery: boolean;
+    nextAction: 'create_thread' | 'show_picker';
 };
 
 export class AiRouterService extends BaseService {
@@ -94,6 +107,81 @@ export class AiRouterService extends BaseService {
             throw new NotFoundError('AI router is not enabled');
         }
         return router;
+    }
+
+    public async routePromptToAgent(
+        account: RegisteredAccount,
+        {
+            prompt,
+            projectUuid,
+            mode,
+        }: {
+            prompt: string;
+            projectUuid: string;
+            mode: RoutePromptMode;
+        },
+    ): Promise<PromptRouteSelection> {
+        const organizationUuid = AiRouterService.organizationUuidOf(account);
+        this.assertViewAiAgent(account, organizationUuid);
+
+        const candidates = await this.aiAgentService.getAvailableAgents(
+            organizationUuid,
+            account.user.userUuid,
+            { aiRequireOAuth: true },
+            { projectFilter: { projectUuid } },
+        );
+
+        if (candidates.length === 0) {
+            throw new ParameterError(
+                'No accessible AI agents are available for this project',
+            );
+        }
+
+        if (candidates.length === 1) {
+            return {
+                candidates,
+                suggestedAgent: candidates[0],
+                routerUuid: null,
+                confidence: 'high',
+                reasoning: 'Only one agent available',
+                shouldSkipForwardingQuery: false,
+                nextAction: 'create_thread',
+            };
+        }
+
+        const router = await this.getEnabledRouter(organizationUuid);
+        const instruction = await this.aiRouterModel.getLatestInstruction({
+            routerUuid: router.routerUuid,
+            projectUuid,
+        });
+
+        const { model } = getModel(this.lightdashConfig.ai.copilot);
+        const brain = await selectAgent({
+            model,
+            candidates,
+            prompt,
+            instructions: instruction?.instruction ?? null,
+        });
+
+        const suggestedAgent =
+            candidates.find(
+                (candidate) => candidate.uuid === brain.selectedAgentUuid,
+            ) ?? candidates[0];
+
+        return {
+            candidates,
+            suggestedAgent,
+            routerUuid: router.routerUuid,
+            confidence: brain.confidence,
+            reasoning: brain.reasoning,
+            shouldSkipForwardingQuery: brain.shouldSkipForwardingQuery,
+            nextAction:
+                mode === 'mcp' ||
+                (brain.confidence === 'high' &&
+                    !brain.shouldSkipForwardingQuery)
+                    ? 'create_thread'
+                    : 'show_picker',
+        };
     }
 
     async getConfig(account: RegisteredAccount): Promise<AiRouter> {
@@ -238,48 +326,23 @@ export class AiRouterService extends BaseService {
     ): Promise<AiRouterRouteResponseResult> {
         const organizationUuid = AiRouterService.organizationUuidOf(account);
         this.assertViewAiAgent(account, organizationUuid);
-
-        const router = await this.getEnabledRouter(organizationUuid);
-
-        const candidates = await this.aiAgentService.getAvailableAgents(
-            organizationUuid,
-            account.user.userUuid,
-            { aiRequireOAuth: true },
-            { projectFilter: { projectUuid } },
-        );
-
-        if (candidates.length < 2) {
-            throw new ParameterError(
-                'AI router requires at least two accessible agents',
-            );
-        }
-
-        const instruction = await this.aiRouterModel.getLatestInstruction({
-            routerUuid: router.routerUuid,
-            projectUuid,
-        });
-
-        const { model } = getModel(this.lightdashConfig.ai.copilot);
-        const brain = await selectAgent({
-            model,
-            candidates,
+        const selection = await this.routePromptToAgent(account, {
             prompt,
-            instructions: instruction?.instruction ?? null,
+            projectUuid,
+            mode: 'web',
         });
-
-        const nextAction =
-            brain.confidence === 'high' && !brain.shouldSkipForwardingQuery
-                ? 'create_thread'
-                : 'show_picker';
+        const routerUuid =
+            selection.routerUuid ??
+            (await this.getEnabledRouter(organizationUuid)).routerUuid;
 
         const decision = await this.aiRouterModel.createDecision({
-            routerUuid: router.routerUuid,
+            routerUuid,
             userUuid: account.user.userUuid,
             prompt,
-            suggestedAgentUuid: brain.selectedAgentUuid,
-            confidence: brain.confidence,
-            reasoning: brain.reasoning,
-            candidateAgentUuids: candidates.map((c) => c.uuid),
+            suggestedAgentUuid: selection.suggestedAgent.uuid,
+            confidence: selection.confidence,
+            reasoning: selection.reasoning,
+            candidateAgentUuids: selection.candidates.map((c) => c.uuid),
         });
 
         this.analytics.track<AiRouterMessageRoutedEvent>({
@@ -288,25 +351,25 @@ export class AiRouterService extends BaseService {
             properties: {
                 organizationId: organizationUuid,
                 projectId: projectUuid,
-                confidence: brain.confidence,
-                nextAction,
-                candidatesCount: candidates.length,
+                confidence: selection.confidence,
+                nextAction: selection.nextAction,
+                candidatesCount: selection.candidates.length,
             },
         });
 
         return {
             decision: {
                 decisionUuid: decision.decisionUuid,
-                suggestedAgentUuid: brain.selectedAgentUuid,
-                confidence: brain.confidence,
-                reasoning: brain.reasoning,
-                candidates: candidates.map((c) => ({
+                suggestedAgentUuid: selection.suggestedAgent.uuid,
+                confidence: selection.confidence,
+                reasoning: selection.reasoning,
+                candidates: selection.candidates.map((c) => ({
                     agentUuid: c.uuid,
                     name: c.name,
                     description: c.description ?? null,
                 })),
             },
-            nextAction,
+            nextAction: selection.nextAction,
         };
     }
 

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -340,12 +340,15 @@ export class AiRouterService extends BaseService {
             projectUuid,
             mode: 'web',
         });
-        const routerUuid =
-            selection.routerUuid ??
-            (await this.getEnabledRouter(organizationUuid)).routerUuid;
+        // Web routing requires at least two agents, so it always runs through an
+        // enabled router and never hits the single-agent fast-path that returns
+        // a null routerUuid.
+        if (!selection.routerUuid) {
+            throw new NotFoundError('AI router is not enabled');
+        }
 
         const decision = await this.aiRouterModel.createDecision({
-            routerUuid,
+            routerUuid: selection.routerUuid,
             userUuid: account.user.userUuid,
             prompt,
             suggestedAgentUuid: selection.suggestedAgent.uuid,

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -225,6 +225,7 @@ const makeMcpService = ({
         aiOrganizationSettingsService: {
             getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
         },
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: { track: jest.fn() },
         asyncQueryService: {},

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -420,6 +420,7 @@ const makeMcpService = ({
         aiOrganizationSettingsService: {
             getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
         },
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: { track: jest.fn() },
         asyncQueryService,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -1,0 +1,340 @@
+import type { AiAgentWithContext } from '@lightdash/common';
+import { McpService, McpToolName } from './McpService';
+
+type RegisteredToolCallback = (
+    args: Record<string, unknown>,
+    extra: Record<string, unknown>,
+) => Promise<unknown>;
+
+const mockRegisteredMcpTools = new Map<string, RegisteredToolCallback>();
+
+jest.mock('@sentry/node', () => ({
+    captureException: jest.fn(),
+    getActiveSpan: () => undefined,
+    isEnabled: () => false,
+    startSpanManual: (_options: unknown, callback: CallableFunction) =>
+        callback({ spanContext: () => ({ spanId: 'span-id' }) }, jest.fn()),
+    wrapMcpServerWithSentry: (server: unknown) => server,
+}));
+
+jest.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+    McpServer: jest.fn().mockImplementation(() => ({
+        registerResource: jest.fn(),
+        registerPrompt: jest.fn(),
+        registerTool: jest.fn(
+            (
+                name: string,
+                _config: Record<string, unknown>,
+                callback: RegisteredToolCallback,
+            ) => {
+                mockRegisteredMcpTools.set(name, callback);
+                return {};
+            },
+        ),
+    })),
+}));
+
+const projectUuid = 'project-uuid';
+const organizationUuid = 'organization-uuid';
+const userUuid = 'user-uuid';
+const allowedSpaceUuid = 'allowed-space-uuid';
+const blockedSpaceUuid = 'blocked-space-uuid';
+
+const account = {
+    user: {
+        userUuid,
+        ability: {
+            can: jest.fn(() => true),
+            cannot: jest.fn(() => false),
+            relevantRuleFor: jest.fn(() => undefined),
+            rules: [],
+        },
+    },
+    organization: { organizationUuid },
+    authentication: { type: 'pat' },
+};
+
+const user = {
+    userUuid,
+    organizationUuid,
+    ability: account.user.ability,
+};
+
+const extra = {
+    signal: new AbortController().signal,
+    requestId: 'request-id',
+    sendNotification: jest.fn(),
+    sendRequest: jest.fn(),
+    authInfo: {
+        extra: {
+            user,
+            account,
+        },
+    },
+};
+
+const selectedAgent: AiAgentWithContext = {
+    uuid: 'agent-uuid',
+    projectUuid,
+    organizationUuid,
+    name: 'Finance',
+    description: 'Finance specialist',
+    imageUrl: null,
+    tags: ['finance'],
+    integrations: [],
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    instruction: 'Prioritize revenue metrics.',
+    groupAccess: [],
+    userAccess: [],
+    spaceAccess: [allowedSpaceUuid],
+    enableDataAccess: true,
+    enableSelfImprovement: true,
+    enableContentTools: true,
+    version: 1,
+    context: {
+        uuid: 'agent-uuid',
+        projectUuid,
+        name: 'Finance',
+        description: 'Finance specialist',
+        explores: ['orders'],
+        verifiedQuestions: ['What is monthly revenue?'],
+        instruction: 'Prioritize revenue metrics.',
+    },
+};
+
+const routeCandidates = [
+    selectedAgent,
+    {
+        ...selectedAgent,
+        uuid: 'agent-2',
+        name: 'General',
+        context: {
+            ...selectedAgent.context,
+            uuid: 'agent-2',
+            name: 'General',
+        },
+    },
+];
+
+const makeMcpService = () => {
+    const storedContext = {
+        projectUuid,
+        projectName: 'Project',
+        agentUuid: null as string | null,
+        agentName: null as string | null,
+        tags: ['finance-only'],
+    };
+
+    const mcpContextModel = {
+        getContext: jest.fn().mockImplementation(async () => ({
+            context: { ...storedContext },
+        })),
+        setContext: jest.fn().mockImplementation(async ({ context }) => {
+            Object.assign(storedContext, context);
+            return { context: { ...storedContext } };
+        }),
+    };
+
+    const aiAgentService = {
+        getAgent: jest.fn().mockResolvedValue(selectedAgent),
+    };
+
+    const aiAgentToolsService = {
+        createRuntime: jest.fn(({ spaceAccess, agentUuid }) => ({
+            listContent: jest.fn(async ({ spaceSlug }: { spaceSlug: null }) => {
+                const visibleSpaceUuids =
+                    spaceAccess?.length === 0 || !spaceAccess
+                        ? [allowedSpaceUuid, blockedSpaceUuid]
+                        : [allowedSpaceUuid, blockedSpaceUuid].filter((uuid) =>
+                              spaceAccess.includes(uuid),
+                          );
+
+                return {
+                    spaceSlug,
+                    items: visibleSpaceUuids.map((uuid) => ({
+                        contentType: 'space',
+                        name:
+                            uuid === allowedSpaceUuid
+                                ? 'Allowed Space'
+                                : 'Blocked Space',
+                        slug:
+                            uuid === allowedSpaceUuid
+                                ? 'allowed-space'
+                                : 'blocked-space',
+                        chartCount: 0,
+                        dashboardCount: 0,
+                        childSpaceCount: 0,
+                        appCount: 0,
+                        directAccess: true,
+                        agentUuid,
+                    })),
+                    pagination: {
+                        page: 1,
+                        pageSize: 25,
+                        totalResults: visibleSpaceUuids.length,
+                        totalPageCount: 1,
+                    },
+                };
+            }),
+        })),
+    };
+
+    const aiRouterService = {
+        routePromptToAgent: jest.fn().mockResolvedValue({
+            candidates: routeCandidates,
+            suggestedAgent: selectedAgent,
+            routerUuid: 'router-uuid',
+            confidence: 'low',
+            reasoning: 'Finance agent is the closest fit.',
+            shouldSkipForwardingQuery: false,
+            nextAction: 'create_thread',
+        }),
+    };
+
+    const service = new McpService({
+        aiAgentService,
+        aiAgentToolsService,
+        aiOrganizationSettingsService: {
+            getSettings: jest.fn().mockResolvedValue({ aiAgentsVisible: true }),
+        },
+        aiRouterService,
+        aiWritebackService: {},
+        analytics: { track: jest.fn() },
+        asyncQueryService: {},
+        catalogService: {},
+        contentVerificationService: {},
+        featureFlagService: {},
+        lightdashConfig: {
+            ai: {
+                copilot: {
+                    maxQueryLimit: 500,
+                },
+            },
+            mcp: {
+                enabled: true,
+                runSqlMaxLimit: 500,
+            },
+            siteUrl: 'https://lightdash.example',
+        },
+        mcpContextModel,
+        projectModel: {},
+        projectService: {
+            getProject: jest
+                .fn()
+                .mockResolvedValue({ organizationUuid, name: 'Project' }),
+            getSpaces: jest.fn().mockResolvedValue([]),
+        },
+        searchModel: {},
+        shareService: {},
+        spaceService: {},
+        userAttributesModel: {},
+    } as unknown as ConstructorParameters<typeof McpService>[0]);
+
+    return {
+        service,
+        aiAgentService,
+        aiAgentToolsService,
+        aiRouterService,
+        mcpContextModel,
+        storedContext,
+    };
+};
+
+describe('McpService route_agent', () => {
+    beforeEach(() => {
+        mockRegisteredMcpTools.clear();
+    });
+
+    it('writes the routed agent into context and get_current_agent returns it', async () => {
+        const { aiRouterService, mcpContextModel } = makeMcpService();
+
+        const routeAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.ROUTE_AGENT,
+        );
+        const getCurrentAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.GET_CURRENT_AGENT,
+        );
+
+        expect(routeAgentTool).toBeDefined();
+        expect(getCurrentAgentTool).toBeDefined();
+
+        const routeResult = (await routeAgentTool!(
+            { prompt: 'show revenue by month' },
+            extra,
+        )) as {
+            content: Array<{ text: string }>;
+            structuredContent: Record<string, unknown>;
+        };
+
+        expect(aiRouterService.routePromptToAgent).toHaveBeenCalledWith(
+            account,
+            {
+                prompt: 'show revenue by month',
+                projectUuid,
+                mode: 'mcp',
+            },
+        );
+        expect(mcpContextModel.setContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                context: expect.objectContaining({
+                    projectUuid,
+                    projectName: 'Project',
+                    tags: ['finance-only'],
+                    agentUuid: 'agent-uuid',
+                    agentName: 'Finance',
+                }),
+            }),
+        );
+        expect(routeResult.structuredContent).toEqual(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                agentName: 'Finance',
+                confidence: 'low',
+                reasoning: 'Finance agent is the closest fit.',
+            }),
+        );
+
+        const currentResult = (await getCurrentAgentTool!({}, extra)) as {
+            content: Array<{ text: string }>;
+        };
+        expect(JSON.parse(currentResult.content[0].text)).toEqual(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                agentName: 'Finance',
+                explores: ['orders'],
+            }),
+        );
+    });
+
+    it('applies routed agent scope to later tool calls', async () => {
+        const { aiAgentToolsService } = makeMcpService();
+
+        const routeAgentTool = mockRegisteredMcpTools.get(
+            McpToolName.ROUTE_AGENT,
+        );
+        const listContentTool = mockRegisteredMcpTools.get(
+            McpToolName.LIST_CONTENT,
+        );
+
+        await routeAgentTool!({ prompt: 'show revenue by month' }, extra);
+
+        const listContentResult = (await listContentTool!(
+            { spaceSlug: null, page: 1, pageSize: 25 },
+            extra,
+        )) as {
+            content: Array<{ text: string }>;
+        };
+        const rendered = listContentResult.content[0].text;
+
+        expect(aiAgentToolsService.createRuntime).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                agentUuid: 'agent-uuid',
+                tags: ['finance'],
+                spaceAccess: [allowedSpaceUuid],
+            }),
+        );
+        expect(rendered).toContain('slug="allowed-space"');
+        expect(rendered).not.toContain('slug="blocked-space"');
+    });
+});

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     Account,
+    AiAgentWithContext,
     AiResultType,
     ApiKeyAccount,
     assertUnreachable,
@@ -48,6 +49,7 @@ import {
     readSkillResourceToolDefinition,
     readSkillToolDefinition,
     renderChartToolDefinition,
+    routeAgentToolDefinition,
     runAiWritebackToolDefinition,
     runQueryToolDefinition,
     runSqlToolDefinition,
@@ -129,6 +131,7 @@ import {
     AiAgentToolsService,
 } from '../AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
+import { AiRouterService } from '../AiRouterService/AiRouterService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
 import { buildMcpExploreConfigState } from './buildMcpExploreConfigState';
 import {
@@ -152,6 +155,7 @@ export enum McpToolName {
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
     LIST_AGENTS = 'list_agents',
+    ROUTE_AGENT = 'route_agent',
     SET_AGENT = 'set_agent',
     CLEAR_AGENT = 'clear_agent',
     GET_CURRENT_AGENT = 'get_current_agent',
@@ -184,6 +188,7 @@ const mcpListProjectsTool = mcpListProjectsToolDefinition.for('mcp');
 const mcpSetProjectTool = setProjectToolDefinition.for('mcp');
 const mcpGetCurrentProjectTool = getCurrentProjectToolDefinition.for('mcp');
 const mcpListAgentsTool = listAgentsToolDefinition.for('mcp');
+const mcpRouteAgentTool = routeAgentToolDefinition.for('mcp');
 const mcpSetAgentTool = setAgentToolDefinition.for('mcp');
 const mcpClearAgentTool = clearAgentToolDefinition.for('mcp');
 const mcpGetCurrentAgentTool = getCurrentAgentToolDefinition.for('mcp');
@@ -214,6 +219,7 @@ type McpServiceArguments = {
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     aiAgentService: AiAgentService;
     aiAgentToolsService: AiAgentToolsService;
+    aiRouterService: AiRouterService;
     aiWritebackService: AiWritebackService;
 };
 
@@ -294,6 +300,8 @@ export class McpService extends BaseService {
 
     private aiAgentToolsService: AiAgentToolsService;
 
+    private aiRouterService: AiRouterService;
+
     private aiWritebackService: AiWritebackService;
 
     private mcpServer: McpServer;
@@ -317,6 +325,7 @@ export class McpService extends BaseService {
         aiOrganizationSettingsService,
         aiAgentService,
         aiAgentToolsService,
+        aiRouterService,
         aiWritebackService,
     }: McpServiceArguments) {
         super();
@@ -336,6 +345,7 @@ export class McpService extends BaseService {
         this.aiOrganizationSettingsService = aiOrganizationSettingsService;
         this.aiAgentService = aiAgentService;
         this.aiAgentToolsService = aiAgentToolsService;
+        this.aiRouterService = aiRouterService;
         this.aiWritebackService = aiWritebackService;
         this.mcpCompatLayer = new McpSchemaCompatLayer();
         try {
@@ -414,6 +424,53 @@ export class McpService extends BaseService {
         return structuredContent !== undefined
             ? { content, structuredContent }
             : { content };
+    }
+
+    private static buildAgentContextResponse(agent: AiAgentWithContext) {
+        return {
+            agentUuid: agent.uuid,
+            agentName: agent.name,
+            agentDescription: agent.description,
+            agentTags: agent.tags,
+            agentSpaceAccess: agent.spaceAccess,
+            agentProjectUuid: agent.projectUuid,
+            explores: agent.context.explores,
+            verifiedQuestions: agent.context.verifiedQuestions,
+            instruction: agent.context.instruction,
+        };
+    }
+
+    private async setActiveAgentContext(
+        user: SessionUser,
+        organizationUuid: string,
+        {
+            projectUuid,
+            projectName,
+            agentUuid,
+            agentName,
+        }: {
+            projectUuid: string;
+            projectName: string;
+            agentUuid: string;
+            agentName: string;
+        },
+    ) {
+        const existingContext = await this.mcpContextModel.getContext(
+            user.userUuid,
+            organizationUuid,
+        );
+
+        await this.mcpContextModel.setContext({
+            userUuid: user.userUuid,
+            organizationUuid,
+            context: {
+                projectUuid,
+                projectName,
+                tags: existingContext?.context.tags || null,
+                agentUuid,
+                agentName,
+            },
+        });
     }
 
     static async streamToolResult<T extends { result: string }>(
@@ -1728,6 +1785,85 @@ export class McpService extends BaseService {
         );
 
         this.mcpServer.registerTool(
+            mcpRouteAgentTool.name,
+            {
+                title: mcpRouteAgentTool.title,
+                description: mcpRouteAgentTool.description,
+                inputSchema: this.getMcpCompatibleSchema(
+                    mcpRouteAgentTool.inputSchema,
+                ),
+                annotations: mcpRouteAgentTool.annotations,
+                outputSchema: mcpRouteAgentTool.outputSchema.shape,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+                const { user, organizationUuid, account } =
+                    McpService.getAccount(ctx);
+
+                await this.checkAiAgentsVisible(user);
+
+                const projectUuid =
+                    args.projectUuid ?? (await this.resolveProjectUuid(ctx));
+
+                this.trackToolCall(ctx, McpToolName.ROUTE_AGENT, projectUuid);
+
+                let selection;
+                try {
+                    selection = await this.aiRouterService.routePromptToAgent(
+                        account,
+                        {
+                            prompt: args.prompt,
+                            projectUuid,
+                            mode: 'mcp',
+                        },
+                    );
+                } catch (error) {
+                    if (error instanceof NotFoundError) {
+                        throw new ParameterError(
+                            'AI router is not enabled for this organization. Use set_agent to choose an agent manually or ask an admin to enable the AI router.',
+                        );
+                    }
+                    throw error;
+                }
+
+                const project = await this.projectService.getProject(
+                    projectUuid,
+                    account,
+                );
+
+                await this.setActiveAgentContext(user, organizationUuid, {
+                    projectUuid: selection.suggestedAgent.projectUuid,
+                    projectName: project.name,
+                    agentUuid: selection.suggestedAgent.uuid,
+                    agentName: selection.suggestedAgent.name,
+                });
+
+                const structuredContent = {
+                    ...McpService.buildAgentContextResponse(
+                        selection.suggestedAgent,
+                    ),
+                    confidence: selection.confidence,
+                    reasoning: selection.reasoning,
+                    candidates: selection.candidates.map((candidate) => ({
+                        agentUuid: candidate.uuid,
+                        name: candidate.name,
+                        description: candidate.description ?? null,
+                    })),
+                };
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(structuredContent, null, 2),
+                        },
+                    ],
+                    structuredContent,
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
             mcpSetAgentTool.name,
             {
                 title: mcpSetAgentTool.title,
@@ -1765,21 +1901,11 @@ export class McpService extends BaseService {
                     { includeSummaryContext: true },
                 );
 
-                const existingContext = await this.mcpContextModel.getContext(
-                    user.userUuid,
-                    organizationUuid,
-                );
-
-                await this.mcpContextModel.setContext({
-                    userUuid: user.userUuid,
-                    organizationUuid,
-                    context: {
-                        projectUuid: agent.projectUuid,
-                        projectName: project.name,
-                        tags: existingContext?.context.tags || null,
-                        agentUuid: agent.uuid,
-                        agentName: agent.name,
-                    },
+                await this.setActiveAgentContext(user, organizationUuid, {
+                    projectUuid: agent.projectUuid,
+                    projectName: project.name,
+                    agentUuid: agent.uuid,
+                    agentName: agent.name,
                 });
 
                 return {
@@ -1787,18 +1913,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: JSON.stringify(
-                                {
-                                    agentUuid: agent.uuid,
-                                    agentName: agent.name,
-                                    agentDescription: agent.description,
-                                    agentTags: agent.tags,
-                                    agentSpaceAccess: agent.spaceAccess,
-                                    agentProjectUuid: agent.projectUuid,
-                                    explores: agent.context.explores,
-                                    verifiedQuestions:
-                                        agent.context.verifiedQuestions,
-                                    instruction: agent.context.instruction,
-                                },
+                                McpService.buildAgentContextResponse(agent),
                                 null,
                                 2,
                             ),
@@ -1913,18 +2028,7 @@ export class McpService extends BaseService {
                         {
                             type: 'text',
                             text: JSON.stringify(
-                                {
-                                    agentUuid: agent.uuid,
-                                    agentName: agent.name,
-                                    agentDescription: agent.description,
-                                    agentTags: agent.tags,
-                                    agentSpaceAccess: agent.spaceAccess,
-                                    agentProjectUuid: agent.projectUuid,
-                                    explores: agent.context.explores,
-                                    verifiedQuestions:
-                                        agent.context.verifiedQuestions,
-                                    instruction: agent.context.instruction,
-                                },
+                                McpService.buildAgentContextResponse(agent),
                                 null,
                                 2,
                             ),
@@ -2531,7 +2635,7 @@ export class McpService extends BaseService {
             {
                 title: 'Lightdash Data Analyst',
                 description:
-                    'Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
+                    'Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.',
                 argsSchema: {},
             },
             async (_args, extra) => {

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -10,12 +10,13 @@ exports[`MCP tool contracts matches the current MCP tool and prompt contract sna
         "properties": {},
         "type": "object",
       },
-      "description": "Guidelines for querying Lightdash data using MCP tools. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
+      "description": "Guidelines for querying Lightdash data using MCP tools. After setting project context, call route_agent at the start of each new user request to activate the best agent automatically. Includes explore selection, query building, visualization rules, and active agent context (instructions, verified questions, available explores). Inject this into your system prompt for best results.",
       "name": "lightdash-analyst",
       "prompt": "# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
+0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean
@@ -536,7 +537,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.",
+      "description": "Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -573,7 +574,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.",
+      "description": "List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -589,7 +590,139 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+      "description": "Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "projectUuid": {
+            "type": "string",
+          },
+          "prompt": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "prompt",
+        ],
+        "type": "object",
+      },
+      "name": "route_agent",
+      "outputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "agentDescription": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "agentName": {
+            "type": "string",
+          },
+          "agentProjectUuid": {
+            "type": "string",
+          },
+          "agentSpaceAccess": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "agentTags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              {
+                "type": "null",
+              },
+            ],
+          },
+          "agentUuid": {
+            "type": "string",
+          },
+          "candidates": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "agentUuid": {
+                  "type": "string",
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "agentUuid",
+                "name",
+                "description",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "confidence": {
+            "enum": [
+              "high",
+              "medium",
+              "low",
+            ],
+            "type": "string",
+          },
+          "explores": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "instruction": {
+            "type": [
+              "string",
+              "null",
+            ],
+          },
+          "reasoning": {
+            "type": "string",
+          },
+          "verifiedQuestions": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "agentUuid",
+          "agentName",
+          "agentDescription",
+          "agentTags",
+          "agentSpaceAccess",
+          "agentProjectUuid",
+          "explores",
+          "verifiedQuestions",
+          "instruction",
+          "confidence",
+          "reasoning",
+          "candidates",
+        ],
+        "type": "object",
+      },
+      "title": "Route agent",
+    },
+    {
+      "agentName": null,
+      "description": "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -620,7 +753,7 @@ Usage tips:
     },
     {
       "agentName": null,
-      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+      "description": "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
@@ -8089,6 +8222,7 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
   "set_project",
   "get_current_project",
   "list_agents",
+  "route_agent",
   "set_agent",
   "clear_agent",
   "get_current_agent",

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -83,6 +83,7 @@ const makeMcpService = (): McpService =>
         aiAgentService: {},
         aiAgentToolsService: { createRuntime: jest.fn() },
         aiOrganizationSettingsService: {},
+        aiRouterService: {},
         aiWritebackService: {},
         analytics: {},
         asyncQueryService: {},

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -2,6 +2,7 @@ export const MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 
 ## Query Building Workflow
 
+0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -134,6 +134,7 @@ describe('defineTool', () => {
             'read_skill',
             'read_skill_resource',
             'render_chart',
+            'route_agent',
             'run_ai_writeback',
             'run_metric_query',
             'run_sql',

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -254,6 +254,32 @@ const writeAnnotations: McpToolAnnotations = {
 
 const emptyInputSchema = z.object({});
 
+const routeAgentArgsSchema = z.object({
+    prompt: z.string(),
+    projectUuid: z.string().optional(),
+});
+
+const routeAgentStructuredOutputSchema = z.object({
+    agentUuid: z.string(),
+    agentName: z.string(),
+    agentDescription: z.string().nullable(),
+    agentTags: z.array(z.string()).nullable(),
+    agentSpaceAccess: z.array(z.string()),
+    agentProjectUuid: z.string(),
+    explores: z.array(z.string()),
+    verifiedQuestions: z.array(z.string()),
+    instruction: z.string().nullable(),
+    confidence: z.enum(['high', 'medium', 'low']),
+    reasoning: z.string(),
+    candidates: z.array(
+        z.object({
+            agentUuid: z.string(),
+            name: z.string(),
+            description: z.string().nullable(),
+        }),
+    ),
+});
+
 export const findExploresToolDefinition = defineTool({
     name: 'findExplores',
     title: 'Find explores',
@@ -758,7 +784,7 @@ export const setProjectToolDefinition = defineTool({
     name: 'setProject',
     title: 'Set project',
     description:
-        'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.',
+        'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, prefer route_agent to auto-select the best agent for each request; use list_agents and set_agent only for manual override.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string(),
@@ -781,7 +807,7 @@ export const listAgentsToolDefinition = defineTool({
     name: 'listAgents',
     title: 'List agents',
     description:
-        'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.',
+        'List accessible AI agents for the active project. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Prefer route_agent for automatic selection; use this tool when you need to inspect candidates or choose one manually before calling set_agent.',
     availability: ['mcp'],
     inputSchema: z.object({
         projectUuid: z.string().optional(),
@@ -789,11 +815,24 @@ export const listAgentsToolDefinition = defineTool({
     mcp: { annotations: readOnlyAnnotations },
 });
 
+export const routeAgentToolDefinition = defineTool({
+    name: 'routeAgent',
+    title: 'Route agent',
+    description:
+        'Automatically select and activate the best AI agent for a user request within the active project. Call this at the start of each new user request after setting project context. Returns routing metadata plus the selected agent context; use set_agent only when you want to override the automatic choice manually.',
+    availability: ['mcp'],
+    inputSchema: routeAgentArgsSchema,
+    mcp: {
+        annotations: writeAnnotations,
+        structuredContentSchema: routeAgentStructuredOutputSchema,
+    },
+});
+
 export const setAgentToolDefinition = defineTool({
     name: 'setAgent',
     title: 'Set agent',
     description:
-        "Set the active AI agent for the active project. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+        "Manually set the active AI agent for the active project. Prefer route_agent for default automatic selection; use this when you need to override that choice explicitly. Returns the agent's full context including: explores it has access to, space restrictions, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
     availability: ['mcp'],
     inputSchema: z.object({
         agentUuid: z.string(),
@@ -815,7 +854,7 @@ export const getCurrentAgentToolDefinition = defineTool({
     name: 'getCurrentAgent',
     title: 'Get current agent',
     description:
-        "Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+        'Get the currently active AI agent with its full context: explores it has access to, space restrictions, verified questions (curated example queries), and custom instructions. The active agent is usually established by route_agent; use this to inspect the current automatic or manually overridden selection before making data queries.',
     availability: ['mcp'],
     inputSchema: emptyInputSchema,
     mcp: { annotations: readOnlyAnnotations },
@@ -975,6 +1014,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     setProjectToolDefinition,
     getCurrentProjectToolDefinition,
     listAgentsToolDefinition,
+    routeAgentToolDefinition,
     setAgentToolDefinition,
     clearAgentToolDefinition,
     getCurrentAgentToolDefinition,


### PR DESCRIPTION
## Summary

Enables automatic routing of user prompts to the most appropriate agent in the Lightdash MCP, matching the Ask AI experience in the product.

Users no longer need to manually select agents - the system automatically chooses the best agent based on query intent, improving answer quality and consistency.

## Changes

- Add `routePromptToAgent` method to AiRouterService for automatic agent selection
- Integrate routing into MCP service via new `route_agent` tool
- Update tool definitions and prompts for routing support
- Add comprehensive test coverage for routing functionality

Closes: #23753

🤖 Generated with [Claude Code](https://claude.com/claude-code)