### PR TITLE
fix(ai-agents): hide edit suggestion chips for non-editing agents

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1236,6 +1236,7 @@ export class AiAgentService extends BaseService {
                 {
                     agentName: agent.name,
                     agentInstruction: agent.instruction,
+                    canManageContent: agent.enableContentTools,
                     enabledTools,
                     explores,
                     verifiedQuestions,

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.test.ts
@@ -1,0 +1,46 @@
+import { buildSuggestionSystemPrompt } from './suggestionGenerator';
+
+describe('buildSuggestionSystemPrompt', () => {
+    it('appends the no-content-edit rule when the agent cannot manage content', () => {
+        const postResponse = buildSuggestionSystemPrompt({
+            isPostResponse: true,
+            canManageContent: false,
+        });
+        const emptyState = buildSuggestionSystemPrompt({
+            isPostResponse: false,
+            canManageContent: false,
+        });
+
+        expect(postResponse).toContain('CAPABILITY LIMIT');
+        expect(postResponse).toContain('CANNOT manage Lightdash content');
+        expect(emptyState).toContain('CAPABILITY LIMIT');
+    });
+
+    it('omits the no-content-edit rule when the agent can manage content', () => {
+        const postResponse = buildSuggestionSystemPrompt({
+            isPostResponse: true,
+            canManageContent: true,
+        });
+        const emptyState = buildSuggestionSystemPrompt({
+            isPostResponse: false,
+            canManageContent: true,
+        });
+
+        expect(postResponse).not.toContain('CAPABILITY LIMIT');
+        expect(emptyState).not.toContain('CAPABILITY LIMIT');
+    });
+
+    it('selects the post-response vs empty-state base prompt', () => {
+        const postResponse = buildSuggestionSystemPrompt({
+            isPostResponse: true,
+            canManageContent: true,
+        });
+        const emptyState = buildSuggestionSystemPrompt({
+            isPostResponse: false,
+            canManageContent: true,
+        });
+
+        expect(postResponse).toContain('AFTER the agent has just replied');
+        expect(emptyState).toContain('starter "chips"');
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/suggestionGenerator.ts
@@ -67,6 +67,29 @@ Tool guide:
 - \`generateDashboard\`: "build me an overview" or multi-chart
 - \`findContent\`: "is there already a saved chart for this", or to surface a verified chart`;
 
+// Appended when the agent cannot manage Lightdash content. The agent can run
+// queries and build NEW artifacts in chat, but cannot edit, update, overwrite,
+// or replace saved charts, dashboards, or dashboard tiles — so chips must never
+// offer those actions, even if the conversation drifts toward them.
+const NO_CONTENT_EDIT_RULE = `
+
+CAPABILITY LIMIT — This agent CANNOT manage Lightdash content. It can run queries, build NEW charts/dashboards in chat, and find existing content, but it CANNOT edit, update, overwrite, replace, or modify saved charts, dashboards, or dashboard tiles. NEVER write a chip that implies editing existing content (e.g. "Yes, update that dashboard tile", "Overwrite the chart", "Fix the saved filter", "Apply this to the dashboard"). If the conversation is heading toward changing existing content, pivot to what the agent CAN do — rebuild the corrected chart fresh in chat, or find related content.`;
+
+export function buildSuggestionSystemPrompt({
+    isPostResponse,
+    canManageContent,
+}: {
+    isPostResponse: boolean;
+    canManageContent: boolean;
+}): string {
+    const basePrompt = isPostResponse
+        ? POST_RESPONSE_PROMPT
+        : EMPTY_STATE_PROMPT;
+    return canManageContent
+        ? basePrompt
+        : `${basePrompt}${NO_CONTENT_EDIT_RULE}`;
+}
+
 export const SUGGESTION_FALLBACK_CHIPS: AgentSuggestion[] = [
     {
         kind: 'prompt',
@@ -126,6 +149,9 @@ type SuggestionFieldContext = {
 export type SuggestionPromptContext = {
     agentName: string;
     agentInstruction: string | null;
+    // When false, the agent has no content-editing tools — chips must not
+    // offer to edit/update/overwrite saved charts, dashboards, or tiles.
+    canManageContent: boolean;
     enabledTools: readonly string[];
     explores: Array<{
         name: string;
@@ -193,6 +219,11 @@ export async function generateAgentSuggestions(
         2,
     );
 
+    const systemContent = buildSuggestionSystemPrompt({
+        isPostResponse,
+        canManageContent: context.canManageContent,
+    });
+
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
@@ -201,9 +232,7 @@ export async function generateAgentSuggestions(
         messages: [
             {
                 role: 'system',
-                content: isPostResponse
-                    ? POST_RESPONSE_PROMPT
-                    : EMPTY_STATE_PROMPT,
+                content: systemContent,
             },
             {
                 role: 'user',


### PR DESCRIPTION
## What & why

When an AI agent has **content management disabled** (the "Allow agent to manage Lightdash content" toggle is off), the post-response suggestion chips could still offer edit actions such as **"Yes, update that dashboard tile"**. Clicking the chip sent the agent a request it cannot fulfil, and it replied that it cannot overwrite an existing tile — a confusing dead-end.

The empty-state suggestion prompt already forbade `"Update the {dashboard}"`-style chips, but the **post-response prompt had no such guard**, and neither prompt was aware of the agent's actual capabilities.

## Changes

- `suggestionGenerator.ts`: added a `canManageContent` field to `SuggestionPromptContext` and a `NO_CONTENT_EDIT_RULE` appended to the system prompt when the agent cannot manage content. It forbids chips that imply editing/updating/overwriting saved charts, dashboards, or tiles, and steers the model to what the agent *can* do (rebuild fresh, find content). Prompt assembly extracted into a pure, unit-testable `buildSuggestionSystemPrompt(...)`.
- `AiAgentService.ts`: passes `canManageContent: agent.enableContentTools` into the generator. `enableContentTools` is only persisted as `true` when `enableDataAccess` is also on, so it is a correct proxy for the agent's editing capability.
- `suggestionGenerator.test.ts`: regression tests asserting the rule is present iff `canManageContent` is false, across both prompt modes.

## Regression analysis

- **Agents with content management enabled** (`enableContentTools = true`): unaffected — the rule is not appended, so they can still surface edit/update chips, which they can act on.
- **Agents with content management disabled**: edit/update chips are now suppressed; they still get query / build-new / find-content chips.

## Notes

These chips are LLM-generated, so this is a prompt-level guard (matching the existing convention used for the empty-state forbidden patterns). It strongly reduces but does not 100%-guarantee the model never emits an edit chip. A hard server-side label filter was considered but rejected as too brittle (false drops on legitimate "update my view"-style phrasings).

## Verification

- `pnpm -F backend typecheck:fast` ✅
- `suggestionGenerator.test.ts` — 3/3 pass ✅
- backend lint on changed files ✅

Closes: ZAP-505