### PR TITLE
perf: replace correlated subquery in getInfoForAvailableFilters with lateral join

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -1950,10 +1950,19 @@ export class SavedChartModel {
                     `${SavedChartsTableName}.space_id`,
                 );
             })
-            .innerJoin(
-                SavedChartVersionsTableName,
-                `${SavedChartsTableName}.saved_query_id`,
-                'saved_queries_versions.saved_query_id',
+            .joinRaw(
+                `inner join lateral (
+                    select sqv.explore_name
+                    from ?? as sqv
+                    where sqv.saved_query_id = ??.saved_query_id
+                    order by sqv.saved_queries_version_id desc
+                    limit 1
+                ) as ?? on true`,
+                [
+                    SavedChartVersionsTableName,
+                    SavedChartsTableName,
+                    SavedChartVersionsTableName,
+                ],
             )
             .leftJoin(
                 'projects',
@@ -1964,15 +1973,6 @@ export class SavedChartModel {
                 OrganizationTableName,
                 'organizations.organization_id',
                 'projects.organization_id',
-            )
-            .where(
-                // filter by last version
-                `saved_queries_version_id`,
-                this.database.raw(`(select saved_queries_version_id
-                                           from ${SavedChartVersionsTableName}
-                                           where ${SavedChartsTableName}.saved_query_id = ${SavedChartVersionsTableName}.saved_query_id
-                                           order by ${SavedChartVersionsTableName}.created_at desc
-                                           limit 1)`),
             )
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .whereNull(`${SpaceTableName}.deleted_at`);


### PR DESCRIPTION
Closes: SPK-504

### Description:

`SavedChartModel.getInfoForAvailableFilters` filtered to the latest chart version with a correlated subquery (`WHERE saved_queries_version_id = (SELECT … ORDER BY created_at DESC LIMIT 1)`), which Postgres re-evaluated once per joined row — so a dashboard with N chart tiles incurred N implicit sub-plans. This replaces it with an `INNER JOIN LATERAL` that fetches the latest version per chart in a single indexed pass, ordered by `saved_queries_version_id DESC` to reuse the existing `(saved_query_id, saved_queries_version_id DESC)` index. Semantics are unchanged: it still returns one row per chart at its latest version and still excludes charts with no versions. Benefits both endpoints that call this method (`GET dashboards/{uuid}` and `POST dashboards/availableFilters`).