### PR TITLE
feat(ai-agents): enable content editing from chat for non-editing agents (ZAP-506 pt 1)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -409,6 +409,22 @@ function detectRefusal(text: string): boolean {
     return REFUSAL_RE.test(text);
 }
 
+// Matches the agent stating it cannot change EXISTING saved content. Requires
+// an inability cue AND an edit-verb-on-content cue so generic refusals (data
+// access, out of scope) don't fire. Deterministic sibling to detectRefusal.
+const CONTENT_EDIT_INABILITY_RE =
+    /\b(can'?t|cannot|can not|unable to|not able to|don'?t have (?:the )?(?:ability|capability)|isn'?t (?:enabled|available|supported)|not (?:enabled|available|supported))\b/i;
+const CONTENT_EDIT_TARGET_RE =
+    /\b(edit|editing|update|updating|overwrite|overwriting|modify|modifying|change|changing|replace|replacing)\b[^.?!]*\b(chart|dashboard|tile|saved|content|filter)\b/i;
+
+export function detectContentEditBlock(text: string): boolean {
+    if (!text) return false;
+    return (
+        CONTENT_EDIT_INABILITY_RE.test(text) &&
+        CONTENT_EDIT_TARGET_RE.test(text)
+    );
+}
+
 // Find the explore the agent's most recent query-producing tool call hit.
 // Returns a compact slice of its fields (labels) so the suggestion prompt can
 // stay grounded in fields the agent JUST used instead of the full catalogue.

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -409,9 +409,7 @@ function detectRefusal(text: string): boolean {
     return REFUSAL_RE.test(text);
 }
 
-// Matches the agent stating it cannot change EXISTING saved content. Requires
-// an inability cue AND an edit-verb-on-content cue so generic refusals (data
-// access, out of scope) don't fire. Deterministic sibling to detectRefusal.
+// Requires inability cue + edit-verb-on-content cue; sibling to detectRefusal.
 const CONTENT_EDIT_INABILITY_RE =
     /\b(can'?t|cannot|can not|unable to|not able to|don'?t have (?:the )?(?:ability|capability)|isn'?t (?:enabled|available|supported)|not (?:enabled|available|supported))\b/i;
 const CONTENT_EDIT_TARGET_RE =

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1124,7 +1124,7 @@ export class AiAgentService extends BaseService {
             afterMessageUuid?: string;
             enableSqlMode?: boolean;
         },
-    ): Promise<{ chips: AgentSuggestion[] }> {
+    ): Promise<{ chips: AgentSuggestion[]; contentEditBlocked: boolean }> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -1135,7 +1135,7 @@ export class AiAgentService extends BaseService {
             featureFlagId: FeatureFlags.AiAgentSuggestions,
         });
         if (!featureEnabled.enabled) {
-            return { chips: [] };
+            return { chips: [], contentEditBlocked: false };
         }
 
         const agent = await this.getAgent(user, agentUuid, projectUuid);
@@ -1152,7 +1152,7 @@ export class AiAgentService extends BaseService {
             }
 
             if (!canGeneratePostResponseSuggestions(user.userUuid, thread)) {
-                return { chips: [] };
+                return { chips: [], contentEditBlocked: false };
             }
         }
 
@@ -1345,7 +1345,13 @@ export class AiAgentService extends BaseService {
             },
         });
 
-        return { chips };
+        const contentEditBlocked = Boolean(
+            !agent.enableContentTools &&
+                threadContext?.latestAssistantTurn?.text != null &&
+                detectContentEditBlock(threadContext.latestAssistantTurn.text),
+        );
+
+        return { chips, contentEditBlocked };
     }
 
     private async buildSuggestionsThreadContext({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1345,11 +1345,11 @@ export class AiAgentService extends BaseService {
             },
         });
 
-        const contentEditBlocked = Boolean(
+        const latestText = threadContext?.latestAssistantTurn?.text;
+        const contentEditBlocked =
             !agent.enableContentTools &&
-                threadContext?.latestAssistantTurn?.text != null &&
-                detectContentEditBlock(threadContext.latestAssistantTurn.text),
-        );
+            latestText !== undefined &&
+            detectContentEditBlock(latestText);
 
         return { chips, contentEditBlocked };
     }

