### PR TITLE
feat(cli): read disable-timestamp-conversion from project settings

### DIFF
--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -136,6 +136,7 @@ type CreateProjectOptions = {
     targetPath?: string;
     assumeYes?: boolean;
     expiresIn?: number;
+    disableTimestampConversion?: boolean;
 };
 
 const isSnowflakeSsoEnabled = async (): Promise<boolean> => {
@@ -379,6 +380,16 @@ export const createProject = async (
         targetName = loaded.targetName;
         isDbtCloudCLI = loaded.isDbtCloudCLI;
         dbtVersionOption = loaded.dbtVersionOption;
+
+        if (
+            options.disableTimestampConversion !== undefined &&
+            credentials.type === WarehouseTypes.SNOWFLAKE
+        ) {
+            credentials = {
+                ...credentials,
+                disableTimestampConversion: options.disableTimestampConversion,
+            };
+        }
     }
 
     const project: CreateProjectOptionalCredentials = {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -38,7 +38,12 @@ import {
 } from './dbt/apiClient';
 import { DbtCompileOptions } from './dbt/compile';
 import { tryGetDbtVersion } from './dbt/getDbtVersion';
-import { logSelectedProject, selectProject } from './selectProject';
+import {
+    logSelectedProject,
+    selectProject,
+    type ProjectSelection,
+} from './selectProject';
+import { getProjectDisableTimestampConversion } from './timestampConversion';
 
 type DeployHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -57,6 +62,7 @@ type DeployHandlerOptions = DbtCompileOptions & {
     batchSize?: string;
     parallelBatches?: string;
     gzip?: boolean;
+    disableTimestampConversion?: boolean;
 };
 
 type DeployArgs = DeployHandlerOptions & {
@@ -657,9 +663,34 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
     }
     await checkLightdashVersion();
     const executionId = uuidv4();
+    const config = await getConfig();
+
+    let existingProjectSelection: ProjectSelection | undefined;
+    if (options.create === undefined) {
+        if (!config.context?.serverUrl) {
+            throw new AuthorizationError(
+                `No active Lightdash project. Run 'lightdash login --help'`,
+            );
+        }
+        existingProjectSelection = await selectProject(config, options.project);
+        if (!existingProjectSelection) {
+            throw new AuthorizationError(
+                `No active Lightdash project. Run 'lightdash login --help'`,
+            );
+        }
+
+        // Log current project info
+        logSelectedProject(existingProjectSelection, config, 'Deploying to');
+
+        options.disableTimestampConversion =
+            await getProjectDisableTimestampConversion(
+                options.disableTimestampConversion,
+                existingProjectSelection.projectUuid,
+            );
+    }
+
     const explores = await compile(options);
 
-    const config = await getConfig();
     let projectUuid: string;
 
     if (options.create !== undefined) {
@@ -680,22 +711,12 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
         }
         projectUuid = project.projectUuid;
         await setProject(projectUuid, project.name);
+    } else if (existingProjectSelection) {
+        projectUuid = existingProjectSelection.projectUuid;
     } else {
-        if (!config.context?.serverUrl) {
-            throw new AuthorizationError(
-                `No active Lightdash project. Run 'lightdash login --help'`,
-            );
-        }
-        const projectSelection = await selectProject(config, options.project);
-        if (!projectSelection) {
-            throw new AuthorizationError(
-                `No active Lightdash project. Run 'lightdash login --help'`,
-            );
-        }
-        projectUuid = projectSelection.projectUuid;
-
-        // Log current project info
-        logSelectedProject(projectSelection, config, 'Deploying to');
+        throw new AuthorizationError(
+            `No active Lightdash project. Run 'lightdash login --help'`,
+        );
     }
 
     await deploy(explores, { ...options, projectUuid });

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -22,6 +22,10 @@ import { createProject } from './createProject';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { DbtCompileOptions } from './dbt/compile';
 import { deploy } from './deploy';
+import {
+    getDisableTimestampConversionFromProject,
+    getProjectDisableTimestampConversion,
+} from './timestampConversion';
 
 type PreviewHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -41,6 +45,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     batchSize?: string;
     parallelBatches?: string;
     expiresIn?: string;
+    disableTimestampConversion?: boolean;
 };
 
 type StopPreviewHandlerOptions = {
@@ -124,8 +129,9 @@ const getPreviewProject = async (name: string) => {
     );
 };
 export const previewHandler = async (
-    options: PreviewHandlerOptions,
+    originalOptions: PreviewHandlerOptions,
 ): Promise<void> => {
+    const options = { ...originalOptions };
     GlobalState.setVerbose(options.verbose);
     const executionId = uuidv4();
     await checkLightdashVersion();
@@ -274,6 +280,18 @@ export const previewHandler = async (
         return;
     }
 
+    if (options.disableTimestampConversion === undefined) {
+        options.disableTimestampConversion =
+            getDisableTimestampConversionFromProject(
+                project.warehouseConnection,
+            );
+        GlobalState.debug(
+            `> Using disable-timestamp-conversion=${String(
+                options.disableTimestampConversion ?? false,
+            )} from preview project settings`,
+        );
+    }
+
     const previewStartTime = Date.now();
     await LightdashAnalytics.track({
         event: 'preview.started',
@@ -406,8 +424,9 @@ export const previewHandler = async (
 };
 
 export const startPreviewHandler = async (
-    options: PreviewHandlerOptions,
+    originalOptions: PreviewHandlerOptions,
 ): Promise<void> => {
+    const options = { ...originalOptions };
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
     const executionId = uuidv4();
@@ -454,6 +473,11 @@ export const startPreviewHandler = async (
         });
 
         // Update
+        options.disableTimestampConversion =
+            await getProjectDisableTimestampConversion(
+                options.disableTimestampConversion,
+                previewProject.projectUuid,
+            );
         const explores = await compile(options);
         await deploy(explores, {
             ...options,
@@ -533,6 +557,19 @@ export const startPreviewHandler = async (
                 name: options.name,
             },
         });
+
+        if (options.disableTimestampConversion === undefined) {
+            options.disableTimestampConversion =
+                getDisableTimestampConversionFromProject(
+                    project.warehouseConnection,
+                );
+            GlobalState.debug(
+                `> Using disable-timestamp-conversion=${String(
+                    options.disableTimestampConversion ?? false,
+                )} from preview project settings`,
+            );
+        }
+
         const explores = await compile(options);
         await deploy(explores, {
             ...options,

--- a/packages/cli/src/handlers/timestampConversion.test.ts
+++ b/packages/cli/src/handlers/timestampConversion.test.ts
@@ -1,0 +1,158 @@
+import { WarehouseTypes, type Project } from '@lightdash/common';
+import { lightdashApi } from './dbt/apiClient';
+import {
+    getDisableTimestampConversionFromProject,
+    getProjectDisableTimestampConversion,
+} from './timestampConversion';
+
+jest.mock('./dbt/apiClient', () => ({
+    lightdashApi: jest.fn(),
+}));
+
+const mockLightdashApi = lightdashApi as jest.MockedFunction<
+    typeof lightdashApi
+>;
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+
+const snowflakeConnection = (disableTimestampConversion?: boolean) =>
+    ({
+        type: WarehouseTypes.SNOWFLAKE,
+        ...(disableTimestampConversion !== undefined
+            ? { disableTimestampConversion }
+            : {}),
+    }) as Project['warehouseConnection'];
+
+const postgresConnection = {
+    type: WarehouseTypes.POSTGRES,
+} as Project['warehouseConnection'];
+
+const mockProjectResponse = (
+    warehouseConnection: Project['warehouseConnection'],
+) => {
+    mockLightdashApi.mockResolvedValueOnce({
+        projectUuid: PROJECT_UUID,
+        warehouseConnection,
+    } as never);
+};
+
+describe('getDisableTimestampConversionFromProject', () => {
+    it('returns the setting for snowflake connections', () => {
+        expect(
+            getDisableTimestampConversionFromProject(snowflakeConnection(true)),
+        ).toBe(true);
+        expect(
+            getDisableTimestampConversionFromProject(
+                snowflakeConnection(false),
+            ),
+        ).toBe(false);
+    });
+
+    it('returns undefined when the setting is not set', () => {
+        expect(
+            getDisableTimestampConversionFromProject(snowflakeConnection()),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined for non-snowflake connections', () => {
+        expect(
+            getDisableTimestampConversionFromProject(postgresConnection),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when there is no warehouse connection', () => {
+        expect(
+            getDisableTimestampConversionFromProject(undefined),
+        ).toBeUndefined();
+    });
+});
+
+describe('getProjectDisableTimestampConversion', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        consoleErrorSpy = jest
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+        jest.clearAllMocks();
+    });
+
+    it('returns the project setting when the CLI flag is not provided', async () => {
+        mockProjectResponse(snowflakeConnection(true));
+
+        const result = await getProjectDisableTimestampConversion(
+            undefined,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBe(true);
+        expect(mockLightdashApi).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the snowflake project has no setting', async () => {
+        mockProjectResponse(snowflakeConnection());
+
+        const result = await getProjectDisableTimestampConversion(
+            undefined,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for non-snowflake projects', async () => {
+        mockProjectResponse(postgresConnection);
+
+        const result = await getProjectDisableTimestampConversion(
+            undefined,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBeUndefined();
+    });
+
+    it('ignores the CLI flag, warns, and uses the project setting', async () => {
+        mockProjectResponse(snowflakeConnection(true));
+
+        const result = await getProjectDisableTimestampConversion(
+            false,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBe(true);
+        expect(mockLightdashApi).toHaveBeenCalledTimes(1);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Ignoring --disable-timestamp-conversion'),
+        );
+    });
+
+    it('ignores a truthy CLI flag when the project has no setting', async () => {
+        mockProjectResponse(snowflakeConnection());
+
+        const result = await getProjectDisableTimestampConversion(
+            true,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBeUndefined();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Ignoring --disable-timestamp-conversion'),
+        );
+    });
+
+    it('returns undefined and does not throw when the project fetch fails', async () => {
+        mockLightdashApi.mockRejectedValueOnce(new Error('network error'));
+
+        const result = await getProjectDisableTimestampConversion(
+            undefined,
+            PROJECT_UUID,
+        );
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/packages/cli/src/handlers/timestampConversion.ts
+++ b/packages/cli/src/handlers/timestampConversion.ts
@@ -1,0 +1,53 @@
+import { getErrorMessage, Project, WarehouseTypes } from '@lightdash/common';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { lightdashApi } from './dbt/apiClient';
+
+export const getDisableTimestampConversionFromProject = (
+    warehouseConnection: Project['warehouseConnection'],
+): boolean | undefined =>
+    warehouseConnection?.type === WarehouseTypes.SNOWFLAKE
+        ? warehouseConnection.disableTimestampConversion
+        : undefined;
+
+/**
+ * Reads `disableTimestampConversion` from an existing project's settings.
+ * The CLI flag is ignored for commands targeting an existing project — the
+ * project settings are the source of truth.
+ */
+export const getProjectDisableTimestampConversion = async (
+    cliValue: boolean | undefined,
+    projectUuid: string,
+): Promise<boolean | undefined> => {
+    if (cliValue !== undefined) {
+        console.error(
+            styles.warning(
+                'Ignoring --disable-timestamp-conversion: this command reads the setting from the project settings.',
+            ),
+        );
+    }
+    try {
+        const project = await lightdashApi<Project>({
+            method: 'GET',
+            url: `/api/v1/projects/${projectUuid}`,
+            body: undefined,
+        });
+        const disableTimestampConversion =
+            getDisableTimestampConversionFromProject(
+                project.warehouseConnection,
+            );
+        GlobalState.debug(
+            `> Using disable-timestamp-conversion=${String(
+                disableTimestampConversion ?? false,
+            )} from project settings`,
+        );
+        return disableTimestampConversion;
+    } catch (e) {
+        GlobalState.debug(
+            `> Could not fetch project settings for timestamp conversion: ${getErrorMessage(
+                e,
+            )}`,
+        );
+        return undefined;
+    }
+};

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -23,6 +23,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { compile, CompileHandlerOptions } from './compile';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { getProjectDisableTimestampConversion } from './timestampConversion';
 
 export const requestValidation = async (
     projectUuid: string,
@@ -86,7 +87,10 @@ export const waitUntilFinished = async (jobUuid: string): Promise<string> => {
     return delay(REFETCH_JOB_INTERVAL).then(() => waitUntilFinished(jobUuid));
 };
 
-export const validateHandler = async (options: ValidateHandlerOptions) => {
+export const validateHandler = async (
+    originalOptions: ValidateHandlerOptions,
+) => {
+    const options = { ...originalOptions };
     GlobalState.setVerbose(options.verbose);
     await checkLightdashVersion();
 
@@ -132,6 +136,12 @@ export const validateHandler = async (options: ValidateHandlerOptions) => {
     } else {
         console.error(`Validating project ${projectUuid}\n`);
     }
+
+    options.disableTimestampConversion =
+        await getProjectDisableTimestampConversion(
+            options.disableTimestampConversion,
+            projectUuid,
+        );
 
     const validationTargets = options.only ? options.only : [];
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -999,10 +999,13 @@ program
         parseUseDbtListOption,
         true,
     )
-    .option(
-        '--disable-timestamp-conversion [true|false]',
-        'Ignored: the setting is read from the project settings.',
-        parseDisableTimestampConversionOption,
+    .addOption(
+        new Option(
+            '--disable-timestamp-conversion [true|false]',
+            '(deprecated) Ignored: the setting is read from the project settings.',
+        )
+            .argParser(parseDisableTimestampConversionOption)
+            .hideHelp(),
     )
     .option(
         '--show-chart-configuration-warnings',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -446,7 +446,6 @@ program
         '--disable-timestamp-conversion [true|false]',
         'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
         parseDisableTimestampConversionOption,
-        false,
     )
     .action(compileHandler);
 
@@ -547,9 +546,8 @@ program
     )
     .option(
         '--disable-timestamp-conversion [true|false]',
-        'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
+        'Disable timestamp conversion to UTC for Snowflake warehouses. Applied when creating the preview project; ignored when updating an existing preview (read from project settings).',
         parseDisableTimestampConversionOption,
-        false,
     )
     .option(
         '--no-warehouse-credentials',
@@ -677,9 +675,8 @@ program
     )
     .option(
         '--disable-timestamp-conversion [true|false]',
-        'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
+        'Disable timestamp conversion to UTC for Snowflake warehouses. Applied when creating the preview project; ignored when updating an existing preview (read from project settings).',
         parseDisableTimestampConversionOption,
-        false,
     )
     .option(
         '--no-warehouse-credentials',
@@ -910,9 +907,8 @@ program
     )
     .option(
         '--disable-timestamp-conversion [true|false]',
-        'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
+        'Disable timestamp conversion to UTC for Snowflake warehouses. Only used when creating a new project with --create; otherwise the setting is read from the project settings.',
         parseDisableTimestampConversionOption,
-        false,
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
     .option(
@@ -1005,9 +1001,8 @@ program
     )
     .option(
         '--disable-timestamp-conversion [true|false]',
-        'Disable timestamp conversion to UTC for Snowflake warehouses. Only use this if your timestamp values are already in UTC.',
+        'Ignored: the setting is read from the project settings.',
         parseDisableTimestampConversionOption,
-        false,
     )
     .option(
         '--show-chart-configuration-warnings',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: SPK-237
Closes: #18506

### Description:

The CLI `--disable-timestamp-conversion` flag is now read automatically from the active project's Snowflake connection settings for `deploy`, `preview`, `start-preview`, and `validate`, so developers no longer need to pass it on every command. The flag is only honored when *creating* a project/preview (and is persisted into the new project's connection); for commands targeting an existing project it is ignored with a warning and the saved project setting is used. The flag continues to work locally for `compile`, and `deploy --create` is unaffected.