### PR TITLE
perf(backend): fire-and-forget chart-view event in SavedChartService.get

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -1220,10 +1220,16 @@ export class SavedChartService
         const { access, inheritsFromOrgOrProject } =
             await this.checkPermissions(account, space, savedChart);
 
-        await this.analyticsModel.addChartViewEvent(
-            savedChart.uuid,
-            account.isRegisteredUser() ? account.user.id : null,
-        );
+        void this.analyticsModel
+            .addChartViewEvent(
+                savedChart.uuid,
+                account.isRegisteredUser() ? account.user.id : null,
+            )
+            .catch((e) =>
+                this.logger.warn('Failed to track chart view event', {
+                    error: e,
+                }),
+            );
 
         this.analytics.trackAccount(account, {
             event: 'saved_chart.view',


### PR DESCRIPTION
Closes: SPK-513

### Description:

`SavedChartService.get` (reused across many chart-load paths) blocked the response on an awaited `addChartViewEvent` analytics DB insert + `views_count` update before returning the chart. This converts it to the fire-and-forget pattern already used in `DashboardService` and `AsyncQueryService`, so the chart returns without waiting on best-effort analytics. Failures are logged via `this.logger.warn` rather than propagated.