### PR TITLE
feat: support one-character CJK omnibar searches

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -15,7 +15,7 @@ import MantineIcon from '../../../../components/common/MantineIcon';
 import OmnibarItem from '../../../../features/omnibar/components/OmnibarItem';
 import { getSearchResultsGroupsSorted } from '../../../../features/omnibar/components/utils';
 import useSearch, {
-    OMNIBAR_MIN_QUERY_LENGTH,
+    hasMinQueryLength,
 } from '../../../../features/omnibar/hooks/useSearch';
 import { type SearchItem } from '../../../../features/omnibar/types/searchItem';
 import { getSearchItemLabel } from '../../../../features/omnibar/utils/getSearchItemLabel';
@@ -76,7 +76,7 @@ export const SearchDropdown: FC<Props> = ({
 
     const handleInputChange = (newValue: string) => {
         onChange(newValue);
-        if (newValue.length >= OMNIBAR_MIN_QUERY_LENGTH) {
+        if (hasMinQueryLength(newValue)) {
             combobox.openDropdown();
         } else {
             combobox.closeDropdown();

--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -34,7 +34,7 @@ import { useValidationUserAbility } from '../../../hooks/validation/useValidatio
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useOmnibarSettingsItems } from '../hooks/useOmnibarSettingsItems';
-import useSearch, { OMNIBAR_MIN_QUERY_LENGTH } from '../hooks/useSearch';
+import useSearch, { hasMinQueryLength } from '../hooks/useSearch';
 import {
     allSearchItemTypes,
     type FocusedItemIndex,
@@ -163,7 +163,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
 
     const hasEnteredQuery = query !== undefined && query !== '';
     const hasEnteredMinQueryLength =
-        hasEnteredQuery && query.length >= OMNIBAR_MIN_QUERY_LENGTH;
+        hasEnteredQuery && hasMinQueryLength(query);
 
     const sortedGroupEntries = useMemo(() => {
         const contentGroups = searchResults

--- a/packages/frontend/src/features/omnibar/hooks/useOmnibarSettingsItems.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useOmnibarSettingsItems.ts
@@ -4,7 +4,7 @@ import { searchSettingsNavigationItemsWithPath } from '../../../hooks/settings/f
 import { useSettingsContext } from '../../../hooks/settings/useSettingsContext';
 import { useSettingsNavigation } from '../../../hooks/settings/useSettingsNavigation';
 import { type SearchItem } from '../types/searchItem';
-import { OMNIBAR_MIN_QUERY_LENGTH } from './useSearch';
+import { hasMinQueryLength } from './useSearch';
 
 /**
  * Settings pages matching `query`, as omnibar `SearchItem`s. The nav model is
@@ -15,7 +15,7 @@ export const useOmnibarSettingsItems = (query: string): SearchItem[] => {
     const sections = useSettingsNavigation(context);
 
     return useMemo(() => {
-        if (query.trim().length < OMNIBAR_MIN_QUERY_LENGTH) {
+        if (!hasMinQueryLength(query)) {
             return [];
         }
 

--- a/packages/frontend/src/features/omnibar/hooks/useSearch.test.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useSearch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { hasMinQueryLength } from './useSearch';
+
+describe('hasMinQueryLength', () => {
+    it.each([
+        { name: 'undefined query', query: undefined, expected: false },
+        { name: 'empty query', query: '', expected: false },
+        { name: 'ASCII below minimum length', query: 'ab', expected: false },
+        {
+            name: 'trimmed ASCII below minimum length',
+            query: 'ab ',
+            expected: false,
+        },
+        { name: 'ASCII at minimum length', query: 'abc', expected: true },
+        {
+            name: 'trimmed ASCII at minimum length',
+            query: ' abc ',
+            expected: true,
+        },
+        { name: 'Han character', query: '売', expected: true },
+        { name: 'trimmed Han character', query: ' 売 ', expected: true },
+        { name: 'Hiragana character', query: 'あ', expected: true },
+        { name: 'Katakana character', query: 'カ', expected: true },
+        { name: 'Hangul character', query: '한', expected: true },
+        { name: 'multi-character Han query', query: '売上', expected: true },
+        { name: 'mixed ASCII and CJK query', query: 'a売', expected: true },
+        { name: 'whitespace-only query', query: '　 ', expected: false },
+    ])('returns $expected for $name', ({ query, expected }) => {
+        expect(hasMinQueryLength(query)).toBe(expected);
+    });
+});

--- a/packages/frontend/src/features/omnibar/hooks/useSearch.ts
+++ b/packages/frontend/src/features/omnibar/hooks/useSearch.ts
@@ -8,7 +8,26 @@ import { getSearchResults } from '../api/search';
 import { type SearchResultMap } from '../types/searchResultMap';
 import { getSearchItemMap } from '../utils/getSearchItemMap';
 
-export const OMNIBAR_MIN_QUERY_LENGTH = 3;
+const OMNIBAR_MIN_QUERY_LENGTH = 3;
+const OMNIBAR_MIN_QUERY_LENGTH_CJK = 1;
+
+// Detect CJK input: Han characters, Japanese kana, and Korean Hangul.
+const CJK_CHARACTER_REGEX =
+    /[\p{Script_Extensions=Han}\p{Script_Extensions=Hiragana}\p{Script_Extensions=Katakana}\p{Script_Extensions=Hangul}]/u;
+
+export const hasMinQueryLength = (query: string | undefined): boolean => {
+    const trimmedQuery = query?.trim();
+
+    if (!trimmedQuery) {
+        return false;
+    }
+
+    const minLength = CJK_CHARACTER_REGEX.test(trimmedQuery)
+        ? OMNIBAR_MIN_QUERY_LENGTH_CJK
+        : OMNIBAR_MIN_QUERY_LENGTH;
+
+    return trimmedQuery.length >= minLength;
+};
 
 type Params = UseQueryOptions<SearchResults, ApiError, SearchResultMap> & {
     projectUuid: string;
@@ -29,7 +48,7 @@ const useSearch = ({
         queryFn: () =>
             getSearchResults({ projectUuid, query, filters, source }),
         retry: false,
-        enabled: query.length >= OMNIBAR_MIN_QUERY_LENGTH,
+        enabled: hasMinQueryLength(query),
         select: (data) => getSearchItemMap(data, projectUuid),
         ...params,
     });


### PR DESCRIPTION
Closes #24286

### Description:
This PR updates omnibar search minimum query length handling for CJK queries.

Previously, omnibar search required at least 3 characters before showing results. That works well for English queries, but it makes Japanese, Chinese, and Korean searches harder to use because a single CJK character can already be a meaningful search term.

This change keeps the existing 3-character minimum for non-CJK queries, while allowing queries that contain CJK characters to search from 1 character.

The shared minimum-length helper is used in:
- omnibar search query enabling
- omnibar empty/searching state handling
- settings search items
- AI search dropdown behavior

It also adds unit tests covering:
- empty and whitespace-only queries
- ASCII queries below and at the 3-character minimum
- Han, Hiragana, Katakana, and Hangul single-character queries
- mixed ASCII/CJK queries

<img width="977" height="320" alt="image" src="https://github.com/user-attachments/assets/a5123228-5012-4e95-9ca9-412205ff8924" />