### PR TITLE
fix(pivot): only top-align merged dimension cells that span more than one row

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
+++ b/packages/frontend/src/components/common/PivotTable/PivotTable.module.css
@@ -45,4 +45,7 @@
 
 .mergedDimCell {
     vertical-align: top;
+    /* nudge the top-aligned value off the border so it lines up with the first
+       row's centered content (cells are 32px tall) */
+    padding-top: var(--mantine-spacing-xs);
 }

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -1896,7 +1896,11 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 : undefined
                                         }
                                         className={
-                                            rowSpanMerge
+                                            // Only top-align cells that actually
+                                            // span >1 row; single-row blocks stay
+                                            // centered so they don't shift up.
+                                            rowSpanMerge &&
+                                            rowSpanMerge.rowSpan > 1
                                                 ? `${pivotStyles.mergedDimCell}${
                                                       stickyCellProps.className
                                                           ? ` ${stickyCellProps.className}`


### PR DESCRIPTION
Closes:

### Description:
Fixes an alignment issue in the pivot table where dimension cells that only span a single row were being incorrectly top-aligned, causing their content to shift upward. The `mergedDimCell` CSS class (which applies `vertical-align: top`) is now only applied to cells that span more than one row.

Additionally, a small `padding-top` has been added to `mergedDimCell` so that top-aligned values in multi-row spanning cells are nudged away from the border, visually aligning them with the centered content of the first row they span.