### PR TITLE
feat: add space_uuid, space_path, project_uuid to usage analytics export

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.test.ts
@@ -1,0 +1,56 @@
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { AnalyticsModel } from './AnalyticsModel';
+
+describe('AnalyticsModel.getViewsRawData', () => {
+    const model = new AnalyticsModel({
+        database: knex({ client: MockClient, dialect: 'pg' }),
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('selects the space identifier columns and builds the space_paths recursive CTE', async () => {
+        tracker.on
+            .select(() => true)
+            .response([
+                {
+                    type: 'chart',
+                    timestamp: '2026-06-15T00:00:00Z',
+                    uuid: 'chart-uuid',
+                    name: 'My Chart',
+                    user_uuid: 'user-uuid',
+                    user_first_name: 'Ada',
+                    user_last_name: 'Lovelace',
+                    space_name: 'Commercial',
+                    space_uuid: 'space-uuid',
+                    space_path: 'LCT / Commercial',
+                    project_uuid: 'project-uuid',
+                },
+            ]);
+
+        const results = await model.getViewsRawData('project-uuid');
+
+        // Row shape includes the three new columns (pass-through).
+        expect(results[0]).toEqual(
+            expect.objectContaining({
+                space_uuid: 'space-uuid',
+                space_path: 'LCT / Commercial',
+                project_uuid: 'project-uuid',
+            }),
+        );
+
+        // Generated SQL selects the new columns and builds the recursive CTE.
+        const sql = tracker.history.select[0].sql.toLowerCase();
+        expect(sql).toContain('with recursive');
+        expect(sql).toContain('space_paths');
+        expect(sql).toContain('space_uuid');
+        expect(sql).toContain('space_path');
+        expect(sql).toContain('project_uuid');
+    });
+});

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -300,9 +300,30 @@ export class AnalyticsModel {
             user_first_name: string;
             user_last_name: string;
             space_name: string;
+            space_uuid: string;
+            space_path: string;
+            project_uuid: string;
         };
         const results = await this.database.transaction(async (trx) => {
+            const spacePathsCte = this.database.raw(
+                `
+                SELECT s.space_id, s.space_uuid, CAST(s.name AS text) AS path
+                FROM ${SpaceTableName} s
+                INNER JOIN ${ProjectTableName} p ON p.project_id = s.project_id
+                WHERE s.parent_space_uuid IS NULL
+                  AND s.deleted_at IS NULL
+                  AND p.project_uuid = ?
+                UNION ALL
+                SELECT c.space_id, c.space_uuid, sp.path || ' / ' || c.name
+                FROM ${SpaceTableName} c
+                INNER JOIN space_paths sp ON c.parent_space_uuid = sp.space_uuid
+                WHERE c.deleted_at IS NULL
+                `,
+                [projectUuid],
+            );
+
             const chartViews = trx
+                .withRecursive('space_paths', spacePathsCte)
                 .select<RawViewType[]>(
                     this.database.raw(`'chart' as type`),
                     this.database.raw(
@@ -314,6 +335,9 @@ export class AnalyticsModel {
                     `${UserTableName}.first_name as user_first_name`,
                     `${UserTableName}.last_name as user_last_name`,
                     `${SpaceTableName}.name as space_name`,
+                    `${SpaceTableName}.space_uuid as space_uuid`,
+                    `space_paths.path as space_path`,
+                    `${ProjectTableName}.project_uuid as project_uuid`,
                 )
                 .from(AnalyticsChartViewsTableName)
                 .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
@@ -338,6 +362,11 @@ export class AnalyticsModel {
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
                 )
+                .leftJoin(
+                    'space_paths',
+                    `space_paths.space_id`,
+                    `${SpaceTableName}.space_id`,
+                )
                 .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .whereNull(`${SpaceTableName}.deleted_at`);
 
@@ -353,6 +382,9 @@ export class AnalyticsModel {
                     `${UserTableName}.first_name as user_first_name`,
                     `${UserTableName}.last_name as user_last_name`,
                     `${SpaceTableName}.name as space_name`,
+                    `${SpaceTableName}.space_uuid as space_uuid`,
+                    `space_paths.path as space_path`,
+                    `${ProjectTableName}.project_uuid as project_uuid`,
                 )
                 .from(AnalyticsDashboardViewsTableName)
                 .leftJoin(
@@ -374,6 +406,11 @@ export class AnalyticsModel {
                     ProjectTableName,
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
+                )
+                .leftJoin(
+                    'space_paths',
+                    `space_paths.space_id`,
+                    `${SpaceTableName}.space_id`,
                 )
                 .where(`${ProjectTableName}.project_uuid`, projectUuid)
                 .whereNull(`${SpaceTableName}.deleted_at`);


### PR DESCRIPTION
## Problem

The Extended Usage Analytics CSV export identified each viewed asset's space only by `space_name` (the flattened leaf name). When a project has two spaces sharing a name in different parts of the space tree (e.g. a nested `Commercial` under an `LCT` parent **and** a separate root-level `Commercial`), the export collapsed both into a single `space_name` with no way to tell them apart. This surfaced during an enterprise adoption analysis, where one `space_name` bucket mixed content from two distinct teams, making per-team adoption metrics unreliable.

## Change

Add three columns to `AnalyticsModel.getViewsRawData()`:

- `space_uuid` — stable unique key for joins/dedupe (from the already-joined `spaces` table)
- `space_path` — human-readable ancestor breadcrumb, e.g. `LCT / Commercial`, computed by a recursive CTE that walks **down from root spaces** accumulating names
- `project_uuid` — for aggregating across projects (from the already-joined `projects` table)

`space_name` is retained (purely additive). The CSV header is auto-generated from row keys in `AnalyticsService.exportUserActivityRawCsv()`, so no service/controller changes are needed.

The `space_path` CTE walks the `parent_space_uuid` FK rather than the `path` ltree column, which is lossy (slug→path conversion can produce duplicates) and stores slugs rather than display names.

## Testing

- Unit test (`AnalyticsModel.test.ts`) asserts the new columns appear in the row and that the generated SQL builds the `space_paths` recursive CTE.
- Verified end-to-end against a local Postgres: two same-named `Commercial` spaces (one root, one nested under `LCT`) export with distinct `space_uuid` and `space_path` (`Commercial` vs `LCT / Commercial`). Confirmed an asset with no space still exports with empty space columns (no error).

Closes: PROD-8317

🤖 Generated with [Claude Code](https://claude.com/claude-code)