### PR TITLE
feat(ai-agents): route to an edit-capable agent from chat (ZAP-506 pt 2)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -89,7 +89,6 @@ interface AgentChatInputProps {
     clearOnSubmit?: boolean;
     showSuggestions?: boolean;
     contentMentionPriorityItems?: ContentMentionSuggestionItem[];
-    // Enables launcher-specific routing to a capable sibling agent.
     onRouteToAgent?: (agentUuid: string, prompt: string) => void;
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -89,6 +89,8 @@ interface AgentChatInputProps {
     clearOnSubmit?: boolean;
     showSuggestions?: boolean;
     contentMentionPriorityItems?: ContentMentionSuggestionItem[];
+    // Enables launcher-specific routing to a capable sibling agent.
+    onRouteToAgent?: (agentUuid: string, prompt: string) => void;
 }
 
 const extractToolHints = (editor: Editor | null): string[] => {
@@ -131,6 +133,7 @@ export const AgentChatInput = ({
     clearOnSubmit = true,
     showSuggestions = true,
     contentMentionPriorityItems = [],
+    onRouteToAgent,
 }: AgentChatInputProps) => {
     const user = useUser(true);
     const [value, setValueState] = useState(defaultValue ?? '');
@@ -460,6 +463,7 @@ export const AgentChatInput = ({
                 onResend={(message) =>
                     onSubmitRef.current({ message, toolHints: [] })
                 }
+                onRouteToAgent={onRouteToAgent}
             />
         ) : null;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
@@ -95,6 +95,7 @@ export const AgentContentEditCallout: FC<Props> = ({
         canManageAgent: canManageAgent ?? false,
         capableAgent,
     });
+    const routeAgent = actions.routeAgent;
 
     if (!hasContentEditCalloutActions(actions)) return null;
 
@@ -159,22 +160,17 @@ export const AgentContentEditCallout: FC<Props> = ({
                             </Popover.Dropdown>
                         </Popover>
                     )}
-                    {actions.routeAgent &&
-                        onRouteToAgent &&
-                        lastUserMessage && (
-                            <Button
-                                size="xs"
-                                variant="default"
-                                onClick={() =>
-                                    onRouteToAgent(
-                                        actions.routeAgent!.uuid,
-                                        lastUserMessage,
-                                    )
-                                }
-                            >
-                                Continue with {actions.routeAgent.name}
-                            </Button>
-                        )}
+                    {routeAgent && onRouteToAgent && lastUserMessage && (
+                        <Button
+                            size="xs"
+                            variant="default"
+                            onClick={() =>
+                                onRouteToAgent(routeAgent.uuid, lastUserMessage)
+                            }
+                        >
+                            Continue with {routeAgent.name}
+                        </Button>
+                    )}
                 </Group>
             </Stack>
         </Callout>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentContentEditCallout.tsx
@@ -8,18 +8,21 @@ import { AGENT_SUGGESTIONS_KEY } from '../../hooks/useAgentSuggestions';
 import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
 import {
     useAiAgentThread,
+    useProjectAiAgents,
     useProjectUpdateAiAgentMutation,
 } from '../../hooks/useProjectAiAgents';
 import {
     getContentEditCalloutActions,
     hasContentEditCalloutActions,
 } from './contentEditCallout';
+import { pickCapableAgent } from './pickCapableAgent';
 
 type Props = {
     projectUuid: string;
     agentUuid: string;
     threadUuid: string;
     onResend: (message: string) => void;
+    onRouteToAgent?: (agentUuid: string, prompt: string) => void;
 };
 
 export const AgentContentEditCallout: FC<Props> = ({
@@ -27,6 +30,7 @@ export const AgentContentEditCallout: FC<Props> = ({
     agentUuid,
     threadUuid,
     onResend,
+    onRouteToAgent,
 }) => {
     const canManageAgent = useAiAgentPermission({
         action: 'manage',
@@ -75,10 +79,21 @@ export const AgentContentEditCallout: FC<Props> = ({
         onResend,
     ]);
 
-    // Route action (capableAgent) is added in a later task.
+    const { data: agents } = useProjectAiAgents({
+        projectUuid,
+        redirectOnUnauthorized: false,
+    });
+    const capableAgent = useMemo(
+        () =>
+            onRouteToAgent && agents
+                ? pickCapableAgent({ agents, currentAgentUuid: agentUuid })
+                : null,
+        [onRouteToAgent, agents, agentUuid],
+    );
+
     const actions = getContentEditCalloutActions({
         canManageAgent: canManageAgent ?? false,
-        capableAgent: null,
+        capableAgent,
     });
 
     if (!hasContentEditCalloutActions(actions)) return null;
@@ -144,6 +159,22 @@ export const AgentContentEditCallout: FC<Props> = ({
                             </Popover.Dropdown>
                         </Popover>
                     )}
+                    {actions.routeAgent &&
+                        onRouteToAgent &&
+                        lastUserMessage && (
+                            <Button
+                                size="xs"
+                                variant="default"
+                                onClick={() =>
+                                    onRouteToAgent(
+                                        actions.routeAgent!.uuid,
+                                        lastUserMessage,
+                                    )
+                                }
+                            >
+                                Continue with {actions.routeAgent.name}
+                            </Button>
+                        )}
                 </Group>
             </Stack>
         </Callout>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/pickCapableAgent.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/pickCapableAgent.test.ts
@@ -1,0 +1,34 @@
+import { pickCapableAgent } from './pickCapableAgent';
+
+const make = (uuid: string, name: string, enableContentTools: boolean) =>
+    ({ uuid, name, enableContentTools }) as Parameters<
+        typeof pickCapableAgent
+    >[0]['agents'][number];
+
+describe('pickCapableAgent', () => {
+    it('returns the first content-capable agent that is not the current one, by name', () => {
+        const agents = [
+            make('cur', 'Current', false),
+            make('b', 'Zeta', true),
+            make('a', 'Alpha', true),
+        ];
+        expect(pickCapableAgent({ agents, currentAgentUuid: 'cur' })).toEqual({
+            uuid: 'a',
+            name: 'Alpha',
+        });
+    });
+
+    it('returns null when no other capable agent exists', () => {
+        const agents = [make('cur', 'Current', false), make('x', 'X', false)];
+        expect(
+            pickCapableAgent({ agents, currentAgentUuid: 'cur' }),
+        ).toBeNull();
+    });
+
+    it('excludes the current agent even if it is capable', () => {
+        const agents = [make('cur', 'Current', true)];
+        expect(
+            pickCapableAgent({ agents, currentAgentUuid: 'cur' }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/pickCapableAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/pickCapableAgent.ts
@@ -1,0 +1,18 @@
+import { type CapableAgentRef } from './contentEditCallout';
+
+type AgentLike = { uuid: string; name: string; enableContentTools: boolean };
+
+// First edit-capable agent other than the current one, ordered by name.
+export function pickCapableAgent({
+    agents,
+    currentAgentUuid,
+}: {
+    agents: AgentLike[];
+    currentAgentUuid: string;
+}): CapableAgentRef | null {
+    const capable = agents
+        .filter((a) => a.enableContentTools && a.uuid !== currentAgentUuid)
+        .sort((a, b) => a.name.localeCompare(b.name));
+    const first = capable[0];
+    return first ? { uuid: first.uuid, name: first.name } : null;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -2,6 +2,7 @@ import { type AiAgentSummary } from '@lightdash/common';
 import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
 import {
     useCallback,
+    useEffect,
     useMemo,
     useState,
     type CSSProperties,
@@ -18,7 +19,10 @@ import {
     useCreateAgentThreadMessageMutation,
     useCreateAgentThreadMutation,
 } from '../../hooks/useProjectAiAgents';
-import { openPanel } from '../../store/aiAgentLauncherSlice';
+import {
+    clearPendingPrompt,
+    openPanel,
+} from '../../store/aiAgentLauncherSlice';
 import {
     selectThreadSqlMode,
     setThreadSqlMode,
@@ -125,7 +129,17 @@ const NewThreadPanel: FC<{
     // New threads have no uuid yet — keep the toggle in local state and seed
     // the per-thread slice entry once the thread is created.
     const [sqlMode, setSqlMode] = useState(false);
-    const [composerSeed, setComposerSeed] = useState<string | null>(null);
+    const pendingPrompt = useAiAgentStoreSelector(
+        (state) => state.aiAgentLauncher.pendingPrompt,
+    );
+    const [composerSeed, setComposerSeed] = useState<string | null>(
+        pendingPrompt ?? null,
+    );
+    useEffect(() => {
+        if (pendingPrompt) dispatch(clearPendingPrompt());
+        // Consume the one-shot seed on mount only.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(
         (toolResult: AiAgentToolResult) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -89,6 +89,7 @@ export const LauncherPanel: FC<Props> = ({
         />
     ) : (
         <NewThreadPanel
+            key={agent.uuid}
             projectUuid={projectUuid}
             agent={agent}
             agents={agents}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -452,6 +452,15 @@ const ExistingThreadPanel: FC<{
                                       )
                                 : undefined
                         }
+                        onRouteToAgent={(targetAgentUuid, prompt) =>
+                            dispatchToStore(
+                                openPanel({
+                                    threadId: null,
+                                    agentUuid: targetAgentUuid,
+                                    pendingPrompt: prompt,
+                                }),
+                            )
+                        }
                     />
                 </AgentChatDisplay>
             </div>

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -31,6 +31,7 @@ export interface AiAgentLauncherState {
     activeThreadId: string | null;
     activeAgentUuid: string | null;
     pendingContext: LauncherPendingContext | null;
+    pendingPrompt: string | null;
     currentDashboard: LauncherCurrentDashboard | null;
     dashboardRefreshRequest: DashboardRefreshRequest | null;
 }
@@ -40,6 +41,7 @@ const initialState: AiAgentLauncherState = {
     activeThreadId: null,
     activeAgentUuid: null,
     pendingContext: null,
+    pendingPrompt: null,
     currentDashboard: null,
     dashboardRefreshRequest: null,
 };
@@ -54,12 +56,14 @@ export const aiAgentLauncherSlice = createSlice({
                 threadId: string | null;
                 agentUuid: string | null;
                 pendingContext?: LauncherPendingContext | null;
+                pendingPrompt?: string | null;
             }>,
         ) => {
             state.mode = 'panel-open';
             state.activeThreadId = action.payload.threadId;
             state.activeAgentUuid = action.payload.agentUuid;
             state.pendingContext = action.payload.pendingContext ?? null;
+            state.pendingPrompt = action.payload.pendingPrompt ?? null;
         },
         closePanel: (state) => {
             state.mode = 'collapsed';
@@ -69,6 +73,7 @@ export const aiAgentLauncherSlice = createSlice({
             state.activeThreadId = null;
             state.activeAgentUuid = null;
             state.pendingContext = null;
+            state.pendingPrompt = null;
         },
         // Cascade-reset the active panel when a dock item is removed externally
         // (the dock itself is owned by `LauncherDockProvider`/localStorage).
@@ -81,6 +86,7 @@ export const aiAgentLauncherSlice = createSlice({
                 state.activeThreadId = null;
                 state.activeAgentUuid = null;
                 state.pendingContext = null;
+                state.pendingPrompt = null;
             }
         },
         setCurrentDashboard: (
@@ -102,6 +108,9 @@ export const aiAgentLauncherSlice = createSlice({
                 requestId: (state.dashboardRefreshRequest?.requestId ?? 0) + 1,
             };
         },
+        clearPendingPrompt: (state) => {
+            state.pendingPrompt = null;
+        },
     },
 });
 
@@ -112,4 +121,5 @@ export const {
     dockItemRemoved,
     setCurrentDashboard,
     requestDashboardRefresh,
+    clearPendingPrompt,
 } = aiAgentLauncherSlice.actions;


### PR DESCRIPTION
## What & why

**PR 2 of 2** for ZAP-506, stacked on #24327. PR 1 added the "Enable content editing" action to the in-chat capability callout (for admins/devs). This PR adds the second action: when the current agent can't edit content, offer **one-click routing to an edit-capable agent** in the same project.

Clicking **"Continue with [agent]"** opens a new thread with an edit-capable sibling agent, pre-filling the composer with the user's last request — so a viewer who can't enable editing themselves still has a path forward.

> ⚠️ Stacked on #24327 — review/merge that first. The diff here is only PR 2's commits.

## How it works

- **`pickCapableAgent`** (pure, tested): picks the first project agent (other than the current one) with `enableContentTools === true`, ordered by name. Returns null when there's no capable sibling → the route button doesn't render.
- **Launcher routing**: a new `pendingPrompt` on the launcher slice carries the user's last request through `openPanel`. The route action dispatches `openPanel({ threadId: null, agentUuid, pendingPrompt })`; the launcher switches to the new-thread panel for that agent, which seeds its composer from `pendingPrompt` (consumed once on mount, then cleared). `NewThreadPanel` is keyed by `agent.uuid` so the seed is fresh per agent.
- **Surface scoping**: the route action is wired via an optional `onRouteToAgent` prop provided only by the launcher's existing-thread panel. On surfaces that don't provide it (e.g. the full-page thread view), the route button simply doesn't render — launcher-only in v1.

## Changes

- `pendingPrompt` + `clearPendingPrompt` on the launcher slice; `NewThreadPanel` seeds + clears it (keyed by agent).
- `pickCapableAgent` selector + unit tests.
- `AgentContentEditCallout` computes the capable sibling and renders "Continue with [agent]".
- `onRouteToAgent` threaded through `AgentChatInput`; wired in the launcher's existing-thread panel.

## Regression analysis

- **No capable sibling agent / non-launcher surface**: route button doesn't render. Combined with PR 1, a user with neither `manage` permission nor a capable sibling sees no callout — no dead ends.
- **New-thread panels** don't receive `onRouteToAgent` — intentional: a fresh thread has no assistant turn, so `contentEditBlocked` is never true there and the callout can't appear.
- Existing launcher behavior (pinned context, SQL mode, MCP suggested-prompt seeding) is unchanged; `pendingPrompt` is cleared on panel close/reset so it can't leak across sessions.
- The capable-agent list comes from `useProjectAiAgents` (cached; same data the launcher already loads) and only fetches while the callout is mounted.

## Testing

- `pickCapableAgent.test.ts` (filter+sort, no-capable, exclude-self).
- `pnpm -F frontend typecheck:fast` clean for changed files; frontend lint clean.
- Manual: viewer with a capable sibling → only "Continue with [agent]"; click → new thread with that agent, composer pre-filled with the last request.

Closes: ZAP-506
