### PR TITLE
refactor(ai): carry AI custom metrics on the metric query

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -91,7 +91,6 @@ import {
     type AiPromptContextInput,
     type SessionUser,
     type SuggestionValidationCatalog,
-    type TransformedCustomMetric,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { AllMiddlewareArgs, App, SlackEventMiddlewareArgs } from '@slack/bolt';
@@ -1477,7 +1476,6 @@ export class AiAgentService extends BaseService {
         projectUuid: string,
         metricQuery: AiMetricQueryWithFilters,
         vizConfig: AiAgentVizConfig['config'],
-        customMetrics?: TransformedCustomMetric[] | null,
     ) {
         const explore = await this.getExplore(
             user,
@@ -1498,7 +1496,7 @@ export class AiAgentService extends BaseService {
         );
 
         const populatedCustomMetrics = populateCustomMetricsSQL(
-            customMetrics ?? metricQuery.additionalMetrics,
+            metricQuery.customMetrics,
             explore,
         );
         const metricQueryWithCustomMetrics = {
@@ -3816,7 +3814,6 @@ export class AiAgentService extends BaseService {
             projectUuid,
             parsedVizConfig.metricQuery,
             artifact.chartConfig,
-            parsedVizConfig.customMetrics,
         );
 
         const metadata = {
@@ -3952,7 +3949,6 @@ export class AiAgentService extends BaseService {
             projectUuid,
             parsedVizConfig.metricQuery,
             chartConfig,
-            parsedVizConfig.customMetrics,
         );
 
         const metadata = {

--- a/packages/backend/src/ee/services/ai/tools/runContentQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runContentQuery.ts
@@ -108,6 +108,7 @@ export const getRunContentQuery = ({
                     sorts: [],
                     tableCalculations: [],
                     additionalMetrics: [],
+                    customMetrics: null,
                     ...rawMetricQuery,
                     exploreName: rawMetricQuery.exploreName ?? source.tableName,
                     filters: (rawMetricQuery.filters ?? {}) as Filters,

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -253,6 +253,7 @@ export const getRunQuery = ({
                     ),
                     filters: queryTool.queryConfig.filters,
                     additionalMetrics: populatedCustomMetrics,
+                    customMetrics: queryTool.queryConfig.customMetrics,
                     tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
                         queryTool.queryConfig.tableCalculations,
                     ),

--- a/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
@@ -125,6 +125,7 @@ export const getRunSavedChart = ({
                     limit: getValidAiQueryLimit(metricQuery.limit, maxLimit),
                     tableCalculations: metricQuery.tableCalculations,
                     additionalMetrics: metricQuery.additionalMetrics ?? [],
+                    customMetrics: null,
                     filters: metricQuery.filters,
                 };
 

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -65,5 +65,6 @@ export const metricQueryTableViz = ({
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
     additionalMetrics: filterAggregationCustomMetrics(customMetrics),
+    customMetrics: customMetrics ?? null,
     tableCalculations,
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -91,6 +91,7 @@ export const metricQueryTimeSeriesViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: filterAggregationCustomMetrics(customMetrics),
+        customMetrics: customMetrics ?? null,
         tableCalculations,
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -98,6 +98,7 @@ export const metricQueryVerticalBarViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: filterAggregationCustomMetrics(customMetrics),
+        customMetrics: customMetrics ?? null,
         // TODO: add tableCalculations
         tableCalculations,
     };

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -1,5 +1,6 @@
 import type { Filters } from '../../types/filter';
 import type { AdditionalMetric, MetricQuery } from '../../types/metricQuery';
+import type { TransformedCustomMetric } from './schemas/customMetrics';
 import type {
     ToolRunQueryArgs,
     ToolTableVizArgs,
@@ -27,7 +28,11 @@ export type AiMetricQuery = Pick<
     | 'exploreName'
     | 'tableCalculations'
 > & {
+    // Aggregation custom metrics as additional-metric definitions, used for
+    // field-existence validation.
     additionalMetrics: Omit<AdditionalMetric, 'sql'>[];
+    // Full custom-metric set (incl. periodComparison) used to populate SQL.
+    customMetrics: TransformedCustomMetric[] | null;
 };
 
 export type AiMetricQueryWithFilters = AiMetricQuery & {

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -39,7 +39,6 @@ export const parseVizConfig = (
             type: AiResultType.VERTICAL_BAR_RESULT,
             vizTool,
             metricQuery,
-            customMetrics: vizTool.customMetrics ?? null,
         } as const;
     }
 
@@ -60,7 +59,6 @@ export const parseVizConfig = (
             type: AiResultType.TIME_SERIES_RESULT,
             vizTool,
             metricQuery,
-            customMetrics: vizTool.customMetrics ?? null,
         } as const;
     }
 
@@ -81,7 +79,6 @@ export const parseVizConfig = (
             type: AiResultType.TABLE_RESULT,
             vizTool,
             metricQuery,
-            customMetrics: vizTool.customMetrics ?? null,
         } as const;
     }
 
@@ -102,9 +99,13 @@ export const parseVizConfig = (
                 maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
             ),
             filters: vizTool.queryConfig.filters,
+            // additionalMetrics is filtered to aggregations (for field
+            // validation); customMetrics keeps the full set incl.
+            // periodComparison for SQL population.
             additionalMetrics: filterAggregationCustomMetrics(
                 vizTool.queryConfig.customMetrics,
             ),
+            customMetrics: vizTool.queryConfig.customMetrics,
             tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
                 vizTool.queryConfig.tableCalculations,
             ),
@@ -114,10 +115,6 @@ export const parseVizConfig = (
             type: AiResultType.QUERY_RESULT,
             vizTool,
             metricQuery,
-            // Full custom-metric set (incl. periodComparison) for SQL
-            // population; metricQuery.additionalMetrics is filtered to
-            // aggregations only via filterAggregationCustomMetrics.
-            customMetrics: vizTool.queryConfig.customMetrics,
         } as const;
     }
 


### PR DESCRIPTION
Stacked on #24263.

Follow-up cleanup split out of #24261 (kept off that PR deliberately). `parseVizConfig` exposed a top-level `customMetrics` sibling next to `metricQuery`, and `executeAsyncAiMetricQuery` took the full custom-metric set as a separate 5th argument — both because the AI metric query had no home for the full set (incl. `periodComparison`) alongside the aggregation-only `additionalMetrics`.

This threads it onto the metric query itself:

- `AiMetricQuery` gains `customMetrics: TransformedCustomMetric[] | null` — the **full** set used for SQL population, distinct from `additionalMetrics` (`Omit<AdditionalMetric,'sql'>[]`, the aggregation subset used for field-existence validation).
- All `AiMetricQueryWithFilters` constructors set it (the 3 viz builders, `parseVizConfig`, `runQuery`, `runSavedChart`, `runContentQuery`).
- `parseVizConfig` drops the `customMetrics` sibling; the two `AiAgentService` call sites read `parsedVizConfig.metricQuery.customMetrics`.
- `executeAsyncAiMetricQuery` drops its 5th arg and reads `metricQuery.customMetrics` (the redundant `?? additionalMetrics` fallback is gone — `populateCustomMetricsSQL` accepts `null`).

### Scope / follow-up

This unifies the **artifact re-render** path (`executeAsyncAiMetricQuery`). The **live** execution path (`runAsyncQuery` in `AiAgentToolsService`) still populates from `metricQuery.additionalMetrics` and ignores its dead 2nd `_additionalMetrics` arg. Fully collapsing custom/additional metrics into one representation means unifying those two populate paths — left as a separate effort.
