### PR TITLE
fix: use textarea for OAuth redirect URIs in edit modal

### DIFF
--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/EditOAuthClientModal.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/EditOAuthClientModal.tsx
@@ -1,5 +1,5 @@
 import { type OAuthClientSummary } from '@lightdash/common';
-import { Button, Stack, TextInput } from '@mantine-8/core';
+import { Button, Stack, Textarea, TextInput } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { IconPencil } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -77,11 +77,13 @@ export const EditOAuthClientModal: FC<{
                         required
                         {...form.getInputProps('clientName')}
                     />
-                    <TextInput
+                    <Textarea
                         label="Redirect URI"
                         disabled={isLoading}
+                        placeholder="https://myapp.example.com/callback"
                         required
                         description="One URI per line for multiple redirect URIs"
+                        minRows={3}
                         {...form.getInputProps('redirectUris')}
                     />
                 </Stack>


### PR DESCRIPTION
### Description

The OAuth application **edit** modal used a single-line `TextInput` for redirect URIs, while the form logic joins and splits URIs on newlines (`join('\n')` / `split('\n')`). HTML `<input>` elements strip newlines, so multiple callback URLs appeared concatenated in the edit form. Saving from that state could overwrite the stored `redirect_uris` array with a single invalid URI.

The **create** modal already uses a `Textarea` with "one URI per line" — this change makes the edit modal match it (`placeholder`, `description`, `minRows={3}`). No backend or API changes; validation and submit logic are unchanged.

### How to verify

1. Organization settings → OAuth applications → create an app with two or more redirect URIs.
2. Open **Edit** — each URI should appear on its own line.
3. Save without changes — both URIs should remain in the table/API response.
4. Add or remove a URI, save — changes should persist correctly.

---

Duplicate of community contribution #24279 by @yu-iskw, re-pushed to an internal branch so it can run full CI and be merged. Original author credited via co-author trailer.

Closes: NA