### PR TITLE
fix(echarts): restore native sub-day time-axis ticks (GLITCH-502)

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -897,7 +897,7 @@ describe('getSubDayTimeAxisConfig', () => {
         expect(result).toEqual({});
     });
 
-    test('uses raw UTC instants as custom tick values across DST fall-back', () => {
+    test('leaves tick placement to ECharts (emits no customValues)', () => {
         const result = getSubDayTimeAxisConfig(
             axisId,
             createRows([
@@ -909,15 +909,32 @@ describe('getSubDayTimeAxisConfig', () => {
             subDayField('Europe/London'),
         );
 
-        expect(result.axisTick?.customValues).toEqual([
-            Date.parse('2024-10-26T23:00:00.000Z'),
-            Date.parse('2024-10-27T00:00:00.000Z'),
-            Date.parse('2024-10-27T01:00:00.000Z'),
-            Date.parse('2024-10-27T02:00:00.000Z'),
+        // No pinned ticks: ECharts runs its native adaptive tick algorithm.
+        expect((result as { axisTick?: unknown }).axisTick).toBeUndefined();
+        expect(
+            (result.axisLabel as { customValues?: unknown } | undefined)
+                ?.customValues,
+        ).toBeUndefined();
+        // We still relabel ticks in-zone via the formatter.
+        expect(typeof result.axisLabel?.formatter).toBe('function');
+    });
+
+    test('stays inert off the flag hot path (no override when not sub-day-format)', () => {
+        const rows = createRows([
+            '2024-10-26T23:00:00.000Z',
+            '2024-10-27T02:00:00.000Z',
         ]);
-        expect(result.axisLabel?.customValues).toEqual(
-            result.axisTick?.customValues,
-        );
+        // Flag off ⇒ resolveAxisTimezone returns timeAxisField undefined.
+        expect(getSubDayTimeAxisConfig(axisId, rows, undefined)).toEqual({});
+        // Non-sub-day grain (shift mode) ⇒ no sub-day override either.
+        expect(
+            getSubDayTimeAxisConfig(axisId, rows, {
+                fieldId: axisId,
+                timezone: 'Europe/London',
+                flipAxes: false,
+                mode: 'shift',
+            }),
+        ).toEqual({});
     });
 
     test('clears the leveled rich-text style left by the default formatter', () => {
@@ -928,24 +945,6 @@ describe('getSubDayTimeAxisConfig', () => {
         );
 
         expect(result.axisLabel?.rich).toBeUndefined();
-    });
-
-    test('preserves fractional-offset bucket boundaries for hourly ticks', () => {
-        const result = getSubDayTimeAxisConfig(
-            axisId,
-            createRows([
-                '2024-01-01T00:15:00.000Z',
-                '2024-01-01T01:15:00.000Z',
-                '2024-01-01T02:15:00.000Z',
-            ]),
-            subDayField('Asia/Kathmandu'),
-        );
-
-        expect(result.axisTick?.customValues).toEqual([
-            Date.parse('2024-01-01T00:15:00.000Z'),
-            Date.parse('2024-01-01T01:15:00.000Z'),
-            Date.parse('2024-01-01T02:15:00.000Z'),
-        ]);
     });
 
     const getFormatter = (timezone: string, raw: string) =>

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1510,29 +1510,13 @@ type CategoryDateAxisConfig = {
     boundaryGap?: boolean;
 };
 
-// Sub-day axes pin ticks/labels to the raw UTC bucket instants and relabel them
-// in-zone, so both configs are keyed on the same `customValues` instant list.
+// Sub-day axes relabel ticks in the resolved zone but leave tick placement to
+// ECharts' native time-axis algorithm (GLITCH-502).
 type SubDayTimeAxisConfig = {
-    axisTick?: { customValues: number[] };
     axisLabel?: {
-        customValues: number[];
         rich: undefined;
         formatter: (value: number) => string;
     };
-};
-
-const getAxisInstantMs = (raw: unknown): number | undefined => {
-    if (typeof raw === 'number') {
-        return Number.isFinite(raw) ? raw : undefined;
-    }
-    if (raw instanceof Date) {
-        return Number.isFinite(raw.getTime()) ? raw.getTime() : undefined;
-    }
-    if (typeof raw !== 'string') {
-        return undefined;
-    }
-    const parsed = dayjs.utc(raw).valueOf();
-    return Number.isFinite(parsed) ? parsed : undefined;
 };
 
 // Sub-day axes are positioned by raw UTC instant, so ECharts (useUTC) would
@@ -1552,7 +1536,9 @@ const formatSubDayAxisLabel = (value: number, timezone: string): string => {
 };
 
 // resolveAxisTimezone decides which field qualifies and forwards it as a
-// sub-day-format timeAxisField; here we only build its tick/label config.
+// sub-day-format timeAxisField. Bars are positioned by raw UTC instant, so this
+// is labels-only: render each tick in the resolved zone and let ECharts place
+// the ticks natively (GLITCH-502). DST continuity is untouched.
 export const getSubDayTimeAxisConfig = (
     axisId: string | undefined,
     rows: ResultRow[] | undefined,
@@ -1567,22 +1553,8 @@ export const getSubDayTimeAxisConfig = (
         return {};
     }
 
-    const customValues = Array.from(
-        new Set(
-            rows
-                .map((row) => getAxisInstantMs(row[axisId]?.value.raw))
-                .filter((value): value is number => value !== undefined),
-        ),
-    ).sort((a, b) => a - b);
-
-    if (!customValues.length) {
-        return {};
-    }
-
     return {
-        axisTick: { customValues },
         axisLabel: {
-            customValues,
             // Drop the rich-text style ECharts' leveled formatter leaves behind.
             rich: undefined,
             formatter: (value: number) =>
@@ -2245,7 +2217,6 @@ const getEchartAxes = ({
                     ...getAxisTickStyle(
                         validCartesianConfig?.eChartsConfig?.showAxisTicks,
                     ),
-                    ...bottomAxisSubDayConfig.axisTick,
                 },
                 // Spread last so a category-date axisTick keeps replacing the
                 // tick style (sub-day time axes never set extraConfig.axisTick).
@@ -2347,7 +2318,6 @@ const getEchartAxes = ({
                     ...getAxisTickStyle(
                         validCartesianConfig?.eChartsConfig?.showAxisTicks,
                     ),
-                    ...leftAxisSubDayConfig.axisTick,
                 },
                 // Spread last so a category-date axisTick keeps replacing the
                 // tick style (sub-day time axes never set extraConfig.axisTick).


### PR DESCRIPTION
## What & why

Closes: **GLITCH-502** (follow-up to GLITCH-449)

GLITCH-449 fixed sub-day (SECOND/MINUTE/HOUR) DST breakage by positioning bars at raw UTC instants and pinning the axis ticks/labels to **every distinct bucket instant** via `axisTick.customValues` + `axisLabel.customValues`. Side effect: ticks became static — one per bucket, no adaptive density, no re-densification on zoom.

The real GLITCH-449 acceptance criteria only required DST continuity (no jump / duplicated / missing hour at spring-forward and fall-back). The per-bucket tick pinning was self-imposed and is the thing this PR removes.

## Change

Subtractive, one file (`useEchartsCartesianConfig.ts`). In the `sub-day-format` branch of `getSubDayTimeAxisConfig`, drop both `customValues` and keep only the in-zone label formatter:

- ECharts runs its **native adaptive time-axis tick algorithm** again (axis is already raw-UTC + `useUTC: true`).
- `formatSubDayAxisLabel` relabels each native tick into the resolved project zone.
- Bar positions (raw UTC instants) and the `resolveAxisTimezone` routing are untouched, so **DST continuity is preserved**.
- Also removes the per-render O(rows) `customValues` scan.

This is the `useUTC` + label-formatter path the ticket itself suggested.

## Gating (unchanged)

The flag gate is upstream in `resolveAxisTimezone` → `detectTimezoneShiftedField`, which early-returns when `resolvedTimezone` is null/`UTC`. With `enable-timezone-support` **off**, `timeAxisField` is `undefined`, so `getSubDayTimeAxisConfig` returns `{}` and ECharts' default UTC ticks/labels render — byte-identical to pre-feature. Verified empirically: with the flag off, `formatSubDayAxisLabel` is invoked **0 times** (instrumented, then reverted).

## Test plan

- Unit: `useEchartsCartesianConfig.test.ts` + `timezoneShift.test.ts` — 121 pass. Retired the `customValues`-equal-bucket-instants tests, added a native-ticks assertion (`axisTick` undefined, formatter present) and a flag-off gating test.
- Live (BigQuery `timezone_test`, HOUR grain, America/New_York): native adaptive ticks with the flag on; identical tick density + format with the flag off (only the label timezone differs); DST fall-back (Nov 3) keeps the two folded 01:00 hours as distinct bars at raw-UTC positions.

## Screenshots

| | Flag OFF | Flag ON |
|---|---|---|
| **Before fix** | <img width="1200" height="1133" alt="before-fix-flagOFF" src="https://github.com/user-attachments/assets/5c2b23ed-a279-4299-ae2d-730557f7b396" /> | <img width="1200" height="1133" alt="before-fix-flagON" src="https://github.com/user-attachments/assets/eb2454f9-6693-4e7e-bba1-fafd3ebbfaac" /> |
| **After fix** | <img width="1200" height="1133" alt="after-fix-flagOFF" src="https://github.com/user-attachments/assets/c23ee44d-bbda-4e85-9c7c-e00ff524c597" /> | <img width="1200" height="1133" alt="after-fix-flagON" src="https://github.com/user-attachments/assets/45252d5f-87a9-407f-87c2-8f32b2c67d38" /> |
