### PR TITLE
feat(preview): project-level S3 manifest source for UI previews

### DIFF
--- a/packages/backend/src/database/entities/projects.ts
+++ b/packages/backend/src/database/entities/projects.ts
@@ -41,6 +41,7 @@ export type DbProject = {
     expires_at: Date | null;
     default_preview_expiration_hours: number;
     max_preview_expiration_hours: number;
+    preview_manifest_s3_path: string | null;
 };
 
 type CreateDbProject = Pick<
@@ -82,6 +83,7 @@ type UpdateDbProject = Partial<
         | 'table_groups'
         | 'default_preview_expiration_hours'
         | 'max_preview_expiration_hours'
+        | 'preview_manifest_s3_path'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260615180000_add_preview_manifest_s3_path_to_projects.ts
+++ b/packages/backend/src/database/migrations/20260615180000_add_preview_manifest_s3_path_to_projects.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('projects', (table) => {
+        // S3 key of a pre-combined manifest.json. When set, UI-created previews
+        // of this project source their manifest from here instead of asking the
+        // user to paste/upload one (for large multi-repo combined manifests).
+        table.text('preview_manifest_s3_path').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('projects', (table) => {
+        table.dropColumn('preview_manifest_s3_path');
+    });
+}

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1165,6 +1165,26 @@ export class ProjectModel {
         }
     }
 
+    // S3 key of a pre-combined manifest.json used to source the manifest for
+    // UI-created previews of this project (large multi-repo combined manifests).
+    async getPreviewManifestS3Path(
+        projectUuid: string,
+    ): Promise<string | null> {
+        const [row] = await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .select('preview_manifest_s3_path');
+        return row?.preview_manifest_s3_path ?? null;
+    }
+
+    async updatePreviewManifestS3Path(
+        projectUuid: string,
+        s3Path: string | null,
+    ): Promise<void> {
+        await this.database(ProjectTableName)
+            .where('project_uuid', projectUuid)
+            .update({ preview_manifest_s3_path: s3Path });
+    }
+
     async get(projectUuid: string): Promise<Project> {
         const project = await this.getWithSensitiveFields(projectUuid);
         const sensitiveCredentials = project.warehouseConnection;

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -7,7 +7,9 @@ import {
     resolveDbtVersion,
 } from '@lightdash/common';
 import { warehouseClientFromCredentials } from '@lightdash/warehouses';
+import { type Readable } from 'stream';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { type FileStorageClient } from '../clients/FileStorage/FileStorageClient';
 import { getInstallationToken } from '../clients/github/Github';
 import Logger from '../logging/logger';
 import { CachedWarehouse, ProjectAdapter } from '../types';
@@ -20,12 +22,21 @@ import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectA
 import { DbtManifestProjectAdapter } from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
 
+const streamToString = async (stream: Readable): Promise<string> => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+};
+
 export const projectAdapterFromConfig = async (
     config: DbtProjectConfig,
     warehouseCredentials: CreateWarehouseCredentials,
     cachedWarehouse: CachedWarehouse,
     dbtVersionOption: DbtVersionOption,
     analytics?: LightdashAnalytics,
+    fileStorageClient?: FileStorageClient,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -56,14 +67,32 @@ export const projectAdapterFromConfig = async (
                 warehouseClient,
             });
 
