### PR TITLE
fix: escape embed JWT user attribute values

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -1,7 +1,7 @@
 import {
     ForbiddenError,
-    ParameterError,
     type AnonymousAccount,
+    type CreateEmbedJwt,
 } from '@lightdash/common';
 import { EmbedService } from './EmbedService';
 import {
@@ -254,6 +254,85 @@ describe('EmbedService', () => {
                 chartUuids: [],
                 type: 'dataApp',
                 explores: [],
+            });
+        });
+    });
+
+    describe('getEmbedUserAttributes', () => {
+        const embedJwt = {
+            content: { type: 'dashboard', dashboardUuid: 'dashboard-1' },
+            exp: Date.now() / 1000 + 3600,
+        } as CreateEmbedJwt;
+
+        const getServiceWithUserAttributes = (
+            orgUserAttributes: Array<{
+                name: string;
+                attributeDefault: string | null;
+            }> = [],
+        ) =>
+            new EmbedService({
+                ...EmbedServiceArgumentsMock,
+                userAttributesModel: {
+                    find: jest.fn().mockResolvedValue(orgUserAttributes),
+                },
+            } as unknown as ConstructorParameters<typeof EmbedService>[0]);
+
+        test('returns safe JWT user attributes and intrinsic email', async () => {
+            const scopedService = getServiceWithUserAttributes([
+                { name: 'region', attributeDefault: 'default-region' },
+                { name: 'tier', attributeDefault: 'enterprise' },
+            ]);
+
+            await expect(
+                scopedService.getEmbedUserAttributes(mockOrganizationUuid, {
+                    ...embedJwt,
+                    user: { email: 'viewer@example.com' },
+                    userAttributes: {
+                        region: 'EMEA',
+                    },
+                }),
+            ).resolves.toEqual({
+                intrinsicUserAttributes: {
+                    email: 'viewer@example.com',
+                },
+                userAttributes: {
+                    region: ['EMEA'],
+                    tier: ['enterprise'],
+                },
+            });
+        });
+
+        test('escapes JWT user attribute values', async () => {
+            const scopedService = getServiceWithUserAttributes();
+
+            await expect(
+                scopedService.getEmbedUserAttributes(mockOrganizationUuid, {
+                    ...embedJwt,
+                    userAttributes: {
+                        region: "EU' UNION SELECT email FROM users --",
+                    },
+                }),
+            ).resolves.toMatchObject({
+                userAttributes: {
+                    region: ["EU'' UNION SELECT email FROM users --"],
+                },
+            });
+        });
+
+        test('escapes JWT intrinsic email values', async () => {
+            const scopedService = getServiceWithUserAttributes();
+
+            await expect(
+                scopedService.getEmbedUserAttributes(mockOrganizationUuid, {
+                    ...embedJwt,
+                    user: {
+                        email: "x'/**/OR/**/1=1/**/--@example.com",
+                    },
+                }),
+            ).resolves.toMatchObject({
+                intrinsicUserAttributes: {
+                    email: "x''/**/OR/**/1=1/**/--@example.com",
+                },
             });
         });
     });

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -101,6 +101,9 @@ import { SubtotalsCalculator } from '../../../utils/SubtotalsCalculator';
 import { EmbedDashboardViewed, EmbedQueryViewed } from '../../analytics';
 import { EmbedModel } from '../../models/EmbedModel';
 
+const escapeEmbedJwtUserAttributeValue = (value: string): string =>
+    value.replaceAll("'", "''");
+
 type Dependencies = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
@@ -852,13 +855,21 @@ export class EmbedService extends BaseService {
                   if (value !== null && value !== undefined) {
                       let sanitizedValue: string[];
                       if (typeof value === 'string') {
-                          sanitizedValue = [value];
+                          sanitizedValue = [
+                              escapeEmbedJwtUserAttributeValue(value),
+                          ];
                       } else if (isArray(value)) {
                           sanitizedValue = (value as unknown[]).map((v) =>
-                              typeof v === 'string' ? v : JSON.stringify(v),
+                              escapeEmbedJwtUserAttributeValue(
+                                  typeof v === 'string' ? v : JSON.stringify(v),
+                              ),
                           );
                       } else {
-                          sanitizedValue = [JSON.stringify(value)];
+                          sanitizedValue = [
+                              escapeEmbedJwtUserAttributeValue(
+                                  JSON.stringify(value),
+                              ),
+                          ];
                       }
                       acc[key] = sanitizedValue;
                   }
@@ -872,7 +883,9 @@ export class EmbedService extends BaseService {
         };
 
         const intrinsicUserAttributes: IntrinsicUserAttributes = {
-            email: embedJwt.user?.email,
+            email: embedJwt.user?.email
+                ? escapeEmbedJwtUserAttributeValue(embedJwt.user.email)
+                : undefined,
         };
 
         return { userAttributes, intrinsicUserAttributes };


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/security/advisories/GHSA-r4xc-vwqr-3252

### Description:
Embed JWT user attribute values and intrinsic email addresses are now escaped before being used in queries. Single quotes in these values are doubled (`'` → `''`). This applies to string, array, and JSON-serialized attribute values, as well as the `email` field on the embedded user object.