### PR TITLE
perf: thread warehouse credentials into executePreparedAsyncQuery

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -130,6 +130,11 @@ jest.mock('@lightdash/warehouses', () => ({
     SshTunnel: jest.fn(() => mockSshTunnel),
 }));
 
+const warehouseCredentialsMock = {
+    ...warehouseClientMock.credentials,
+    userWarehouseCredentialsUuid: undefined,
+};
+
 const projectModel = {
     getWithSensitiveFields: jest.fn(async () => projectWithSensitiveFields),
     get: jest.fn(async () => projectWithSensitiveFields),
@@ -540,6 +545,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -633,6 +639,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -738,6 +745,7 @@ describe('AsyncQueryService', () => {
                     timezone: 'Asia/Tokyo',
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -790,6 +798,7 @@ describe('AsyncQueryService', () => {
                     timezone: 'Asia/Tokyo',
                     displayTimezone: 'Asia/Tokyo',
                     useTimezoneAwareDateTrunc: true,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -847,6 +856,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -935,6 +945,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock, invalidateCache: true },
             );
@@ -997,6 +1008,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -1091,6 +1103,7 @@ describe('AsyncQueryService', () => {
                     ],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -1170,6 +1183,7 @@ describe('AsyncQueryService', () => {
                     availableParameterDefinitions: {},
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -1241,6 +1255,7 @@ describe('AsyncQueryService', () => {
                     availableParameterDefinitions: {},
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 {
                     query: {
@@ -1322,6 +1337,7 @@ describe('AsyncQueryService', () => {
                     availableParameterDefinitions: {},
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 {
                     query: {
@@ -1404,6 +1420,7 @@ describe('AsyncQueryService', () => {
                     availableParameterDefinitions: {},
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );
@@ -2551,6 +2568,7 @@ describe('AsyncQueryService', () => {
                     missingParameterReferences: [],
                     displayTimezone: null,
                     useTimezoneAwareDateTrunc: false,
+                    warehouseCredentials: warehouseCredentialsMock,
                 },
                 { query: metricQueryMock },
             );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -276,6 +276,10 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     preAggregateStrategy?: PreAggregateStrategy;
 };
 
+type ResolvedWarehouseCredentials = CreateWarehouseCredentials & {
+    userWarehouseCredentialsUuid: string | undefined;
+};
+
 export class AsyncQueryService extends ProjectService {
     private static sleep(ms: number, signal?: AbortSignal) {
         if (signal?.aborted) {
@@ -3436,6 +3440,7 @@ export class AsyncQueryService extends ProjectService {
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
             availableParameterDefinitions?: ParameterDefinitions;
+            warehouseCredentials: ResolvedWarehouseCredentials;
         },
         requestParameters: ExecuteAsyncQueryRequestParams,
         organizationUuid: string,
@@ -3465,19 +3470,11 @@ export class AsyncQueryService extends ProjectService {
                     preAggregationRoute,
                     userAccessControls,
                     availableParameterDefinitions,
+                    warehouseCredentials,
                 } = args;
 
                 try {
                     assertIsAccountWithOrg(account);
-
-                    // Once we remove the feature flag we won't need to fetch the credentials here, they will only be fetched in the scheduler task
-                    const warehouseCredentials =
-                        await this.getWarehouseCredentials({
-                            projectUuid,
-                            userId: account.user.id,
-                            isRegisteredUser: account.isRegisteredUser(),
-                            isServiceAccount: account.isServiceAccount(),
-                        });
 
                     const warehouseCredentialsType = warehouseCredentials.type;
                     const warehouseCredentialsOverrides: RunAsyncWarehouseQueryArgs['warehouseCredentialsOverrides'] =
@@ -4002,6 +3999,7 @@ export class AsyncQueryService extends ProjectService {
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
             availableParameterDefinitions?: ParameterDefinitions;
+            warehouseCredentials: ResolvedWarehouseCredentials;
             // Preloaded org from the caller (e.g. saved chart) to skip a redundant getSummary
             organizationUuid?: string;
         },
@@ -4262,6 +4260,7 @@ export class AsyncQueryService extends ProjectService {
                 displayTimezone,
                 useTimezoneAwareDateTrunc,
                 pivotConfiguration,
+                warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
@@ -4505,6 +4504,7 @@ export class AsyncQueryService extends ProjectService {
                 timezone: resolvedTimezone,
                 displayTimezone,
                 useTimezoneAwareDateTrunc,
+                warehouseCredentials,
                 routingTarget: 'warehouse',
             },
             requestParameters,
@@ -4792,6 +4792,7 @@ export class AsyncQueryService extends ProjectService {
                 displayTimezone,
                 useTimezoneAwareDateTrunc,
                 pivotConfiguration,
+                warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
@@ -5252,6 +5253,7 @@ export class AsyncQueryService extends ProjectService {
                 displayTimezone,
                 useTimezoneAwareDateTrunc,
                 pivotConfiguration,
+                warehouseCredentials,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
@@ -5569,6 +5571,7 @@ export class AsyncQueryService extends ProjectService {
                     timezone: resolvedTimezone,
                     displayTimezone,
                     useTimezoneAwareDateTrunc,
+                    warehouseCredentials,
                 },
                 requestParameters,
             );
@@ -5619,6 +5622,7 @@ export class AsyncQueryService extends ProjectService {
 
         const {
             warehouseConnection,
+            warehouseCredentials,
             queryTags,
             metricQuery,
             virtualView,
@@ -5656,6 +5660,7 @@ export class AsyncQueryService extends ProjectService {
                 pivotConfiguration,
                 displayTimezone: null,
                 useTimezoneAwareDateTrunc: false,
+                warehouseCredentials,
             },
             {
                 sql,
@@ -5709,14 +5714,15 @@ export class AsyncQueryService extends ProjectService {
 
         // 1. Warehouse Client & Credentials
         const sectionStartWarehouse = performance.now();
+        const warehouseCredentials = await this.getWarehouseCredentials({
+            projectUuid,
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
         const warehouseConnection = await this._getWarehouseClient(
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
+            warehouseCredentials,
         );
 
         const queryTags: RunQueryTags = {
@@ -5988,6 +5994,7 @@ export class AsyncQueryService extends ProjectService {
             virtualView,
             queryTags,
             warehouseConnection,
+            warehouseCredentials,
             sql: replacedSql,
             parameterReferences: Array.from(parameterReferences),
             missingParameterReferences: Array.from(missingParameterReferences),
@@ -6023,6 +6030,7 @@ export class AsyncQueryService extends ProjectService {
 
         const {
             warehouseConnection,
+            warehouseCredentials,
             queryTags,
             metricQuery,
             virtualView,
@@ -6063,6 +6071,7 @@ export class AsyncQueryService extends ProjectService {
                 pivotConfiguration,
                 displayTimezone: null,
                 useTimezoneAwareDateTrunc: false,
+                warehouseCredentials,
             },
             {
                 query: metricQuery,
@@ -6166,6 +6175,7 @@ export class AsyncQueryService extends ProjectService {
 
         const {
             warehouseConnection,
+            warehouseCredentials,
             queryTags,
             metricQuery,
             virtualView,
@@ -6211,6 +6221,7 @@ export class AsyncQueryService extends ProjectService {
                 pivotConfiguration,
                 displayTimezone: null,
                 useTimezoneAwareDateTrunc: false,
+                warehouseCredentials,
             },
             {
                 query: metricQuery,
@@ -6604,6 +6615,7 @@ export class AsyncQueryService extends ProjectService {
                     timezone: resolvedTimezone,
                     displayTimezone,
                     useTimezoneAwareDateTrunc,
+                    warehouseCredentials,
                     routingTarget: routingDecision.target,
                     ...(routingDecision.target === 'pre_aggregate' && {
                         preAggregationRoute: routingDecision.route,


### PR DESCRIPTION
Closes: SPK-499

### Description:
Warehouse credentials were fetched twice on the async query path: once during query prep (to build the SQL builder) and again inside `executePreparedAsyncQuery`. This threads the already-loaded credentials through the execute args instead of re-fetching, removing the redundant `getWarehouseCredentials` call — and its preceding `getProjectWarehouseConfig` lookup — from the critical path (−1 to −2 Postgres round-trips per query on cache miss). All execute methods (metric, saved chart, dashboard chart, underlying data, field-value search, SQL/SQL-chart, and totals) now pass the credentials resolved during prep, and the SQL prep helper returns the credentials it already loads. Behaviour is unchanged since both fetches used identical arguments; tests updated accordingly.