### PR TITLE
fix(mcp): surface verified answers in find explores

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -3413,6 +3413,9 @@ export class AiAgentModel {
             artifactVersionUuid: string;
             chartConfig: Record<string, unknown>;
             artifactType: 'chart' | 'dashboard';
+            verifiedQuestion: string | null;
+            title: string | null;
+            description: string | null;
             similarity: number;
         }[]
     > {
@@ -3433,6 +3436,9 @@ export class AiAgentModel {
                     .select(
                         `${AiArtifactVersionsTableName}.ai_artifact_version_uuid`,
                         `${AiArtifactVersionsTableName}.chart_config`,
+                        `${AiArtifactVersionsTableName}.verified_question`,
+                        `${AiArtifactVersionsTableName}.title`,
+                        `${AiArtifactVersionsTableName}.description`,
                         `${AiArtifactsTableName}.artifact_type`,
                         this.database.raw(
                             `1 - (${AiArtifactVersionsTableName}.embedding_vector <=> ?::vector) AS similarity`,
@@ -3484,6 +3490,9 @@ export class AiAgentModel {
                     artifactVersionUuid: row.ai_artifact_version_uuid,
                     chartConfig: row.chart_config,
                     artifactType: row.artifact_type,
+                    verifiedQuestion: row.verified_question,
+                    title: row.title,
+                    description: row.description,
                     similarity: row.similarity,
                 }));
             },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -332,6 +332,20 @@ type AiAgentServiceDependencies = {
     prometheusMetrics?: PrometheusMetrics;
 };
 
+export type RelevantVerifiedAnswer = {
+    artifactVersionUuid: string;
+    chartConfig: Record<string, unknown>;
+    artifactType: 'chart' | 'dashboard';
+    verifiedQuestion: string | null;
+    title: string | null;
+    description: string | null;
+    similarity: number;
+};
+
+export type RelevantVerifiedAnswerContext = {
+    relevantVerifiedAnswers: RelevantVerifiedAnswer[];
+};
+
 // Cache for OAuth response URLs, keyed by "teamId-channelId-messageTs"
 // Used to update the ephemeral "Redirected to Lightdash..." message after OAuth completes
 // Entries auto-expire after 10 minutes
@@ -4649,12 +4663,97 @@ export class AiAgentService extends BaseService {
             return this.aiAgentModel.getArtifactVersionsByUuids(existingRefs);
         }
 
+        const { relevantVerifiedAnswers } =
+            await this.getRelevantVerifiedAnswerContext({
+                organizationUuid,
+                projectUuid,
+                agentUuid,
+                searchQuery,
+                limit: 3,
+            });
+
+        if (relevantVerifiedAnswers.length > 0) {
+            await this.aiAgentModel.recordArtifactReferences({
+                promptUuid,
+                projectUuid,
+                artifactReferences: relevantVerifiedAnswers.map((answer) => ({
+                    artifactVersionUuid: answer.artifactVersionUuid,
+                    similarityScore: answer.similarity,
+                })),
+            });
+
+            const averageSimilarity =
+                relevantVerifiedAnswers.reduce(
+                    (sum, answer) => sum + answer.similarity,
+                    0,
+                ) / relevantVerifiedAnswers.length;
+
+            this.analytics.track<AiAgentArtifactsRetrievedEvent>({
+                event: 'ai_agent.artifacts_retrieved',
+                anonymousId: LightdashAnalytics.anonymousId,
+                properties: {
+                    organizationId: organizationUuid,
+                    projectId: projectUuid,
+                    agentId: agentUuid,
+                    promptId: promptUuid,
+                    artifactCount: relevantVerifiedAnswers.length,
+                    averageSimilarity,
+                },
+            });
+        }
+
+        return relevantVerifiedAnswers;
+    }
+
+    async getRelevantVerifiedAnswerContextForAgent(
+        user: SessionUser,
+        {
+            projectUuid,
+            agentUuid,
+            searchQuery,
+            limit = 3,
+        }: {
+            projectUuid: string;
+            agentUuid: string;
+            searchQuery: string;
+            limit?: number;
+        },
+    ): Promise<RelevantVerifiedAnswerContext> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        await this.getAgent(user, agentUuid, projectUuid);
+
+        return this.getRelevantVerifiedAnswerContext({
+            organizationUuid,
+            projectUuid,
+            agentUuid,
+            searchQuery,
+            limit,
+        });
+    }
+
+    async getRelevantVerifiedAnswerContext({
+        organizationUuid,
+        projectUuid,
+        agentUuid,
+        searchQuery,
+        limit = 3,
+    }: {
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        searchQuery: string;
+        limit?: number;
+    }): Promise<RelevantVerifiedAnswerContext> {
         const embeddingResult = await generateEmbedding(
             searchQuery,
             this.lightdashConfig,
         );
         if (!embeddingResult) {
-            return [];
+            return { relevantVerifiedAnswers: [] };
         }
         const {
             embedding: queryEmbedding,
@@ -4670,38 +4769,10 @@ export class AiAgentService extends BaseService {
                 queryEmbedding,
                 embeddingModelProvider: provider,
                 embeddingModel: modelName,
-                limit: 3,
+                limit,
             });
 
-        if (verifiedArtifacts.length > 0) {
-            await this.aiAgentModel.recordArtifactReferences({
-                promptUuid,
-                projectUuid,
-                artifactReferences: verifiedArtifacts.map((a) => ({
-                    artifactVersionUuid: a.artifactVersionUuid,
-                    similarityScore: a.similarity,
-                })),
-            });
-
-            const averageSimilarity =
-                verifiedArtifacts.reduce((sum, a) => sum + a.similarity, 0) /
-                verifiedArtifacts.length;
-
-            this.analytics.track<AiAgentArtifactsRetrievedEvent>({
-                event: 'ai_agent.artifacts_retrieved',
-                anonymousId: LightdashAnalytics.anonymousId,
-                properties: {
-                    organizationId: organizationUuid,
-                    projectId: projectUuid,
-                    agentId: agentUuid,
-                    promptId: promptUuid,
-                    artifactCount: verifiedArtifacts.length,
-                    averageSimilarity,
-                },
-            });
-        }
-
-        return verifiedArtifacts;
+        return { relevantVerifiedAnswers: verifiedArtifacts };
     }
 
     static createRelevantArtifactsMessage(

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -304,6 +304,9 @@ const makeMcpService = ({
                 ...agent,
             };
         }),
