### PR TITLE
perf(query): reuse known organizationUuid in executeAsyncQuery

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -110,6 +110,14 @@ module.exports = {
                 '@typescript-eslint/no-unsafe-assignment': 'off',
                 '@typescript-eslint/no-unsafe-call': 'off',
                 'no-restricted-imports': 'off',
+                // Allow bracket access to private/protected members for testing
+                '@typescript-eslint/dot-notation': [
+                    'error',
+                    {
+                        allowPrivateClassPropertyAccess: true,
+                        allowProtectedClassPropertyAccess: true,
+                    },
+                ],
             },
         },
         {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -523,7 +523,7 @@ describe('AsyncQueryService', () => {
             );
 
             // WHEN: executeAsyncQuery is called
-            const result = await serviceWithCache.executeAsyncQuery(
+            const result = await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -616,7 +616,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(undefined);
 
             // WHEN: executeAsyncQuery is called
-            const result = await serviceWithCache.executeAsyncQuery(
+            const result = await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -716,7 +716,7 @@ describe('AsyncQueryService', () => {
                 'runAsyncWarehouseQuery',
             ).mockResolvedValue(undefined);
 
-            await serviceWithCache.executeAsyncQuery(
+            await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -772,7 +772,7 @@ describe('AsyncQueryService', () => {
                 'runAsyncWarehouseQuery',
             ).mockResolvedValue(undefined);
 
-            await serviceWithCache.executeAsyncQuery(
+            await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -830,7 +830,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(undefined);
 
             // WHEN: executeAsyncQuery is called with invalidateCache: true
-            const result = await serviceWithCache.executeAsyncQuery(
+            const result = await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -918,7 +918,7 @@ describe('AsyncQueryService', () => {
                 'runAsyncWarehouseQuery',
             ).mockResolvedValue(undefined);
 
-            await serviceWithCache.executeAsyncQuery(
+            await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -980,7 +980,7 @@ describe('AsyncQueryService', () => {
                 .mockResolvedValue(undefined);
 
             // WHEN: executeAsyncQuery is called
-            const result = await serviceWithoutCache.executeAsyncQuery(
+            const result = await serviceWithoutCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1071,7 +1071,7 @@ describe('AsyncQueryService', () => {
             );
 
             // WHEN: executeAsyncQuery is called with missing parameter references
-            const result = await serviceWithCache.executeAsyncQuery(
+            const result = await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1143,7 +1143,7 @@ describe('AsyncQueryService', () => {
                 .spyOn(service, 'runAsyncPreAggregateQuery')
                 .mockResolvedValue(undefined);
 
-            await service.executeAsyncQuery(
+            await service['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1212,7 +1212,7 @@ describe('AsyncQueryService', () => {
                 'runAsyncPreAggregateQuery',
             );
 
-            await service.executeAsyncQuery(
+            await service['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1293,7 +1293,7 @@ describe('AsyncQueryService', () => {
                 'enqueuePreAggregateQuery',
             );
 
-            await service.executeAsyncQuery(
+            await service['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1377,7 +1377,7 @@ describe('AsyncQueryService', () => {
                 'enqueueWarehouseQuery',
             );
 
-            await service.executeAsyncQuery(
+            await service['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -1489,7 +1489,7 @@ describe('AsyncQueryService', () => {
                     },
                     availableParameterDefinitions: {},
                 });
-            service.executeAsyncQuery = jest.fn().mockResolvedValue({
+            service['executeAsyncQuery'] = jest.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',
                 cacheMetadata: {
                     cacheHit: false,
@@ -1510,7 +1510,7 @@ describe('AsyncQueryService', () => {
                 pivotConfiguration: undefined,
             });
 
-            expect(service.executeAsyncQuery).toHaveBeenCalledWith(
+            expect(service['executeAsyncQuery']).toHaveBeenCalledWith(
                 expect.objectContaining({
                     preAggregationRoute: {
                         sourceExploreName: 'valid_explore',
@@ -2533,7 +2533,7 @@ describe('AsyncQueryService', () => {
                 .spyOn(serviceWithCache, 'runAsyncWarehouseQuery')
                 .mockResolvedValue(undefined);
 
-            await serviceWithCache.executeAsyncQuery(
+            await serviceWithCache['executeAsyncQuery'](
                 {
                     account: sessionAccount,
                     projectUuid,
@@ -2817,7 +2817,7 @@ describe('AsyncQueryService', () => {
             jest.spyOn(projectModel, 'getExploreFromCache').mockResolvedValue(
                 materializationExplore,
             );
-            service.executeAsyncQuery = jest.fn().mockResolvedValue({
+            service['executeAsyncQuery'] = jest.fn().mockResolvedValue({
                 queryUuid: 'queryUuid',
                 cacheMetadata: {
                     cacheHit: false,
@@ -2840,19 +2840,19 @@ describe('AsyncQueryService', () => {
             });
 
             expect(service.getUserAttributes).not.toHaveBeenCalled();
-            expect(service.executeAsyncQuery).toHaveBeenCalledWith(
+            expect(service['executeAsyncQuery']).toHaveBeenCalledWith(
                 expect.objectContaining({
                     sql: expect.stringContaining("'EMEA', 'APAC'"),
                 }),
                 expect.any(Object),
             );
-            expect(service.executeAsyncQuery).toHaveBeenCalledWith(
+            expect(service['executeAsyncQuery']).toHaveBeenCalledWith(
                 expect.objectContaining({
                     sql: expect.stringContaining('materialize@acme.com'),
                 }),
                 expect.any(Object),
             );
-            expect(service.executeAsyncQuery).not.toHaveBeenCalledWith(
+            expect(service['executeAsyncQuery']).not.toHaveBeenCalledWith(
                 expect.objectContaining({
                     sql: expect.stringContaining('viewer-region'),
                 }),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3986,7 +3986,7 @@ export class AsyncQueryService extends ProjectService {
         );
     }
 
-    async executeAsyncQuery(
+    private async executeAsyncQuery(
         // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
         args: ExecuteAsyncMetricQueryArgs & {
             queryTags: RunQueryTags;
@@ -4002,14 +4002,17 @@ export class AsyncQueryService extends ProjectService {
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
             availableParameterDefinitions?: ParameterDefinitions;
+            // Preloaded org from the caller (e.g. saved chart) to skip a redundant getSummary
+            organizationUuid?: string;
         },
         requestParameters: ExecuteAsyncQueryRequestParams,
     ): Promise<ExecuteAsyncQueryReturn> {
         assertIsAccountWithOrg(args.account);
 
-        const { organizationUuid } = await this.projectModel.getSummary(
-            args.projectUuid,
-        );
+        const organizationUuid =
+            args.organizationUuid ??
+            (await this.projectModel.getSummary(args.projectUuid))
+                .organizationUuid;
         const auditedAbility = this.createAuditedAbility(args.account);
         const isForbidden =
             auditedAbility.cannot(
@@ -4244,6 +4247,7 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 metricQuery,
                 projectUuid,
+                organizationUuid,
                 explore,
                 context,
                 queryTags,
@@ -4488,6 +4492,7 @@ export class AsyncQueryService extends ProjectService {
                 account,
                 metricQuery,
                 projectUuid,
+                organizationUuid,
                 explore,
                 context,
                 queryTags,
@@ -4772,6 +4777,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 account,
                 projectUuid,
+                organizationUuid: savedChartOrganizationUuid,
                 explore,
                 context,
                 queryTags,
@@ -5230,6 +5236,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 account,
                 projectUuid,
+                organizationUuid,
                 explore,
                 metricQuery: metricQueryWithLimit,
                 context,
@@ -5549,6 +5556,7 @@ export class AsyncQueryService extends ProjectService {
                     account,
                     metricQuery: underlyingDataMetricQueryWithLimit,
                     projectUuid,
+                    organizationUuid,
                     explore,
                     context,
                     queryTags,
@@ -5636,6 +5644,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 account,
                 projectUuid,
+                organizationUuid,
                 explore: virtualView,
                 queryTags,
                 metricQuery,
@@ -6042,6 +6051,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 account,
                 projectUuid,
+                organizationUuid: sqlChart.organization.organizationUuid,
                 explore: virtualView,
                 queryTags,
                 metricQuery,
@@ -6189,6 +6199,7 @@ export class AsyncQueryService extends ProjectService {
             {
                 account,
                 projectUuid,
+                organizationUuid: savedChart.organization.organizationUuid,
                 explore: virtualView,
                 queryTags,
                 metricQuery,


### PR DESCRIPTION
Closes: SPK-500

### Description:

`executeAsyncQuery` re-fetched `organizationUuid` via `projectModel.getSummary` solely for its CASL authorization check, even though every caller already knows the org (from the loaded chart entity, or from an earlier `getSummary`). This plumbs the known `organizationUuid` in as an optional preloaded arg and skips the redundant lookup when it's provided, removing a Postgres round-trip on the dashboard chart critical path (and the other execute paths). The method is made `private` since it has no controller/service callers, confining the trust boundary for the preloaded org to this file where all callers derive it from the project. Tests reach the now-private method via bracket access, enabled by a scoped `dot-notation` ESLint override for test files.