-        case DbtProjectType.MANIFEST:
+        case DbtProjectType.MANIFEST: {
+            // When the manifest is sourced from S3 (large multi-repo combined
+            // manifests), fetch it at compile time rather than reading it inline.
+            let { manifest } = config;
+            if (config.manifestS3Path) {
+                if (!fileStorageClient) {
+                    throw new ParameterError(
+                        'Cannot resolve manifest from S3: file storage is not configured',
+                    );
+                }
+                Logger.debug(
+                    `Fetching preview manifest from S3: ${config.manifestS3Path}`,
+                );
+                const stream = await fileStorageClient.getFileStream(
+                    config.manifestS3Path,
+                );
+                manifest = await streamToString(stream);
+            }
             return new DbtManifestProjectAdapter({
                 warehouseClient,
                 cachedWarehouse,
                 dbtVersion,
                 analytics,
-                manifest: config.manifest,
+                manifest,
             });
+        }
 
         case DbtProjectType.DBT_CLOUD_IDE:
             return new DbtCloudIdeProjectAdapter({

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3271,6 +3271,7 @@ export class ProjectService extends BaseService {
             },
             data.dbtVersion || DefaultSupportedDbtVersion,
             this.analytics,
+            this.fileStorageClient,
         );
         try {
             await adapter.test();
@@ -3628,6 +3629,7 @@ export class ProjectService extends BaseService {
             },
             project.dbtVersion || DefaultSupportedDbtVersion,
             this.analytics,
+            this.fileStorageClient,
         );
         return { adapter, sshTunnel };
     }
@@ -7920,6 +7922,13 @@ export class ProjectService extends BaseService {
                 `Missing warehouse connection for project ${projectUuid}`,
             );
         }