+        getRelevantVerifiedAnswerContextForAgent: jest.fn().mockResolvedValue({
+            relevantVerifiedAnswers: [],
+        }),
     };
 
     const contentVerificationService = {
@@ -617,6 +620,64 @@ describe('MCP async query polling', () => {
             agentUuid: 'agent-uuid',
             agentTags: ['ai'],
             agentSpaceAccess: ['space-uuid'],
+        });
+    });
+
+    it('returns relevant verified answers in find_explores for the active agent', async () => {
+        const relevantVerifiedAnswer = {
+            artifactVersionUuid: 'artifact-version-uuid',
+            artifactType: 'chart',
+            verifiedQuestion: 'What is revenue by month?',
+            title: 'Revenue by month',
+            description: 'Verified monthly revenue trend',
+            similarity: 0.98,
+            chartConfig: {
+                tableName: 'orders',
+                metricQuery: {
+                    metrics: ['orders_revenue'],
+                },
+            },
+        };
+
+        const { aiAgentService } = makeMcpService({
+            context: {
+                projectUuid,
+                projectName: 'Project',
+                agentUuid: 'agent-uuid',
+                agentName: 'Agent',
+                tags: null,
+            },
+            agent: {
+                uuid: 'agent-uuid',
+                name: 'Agent',
+                tags: ['ai'],
+                spaceAccess: [],
+            },
+        });
+        aiAgentService.getRelevantVerifiedAnswerContextForAgent.mockResolvedValue(
+            {
+                relevantVerifiedAnswers: [relevantVerifiedAnswer],
+            },
+        );
+
+        const result = await getToolCallback(McpToolName.FIND_EXPLORES)(
+            { searchQuery: 'Show me revenue by month' },
+            extra,
+        );
+
+        expect(
+            aiAgentService.getRelevantVerifiedAnswerContextForAgent,
+        ).toHaveBeenCalledWith(user, {
+            projectUuid,
+            agentUuid: 'agent-uuid',
+            searchQuery: 'Show me revenue by month',
+        });
+        expect(getTextResult(result)).toContain('<verifiedAnswers count="1">');
+        expect(getTextResult(result)).toContain('Revenue by month');
+        expect(result).toMatchObject({
+            structuredContent: {
+                relevantVerifiedAnswers: [relevantVerifiedAnswer],
+            },
         });
     });
 

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1239,6 +1239,7 @@ export class McpService extends BaseService {
             },
             async (args, extra) => {
                 const ctx = getMcpContext(extra);
+                const { user } = McpService.getAccount(ctx);
 
                 const projectUuid = await this.resolveProjectUuid(ctx);
                 const argsWithProject = { ...args, projectUuid };
@@ -1267,11 +1268,33 @@ export class McpService extends BaseService {
                         experimental_context: { availableExplores },
                     },
                 );
