### PR TITLE
perf(dashboard): parallelize views/tiles/tabs/verification queries

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -884,12 +884,12 @@ export class DashboardModel {
             throw new NotFoundError('Dashboard not found');
         }
 
-        const [view] = await this.database(DashboardViewsTableName)
+        const viewQuery = this.database(DashboardViewsTableName)
             .select('*')
             .orderBy(`${DashboardViewsTableName}.created_at`, 'desc')
             .where(`dashboard_version_id`, dashboard.dashboard_version_id);
 
-        const tiles = await this.database(DashboardTilesTableName)
+        const tilesQuery = this.database(DashboardTilesTableName)
             .select<
                 {
                     x_offset: number;
@@ -1078,7 +1078,7 @@ export class DashboardModel {
                 },
             ]);
 
-        const tabs = await this.database(DashboardTabsTableName)
+        const tabsQuery = this.database(DashboardTabsTableName)
             .select<DashboardTab[]>(
                 `${DashboardTabsTableName}.name`,
                 `${DashboardTabsTableName}.uuid`,
@@ -1094,6 +1094,19 @@ export class DashboardModel {
                 dashboard.dashboard_id,
             );
 
+        const verificationQuery = this.contentVerificationModel?.getByContent(
+            ContentType.DASHBOARD,
+            dashboard.dashboard_uuid,
+        );
+
+        const [[view], tiles, tabs, verificationResult] = await Promise.all([
+            viewQuery,
+            tilesQuery,
+            tabsQuery,
+            verificationQuery,
+        ]);
+        const verification = verificationResult ?? null;
+
         // A version may have no dashboard_views row (e.g. legacy or partially
         // written data). Guard the backfill — the return below already defaults
         // `filters` when `view` is absent.
@@ -1101,12 +1114,6 @@ export class DashboardModel {
             view.filters.tableCalculations =
                 view.filters.tableCalculations || [];
         }
-
-        const verification =
-            (await this.contentVerificationModel?.getByContent(
-                ContentType.DASHBOARD,
-                dashboard.dashboard_uuid,
-            )) ?? null;
 
         return {
             organizationUuid: dashboard.organization_uuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: SPK-502
Relates: SPK-489

### Description:

`DashboardModel.getByIdOrSlug` (the page-spinner root request, `GET /api/v2/projects/{p}/dashboards/{d}`) ran 5 sequential queries. After the header query returns `dashboard_version_id`, the next four — views/filters, tiles, tabs, and content verification — are all independent, yet ran as bare sequential `await`s. This wraps those four in a single `Promise.all`, collapsing 4 sequential round-trips into 1 (−3 on the critical path).

### Analytics data

Server-side execution time of the four queries that were running sequentially:

| # | Query | avg | p50 | p95 |
|---|-------|-----|-----|-----|
| 1 | views/filters (`dashboard_views`) | 20.2 ms | 8.5 ms | 72.3 ms |
| 2 | tiles + tile-type joins (`dashboard_tiles`) | **51.1 ms** | **24.0 ms** | **197.1 ms** |
| 3 | tabs (`dashboard_tabs`) | 34.1 ms | 19.7 ms | 114.7 ms |
| 4 | verification (`content_verification`) | 15.8 ms | 3.9 ms | 69.4 ms |

Sequentially the endpoint pays the **sum**; with `Promise.all` it pays the **max** (the tiles query dominates):

| | Sequential (sum) | Parallel (≈ max) | Saved |
|---|---|---|---|
| avg | ~121 ms | ~51 ms | **~70 ms (−58%)** |
| p50 | ~56 ms | ~24 ms | **~32 ms (−57%)** |

The new floor is the tiles query (~51 ms avg), the slowest of the four — a good follow-up target.
