### PR TITLE
perf(async-query): dedup project_parameters query on dashboard chart path

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3229,6 +3229,7 @@ export class AsyncQueryService extends ProjectService {
         explore,
         warehouseSqlBuilder,
         projectUuid,
+        preloadedProjectParameters,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
         'metricQuery' | 'dateZoom' | 'projectUuid'
@@ -3236,10 +3237,12 @@ export class AsyncQueryService extends ProjectService {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
         pivotConfiguration?: PivotConfiguration;
+        preloadedProjectParameters?: DbProjectParameter[];
     }) {
         const availableParameterDefinitions = await this.getAvailableParameters(
             projectUuid,
             explore,
+            preloadedProjectParameters,
         );
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -5156,6 +5159,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseSqlBuilder,
             projectUuid,
             dateZoom,
+            preloadedProjectParameters: projectParameters,
         });
 
         const pivotConfiguration = pivotResults


### PR DESCRIPTION
Closes: SPK-498

### Description:

The dashboard chart init path in `executeAsyncDashboardChartQuery` loads project parameters once and passes them as `preloadedProjectParameters` into `prepareMetricQueryAsyncQueryArgs`, but the same path also calls `getMetricQueryFields`, which internally called `getAvailableParameters` without the preloaded value — issuing a second identical `ProjectParametersModel.find(projectUuid)` query. This adds a `preloadedProjectParameters` param to `getMetricQueryFields`, threads it into its `getAvailableParameters` call, and passes the already-loaded `projectParameters` from the dashboard chart path, mirroring the existing dedup pattern. Net effect: −1 Postgres round-trip on the dashboard chart critical path.