+                const resultText = await McpService.streamToolResult(result);
+                const metadata = await this.getActiveContextMetadata(ctx);
+
+                const verifiedAnswerContext = metadata.agentUuid
+                    ? await this.aiAgentService.getRelevantVerifiedAnswerContextForAgent(
+                          user,
+                          {
+                              projectUuid,
+                              agentUuid: metadata.agentUuid,
+                              searchQuery: args.searchQuery,
+                          },
+                      )
+                    : { relevantVerifiedAnswers: [] };
+
+                const verifiedAnswersText =
+                    verifiedAnswerContext.relevantVerifiedAnswers.length > 0
+                        ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
+                              verifiedAnswerContext.relevantVerifiedAnswers,
+                              null,
+                              2,
+                          )}\n</verifiedAnswers>`
+                        : '';
 
                 return this.buildScopedResponse(
                     ctx,
-                    await McpService.streamToolResult(result),
-                    undefined,
+                    `${resultText}${verifiedAnswersText}`,
+                    verifiedAnswerContext,
                     projectUuid,
                 );
             },

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -17,7 +17,9 @@ exports[`MCP tool contracts matches the current MCP tool and prompt contract sna
 ## Query Building Workflow
 
 0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
-1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
+1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
+   - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
+   - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean
 2. **Get fields**: Use \`find_fields\` for the chosen explore to see all available dimensions and metrics

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -3,7 +3,9 @@ export const MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 ## Query Building Workflow
 
 0. **Route to the right agent first**: After project context is set, call \`route_agent\` at the start of each new user request so subsequent MCP tools inherit the best agent's scope and instructions
-1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models
+1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
+   - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
+   - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
    - Review the \`topMatchingFields\` to understand which explores match
    - If multiple explores match with similar scores, ask the user which data source they mean
 2. **Get fields**: Use \`find_fields\` for the chosen explore to see all available dimensions and metrics


### PR DESCRIPTION
## Summary
- surface relevant verified answers through MCP `find_explores` when an active agent is set
- share the verified-answer context lookup with the existing web agent path
- keep web-specific prompt reference recording and analytics in the web retrieval wrapper

## Root cause
MCP exposed verified questions in agent context, but did not retrieve or return the verified answer artifact configs that web agents inject before answering.

## Validation
- `git diff --check`
- `pnpm -F backend test -- --runInBand src/ee/services/McpService/McpService.queryPolling.test.ts src/ee/services/McpService/mcpToolContracts.snapshot.test.ts`

Fixes #23755