### PR TITLE
perf: fire-and-forget dashboard view + loaded analytics in GET dashboard

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -521,10 +521,14 @@ export class DashboardService
             );
         }
 
-        await this.analyticsModel.addDashboardViewEvent(
-            dashboard.uuid,
-            user.userUuid,
-        );
+        void this.analyticsModel
+            .addDashboardViewEvent(dashboard.uuid, user.userUuid)
+            .catch((err) => {
+                this.logger.warn('dashboard view event failed', {
+                    dashboardUuid: dashboard.uuid,
+                    err: err instanceof Error ? err.message : String(err),
+                });
+            });
 
         this.analytics.track({
             event: 'dashboard.view',
@@ -539,14 +543,12 @@ export class DashboardService
 
         // Wide observability event for diagnosing stale dashboard filter references
         // (e.g. PROD-5931). Best-effort — never block the request on logging errors.
-        try {
-            await this.logDashboardLoadedEvent(dashboard);
-        } catch (err) {
+        void this.logDashboardLoadedEvent(dashboard).catch((err) => {
             this.logger.warn('dashboard.loaded log failed', {
                 dashboardUuid: dashboard.uuid,
                 err: err instanceof Error ? err.message : String(err),
             });
-        }
+        });
 
         return dashboard;
     }


### PR DESCRIPTION
Closes: SPK-501

### Description:

`GET /api/v2/projects/{p}/dashboards/{d}` is the page-spinner root request, yet it `await`s two analytics operations that have no effect on the response. This `void`s both `addDashboardViewEvent` (a `views_count++` write transaction) and `logDashboardLoadedEvent` (a best-effort observability log that also drags `getCachedExploreNames` + `getInfoForAvailableFilters` onto the blocking path), each with a `.catch` that logs errors. Errors were already swallowed, so semantics are unchanged — only latency, removing 1 write transaction + 2 queries from the critical path. Same pattern as the existing fire-and-forget chart view event.