--- a/packages/backend/src/ee/services/AiAgentService/detectContentEditBlock.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/detectContentEditBlock.test.ts
@@ -1,0 +1,33 @@
+import { detectContentEditBlock } from './AiAgentService';
+
+describe('detectContentEditBlock', () => {
+    it('detects the agent declining to edit existing content', () => {
+        expect(
+            detectContentEditBlock(
+                "I can't directly overwrite an existing dashboard tile from here.",
+            ),
+        ).toBe(true);
+        expect(
+            detectContentEditBlock(
+                'I am not able to update the saved chart for you.',
+            ),
+        ).toBe(true);
+        expect(
+            detectContentEditBlock(
+                "I can't modify that dashboard — editing content isn't enabled.",
+            ),
+        ).toBe(true);
+    });
+
+    it('does not fire on normal replies or unrelated refusals', () => {
+        expect(
+            detectContentEditBlock('Here is a chart of revenue by month.'),
+        ).toBe(false);
+        expect(
+            detectContentEditBlock(
+                "I can't access that data because data access is disabled.",
+            ),
+        ).toBe(false);
+        expect(detectContentEditBlock('')).toBe(false);
+    });
+});

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -11602,7 +11602,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__chips-AgentSuggestion-Array__': {
+    'ApiSuccess__chips-AgentSuggestion-Array--contentEditBlocked-boolean__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -11610,6 +11610,10 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        contentEditBlocked: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
                         chips: {
                             dataType: 'array',
                             array: {
@@ -11630,7 +11634,7 @@ const models: TsoaRoute.Models = {
     ApiAgentSuggestionsResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__chips-AgentSuggestion-Array__',
+            ref: 'ApiSuccess__chips-AgentSuggestion-Array--contentEditBlocked-boolean__',
             validators: {},
         },
     },
@@ -12557,11 +12561,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -12619,11 +12623,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -14219,11 +14223,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -29847,7 +29851,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29857,7 +29861,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29867,7 +29871,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29880,7 +29884,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -13228,10 +13228,13 @@
                     }
                 ]
             },
-            "ApiSuccess__chips-AgentSuggestion-Array__": {
+            "ApiSuccess__chips-AgentSuggestion-Array--contentEditBlocked-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
+                            "contentEditBlocked": {
+                                "type": "boolean"
+                            },
                             "chips": {
                                 "items": {
                                     "$ref": "#/components/schemas/AgentSuggestion"
@@ -13239,7 +13242,7 @@
                                 "type": "array"
                             }
                         },
-                        "required": ["chips"],
+                        "required": ["contentEditBlocked", "chips"],
                         "type": "object"
                     },
                     "status": {
@@ -13252,7 +13255,7 @@
                 "type": "object"
             },
             "ApiAgentSuggestionsResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__chips-AgentSuggestion-Array__"