+
+        // If the upstream project is configured with an S3 manifest source,
+        // previews fetch their (large, multi-repo combined) manifest from there
+        // unless the request supplies an explicit inline manifest override.
+        const previewManifestS3Path =
+            await this.projectModel.getPreviewManifestS3Path(projectUuid);
+
         const previewData: CreateProject = {
             name: data.name,
             type: ProjectType.PREVIEW,
@@ -7927,10 +7936,10 @@ export class ProjectService extends BaseService {
                 project.warehouseConnection,
                 data.warehouseConnectionOverrides ?? {},
             ),
-            dbtConnection: maybeOverrideDbtConnection(
-                project.dbtConnection,
-                data.dbtConnectionOverrides ?? {},
-            ),
+            dbtConnection: maybeOverrideDbtConnection(project.dbtConnection, {
+                ...(data.dbtConnectionOverrides ?? {}),
+                manifestS3Path: previewManifestS3Path ?? undefined,
+            }),
             upstreamProjectUuid: data.copyContent ? projectUuid : undefined,
             organizationWarehouseCredentialsUuid:
                 project.organizationWarehouseCredentialsUuid,

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -1,8 +1,11 @@
 import {
+    DbtProjectType,
     getDbtEnvironmentVariableKeyError,
     getInvalidDbtEnvironmentVariableKeys,
     isSafeDbtEnvironmentVariableKey,
     LIGHTDASH_DBT_PROFILE_ENV_VAR_PREFIX,
+    maybeOverrideDbtConnection,
+    type DbtGithubProjectConfig,
 } from './projects';
 
 describe('dbt environment variable validation', () => {
@@ -48,5 +51,53 @@ describe('dbt environment variable validation', () => {
                 { key: 'PYTHONPATH', value: '/tmp' },
             ]),
         ).toEqual(['GIT_SSH_COMMAND', 'PYTHONPATH']);
+    });
+});
+
+describe('maybeOverrideDbtConnection', () => {
+    const githubConnection: DbtGithubProjectConfig = {
+        type: DbtProjectType.GITHUB,
+        authorization_method: 'personal_access_token',
+        personal_access_token: 'token',
+        repository: 'org/repo',
+        branch: 'main',
+        project_sub_path: '/',
+    };
+
+    test('builds an S3-sourced MANIFEST connection when manifestS3Path is set', () => {
+        const result = maybeOverrideDbtConnection(githubConnection, {
+            manifestS3Path: 'previews/combined-manifest.json',
+        });
+
+        expect(result).toEqual({
+            type: DbtProjectType.MANIFEST,
+            manifest: '',
+            manifestS3Path: 'previews/combined-manifest.json',
+            hideRefreshButton: true,
+        });
+    });
+
+    test('an explicit inline manifest overrides the S3 source for that preview', () => {
+        const result = maybeOverrideDbtConnection(githubConnection, {
+            manifest: '{"nodes":{},"metadata":{}}',
+            manifestS3Path: 'previews/combined-manifest.json',
+        });
+
+        expect(result).toEqual({
+            type: DbtProjectType.MANIFEST,
+            manifest: '{"nodes":{},"metadata":{}}',
+            hideRefreshButton: true,
+        });
+    });
+
+    test('leaves the connection unchanged when no manifest source is provided', () => {
+        const result = maybeOverrideDbtConnection(githubConnection, {
+            branch: 'feature-branch',
+        });
+
+        expect(result).toEqual({
+            ...githubConnection,
+            branch: 'feature-branch',
+        });
     });
 });

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -765,7 +765,13 @@ export interface DbtNoneProjectConfig extends DbtProjectCompilerBase {
 
 export interface DbtManifestProjectConfig extends DbtProjectConfigBase {
     type: DbtProjectType.MANIFEST;
+    // Inline manifest JSON. Empty string when the manifest is sourced from S3
+    // (see manifestS3Path), which is resolved at compile time instead.
     manifest: string;
+    // When set, the manifest is fetched from this S3 key at compile time rather
+    // than read from `manifest`. Used for large multi-repo combined manifests
+    // that are too big to inline/paste.
+    manifestS3Path?: string;
     hideRefreshButton: boolean;
 }
 
@@ -858,13 +864,28 @@ export const maybeOverrideDbtConnection = <T extends DbtProjectConfig>(
         branch?: string;
         environment?: DbtProjectEnvironmentVariable[];
         manifest?: string;
+        manifestS3Path?: string;
     },
 ): T => {
-    // If manifest is provided, create a MANIFEST connection type
+    // An inline manifest is an explicit, opt-in per-preview override (paste box
+    // / direct API caller) — only set when the user deliberately provides one,
+    // so it wins when present.
     if (overrides.manifest) {
         return {
             type: DbtProjectType.MANIFEST,
             manifest: overrides.manifest,
+            hideRefreshButton: true,
+        } as T;
+    }
+
+    // Otherwise fall back to the project's configured S3 manifest source, which
+    // holds the full (multi-repo combined) manifest and is resolved at compile
+    // time. This is the default path for previews when nothing is pasted.
+    if (overrides.manifestS3Path) {
+        return {
+            type: DbtProjectType.MANIFEST,
+            manifest: '',
+            manifestS3Path: overrides.manifestS3Path,
             hideRefreshButton: true,
         } as T;
     }


### PR DESCRIPTION
Part of #24299. Stacked: this is the base; the streaming-parse perf change builds on top (#24304).

## What & why

Multi-repo dbt setups merge models from many repos into a single **combined** `manifest.json`. UI preview creation only accepts a *pasted* manifest, so previews of these projects only see one repo's models — cross-repo joins are skipped and dashboards break. The CLI workaround (`--combine-manifest`) is CLI-only and can't be delegated to non-technical users.

This adds a **project-level S3 manifest source**: a project can be configured with an S3 key holding the combined manifest, and UI-created previews fetch + use it automatically at compile time. The manifest never travels through the browser or the API request body.

## How it works

- New nullable column `projects.preview_manifest_s3_path`.
- `DbtManifestProjectConfig` gains an optional `manifestS3Path`. A preview for a configured project stores an **S3 reference** in its (encrypted) dbt connection, not an inline manifest — so the manifest stays out of Postgres.
- At compile time the manifest adapter reads the object from S3 via `FileStorageClient`.
- `ProjectService.createPreview` applies the upstream project's S3 source.

**Precedence:** an explicit inline manifest (paste box / API) is an opt-in per-preview override and wins when provided; otherwise the configured S3 source is used; otherwise branch/env overrides apply as before.

No new dependencies. Unit tests cover `maybeOverrideDbtConnection` (S3-source branch, inline-override precedence, passthrough). `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, and the common tests are green.

## Follow-ups (separate PRs / out of scope)
- **Streaming parse for very large manifests** → stacked PR #24304 (reads >512 MB manifests that the plain read can't, and is ~2.8× leaner).
- **Config surface** — column is read/written by the model; no settings UI/API yet (can be seeded for a pilot project).
- **Upload path** — how the manifest lands in S3 (customer pipeline → agreed S3 location) is operational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)