### PR TITLE
perf: parallelize getUserAttributes + findExploresFromCache (SPK-505)

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6575,21 +6575,20 @@ export class ProjectService extends BaseService {
                 if (isForbidden) {
                     throw new ForbiddenError();
                 }
-                const explores = await this.projectModel.findExploresFromCache(
-                    projectUuid,
-                    'name',
-                    exploreNames,
-                );
+                const [explores, userAccessControls] = await Promise.all([
+                    this.projectModel.findExploresFromCache(
+                        projectUuid,
+                        'name',
+                        exploreNames,
+                    ),
+                    this.getUserAttributes({ account }),
+                ]);
                 const canViewPreAggregateExplores =
                     this.canViewPreAggregateExplores(
                         account,
                         project.organizationUuid,
                         projectUuid,
                     );
-
-                const userAccessControls = await this.getUserAttributes({
-                    account,
-                });
 
                 const filteredExplores = Object.values(explores).reduce<
                     Record<string, Explore | ExploreError>


### PR DESCRIPTION
Closes: SPK-505

### Description:
Inside `findExploresWithUserAccessControls`, `getUserAttributes` previously ran only after `findExploresFromCache` resolved even though the two have no data dependency. This wraps both awaits in a single `Promise.all` (moving the synchronous `canViewPreAggregateExplores` after it), removing one sequential round-trip on every dashboard load. Small, low-risk change; behaviour is unchanged.