+                "$ref": "#/components/schemas/ApiSuccess__chips-AgentSuggestion-Array--contentEditBlocked-boolean__"
             },
             "ReadinessScoreEvaluation": {
                 "properties": {
@@ -14145,8 +14148,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14204,8 +14207,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -14933,19 +14936,6 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -30511,22 +30501,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39542,7 +39532,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3163.0",
+        "version": "0.3167.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
@@ -86,4 +86,7 @@ export type AgentSuggestionsModelObject = z.infer<
 
 export type ApiAgentSuggestionsResponse = ApiSuccess<{
     chips: AgentSuggestion[];
+    // True when the latest assistant turn declined a content edit and the
+    // agent has content tools disabled. Drives the in-chat capability callout.
+    contentEditBlocked: boolean;
 }>;

--- a/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentSuggestions.ts
@@ -86,7 +86,6 @@ export type AgentSuggestionsModelObject = z.infer<
 
 export type ApiAgentSuggestionsResponse = ApiSuccess<{
     chips: AgentSuggestion[];
-    // True when the latest assistant turn declined a content edit and the
-    // agent has content tools disabled. Drives the in-chat capability callout.
+    // True when the agent declined a content edit and content tools are off.
     contentEditBlocked: boolean;
 }>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -471,16 +471,13 @@ export const AgentChatInput = ({
         (suggestionsQuery.isLoading || suggestionsQuery.isFetching);
 
     const renderChipRow = (extraClassName = '', reserve = false) =>
-        (chipRow || contentEditCallout || reserve) && (
+        (chipRow || reserve) && (
             <Box
                 className={`${styles.chipReveal} ${extraClassName} ${
                     chipsNearBottom ? '' : styles.chipHidden
-                } ${!chipRow && !contentEditCallout ? styles.chipReserved : ''}`}
-                aria-hidden={
-                    !chipsNearBottom || (!chipRow && !contentEditCallout)
-                }
+                } ${!chipRow ? styles.chipReserved : ''}`}
+                aria-hidden={!chipsNearBottom || !chipRow}
             >
-                {contentEditCallout}
                 {chipRow ?? <Box className={styles.chipTrayReserve} />}
             </Box>
         );
@@ -540,6 +537,7 @@ export const AgentChatInput = ({
                 }`}
                 ref={rootRef}
             >
+                {contentEditCallout}
                 {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
                 <Box className={styles.threadInputStack}>
@@ -621,6 +619,7 @@ export const AgentChatInput = ({
                 showDisabledBanner ? styles.disabledBannerVisible : ''
             }`}
         >
+            {contentEditCallout}
             {isThreadInput && renderChipRow(styles.threadChipFlow)}
 
             <Box

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -24,6 +24,7 @@ import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
 import styles from './AgentChatInput.module.css';
+import { AgentContentEditCallout } from './AgentContentEditCallout';
 import { AgentSuggestionChips } from './AgentSuggestionChips';
 import {
     createContentMentionExtension,
@@ -446,6 +447,22 @@ export const AgentChatInput = ({
         handleImpression,
         isThreadInput,
     ]);
+    const contentEditCallout =
+        postResponseMode &&
+        suggestionsQuery.data?.contentEditBlocked &&
+        projectUuid &&
+        agentUuid &&
+        threadUuid ? (
+            <AgentContentEditCallout
+                projectUuid={projectUuid}
+                agentUuid={agentUuid}
+                threadUuid={threadUuid}
+                onResend={(message) =>
+                    onSubmitRef.current({ message, toolHints: [] })
+                }
+            />
+        ) : null;
+
     const shouldReserveEmptyStateSuggestions =
         !isThreadInput &&
         emptyStateMode &&
@@ -454,13 +471,16 @@ export const AgentChatInput = ({
         (suggestionsQuery.isLoading || suggestionsQuery.isFetching);
 
     const renderChipRow = (extraClassName = '', reserve = false) =>
-        (chipRow || reserve) && (
+        (chipRow || contentEditCallout || reserve) && (
             <Box
                 className={`${styles.chipReveal} ${extraClassName} ${
                     chipsNearBottom ? '' : styles.chipHidden
-                } ${!chipRow ? styles.chipReserved : ''}`}
-                aria-hidden={!chipsNearBottom || !chipRow}
+                } ${!chipRow && !contentEditCallout ? styles.chipReserved : ''}`}
+                aria-hidden={
+                    !chipsNearBottom || (!chipRow && !contentEditCallout)
+                }
             >
+                {contentEditCallout}
                 {chipRow ?? <Box className={styles.chipTrayReserve} />}
             </Box>
         );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
@@ -1,0 +1,137 @@
+import { Button, Group, Popover, Stack, Text } from '@mantine-8/core';
+import { IconPencilCog } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import Callout from '../../../../../components/common/Callout';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
+import {
+    useAiAgentThread,
+    useProjectUpdateAiAgentMutation,
+} from '../../hooks/useProjectAiAgents';
+import {
+    getContentEditCalloutActions,
+    hasContentEditCalloutActions,
+} from './contentEditCallout';
+
+type Props = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    onResend: (message: string) => void;
+};
+
+export const AgentContentEditCallout: FC<Props> = ({
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    onResend,
+}) => {
+    const canManageAgent = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
+    const { data: thread } = useAiAgentThread(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
+    const { mutateAsync: updateAgent, isLoading: isEnabling } =
+        useProjectUpdateAiAgentMutation(projectUuid, {
+            showSuccessToast: false,
+        });
+    const [confirmOpened, setConfirmOpened] = useState(false);
+
+    const lastUserMessage = useMemo(() => {
+        const messages = thread?.messages ?? [];
+        for (let i = messages.length - 1; i >= 0; i -= 1) {
+            const msg = messages[i];
+            if (msg.role === 'user') {
+                return msg.message;
+            }
+        }
+        return null;
+    }, [thread?.messages]);
+
+    const handleEnable = useCallback(async () => {
+        await updateAgent({
+            uuid: agentUuid,
+            enableDataAccess: true,
+            enableContentTools: true,
+        });
+        setConfirmOpened(false);
+        if (lastUserMessage) onResend(lastUserMessage);
+    }, [updateAgent, agentUuid, lastUserMessage, onResend]);
+
+    // Route action (capableAgent) is added in a later task.
+    const actions = getContentEditCalloutActions({
+        canManageAgent: canManageAgent ?? false,
+        capableAgent: null,
+    });
+
+    if (!hasContentEditCalloutActions(actions)) return null;
+
+    return (
+        <Callout
+            variant="info"
+            title="This agent can't edit content"
+            icon={<MantineIcon icon={IconPencilCog} />}
+        >
+            <Stack gap="xs">
+                <Text size="xs" c="dimmed">
+                    Turn on content editing for this agent so it can update
+                    saved charts, dashboards, and tiles.
+                </Text>
+                <Group gap="xs">
+                    {actions.showEnable && (
+                        <Popover
+                            opened={confirmOpened}
+                            onChange={setConfirmOpened}
+                            position="top-start"
+                            withArrow
+                            width={280}
+                        >
+                            <Popover.Target>
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    loading={isEnabling}
+                                    onClick={() => setConfirmOpened((o) => !o)}
+                                >
+                                    Enable content editing
+                                </Button>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                                <Stack gap="xs">
+                                    <Text size="xs">
+                                        This also enables data access, letting
+                                        the agent read the data behind charts.
+                                        Continue?
+                                    </Text>
+                                    <Group gap="xs" justify="flex-end">
+                                        <Button
+                                            size="xs"
+                                            variant="subtle"
+                                            color="gray"
+                                            onClick={() =>
+                                                setConfirmOpened(false)
+                                            }
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button
+                                            size="xs"
+                                            loading={isEnabling}
+                                            onClick={() => void handleEnable()}
+                                        >
+                                            Enable
+                                        </Button>
+                                    </Group>
+                                </Stack>
+                            </Popover.Dropdown>
+                        </Popover>
+                    )}
+                </Group>
+            </Stack>
+        </Callout>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
@@ -1,8 +1,10 @@
 import { Button, Group, Popover, Stack, Text } from '@mantine-8/core';
 import { IconPencilCog } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import Callout from '../../../../../components/common/Callout';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { AGENT_SUGGESTIONS_KEY } from '../../hooks/useAgentSuggestions';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
 import {
     useAiAgentThread,
@@ -39,6 +41,7 @@ export const AgentContentEditCallout: FC<Props> = ({
         useProjectUpdateAiAgentMutation(projectUuid, {
             showSuccessToast: false,
         });
+    const queryClient = useQueryClient();
     const [confirmOpened, setConfirmOpened] = useState(false);
 
     const lastUserMessage = useMemo(() => {
@@ -58,9 +61,19 @@ export const AgentContentEditCallout: FC<Props> = ({
             enableDataAccess: true,
             enableContentTools: true,
         });
+        await queryClient.invalidateQueries({
+            queryKey: [AGENT_SUGGESTIONS_KEY, projectUuid, agentUuid],
+        });
         setConfirmOpened(false);
         if (lastUserMessage) onResend(lastUserMessage);
-    }, [updateAgent, agentUuid, lastUserMessage, onResend]);
+    }, [
+        updateAgent,
+        agentUuid,
+        projectUuid,
+        queryClient,
+        lastUserMessage,
+        onResend,
+    ]);
 
     // Route action (capableAgent) is added in a later task.
     const actions = getContentEditCalloutActions({

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
@@ -95,6 +95,7 @@ export const AgentContentEditCallout: FC<Props> = ({
                                     size="xs"
                                     variant="default"
                                     loading={isEnabling}
+                                    disabled={isEnabling}
                                     onClick={() => setConfirmOpened((o) => !o)}
                                 >
                                     Enable content editing

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentEditCallout.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentEditCallout.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getContentEditCalloutActions,
+    hasContentEditCalloutActions,
+} from './contentEditCallout';
+
+describe('getContentEditCalloutActions', () => {
+    it('shows enable when the user can manage the agent', () => {
+        expect(
+            getContentEditCalloutActions({
+                canManageAgent: true,
+                capableAgent: null,
+            }),
+        ).toEqual({ showEnable: true, routeAgent: null });
+    });
+
+    it('shows route when a capable sibling agent exists', () => {
+        const agent = { uuid: 'a1', name: 'Builder' };
+        expect(
+            getContentEditCalloutActions({
+                canManageAgent: false,
+                capableAgent: agent,
+            }),
+        ).toEqual({ showEnable: false, routeAgent: agent });
+    });
+
+    it('shows both when both apply', () => {
+        const agent = { uuid: 'a1', name: 'Builder' };
+        expect(
+            getContentEditCalloutActions({
+                canManageAgent: true,
+                capableAgent: agent,
+            }),
+        ).toEqual({ showEnable: true, routeAgent: agent });
+    });
+
+    it('renders nothing when neither applies', () => {
+        const result = getContentEditCalloutActions({
+            canManageAgent: false,
+            capableAgent: null,
+        });
+        expect(result.showEnable).toBe(false);
+        expect(result.routeAgent).toBe(null);
+    });
+});
+
+describe('hasContentEditCalloutActions', () => {
+    it('returns true when showEnable is true', () => {
+        expect(
+            hasContentEditCalloutActions({
+                showEnable: true,
+                routeAgent: null,
+            }),
+        ).toBe(true);
+    });
+
+    it('returns true when routeAgent is set', () => {
+        expect(
+            hasContentEditCalloutActions({
+                showEnable: false,
+                routeAgent: { uuid: 'a1', name: 'Builder' },
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when neither is set', () => {
+        expect(
+            hasContentEditCalloutActions({
+                showEnable: false,
+                routeAgent: null,
+            }),
+        ).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentEditCallout.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentEditCallout.ts
@@ -1,0 +1,27 @@
+export type CapableAgentRef = { uuid: string; name: string };
+
+export type ContentEditCalloutActions = {
+    showEnable: boolean;
+    routeAgent: CapableAgentRef | null;
+};
+
+// Decides which callout actions to show from real state only — no LLM, no network.
+export function getContentEditCalloutActions({
+    canManageAgent,
+    capableAgent,
+}: {
+    canManageAgent: boolean;
+    capableAgent: CapableAgentRef | null;
+}): ContentEditCalloutActions {
+    return {
+        showEnable: canManageAgent,
+        routeAgent: capableAgent,
+    };
+}
+
+// True when the callout has at least one action to offer.
+export function hasContentEditCalloutActions(
+    actions: ContentEditCalloutActions,
+): boolean {
+    return actions.showEnable || actions.routeAgent !== null;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAgentSuggestions.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAgentSuggestions.ts
@@ -2,7 +2,7 @@ import type { ApiAgentSuggestionsResponse, ApiError } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { lightdashApi } from '../../../../api';
 
-const AGENT_SUGGESTIONS_KEY = 'agentSuggestions';
+export const AGENT_SUGGESTIONS_KEY = 'agentSuggestions';
 
 const getAgentSuggestions = (
     projectUuid: string,


### PR DESCRIPTION
## What & why

Follow-up to the ZAP-505 fix (which stopped non-editing agents from *suggesting* edit actions they can't perform). This PR gives the user a constructive next step instead of a dead end: when the current AI agent can't edit content but the user asked it to, an in-chat callout offers a one-click **"Enable content editing"** for admins/developers.

This is **PR 1 of 2** for ZAP-506. PR 2 (stacked) adds the second action — routing the conversation to an edit-capable agent.

## How it works

**Detection is deterministic — no extra LLM call.** The post-response suggestions endpoint already runs cheap regex turn-analysis (`detectRefusal`, `detectClarifyingQuestion`). This adds a sibling `detectContentEditBlock` that fires only when the assistant's own reply both expresses inability *and* targets editing existing content (so generic refusals — e.g. about data access — don't trigger it). The endpoint returns a single `contentEditBlocked` boolean.

**The callout decides what to show from real state only.** `AgentContentEditCallout` renders beside the suggestion chips (outside the chips' scroll-reveal wrapper, so it stays visible and clickable) when `contentEditBlocked` is true. The "Enable content editing" button shows only for users with `manage` permission on the agent. Clicking it opens a small confirm popover (enabling content editing also turns on data access), PATCHes the agent, invalidates the suggestions query, and auto-resends the user's last message so the now-capable agent performs the edit.

## Changes

- `detectContentEditBlock` regex detector + unit tests (backend).
- `contentEditBlocked: boolean` added to `ApiAgentSuggestionsResponse`, computed in `getAgentSuggestions` (returns `false` in empty-state and on early-exit paths).
- `getContentEditCalloutActions` / `hasContentEditCalloutActions` pure helper + unit tests (frontend).
- `AgentContentEditCallout` component (Enable action) + rendering in `AgentChatInput`.

## Regression analysis

- **Agents with content editing enabled:** `contentEditBlocked` is always `false` for them — no callout, no behavior change.
- **Empty-state / new threads:** flag is `false` (no assistant turn to analyze) — no callout.
- **Non-admin users with a no-edit agent:** the Enable action is gated by `manage` permission, so they see nothing in this PR (PR 2 adds the routing action for them). No dead ends.
- The detector is conservative (requires inability + content-edit-target cues in the same reply); false positives still only surface a valid, dismissible affordance.

## Testing

- Backend: `detectContentEditBlock.test.ts` (positive: overwrite tile / update saved chart / modify dashboard; negative: normal reply, data-access refusal, empty string).
- Frontend: `contentEditCallout.test.ts` (visibility matrix for the action helper).
- `pnpm -F common typecheck:fast` ✓; changed backend/frontend files type-clean; frontend lint clean.

Note: generated OpenAPI files include some unrelated cosmetic enum-reorder drift from `generate-api` (known nondeterministic codegen); the meaningful change is the new `contentEditBlocked` field.

Relates: ZAP-506
