### PR TITLE
fix: handle invalid date filter values

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -5,7 +5,6 @@ import {
     isCustomSqlDimension,
     isDimension,
     isFilterRule,
-    parseDate,
     TimeFrames,
     timeframeToUnitOfTime,
     type BaseFilterRule,
@@ -17,6 +16,10 @@ import { type FilterInputsProps } from '.';
 import useFiltersContext from '../useFiltersContext';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
+import {
+    getInvalidDateFilterValue,
+    parseFilterDateValue,
+} from './DateFilterInputs.utils';
 import DefaultFilterInputs from './DefaultFilterInputs';
 import FilterDatePicker from './FilterDatePicker';
 import FilterDateRangePicker from './FilterDateRangePicker';
@@ -49,6 +52,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
         operator: rule.operator,
         disabled: rule.disabled && !rule.values,
     });
+    const invalidDateFilterValue = getInvalidDateFilterValue(rule.values);
 
     switch (rule.operator) {
         case FilterOperator.EQUALS:
@@ -74,13 +78,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                     placeholder={placeholder}
                                     disabled={disabled}
                                     data-autofocus
+                                    invalidValue={invalidDateFilterValue}
                                     value={
                                         rule.values && rule.values[0]
-                                            ? parseDate(
-                                                  formatDate(
-                                                      rule.values[0],
-                                                      TimeFrames.WEEK,
-                                                  ),
+                                            ? parseFilterDateValue(
+                                                  rule.values[0],
                                                   TimeFrames.WEEK,
                                               )
                                             : null
@@ -117,13 +119,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 placeholder={placeholder}
                                 data-autofocus
                                 popoverProps={popoverProps}
+                                invalidValue={invalidDateFilterValue}
                                 value={
                                     rule.values && rule.values[0]
-                                        ? parseDate(
-                                              formatDate(
-                                                  rule.values[0],
-                                                  TimeFrames.MONTH,
-                                              ),
+                                        ? parseFilterDateValue(
+                                              rule.values[0],
                                               TimeFrames.MONTH,
                                           )
                                         : null
@@ -141,7 +141,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     case TimeFrames.QUARTER:
                         const ruleValue = rule.values?.[0];
                         const parsedValue = ruleValue
-                            ? parseDate(ruleValue, TimeFrames.DAY)
+                            ? parseFilterDateValue(ruleValue, TimeFrames.DAY)
                             : null;
                         return (
                             <FilterQuarterPicker
@@ -149,6 +149,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 placeholder={placeholder}
                                 data-autofocus
                                 popoverProps={popoverProps}
+                                invalidValue={invalidDateFilterValue}
                                 value={parsedValue}
                                 onChange={(newDate: Date) => {
                                     onChange({
@@ -169,13 +170,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 placeholder={placeholder}
                                 data-autofocus
                                 popoverProps={popoverProps}
+                                invalidValue={invalidDateFilterValue}
                                 value={
                                     rule.values && rule.values[0]
-                                        ? parseDate(
-                                              formatDate(
-                                                  rule.values[0],
-                                                  TimeFrames.YEAR,
-                                              ),
+                                        ? parseFilterDateValue(
+                                              rule.values[0],
                                               TimeFrames.YEAR,
                                           )
                                         : null
@@ -199,12 +198,10 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             }
 
             if (isTimestamp) {
-                // For display only
-
-                let value =
-                    rule.values && rule.values[0]
+                const value =
+                    rule.values && rule.values[0] && !invalidDateFilterValue
                         ? dayjs(rule?.values?.[0]).toDate()
-                        : dayjs().toDate(); // Create
+                        : dayjs().toDate();
 
                 return (
                     <FilterDateTimePicker
@@ -219,6 +216,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         // so we need to do it manually and always pass it as a prop
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                         popoverProps={popoverProps}
+                        invalidValue={invalidDateFilterValue}
                         value={value}
                         onChange={(v: Date | null) => {
                             onChange({
@@ -241,10 +239,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     popoverProps={popoverProps}
                     data-autofocus
+                    invalidValue={invalidDateFilterValue}
                     value={
                         rule.values
-                            ? parseDate(
-                                  formatDate(rule.values[0], TimeFrames.DAY),
+                            ? parseFilterDateValue(
+                                  rule.values[0],
                                   TimeFrames.DAY,
                               )
                             : null
@@ -343,20 +342,32 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 />
             );
         case FilterOperator.IN_BETWEEN:
+            const invalidStartValue = getInvalidDateFilterValue(
+                rule.values?.[0] ? [rule.values[0]] : undefined,
+            );
+            const invalidEndValue = getInvalidDateFilterValue(
+                rule.values?.[1] ? [rule.values[1]] : undefined,
+            );
+
             if (isTimestamp) {
+                const startDate =
+                    rule.values?.[0] && !invalidStartValue
+                        ? dayjs(rule.values[0]).toDate()
+                        : null;
+                const endDate =
+                    rule.values?.[1] && !invalidEndValue
+                        ? dayjs(rule.values[1]).toDate()
+                        : null;
+
                 return (
                     <FilterDateTimeRangePicker
                         disabled={disabled}
                         data-autofocus
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                        value={
-                            rule.values && rule.values[0] && rule.values[1]
-                                ? [
-                                      dayjs(rule.values[0]).toDate(),
-                                      dayjs(rule.values[1]).toDate(),
-                                  ]
-                                : null
-                        }
+                        startValue={startDate}
+                        endValue={endDate}
+                        invalidStartValue={invalidStartValue}
+                        invalidEndValue={invalidEndValue}
                         popoverProps={popoverProps}
                         onChange={(value: [Date, Date] | null) => {
                             onChange({
@@ -373,31 +384,24 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 );
             }
 
+            const startDate = parseFilterDateValue(
+                rule.values?.[0],
+                TimeFrames.DAY,
+            );
+            const endDate = parseFilterDateValue(
+                rule.values?.[1],
+                TimeFrames.DAY,
+            );
+
             return (
                 <FilterDateRangePicker
                     disabled={disabled}
                     data-autofocus
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
-                    value={
-                        rule.values && rule.values[0] && rule.values[1]
-                            ? [
-                                  parseDate(
-                                      formatDate(
-                                          rule.values[0],
-                                          TimeFrames.DAY,
-                                      ),
-                                      TimeFrames.DAY,
-                                  ),
-                                  parseDate(
-                                      formatDate(
-                                          rule.values[1],
-                                          TimeFrames.DAY,
-                                      ),
-                                      TimeFrames.DAY,
-                                  ),
-                              ]
-                            : null
-                    }
+                    startValue={startDate}
+                    endValue={endDate}
+                    invalidStartValue={invalidStartValue}
+                    invalidEndValue={invalidEndValue}
                     popoverProps={popoverProps}
                     onChange={(value: [Date, Date] | null) => {
                         onChange({

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.utils.test.ts
@@ -1,0 +1,50 @@
+import { TimeFrames } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getInvalidDateFilterValue,
+    parseFilterDateValue,
+} from './DateFilterInputs.utils';
+
+describe('DateFilterInputs utils', () => {
+    describe('getInvalidDateFilterValue', () => {
+        it('returns invalid persisted date values', () => {
+            expect(getInvalidDateFilterValue(['NaT'])).toBe('NaT');
+            expect(getInvalidDateFilterValue(['2026-13-01'])).toBe(
+                '2026-13-01',
+            );
+            expect(getInvalidDateFilterValue(['Actual Vs Approved'])).toBe(
+                'Actual Vs Approved',
+            );
+        });
+
+        it('ignores empty and valid date values', () => {
+            expect(getInvalidDateFilterValue(['2026-06-16'])).toBeUndefined();
+            expect(getInvalidDateFilterValue([''])).toBeUndefined();
+            expect(getInvalidDateFilterValue(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('parseFilterDateValue', () => {
+        it('returns null for invalid values', () => {
+            expect(parseFilterDateValue('NaT', TimeFrames.DAY)).toBeNull();
+            expect(
+                parseFilterDateValue('2026-13-01', TimeFrames.DAY),
+            ).toBeNull();
+            expect(
+                parseFilterDateValue('Actual Vs Approved', TimeFrames.DAY),
+            ).toBeNull();
+        });
+
+        it('parses valid values for the requested timeframe', () => {
+            const day = parseFilterDateValue('2026-06-16', TimeFrames.DAY);
+            expect(day?.getFullYear()).toBe(2026);
+            expect(day?.getMonth()).toBe(5);
+            expect(day?.getDate()).toBe(16);
+
+            const month = parseFilterDateValue('2026-06-16', TimeFrames.MONTH);
+            expect(month?.getFullYear()).toBe(2026);
+            expect(month?.getMonth()).toBe(5);
+            expect(month?.getDate()).toBe(1);
+        });
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.utils.ts
@@ -1,0 +1,35 @@
+import { formatDate, parseDate, TimeFrames } from '@lightdash/common';
+import dayjs from 'dayjs';
+
+type DateFilterValue = string | number | Date;
+
+const isDateFilterValue = (value: unknown): value is DateFilterValue =>
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    value instanceof Date;
+
+export const getInvalidDateFilterValue = (
+    values: unknown[] | undefined,
+): string | undefined => {
+    const invalidValue = values?.find(
+        (value) =>
+            value !== undefined &&
+            value !== null &&
+            value !== '' &&
+            !parseFilterDateValue(value, TimeFrames.DAY),
+    );
+
+    return invalidValue === undefined ? undefined : String(invalidValue);
+};
+
+export const parseFilterDateValue = (
+    value: unknown,
+    timeFrame: TimeFrames,
+): Date | null => {
+    if (value === undefined || value === null || value === '') return null;
+    if (!isDateFilterValue(value)) return null;
+    if (!dayjs(value).isValid()) return null;
+
+    const parsedValue = parseDate(formatDate(value, timeFrame), timeFrame);
+    return dayjs(parsedValue).isValid() ? parsedValue : null;
+};

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDatePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDatePicker.tsx
@@ -1,5 +1,11 @@
-import { DateInput, type DateInputProps, type DayOfWeek } from '@mantine/dates';
+import {
+    DateInput,
+    DatePicker,
+    type DateInputProps,
+    type DayOfWeek,
+} from '@mantine/dates';
 import { type FC } from 'react';
+import InvalidDateInput from './InvalidDateInput';
 
 interface Props extends Omit<
     DateInputProps,
@@ -8,14 +14,41 @@ interface Props extends Omit<
     value: Date | null;
     onChange: (value: Date) => void;
     firstDayOfWeek: DayOfWeek;
+    invalidValue?: string;
 }
 
 const FilterDatePicker: FC<Props> = ({
     value,
     onChange,
     firstDayOfWeek,
+    invalidValue,
     ...rest
 }) => {
+    if (invalidValue) {
+        return (
+            <InvalidDateInput
+                value={invalidValue}
+                disabled={rest.disabled}
+                popoverProps={rest.popoverProps}
+                autoFocus={rest.autoFocus}
+            >
+                {({ close }) => (
+                    <DatePicker
+                        firstDayOfWeek={firstDayOfWeek}
+                        minDate={rest.minDate}
+                        maxDate={rest.maxDate}
+                        value={null}
+                        onChange={(date) => {
+                            if (!date) return;
+                            onChange(date);
+                            close();
+                        }}
+                    />
+                )}
+            </InvalidDateInput>
+        );
+    }
+
     return (
         <DateInput
             w="100%"

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
@@ -9,20 +9,26 @@ interface Props extends Omit<
     DateInputProps,
     'firstDayOfWeek' | 'getDayProps' | 'value' | 'onChange'
 > {
-    value: [Date, Date] | null;
+    startValue: Date | null;
+    endValue: Date | null;
     onChange: (value: [Date, Date] | null) => void;
     firstDayOfWeek: DayOfWeek;
+    invalidStartValue?: string;
+    invalidEndValue?: string;
 }
 
 const FilterDateRangePicker: FC<Props> = ({
-    value,
+    startValue,
+    endValue,
     disabled,
     firstDayOfWeek,
     onChange,
+    invalidStartValue,
+    invalidEndValue,
     ...rest
 }) => {
-    const [date1, setDate1] = useState(value?.[0] ?? null);
-    const [date2, setDate2] = useState(value?.[1] ?? null);
+    const [date1, setDate1] = useState(startValue);
+    const [date2, setDate2] = useState(endValue);
 
     return (
         <Flex align="center" w="100%" gap="xxs">
@@ -34,6 +40,7 @@ const FilterDateRangePicker: FC<Props> = ({
                     date2 ? dayjs(date2).subtract(1, 'day').toDate() : undefined
                 }
                 firstDayOfWeek={firstDayOfWeek}
+                invalidValue={invalidStartValue}
                 {...rest}
                 value={date1}
                 onChange={(newDate) => {
@@ -55,6 +62,7 @@ const FilterDateRangePicker: FC<Props> = ({
                 placeholder="End date"
                 minDate={dayjs(date1).add(1, 'day').toDate()}
                 firstDayOfWeek={firstDayOfWeek}
+                invalidValue={invalidEndValue}
                 {...rest}
                 value={date2}
                 onChange={(newDate) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -12,7 +12,7 @@ import {
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
-import { useCallback, useMemo, type FC } from 'react';
+import { useCallback, useMemo, useState, type FC } from 'react';
 import { useProject } from '../../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useFiltersContext from '../useFiltersContext';
@@ -21,6 +21,7 @@ import {
     shiftToProjectTimezone,
     unshiftFromProjectTimezone,
 } from './FilterDateTimePicker.utils';
+import InvalidDateInput from './InvalidDateInput';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -35,6 +36,7 @@ interface Props extends Omit<
     onChange: (value: Date) => void;
     firstDayOfWeek: DayOfWeek;
     showTimezone?: boolean;
+    invalidValue?: string;
 }
 
 const FilterDateTimePicker: FC<Props> = ({
@@ -42,9 +44,11 @@ const FilterDateTimePicker: FC<Props> = ({
     onChange,
     firstDayOfWeek,
     showTimezone = true,
+    invalidValue,
     ...rest
 }) => {
     const displayFormat = 'YYYY-MM-DD HH:mm:ss';
+    const [replacementValue, setReplacementValue] = useState<Date | null>(null);
 
     const { projectUuid, metricQueryTimezone } = useFiltersContext();
     const { data: enableTimezoneSupportFlag } = useServerFeatureFlag(
@@ -93,6 +97,55 @@ const FilterDateTimePicker: FC<Props> = ({
     const sideLabel = projectTimezone
         ? (getTimezoneLabel(projectTimezone) ?? projectTimezone)
         : browserTimezone;
+
+    if (invalidValue) {
+        return (
+            <Group wrap="nowrap" gap="xs" align="start" w="100%">
+                <InvalidDateInput
+                    value={invalidValue}
+                    disabled={rest.disabled}
+                    popoverProps={rest.popoverProps}
+                    autoFocus={rest.autoFocus}
+                >
+                    {({ close }) => (
+                        // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
+                        // @ts-ignore
+                        <DateTimePicker
+                            size="xs"
+                            w="100%"
+                            miw={185}
+                            placeholder={invalidValue}
+                            valueFormat={displayFormat}
+                            firstDayOfWeek={firstDayOfWeek}
+                            minDate={rest.minDate}
+                            maxDate={rest.maxDate}
+                            value={replacementValue}
+                            withSeconds={rest.withSeconds}
+                            timeInputProps={rest.timeInputProps}
+                            submitButtonProps={{
+                                ...rest.submitButtonProps,
+                                onClick: (event) => {
+                                    rest.submitButtonProps?.onClick?.(event);
+                                    if (replacementValue) {
+                                        handleChange(replacementValue);
+                                        close();
+                                    }
+                                },
+                            }}
+                            onChange={(date) => {
+                                setReplacementValue(date);
+                            }}
+                        />
+                    )}
+                </InvalidDateInput>
+                {showTimezone && (
+                    <Text fz="xs" c="dimmed" mt={7} className={styles.noWrap}>
+                        {sideLabel}
+                    </Text>
+                )}
+            </Group>
+        );
+    }
 
     return (
         <Group wrap="nowrap" gap="xs" align="start" w="100%">

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -9,20 +9,26 @@ interface Props extends Omit<
     DateTimePickerProps,
     'firstDayOfWeek' | 'getDayProps' | 'value' | 'onChange'
 > {
-    value: [Date, Date] | null;
+    startValue: Date | null;
+    endValue: Date | null;
     onChange: (value: [Date, Date] | null) => void;
     firstDayOfWeek: DayOfWeek;
+    invalidStartValue?: string;
+    invalidEndValue?: string;
 }
 
 const FilterDateTimeRangePicker: FC<Props> = ({
-    value,
+    startValue,
+    endValue,
     disabled,
     firstDayOfWeek,
     onChange,
+    invalidStartValue,
+    invalidEndValue,
     ...rest
 }) => {
-    const [date1, setDate1] = useState(value?.[0] ?? null);
-    const [date2, setDate2] = useState(value?.[1] ?? null);
+    const [date1, setDate1] = useState(startValue);
+    const [date2, setDate2] = useState(endValue);
 
     return (
         <Group wrap="nowrap" align="start" w="100%" gap="xs">
@@ -40,6 +46,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                         : undefined
                 }
                 firstDayOfWeek={firstDayOfWeek}
+                invalidValue={invalidStartValue}
                 {...rest}
                 value={date1}
                 onChange={(newDate) => {
@@ -68,6 +75,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                     date1 ? dayjs(date1).add(1, 'second').toDate() : undefined
                 }
                 firstDayOfWeek={firstDayOfWeek}
+                invalidValue={invalidEndValue}
                 {...rest}
                 value={date2}
                 onChange={(newDate) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMonthAndYearPicker.tsx
@@ -1,17 +1,57 @@
-import { MonthPickerInput, type MonthPickerInputProps } from '@mantine/dates';
+import {
+    MonthPicker,
+    MonthPickerInput,
+    type MonthPickerInputProps,
+} from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
+import InvalidDateInput from './InvalidDateInput';
 
 type Props = Omit<MonthPickerInputProps, 'value' | 'onChange'> & {
     value: Date | null;
     onChange: (value: Date) => void;
+    invalidValue?: string;
 };
 
-const FilterMonthAndYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
+const FilterMonthAndYearPicker: FC<Props> = ({
+    value,
+    onChange,
+    invalidValue,
+    ...props
+}) => {
     const [isPopoverOpen, { open, close, toggle }] = useDisclosure();
 
     const yearValue = value ? dayjs(value).toDate() : null;
+    const handleChange = (date: Date | null | Date[]) => {
+        if (!date || Array.isArray(date)) return;
+        onChange(date);
+        close();
+    };
+
+    if (invalidValue) {
+        return (
+            <InvalidDateInput
+                value={invalidValue}
+                disabled={props.disabled}
+                popoverProps={props.popoverProps}
+                autoFocus={props.autoFocus}
+            >
+                {({ close: closeInvalidInput }) => (
+                    <MonthPicker
+                        value={null}
+                        minDate={dayjs().year(1000).toDate()}
+                        maxDate={dayjs().year(9999).toDate()}
+                        onChange={(date) => {
+                            if (!date || Array.isArray(date)) return;
+                            onChange(date);
+                            closeInvalidInput();
+                        }}
+                    />
+                )}
+            </InvalidDateInput>
+        );
+    }
 
     return (
         <MonthPickerInput
@@ -37,11 +77,7 @@ const FilterMonthAndYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
                 },
             }}
             value={yearValue}
-            onChange={(date) => {
-                if (!date || Array.isArray(date)) return;
-                onChange(date);
-                close();
-            }}
+            onChange={handleChange}
         />
     );
 };

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -20,6 +20,7 @@ type Props = Pick<MonthPickerProps, 'value' | 'onChange'> & {
     disabled?: boolean;
     popoverProps?: any;
     autoFocus?: boolean;
+    invalidValue?: string;
 };
 
 const QUARTERS = [
@@ -36,6 +37,7 @@ const FilterQuarterPicker: FC<Props> = ({
     disabled,
     popoverProps,
     autoFocus,
+    invalidValue,
 }) => {
     const [opened, { open, close }] = useDisclosure(false);
 
@@ -154,10 +156,12 @@ const FilterQuarterPicker: FC<Props> = ({
                     onClick={disabled ? undefined : open}
                     placeholder={placeholder}
                     value={
-                        value
+                        invalidValue ??
+                        (value
                             ? formatDate(value, TimeFrames.QUARTER)
-                            : undefined
+                            : undefined)
                     }
+                    error={invalidValue ? 'Invalid date' : undefined}
                     readOnly
                     styles={{
                         input: {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterWeekPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterWeekPicker.tsx
@@ -1,4 +1,9 @@
-import { DateInput, type DateInputProps, type DayOfWeek } from '@mantine/dates';
+import {
+    DateInput,
+    DatePicker,
+    type DateInputProps,
+    type DayOfWeek,
+} from '@mantine/dates';
 import dayjs from 'dayjs';
 import { useState, type FC } from 'react';
 import {
@@ -6,6 +11,7 @@ import {
     isInWeekRange,
     startOfWeek,
 } from '../utils/filterDateUtils';
+import InvalidDateInput from './InvalidDateInput';
 
 interface Props extends Omit<
     DateInputProps,
@@ -14,15 +20,63 @@ interface Props extends Omit<
     value: Date | null;
     onChange: (value: Date) => void;
     firstDayOfWeek: DayOfWeek;
+    invalidValue?: string;
 }
 
 const FilterWeekPicker: FC<Props> = ({
     firstDayOfWeek,
     value,
     onChange,
+    invalidValue,
     ...rest
 }) => {
     const [hoveredDate, setHoveredDate] = useState<Date | null>(null);
+    const getDayProps = (date: Date) => {
+        const isHovered = isInWeekRange(date, hoveredDate, firstDayOfWeek);
+        const isSelected = isInWeekRange(date, value, firstDayOfWeek);
+        const isInRange = isHovered || isSelected;
+
+        return {
+            onMouseEnter: () => setHoveredDate(date),
+            onMouseLeave: () => setHoveredDate(null),
+            inRange: isInRange,
+            firstInRange: isInRange
+                ? dayjs(startOfWeek(date, firstDayOfWeek)).isSame(date)
+                : false,
+            lastInRange: isInRange
+                ? dayjs(endOfWeek(date, firstDayOfWeek)).isSame(date)
+                : false,
+            selected: isSelected,
+        };
+    };
+    const handleChange = (date: Date | null) => {
+        if (date) {
+            onChange(startOfWeek(date, firstDayOfWeek));
+        }
+    };
+
+    if (invalidValue) {
+        return (
+            <InvalidDateInput
+                value={invalidValue}
+                disabled={rest.disabled}
+                popoverProps={rest.popoverProps}
+                autoFocus={rest.autoFocus}
+            >
+                {({ close }) => (
+                    <DatePicker
+                        firstDayOfWeek={firstDayOfWeek}
+                        value={null}
+                        getDayProps={getDayProps}
+                        onChange={(date) => {
+                            handleChange(date);
+                            close();
+                        }}
+                    />
+                )}
+            </InvalidDateInput>
+        );
+    }
 
     return (
         <DateInput
@@ -30,35 +84,10 @@ const FilterWeekPicker: FC<Props> = ({
             size="xs"
             {...rest}
             popoverProps={{ shadow: 'sm', ...rest.popoverProps }}
-            getDayProps={(date) => {
-                const isHovered = isInWeekRange(
-                    date,
-                    hoveredDate,
-                    firstDayOfWeek,
-                );
-                const isSelected = isInWeekRange(date, value, firstDayOfWeek);
-                const isInRange = isHovered || isSelected;
-
-                return {
-                    onMouseEnter: () => setHoveredDate(date),
-                    onMouseLeave: () => setHoveredDate(null),
-                    inRange: isInRange,
-                    firstInRange: isInRange
-                        ? dayjs(startOfWeek(date, firstDayOfWeek)).isSame(date)
-                        : false,
-                    lastInRange: isInRange
-                        ? dayjs(endOfWeek(date, firstDayOfWeek)).isSame(date)
-                        : false,
-                    selected: isSelected,
-                };
-            }}
+            getDayProps={getDayProps}
             firstDayOfWeek={firstDayOfWeek}
             value={value}
-            onChange={(date) => {
-                if (date) {
-                    onChange(startOfWeek(date, firstDayOfWeek));
-                }
-            }}
+            onChange={handleChange}
         />
     );
 };

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterYearPicker.tsx
@@ -1,16 +1,56 @@
-import { YearPickerInput, type YearPickerInputProps } from '@mantine/dates';
+import {
+    YearPicker,
+    YearPickerInput,
+    type YearPickerInputProps,
+} from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
+import InvalidDateInput from './InvalidDateInput';
 
 type Props = Omit<YearPickerInputProps, 'value' | 'onChange'> & {
     value: Date | null;
     onChange: (value: Date) => void;
+    invalidValue?: string;
 };
-const FilterYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
+const FilterYearPicker: FC<Props> = ({
+    value,
+    onChange,
+    invalidValue,
+    ...props
+}) => {
     const [isPopoverOpen, { open, close, toggle }] = useDisclosure();
 
     const yearValue = value ? dayjs(value).toDate() : null;
+    const handleChange = (date: Date | null | Date[]) => {
+        if (!date || Array.isArray(date)) return;
+        onChange(date);
+        close();
+    };
+
+    if (invalidValue) {
+        return (
+            <InvalidDateInput
+                value={invalidValue}
+                disabled={props.disabled}
+                popoverProps={props.popoverProps}
+                autoFocus={props.autoFocus}
+            >
+                {({ close: closeInvalidInput }) => (
+                    <YearPicker
+                        value={null}
+                        minDate={dayjs().year(1000).toDate()}
+                        maxDate={dayjs().year(9999).toDate()}
+                        onChange={(date) => {
+                            if (!date || Array.isArray(date)) return;
+                            onChange(date);
+                            closeInvalidInput();
+                        }}
+                    />
+                )}
+            </InvalidDateInput>
+        );
+    }
 
     return (
         <YearPickerInput
@@ -36,11 +76,7 @@ const FilterYearPicker: FC<Props> = ({ value, onChange, ...props }) => {
                 },
             }}
             value={yearValue}
-            onChange={(date) => {
-                if (!date || Array.isArray(date)) return;
-                onChange(date);
-                close();
-            }}
+            onChange={handleChange}
         />
     );
 };

--- a/packages/frontend/src/components/common/Filters/FilterInputs/InvalidDateInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/InvalidDateInput.tsx
@@ -1,0 +1,61 @@
+import { Popover, TextInput } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { type FC, type ReactNode } from 'react';
+
+type Props = {
+    value: string;
+    disabled?: boolean;
+    popoverProps?: any;
+    autoFocus?: boolean;
+    children: ({ close }: { close: () => void }) => ReactNode;
+};
+
+const InvalidDateInput: FC<Props> = ({
+    value,
+    disabled,
+    popoverProps,
+    autoFocus,
+    children,
+}) => {
+    const [opened, { open, close }] = useDisclosure(false);
+
+    const openPopover = () => {
+        if (disabled) return;
+        popoverProps?.onOpen?.();
+        open();
+    };
+
+    const closePopover = () => {
+        popoverProps?.onClose?.();
+        close();
+    };
+
+    return (
+        <Popover
+            shadow="sm"
+            withinPortal
+            {...popoverProps}
+            opened={opened}
+            onClose={closePopover}
+        >
+            <Popover.Target>
+                <TextInput
+                    w="100%"
+                    size="xs"
+                    data-autofocus={autoFocus || undefined}
+                    value={value}
+                    error="Invalid date"
+                    disabled={disabled}
+                    readOnly
+                    styles={{ input: { cursor: 'pointer' } }}
+                    onClick={openPopover}
+                />
+            </Popover.Target>
+            <Popover.Dropdown>
+                {children({ close: closePopover })}
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+export default InvalidDateInput;


### PR DESCRIPTION
### Summary
- Show invalid persisted date filter values without crashing the filter panel
- Let users replace invalid single and range date values from the picker
- Preserve range constraints when correcting invalid endpoints

### Testing
- pnpm -F frontend test DateFilterInputs.utils.test.ts -- --runInBand
- pnpm -F frontend typecheck:fast (fails: existing ThreadPreviewSidebar.test.tsx matcher typings)

Closes: PROD-8324