### PR TITLE
feat(ai-agent): add 'Save to current dashboard' quick action

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -164,8 +164,6 @@ export const AiChartQuickOptions = ({
         close();
     };
 
-    // Only offer "Save to current dashboard" when the dashboard the user is
-    // viewing belongs to the same project as the agent's chart.
     const quickSaveDashboard: LauncherCurrentDashboard | null =
         currentDashboard?.projectUuid === projectUuid ? currentDashboard : null;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -1,6 +1,7 @@
 import {
     type AiAgentMessageAssistant,
     type AiArtifact,
+    type ApiError,
     type SavedChart,
 } from '@lightdash/common';
 import { ActionIcon, Button, HoverCard, Menu, Tooltip } from '@mantine-8/core';
@@ -14,23 +15,34 @@ import {
     IconDots,
     IconExternalLink,
     IconEye,
+    IconLayoutDashboard,
     IconTableShortcut,
     IconTerminal2,
 } from '@tabler/icons-react';
-import { Fragment, useCallback, useMemo } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { SaveToSpaceOrDashboard } from '../../../../../components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard';
 import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
+import useToaster from '../../../../../hooks/toaster/useToaster';
 import { useCreateShareMutation } from '../../../../../hooks/useShare';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { getOpenInExploreUrl } from '../../../../../utils/getOpenInExploreUrl';
+import { useAddChartToDashboard } from '../../hooks/useAddChartToDashboard';
 import { useSetArtifactVersionVerified } from '../../hooks/useAiAgentArtifacts';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
 import { useSavePromptQuery } from '../../hooks/useProjectAiAgents';
+import {
+    requestDashboardRefresh,
+    type LauncherCurrentDashboard,
+} from '../../store/aiAgentLauncherSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
 
 type Props = {
     projectUuid: string;
@@ -55,6 +67,14 @@ export const AiChartQuickOptions = ({
 }: Props) => {
     const { track } = useTracking();
     const { user } = useApp();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    const dispatch = useAiAgentStoreDispatch();
+    const currentDashboard = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.currentDashboard,
+    );
+    const addChartToDashboard = useAddChartToDashboard(projectUuid);
+    const [isSavingToDashboard, setIsSavingToDashboard] = useState(false);
 
     const [opened, { open, close }] = useDisclosure(false);
     const [
@@ -88,12 +108,21 @@ export const AiChartQuickOptions = ({
     const isVerified = artifactData?.verifiedByUserUuid !== null;
 
     const isDisabled = !metricQuery || !type || !visualizationConfig;
-    const onSaveChart = (savedData: SavedChart) => {
-        if (!saveChartOptions.linkToMessage) {
-            close();
-            return;
-        }
-        savePromptQuery({ savedQueryUuid: savedData.uuid });
+
+    const savedData = useMemo(() => {
+        if (!metricQuery) return undefined;
+        return {
+            metricQuery,
+            tableName: metricQuery.exploreName,
+            chartConfig,
+            tableConfig: { columnOrder },
+            pivotConfig: pivotDimensions?.length
+                ? { columns: pivotDimensions }
+                : undefined,
+        };
+    }, [metricQuery, chartConfig, columnOrder, pivotDimensions]);
+
+    const trackChartCreated = useCallback(() => {
         if (
             user?.data?.userUuid &&
             user?.data?.organizationUuid &&
@@ -114,8 +143,77 @@ export const AiChartQuickOptions = ({
                 },
             });
         }
+    }, [
+        user?.data?.userUuid,
+        user?.data?.organizationUuid,
+        projectUuid,
+        agentUuid,
+        metricQuery?.exploreName,
+        track,
+        message.threadUuid,
+        message.uuid,
+    ]);
+
+    const onSaveChart = (chart: SavedChart) => {
+        if (!saveChartOptions.linkToMessage) {
+            close();
+            return;
+        }
+        savePromptQuery({ savedQueryUuid: chart.uuid });
+        trackChartCreated();
         close();
     };
+
+    // Only offer "Save to current dashboard" when the dashboard the user is
+    // viewing belongs to the same project as the agent's chart.
+    const quickSaveDashboard: LauncherCurrentDashboard | null =
+        currentDashboard?.projectUuid === projectUuid ? currentDashboard : null;
+
+    const handleSaveToCurrentDashboard = useCallback(async () => {
+        if (!savedData || !quickSaveDashboard) return;
+        setIsSavingToDashboard(true);
+        try {
+            const chart = await addChartToDashboard({
+                savedData,
+                name: saveChartOptions.name ?? 'Untitled chart',
+                description: saveChartOptions.description,
+                dashboardUuid: quickSaveDashboard.uuid,
+                activeTabUuid: quickSaveDashboard.activeTabUuid,
+            });
+            if (saveChartOptions.linkToMessage) {
+                savePromptQuery({ savedQueryUuid: chart.uuid });
+            }
+            trackChartCreated();
+            dispatch(
+                requestDashboardRefresh({
+                    dashboardUuid: quickSaveDashboard.uuid,
+                    focusChartSlug: chart.slug,
+                }),
+            );
+            showToastSuccess({
+                title: `Chart added to "${quickSaveDashboard.name}"`,
+            });
+        } catch (e) {
+            showToastApiError({
+                title: 'Failed to add chart to dashboard',
+                apiError: (e as ApiError).error,
+            });
+        } finally {
+            setIsSavingToDashboard(false);
+        }
+    }, [
+        savedData,
+        quickSaveDashboard,
+        addChartToDashboard,
+        saveChartOptions.name,
+        saveChartOptions.description,
+        saveChartOptions.linkToMessage,
+        savePromptQuery,
+        trackChartCreated,
+        dispatch,
+        showToastSuccess,
+        showToastApiError,
+    ]);
 
     const openInExploreUrl = useMemo(() => {
         if (isDisabled) return undefined;
@@ -253,14 +351,31 @@ export const AiChartQuickOptions = ({
                             View saved chart
                         </Menu.Item>
                     ) : (
-                        <Menu.Item
-                            onClick={() => open()}
-                            leftSection={
-                                <MantineIcon icon={IconDeviceFloppy} />
-                            }
-                        >
-                            Save
-                        </Menu.Item>
+                        <>
+                            {quickSaveDashboard && (
+                                <Menu.Item
+                                    onClick={() =>
+                                        void handleSaveToCurrentDashboard()
+                                    }
+                                    disabled={isDisabled || isSavingToDashboard}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconLayoutDashboard}
+                                        />
+                                    }
+                                >
+                                    Save to current dashboard
+                                </Menu.Item>
+                            )}
+                            <Menu.Item
+                                onClick={() => open()}
+                                leftSection={
+                                    <MantineIcon icon={IconDeviceFloppy} />
+                                }
+                            >
+                                {quickSaveDashboard ? 'Save to…' : 'Save'}
+                            </Menu.Item>
+                        </>
                     )}
 
                     <Menu.Item

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAddChartToDashboard.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAddChartToDashboard.ts
@@ -23,13 +23,6 @@ type AddChartArgs = {
     activeTabUuid: string | null;
 };
 
-/**
- * Creates a chart that belongs to an existing dashboard and appends it as a new
- * tile to the bottom of that dashboard. Mirrors the `SaveDestination.Dashboard`
- * branch of `SaveToSpaceOrDashboard`, but skips navigation and toasts so the AI
- * agent launcher can save in a single click while the user keeps viewing the
- * dashboard. Errors propagate to the caller, which owns the toast.
- */
 export const useAddChartToDashboard = (projectUuid: string) => {
     return useCallback(
         async ({

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAddChartToDashboard.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAddChartToDashboard.ts
@@ -1,0 +1,82 @@
+import {
+    ChartType,
+    DashboardTileTypes,
+    getDefaultChartTileSize,
+    type CreateSavedChartVersion,
+    type DashboardChartTile,
+    type SavedChart,
+} from '@lightdash/common';
+import { useCallback } from 'react';
+import { v4 as uuid4 } from 'uuid';
+import {
+    appendNewTilesToBottom,
+    getDashboard,
+    updateDashboardApi,
+} from '../../../../hooks/dashboard/useDashboard';
+import { createSavedQuery } from '../../../../hooks/useSavedQuery';
+
+type AddChartArgs = {
+    savedData: CreateSavedChartVersion;
+    name: string;
+    description: string | null;
+    dashboardUuid: string;
+    activeTabUuid: string | null;
+};
+
+/**
+ * Creates a chart that belongs to an existing dashboard and appends it as a new
+ * tile to the bottom of that dashboard. Mirrors the `SaveDestination.Dashboard`
+ * branch of `SaveToSpaceOrDashboard`, but skips navigation and toasts so the AI
+ * agent launcher can save in a single click while the user keeps viewing the
+ * dashboard. Errors propagate to the caller, which owns the toast.
+ */
+export const useAddChartToDashboard = (projectUuid: string) => {
+    return useCallback(
+        async ({
+            savedData,
+            name,
+            description,
+            dashboardUuid,
+            activeTabUuid,
+        }: AddChartArgs): Promise<SavedChart> => {
+            const dashboard = await getDashboard(dashboardUuid, projectUuid);
+
+            const savedChart = await createSavedQuery(projectUuid, {
+                ...savedData,
+                name,
+                description: description ?? undefined,
+                dashboardUuid,
+            });
+
+            const tabUuid = activeTabUuid ?? dashboard.tabs?.[0]?.uuid;
+            const newTile: DashboardChartTile = {
+                uuid: uuid4(),
+                type: DashboardTileTypes.SAVED_CHART,
+                tabUuid,
+                properties: {
+                    belongsToDashboard: true,
+                    savedChartUuid: savedChart.uuid,
+                    chartName: name,
+                    hideTitle:
+                        savedData.chartConfig?.type === ChartType.BIG_NUMBER
+                            ? true
+                            : undefined,
+                },
+                ...getDefaultChartTileSize(savedData.chartConfig?.type),
+            };
+
+            await updateDashboardApi(
+                dashboardUuid,
+                {
+                    filters: dashboard.filters,
+                    tiles: appendNewTilesToBottom(dashboard.tiles, [newTile]),
+                    tabs: dashboard.tabs,
+                },
+                projectUuid,
+            );
+
+            return savedChart;
+        },
+        [projectUuid],
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -11,6 +11,23 @@ export type LauncherPendingContext = {
     dashboardUuid?: string;
 };
 
+// The dashboard the user is currently viewing, published by the dashboard page
+// so the launcher can offer a "Save to current dashboard" quick action.
+export type LauncherCurrentDashboard = {
+    projectUuid: string;
+    uuid: string;
+    name: string;
+    activeTabUuid: string | null;
+};
+
+// Pub-sub bridge: the launcher asks the dashboard page to refresh its tiles
+// after a chart has been saved into the currently viewed dashboard.
+export type DashboardRefreshRequest = {
+    dashboardUuid: string;
+    focusChartSlug: string | null;
+    requestId: number;
+};
+
 type LauncherMode = 'collapsed' | 'panel-open';
 
 export interface AiAgentLauncherState {
@@ -18,6 +35,8 @@ export interface AiAgentLauncherState {
     activeThreadId: string | null;
     activeAgentUuid: string | null;
     pendingContext: LauncherPendingContext | null;
+    currentDashboard: LauncherCurrentDashboard | null;
+    dashboardRefreshRequest: DashboardRefreshRequest | null;
 }
 
 const initialState: AiAgentLauncherState = {
@@ -25,6 +44,8 @@ const initialState: AiAgentLauncherState = {
     activeThreadId: null,
     activeAgentUuid: null,
     pendingContext: null,
+    currentDashboard: null,
+    dashboardRefreshRequest: null,
 };
 
 export const aiAgentLauncherSlice = createSlice({
@@ -66,8 +87,33 @@ export const aiAgentLauncherSlice = createSlice({
                 state.pendingContext = null;
             }
         },
+        setCurrentDashboard: (
+            state,
+            action: PayloadAction<LauncherCurrentDashboard | null>,
+        ) => {
+            state.currentDashboard = action.payload;
+        },
+        requestDashboardRefresh: (
+            state,
+            action: PayloadAction<{
+                dashboardUuid: string;
+                focusChartSlug: string | null;
+            }>,
+        ) => {
+            state.dashboardRefreshRequest = {
+                dashboardUuid: action.payload.dashboardUuid,
+                focusChartSlug: action.payload.focusChartSlug,
+                requestId: (state.dashboardRefreshRequest?.requestId ?? 0) + 1,
+            };
+        },
     },
 });
 
-export const { openPanel, closePanel, resetActivePanel, dockItemRemoved } =
-    aiAgentLauncherSlice.actions;
+export const {
+    openPanel,
+    closePanel,
+    resetActivePanel,
+    dockItemRemoved,
+    setCurrentDashboard,
+    requestDashboardRefresh,
+} = aiAgentLauncherSlice.actions;

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -11,8 +11,6 @@ export type LauncherPendingContext = {
     dashboardUuid?: string;
 };
 
-// The dashboard the user is currently viewing, published by the dashboard page
-// so the launcher can offer a "Save to current dashboard" quick action.
 export type LauncherCurrentDashboard = {
     projectUuid: string;
     uuid: string;
@@ -20,8 +18,6 @@ export type LauncherCurrentDashboard = {
     activeTabUuid: string | null;
 };
 
-// Pub-sub bridge: the launcher asks the dashboard page to refresh its tiles
-// after a chart has been saved into the currently viewed dashboard.
 export type DashboardRefreshRequest = {
     dashboardUuid: string;
     focusChartSlug: string | null;

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -30,7 +30,7 @@ const isCustomSqlDimensionForbiddenError = (
     typeof error.message === 'string' &&
     error.message.toLowerCase().includes('custom sql dimensions');
 
-const createSavedQuery = async (
+export const createSavedQuery = async (
     projectUuid: string,
     payload: CreateSavedChart,
 ): Promise<SavedChart> => {

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -274,9 +274,6 @@ const DashboardAiAgentContextBridge = () => {
         refreshDashboard,
     ]);
 
-    // Publish the dashboard currently being viewed so the AI agent launcher can
-    // offer a "Save to current dashboard" quick action. Disabled in edit mode to
-    // avoid clobbering unsaved tile edits.
     useEffect(() => {
         if (!projectUuid || !currentDashboardUuid || !dashboard || isEditMode) {
             dispatch(setCurrentDashboard(null));
@@ -306,8 +303,6 @@ const DashboardAiAgentContextBridge = () => {
         [dispatch],
     );
 
-    // React to a refresh requested by the launcher after it saved a chart into
-    // the currently viewed dashboard.
     useEffect(() => {
         if (!dashboardRefreshRequest) return;
         if (

--- a/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardAiAgentContextBridge.tsx
@@ -8,6 +8,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams } from 'react-router';
 import { scrollToDashboardTile } from '../../components/common/Dashboard/scrollToDashboardTile';
+import { setCurrentDashboard } from '../../ee/features/aiCopilot/store/aiAgentLauncherSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../ee/features/aiCopilot/store/hooks';
 import { useActiveAiAgentThreadStreamParts } from '../../ee/features/aiCopilot/streaming/useAiAgentThreadStreamQuery';
 import { getDashboard } from '../../hooks/dashboard/useDashboard';
 import { getSavedQuery } from '../../hooks/useSavedQuery';
@@ -33,11 +38,22 @@ const isDashboardChartReadyQueryForCharts = (
 const DashboardAiAgentContextBridge = () => {
     const queryClient = useQueryClient();
     // useDashboardQuery/saved_dashboard_query use UUID-or-slug; useDashboardChartReadyQuery/dashboard_chart_ready_query uses dashboard.uuid.
-    const { projectUuid, dashboardUuid: dashboardUuidOrSlug } = useParams<{
+    const {
+        projectUuid,
+        dashboardUuid: dashboardUuidOrSlug,
+        mode,
+    } = useParams<{
         projectUuid: string;
         dashboardUuid: string;
+        mode: string;
     }>();
+    const isEditMode = mode === 'edit';
+    const dispatch = useAiAgentStoreDispatch();
+    const dashboardRefreshRequest = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.dashboardRefreshRequest,
+    );
     const dashboard = useDashboardContext((c) => c.dashboard);
+    const activeTab = useDashboardContext((c) => c.activeTab);
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const setDashboardTiles = useDashboardContext((c) => c.setDashboardTiles);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
@@ -56,6 +72,7 @@ const DashboardAiAgentContextBridge = () => {
     const handledToolCallIdsRef = useRef<Set<string>>(new Set());
     const pendingChartSlugToFocusRef = useRef<string | null>(null);
     const focusRequestIdRef = useRef(0);
+    const handledRefreshRequestIdRef = useRef(0);
 
     const currentDashboardSlug = dashboard?.slug;
     const currentDashboardUuid = dashboard?.uuid;
@@ -256,6 +273,56 @@ const DashboardAiAgentContextBridge = () => {
         refreshChartTiles,
         refreshDashboard,
     ]);
+
+    // Publish the dashboard currently being viewed so the AI agent launcher can
+    // offer a "Save to current dashboard" quick action. Disabled in edit mode to
+    // avoid clobbering unsaved tile edits.
+    useEffect(() => {
+        if (!projectUuid || !currentDashboardUuid || !dashboard || isEditMode) {
+            dispatch(setCurrentDashboard(null));
+            return;
+        }
+        dispatch(
+            setCurrentDashboard({
+                projectUuid,
+                uuid: currentDashboardUuid,
+                name: dashboard.name,
+                activeTabUuid: activeTab?.uuid ?? null,
+            }),
+        );
+    }, [
+        dispatch,
+        projectUuid,
+        currentDashboardUuid,
+        dashboard,
+        activeTab?.uuid,
+        isEditMode,
+    ]);
+
+    useEffect(
+        () => () => {
+            dispatch(setCurrentDashboard(null));
+        },
+        [dispatch],
+    );
+
+    // React to a refresh requested by the launcher after it saved a chart into
+    // the currently viewed dashboard.
+    useEffect(() => {
+        if (!dashboardRefreshRequest) return;
+        if (
+            dashboardRefreshRequest.requestId <=
+            handledRefreshRequestIdRef.current
+        )
+            return;
+        if (dashboardRefreshRequest.dashboardUuid !== currentDashboardUuid)
+            return;
+
+        handledRefreshRequestIdRef.current = dashboardRefreshRequest.requestId;
+        void refreshDashboard(
+            dashboardRefreshRequest.focusChartSlug ?? undefined,
+        );
+    }, [dashboardRefreshRequest, currentDashboardUuid, refreshDashboard]);
 
     return null;
 };

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -344,6 +344,20 @@ if [ "$EE_MODE" = true ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# A shared base snapshot bakes in the *creating* instance's warehouse host/port,
+# so a bootstrapped instance points its local-postgres warehouse at a dead port
+# and every query fails with "Unknown object error". Reconcile it to this
+# instance's PG port BEFORE the snapshot so /docker-dev reset stays correct too.
+# Non-fatal: the dev LIGHTDASH_SECRET is stable across instances, but if a row
+# won't decrypt the reconcile skips it rather than blocking startup.
+step "Reconcile warehouse port"
+if ./scripts/dev-reconcile.sh warehouse-port-fix 2>&1; then
+    :
+else
+    echo "WARN: warehouse-port-fix reported an issue (non-fatal) — charts may show 'Unknown object error' until fixed"
+fi
+
+# ---------------------------------------------------------------------------
 step "Ensure instance snapshot"
 if docker volume inspect "${LD_VOLUME_PREFIX}_postgres_data_snapshot" >/dev/null 2>&1; then
     echo "SKIP: snapshot exists"

--- a/scripts/dev-github-reconcile.cjs
+++ b/scripts/dev-github-reconcile.cjs
@@ -261,6 +261,44 @@ async function stepVerifyToken(client) {
   else { console.error(`FAIL: verify-token -- POST access_tokens for id=${id} -> ${res.status}`); process.exit(1); }
 }
 
+// A shared base snapshot bakes in the *creating* instance's warehouse host/port, so a
+// bootstrapped instance points its local-postgres warehouse at a dead port and every
+// query fails with "Unknown object error". Re-point local warehouse credentials at this
+// instance's PG port (PGPORT) and re-encrypt with the running secret. Only touches
+// postgres credentials whose host is clearly local, so a real external warehouse is left
+// alone.
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', 'host.docker.internal', 'postgres', 'db', 'db-dev']);
+async function stepWarehousePortFix(client) {
+  const secret = need('RUNNING_SECRET');
+  const targetPort = parseInt(process.env.PGPORT || '5432', 10);
+  const rows = await client.query(
+    "SELECT warehouse_credentials_id, warehouse_type, encode(encrypted_credentials,'hex') AS hex FROM warehouse_credentials");
+  if (!rows.rows.length) { console.log('OK: no warehouse_credentials rows'); return; }
+  let fixed = 0;
+  for (const row of rows.rows) {
+    if (row.warehouse_type !== 'postgres') continue;
+    let creds;
+    try { creds = JSON.parse(decrypt(Buffer.from(row.hex, 'hex'), secret)); }
+    catch (_) { console.log(`WARN: warehouse_credentials_id=${row.warehouse_credentials_id} will not decrypt with running secret — skipping`); continue; }
+    if (!LOCAL_HOSTS.has(String(creds.host))) {
+      console.log(`SKIP: warehouse_credentials_id=${row.warehouse_credentials_id} host=${creds.host} is not local — leaving as-is`);
+      continue;
+    }
+    if (creds.host === 'localhost' && creds.port === targetPort) continue;
+    const before = `${creds.host}:${creds.port}`;
+    creds.host = 'localhost';
+    creds.port = targetPort;
+    const enc = encrypt(JSON.stringify(creds), secret);
+    if (decrypt(enc, secret) !== JSON.stringify(creds)) throw new Error('round-trip check failed');
+    await client.query(
+      'UPDATE warehouse_credentials SET encrypted_credentials=$1 WHERE warehouse_credentials_id=$2',
+      [enc, row.warehouse_credentials_id]);
+    console.log(`OK: warehouse_credentials_id=${row.warehouse_credentials_id} repointed ${before} -> localhost:${targetPort}`);
+    fixed += 1;
+  }
+  if (!fixed) console.log(`OK: warehouse credentials already point at localhost:${targetPort}`);
+}
+
 (async () => {
   const step = process.argv[2];
   const kvs = {};
@@ -281,6 +319,7 @@ async function stepVerifyToken(client) {
     else if (step === 'dbt-repo-check') await stepDbtRepoCheck(client);
     else if (step === 'dbt-repo-repoint') await stepDbtRepoRepoint(client, kvs);
     else if (step === 'verify-token') await stepVerifyToken(client);
+    else if (step === 'warehouse-port-fix') await stepWarehousePortFix(client);
     else { console.error(`FAIL: reconcile -- unknown step '${step}'`); process.exit(2); }
   } finally {
     await client.end();


### PR DESCRIPTION
When using the AI agent launcher while viewing a dashboard, the chart quick-actions menu now offers a one-click 'Save to current dashboard' option. Previously, adding an AI-generated chart to the dashboard being viewed required opening the full save modal and several clicks.

The dashboard page publishes the currently viewed dashboard into the AI agent store (skipped in edit mode to avoid clobbering unsaved edits). The quick action creates the chart in that dashboard, appends a tile, and the dashboard refreshes in place via a store-driven request handled by the existing DashboardAiAgentContextBridge.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
