### PR TITLE
feat(alerts): support filter & parameter overrides on chart threshold alerts

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -9,6 +9,12 @@ import {
     SchedulerGoogleChatTarget,
     SchedulerMsTeamsTarget,
     SchedulerSlackTarget,
+    type DashboardFilterRule,
+    type Filters,
+    type NotificationFrequency,
+    type ParametersValuesMap,
+    type SchedulerFormat,
+    type ThresholdOptions,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -25,7 +31,7 @@ export type SchedulerDb = {
     scheduler_uuid: string;
     name: string;
     message?: string;
-    format: string;
+    format: SchedulerFormat;
     created_at: Date;
     updated_at: Date;
     created_by: string;
@@ -36,12 +42,12 @@ export type SchedulerDb = {
     saved_sql_uuid: string | null;
     app_uuid: string | null;
     options: Record<string, AnyType>;
-    filters: string | null;
-    parameters: string | null;
+    filters: DashboardFilterRule[] | Filters | null;
+    parameters: ParametersValuesMap | null;
     custom_viewport_width: number | null;
-    thresholds: string | null;
+    thresholds: ThresholdOptions[] | null;
     enabled: boolean;
-    notification_frequency: string | null;
+    notification_frequency: NotificationFrequency | null;
     selected_tabs: string[] | null;
     include_links: boolean;
     deleted_at: Date | null;
@@ -53,12 +59,14 @@ export type ChartSchedulerDb = SchedulerDb & {
     dashboard_uuid: null;
     saved_sql_uuid: null;
     app_uuid: null;
+    filters: Filters | null;
 };
 export type DashboardSchedulerDB = SchedulerDb & {
     saved_chart_uuid: null;
     dashboard_uuid: string;
     saved_sql_uuid: null;
     app_uuid: null;
+    filters: DashboardFilterRule[] | null;
 };
 export type SqlChartSchedulerDb = SchedulerDb & {
     saved_chart_uuid: null;
@@ -72,6 +80,25 @@ export type AppSchedulerDb = SchedulerDb & {
     saved_sql_uuid: null;
     app_uuid: string;
 };
+
+// Discriminate a scheduler row by its resource FK. Generic so callers keep the
+// extra columns of richer row types (e.g. SelectScheduler) while narrowing the
+// `filters` column to the shape stored for that resource type.
+export const isChartSchedulerDb = <T extends SchedulerDb>(
+    row: T,
+): row is T & ChartSchedulerDb => row.saved_chart_uuid !== null;
+
+export const isDashboardSchedulerDb = <T extends SchedulerDb>(
+    row: T,
+): row is T & DashboardSchedulerDB => row.dashboard_uuid !== null;
+
+export const isSqlChartSchedulerDb = <T extends SchedulerDb>(
+    row: T,
+): row is T & SqlChartSchedulerDb => row.saved_sql_uuid !== null;
+
+export const isAppSchedulerDb = <T extends SchedulerDb>(
+    row: T,
+): row is T & AppSchedulerDb => row.app_uuid !== null;
 
 export type SchedulerSlackTargetDb = {
     scheduler_slack_target_uuid: string;
@@ -103,16 +130,33 @@ export type SchedulerEmailTargetDb = {
     recipient: string; // email address
 };
 
+// Written as stringified JSON: a JS array would otherwise be coerced to a
+// Postgres array literal and rejected by the JSONB column.
+type SchedulerJsonWrite = {
+    filters: string | null;
+    parameters: string | null;
+    thresholds: string | null;
+};
+
+export type SchedulerInsert = Omit<
+    | ChartSchedulerDb
+    | DashboardSchedulerDB
+    | SqlChartSchedulerDb
+    | AppSchedulerDb,
+    | 'scheduler_uuid'
+    | 'created_at'
+    | 'deleted_at'
+    | 'deleted_by_user_uuid'
+    | 'filters'
+    | 'parameters'
+    | 'thresholds'
+> &
+    SchedulerJsonWrite;
+
 export type SchedulerTable = Knex.CompositeTableType<
     SchedulerDb,
-    Omit<
-        | ChartSchedulerDb
-        | DashboardSchedulerDB
-        | SqlChartSchedulerDb
-        | AppSchedulerDb,
-        'scheduler_uuid' | 'created_at' | 'deleted_at' | 'deleted_by_user_uuid'
-    >,
-    | Pick<
+    SchedulerInsert,
+    | (Pick<
           SchedulerDb,
           | 'name'
           | 'message'
@@ -121,14 +165,12 @@ export type SchedulerTable = Knex.CompositeTableType<
           | 'timezone'
           | 'format'
           | 'options'
-          | 'filters'
-          | 'parameters'
           | 'custom_viewport_width'
-          | 'thresholds'
           | 'notification_frequency'
           | 'selected_tabs'
           | 'include_links'
-      >
+      > &
+          SchedulerJsonWrite)
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>
     | Pick<SchedulerDb, 'created_by' | 'updated_at'>
     | Pick<SchedulerDb, 'cron'>

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9212,6 +9212,8 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        parameters: { ref: 'ParametersValuesMap' },
+                        filters: { ref: 'Filters' },
                         appUuid: {
                             dataType: 'enum',
                             enums: [null],

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10625,6 +10625,12 @@
                     },
                     {
                         "properties": {
+                            "parameters": {
+                                "$ref": "#/components/schemas/ParametersValuesMap"
+                            },
+                            "filters": {
+                                "$ref": "#/components/schemas/Filters"
+                            },
                             "appUuid": {
                                 "type": "number",
                                 "enum": [null],

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -3,10 +3,12 @@ import {
     CreateSchedulerAndTargets,
     CreateSchedulerLog,
     isAppCreateScheduler,
+    isChartCreateScheduler,
     isChartScheduler,
     isCreateSchedulerGoogleChatTarget,
     isCreateSchedulerMsTeamsTarget,
     isCreateSchedulerSlackTarget,
+    isDashboardCreateScheduler,
     isDashboardScheduler,
     isEmailTarget,
     isGoogleChatTarget,
@@ -23,6 +25,7 @@ import {
     NotFoundError,
     Scheduler,
     SchedulerAndTargets,
+    SchedulerBase,
     SchedulerEmailTarget,
     SchedulerFormat,
     SchedulerGoogleChatTarget,
@@ -37,6 +40,7 @@ import {
     SchedulerSlackTarget,
     SchedulerTaskName,
     SchedulerWithLogs,
+    UnexpectedServerError,
     UpdateSchedulerAndTargets,
     UserSchedulersSummary,
     type SchedulerCronUpdate,
@@ -50,11 +54,16 @@ import { ProjectTableName } from '../../database/entities/projects';
 import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { SavedSqlTableName } from '../../database/entities/savedSql';
 import {
+    isAppSchedulerDb,
+    isChartSchedulerDb,
+    isDashboardSchedulerDb,
+    isSqlChartSchedulerDb,
     SchedulerDb,
     SchedulerEmailTargetDb,
     SchedulerEmailTargetTableName,
     SchedulerGoogleChatTargetDb,
     SchedulerGoogleChatTargetTableName,
+    SchedulerInsert,
     SchedulerLogDb,
     SchedulerLogTableName,
     SchedulerMsTeamsTargetDb,
@@ -108,7 +117,7 @@ export class SchedulerModel {
     }
 
     static convertScheduler(scheduler: SelectScheduler): Scheduler {
-        return {
+        const base: SchedulerBase = {
             schedulerUuid: scheduler.scheduler_uuid,
             name: scheduler.name,
             message: scheduler.message,
@@ -130,17 +139,151 @@ export class SchedulerModel {
             appName: scheduler.app_name,
             format: scheduler.format,
             options: scheduler.options,
-            filters: scheduler.filters,
-            parameters: scheduler.parameters,
-            customViewportWidth: scheduler.custom_viewport_width,
-            thresholds: scheduler.thresholds || undefined,
+            thresholds: scheduler.thresholds ?? undefined,
             enabled: scheduler.enabled,
-            notificationFrequency: scheduler.notification_frequency,
-            selectedTabs: scheduler.selected_tabs,
+            notificationFrequency:
+                scheduler.notification_frequency ?? undefined,
             includeLinks: scheduler.include_links,
             projectUuid: scheduler.project_uuid ?? undefined,
             projectName: scheduler.project_name ?? undefined,
-        } as Scheduler;
+        };
+
+        // Discriminate by resource FK so `filters` is narrowed to the shape
+        // stored for that resource type (no shape-sniffing, no casts).
+        if (isDashboardSchedulerDb(scheduler)) {
+            return {
+                ...base,
+                savedChartUuid: null,
+                dashboardUuid: scheduler.dashboard_uuid,
+                savedSqlUuid: null,
+                appUuid: null,
+                filters: scheduler.filters ?? undefined,
+                parameters: scheduler.parameters ?? undefined,
+                customViewportWidth:
+                    scheduler.custom_viewport_width ?? undefined,
+                selectedTabs: scheduler.selected_tabs,
+            };
+        }
+        if (isChartSchedulerDb(scheduler)) {
+            return {
+                ...base,
+                savedChartUuid: scheduler.saved_chart_uuid,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+                appUuid: null,
+                filters: scheduler.filters ?? undefined,
+                parameters: scheduler.parameters ?? undefined,
+            };
+        }
+        if (isSqlChartSchedulerDb(scheduler)) {
+            return {
+                ...base,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid: scheduler.saved_sql_uuid,
+                appUuid: null,
+            };
+        }
+        if (isAppSchedulerDb(scheduler)) {
+            return {
+                ...base,
+                savedChartUuid: null,
+                dashboardUuid: null,
+                savedSqlUuid: null,
+                appUuid: scheduler.app_uuid,
+            };
+        }
+        throw new UnexpectedServerError(
+            `Scheduler ${scheduler.scheduler_uuid} has no resource reference`,
+        );
+    }
+
+    // Serialize a value for a JSONB column. Stringify (not raw object) so JS
+    // arrays aren't coerced to Postgres array literals.
+    private static toJsonColumn(value: unknown): string | null {
+        return value ? JSON.stringify(value) : null;
+    }
+
+    // Build the row to insert, choosing the resource FK and overrides by
+    // scheduler type. Only dashboard/chart schedulers carry filter & parameter
+    // overrides; only dashboards carry viewport width & selected tabs.
+    private static toSchedulerInsert(
+        newScheduler: CreateSchedulerAndTargets,
+    ): SchedulerInsert {
+        const common = {
+            name: newScheduler.name,
+            message: newScheduler.message,
+            format: newScheduler.format,
+            created_by: newScheduler.createdBy,
+            cron: newScheduler.cron,
+            timezone: newScheduler.timezone ?? null,
+            updated_at: new Date(),
+            options: newScheduler.options,
+            thresholds: SchedulerModel.toJsonColumn(newScheduler.thresholds),
+            enabled: true,
+            notification_frequency: newScheduler.notificationFrequency || null,
+            include_links: newScheduler.includeLinks !== false,
+        };
+
+        if (isDashboardCreateScheduler(newScheduler)) {
+            return {
+                ...common,
+                saved_chart_uuid: null,
+                dashboard_uuid: newScheduler.dashboardUuid,
+                saved_sql_uuid: null,
+                app_uuid: null,
+                filters: SchedulerModel.toJsonColumn(newScheduler.filters),
+                parameters: SchedulerModel.toJsonColumn(
+                    newScheduler.parameters,
+                ),
+                custom_viewport_width: newScheduler.customViewportWidth ?? null,
+                selected_tabs: newScheduler.selectedTabs ?? null,
+            };
+        }
+        if (isChartCreateScheduler(newScheduler)) {
+            return {
+                ...common,
+                saved_chart_uuid: newScheduler.savedChartUuid,
+                dashboard_uuid: null,
+                saved_sql_uuid: null,
+                app_uuid: null,
+                filters: SchedulerModel.toJsonColumn(newScheduler.filters),
+                parameters: SchedulerModel.toJsonColumn(
+                    newScheduler.parameters,
+                ),
+                custom_viewport_width: null,
+                selected_tabs: null,
+            };
+        }
+        if (isSqlChartScheduler(newScheduler)) {
+            return {
+                ...common,
+                saved_chart_uuid: null,
+                dashboard_uuid: null,
+                saved_sql_uuid: newScheduler.savedSqlUuid,
+                app_uuid: null,
+                filters: null,
+                parameters: null,
+                custom_viewport_width: null,
+                selected_tabs: null,
+            };
+        }
+        if (isAppCreateScheduler(newScheduler)) {
+            return {
+                ...common,
+                saved_chart_uuid: null,
+                dashboard_uuid: null,
+                saved_sql_uuid: null,
+                app_uuid: newScheduler.appUuid,
+                filters: null,
+                parameters: null,
+                custom_viewport_width: null,
+                selected_tabs: null,
+            };
+        }
+        throw new UnexpectedServerError(
+            'Cannot create scheduler without a resource reference',
+        );
     }
 
     static convertSlackTarget(
@@ -836,49 +979,7 @@ export class SchedulerModel {
     ): Promise<SchedulerAndTargets> {
         const schedulerUuid = await this.database.transaction(async (trx) => {
             const [scheduler] = await trx(SchedulerTableName)
-                .insert({
-                    name: newScheduler.name,
-                    message: newScheduler.message,
-                    format: newScheduler.format,
-                    created_by: newScheduler.createdBy,
-                    cron: newScheduler.cron,
-                    timezone: newScheduler.timezone ?? null,
-                    saved_chart_uuid: newScheduler.savedChartUuid,
-                    dashboard_uuid: newScheduler.dashboardUuid,
-                    saved_sql_uuid: newScheduler.savedSqlUuid,
-                    app_uuid: isAppCreateScheduler(newScheduler)
-                        ? newScheduler.appUuid
-                        : null,
-                    updated_at: new Date(),
-                    options: newScheduler.options,
-                    filters:
-                        isDashboardScheduler(newScheduler) &&
-                        newScheduler.filters
-                            ? JSON.stringify(newScheduler.filters)
-                            : null,
-                    parameters:
-                        isDashboardScheduler(newScheduler) &&
-                        newScheduler.parameters
-                            ? JSON.stringify(newScheduler.parameters)
-                            : null,
-                    custom_viewport_width:
-                        isDashboardScheduler(newScheduler) &&
-                        newScheduler.customViewportWidth
-                            ? newScheduler.customViewportWidth
-                            : null,
-                    thresholds: newScheduler.thresholds
-                        ? JSON.stringify(newScheduler.thresholds)
-                        : null,
-                    enabled: true,
-                    notification_frequency:
-                        newScheduler.notificationFrequency || null,
-                    selected_tabs:
-                        isDashboardScheduler(newScheduler) &&
-                        newScheduler.selectedTabs
-                            ? newScheduler.selectedTabs
-                            : null,
-                    include_links: newScheduler.includeLinks !== false,
-                })
+                .insert(SchedulerModel.toSchedulerInsert(newScheduler))
                 .returning('*');
             const targetPromises = newScheduler.targets.map(async (target) => {
                 if (isCreateSchedulerSlackTarget(target)) {
@@ -957,22 +1058,15 @@ export class SchedulerModel {
                     timezone: scheduler.timezone ?? null,
                     updated_at: new Date(),
                     options: scheduler.options,
-                    filters:
-                        'filters' in scheduler && scheduler.filters
-                            ? JSON.stringify(scheduler.filters)
-                            : null,
-                    parameters:
-                        'parameters' in scheduler && scheduler.parameters
-                            ? JSON.stringify(scheduler.parameters)
-                            : null,
+                    filters: SchedulerModel.toJsonColumn(scheduler.filters),
+                    parameters: SchedulerModel.toJsonColumn(
+                        scheduler.parameters,
+                    ),
                     custom_viewport_width:
-                        'customViewportWidth' in scheduler &&
-                        scheduler.customViewportWidth
-                            ? scheduler.customViewportWidth
-                            : null,
-                    thresholds: scheduler.thresholds
-                        ? JSON.stringify(scheduler.thresholds)
-                        : null,
+                        scheduler.customViewportWidth ?? null,
+                    thresholds: SchedulerModel.toJsonColumn(
+                        scheduler.thresholds,
+                    ),
                     notification_frequency:
                         scheduler.notificationFrequency || null,
                     selected_tabs:

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -36,6 +36,7 @@ import {
     getSchedulerResourceTypeAndId,
     getSchedulerUuid,
     GsheetsNotificationPayload,
+    isChartScheduler,
     isChartValidationError,
     isCreateScheduler,
     isCreateSchedulerGoogleChatTarget,
@@ -3745,6 +3746,13 @@ export default class SchedulerTask {
             userUuid: schedulerPayload.userUuid,
         };
 
+        const chartFilterOverrides = isChartScheduler(scheduler)
+            ? scheduler.filters
+            : undefined;
+        const chartParameterOverrides = isChartScheduler(scheduler)
+            ? scheduler.parameters
+            : undefined;
+
         try {
             if (thresholds !== undefined && thresholds.length > 0) {
                 // TODO add multiple AND conditions
@@ -3757,6 +3765,8 @@ export default class SchedulerTask {
                                 projectUuid: schedulerPayload.projectUuid,
                                 chartUuid: savedChartUuid,
                                 context: QueryExecutionContext.SCHEDULED_CHART,
+                                filterOverrides: chartFilterOverrides,
+                                parameters: chartParameterOverrides,
                             },
                             SCHEDULER_POLLING_OPTIONS,
                         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     Account,
     addDashboardFiltersToMetricQuery,
+    addFiltersToMetricQuery,
     AnonymousAccount,
     ApiExecuteAsyncDashboardChartQueryResults,
     ApiExecuteAsyncDashboardSqlChartQueryResults,
@@ -4541,6 +4542,7 @@ export class AsyncQueryService extends ProjectService {
         limit,
         parameters,
         pivotResults,
+        filterOverrides,
     }: ExecuteAsyncSavedChartQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         // Check user is in organization
         assertIsAccountWithOrg(account);
@@ -4556,9 +4558,12 @@ export class AsyncQueryService extends ProjectService {
             projectUuid: savedChartProjectUuid,
             spaceUuid: savedChartSpaceUuid,
             tableName: savedChartTableName,
-            metricQuery,
             parameters: savedChartParameters,
         } = savedChart;
+
+        const metricQuery = filterOverrides
+            ? addFiltersToMetricQuery(savedChart.metricQuery, filterOverrides)
+            : savedChart.metricQuery;
 
         // Check chart belongs to project
         if (savedChartProjectUuid !== projectUuid) {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -84,6 +84,7 @@ export type ExecuteAsyncSavedChartQueryArgs = CommonAsyncQueryArgs & {
     versionUuid?: string;
     limit?: number | null | undefined;
     pivotResults?: boolean;
+    filterOverrides?: Filters;
 };
 
 export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -3,7 +3,11 @@ import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
 import type { DownloadFileType } from './downloadFile';
 import { type Explore, type ExploreError } from './explore';
-import { type DashboardFilterRule, type DashboardFilters } from './filter';
+import {
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type Filters,
+} from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type ParametersValuesMap } from './parameters';
 import { type PivotConfig } from './pivot';
@@ -135,6 +139,8 @@ export type ChartScheduler = SchedulerBase & {
     dashboardUuid: null;
     savedSqlUuid: null;
     appUuid: null;
+    filters?: Filters;
+    parameters?: ParametersValuesMap;
 };
 
 export const isDashboardScheduler = (
@@ -152,6 +158,10 @@ export type DashboardScheduler = SchedulerBase & {
     customViewportWidth?: number;
     selectedTabs: string[] | null;
 };
+
+// Filter overrides by scheduler type: chart-native Filters for charts,
+// DashboardFilterRule[] for dashboards.
+export type SchedulerFilters = Filters | DashboardFilterRule[];
 
 export type SqlChartScheduler = SchedulerBase & {
     savedChartUuid: null;
@@ -300,19 +310,18 @@ export type UpdateSchedulerAndTargets = Pick<
     | 'thresholds'
     | 'notificationFrequency'
     | 'includeLinks'
-> &
-    Pick<
-        DashboardScheduler,
-        'filters' | 'parameters' | 'customViewportWidth'
-    > & {
-        targets: Array<
-            | CreateSchedulerTarget
-            | UpdateSchedulerSlackTarget
-            | UpdateSchedulerEmailTarget
-            | UpdateSchedulerMsTeamsTarget
-            | UpdateSchedulerGoogleChatTarget
-        >;
-    };
+> & {
+    filters?: SchedulerFilters;
+    parameters?: ParametersValuesMap;
+    customViewportWidth?: number;
+    targets: Array<
+        | CreateSchedulerTarget
+        | UpdateSchedulerSlackTarget
+        | UpdateSchedulerEmailTarget
+        | UpdateSchedulerMsTeamsTarget
+        | UpdateSchedulerGoogleChatTarget
+    >;
+};
 
 export type UpdateSchedulerAndTargetsWithoutId = Omit<
     UpdateSchedulerAndTargets,

--- a/packages/frontend/src/components/SchedulersView/LogsTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTable.tsx
@@ -723,6 +723,7 @@ const LogsTable: FC<LogsTableProps> = ({
                 opened={isConfirmOpen}
                 onClose={() => setIsConfirmOpen(false)}
                 schedulerName={selectedScheduler?.name || ''}
+                deliveryType="scheduled"
                 loading={sendNowMutation.isLoading}
                 onConfirm={() => {
                     sendNowMutation.mutate();

--- a/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersViewActionMenu.tsx
@@ -12,6 +12,7 @@ import React, { type FC } from 'react';
 import { Link } from 'react-router';
 import { SchedulerDeleteModal } from '../../features/scheduler';
 import ConfirmSendNowModal from '../../features/scheduler/components/ConfirmSendNowModal';
+import { getSchedulerDeliveryType } from '../../features/scheduler/components/types';
 import { useSendNowSchedulerByUuid } from '../../features/scheduler/hooks/useScheduler';
 import MantineIcon from '../common/MantineIcon';
 import {
@@ -135,6 +136,7 @@ const SchedulersViewActionMenu: FC<SchedulersViewActionMenuProps> = ({
                 opened={isConfirmOpen}
                 onClose={() => setIsConfirmOpen(false)}
                 schedulerName={item.name}
+                deliveryType={getSchedulerDeliveryType(item)}
                 loading={sendNowMutation.isLoading}
                 onConfirm={() => {
                     sendNowMutation.mutate();

--- a/packages/frontend/src/features/scheduler/components/ConfirmSendNowModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/ConfirmSendNowModal.tsx
@@ -2,18 +2,27 @@ import { Button } from '@mantine-8/core';
 import { IconSend } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
+import { type SchedulerDeliveryType } from './types';
 
 type ConfirmSendNowModalProps = {
     opened: boolean;
     schedulerName: string;
+    deliveryType: SchedulerDeliveryType;
     loading?: boolean;
     onClose: () => void;
     onConfirm: () => void;
 };
 
+const DESCRIPTION_BY_TYPE: Record<SchedulerDeliveryType, string> = {
+    scheduled:
+        'This will trigger the scheduled delivery immediately. It will not change or affect the configured schedule or future deliveries.',
+    alert: 'This will evaluate the alert and send it immediately if the threshold is met. It will not change or affect the configured schedule.',
+};
+
 const ConfirmSendNowModal: FC<ConfirmSendNowModalProps> = ({
     opened,
     schedulerName,
+    deliveryType,
     loading,
     onClose,
     onConfirm,
@@ -30,7 +39,7 @@ const ConfirmSendNowModal: FC<ConfirmSendNowModalProps> = ({
                     Send now
                 </Button>
             }
-            description="This will trigger the scheduled delivery immediately. It will not change or affect the configured schedule or future deliveries."
+            description={DESCRIPTION_BY_TYPE[deliveryType]}
         />
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormChartFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormChartFiltersTab.tsx
@@ -1,0 +1,31 @@
+import { type Filters, type ItemsMap } from '@lightdash/common';
+import { type FC } from 'react';
+import FiltersForm from '../../../../components/common/Filters';
+import FiltersProvider from '../../../../components/common/Filters/FiltersProvider';
+
+type Props = {
+    projectUuid: string | undefined;
+    itemsMap: ItemsMap | undefined;
+    filters: Filters;
+    onChange: (filters: Filters) => void;
+};
+
+const EMPTY_ITEMS_MAP: ItemsMap = {};
+
+export const SchedulerFormChartFiltersTab: FC<Props> = ({
+    projectUuid,
+    itemsMap,
+    filters,
+    onChange,
+}) => {
+    return (
+        <FiltersProvider
+            projectUuid={projectUuid}
+            itemsMap={itemsMap ?? EMPTY_ITEMS_MAP}
+            popoverProps={{ withinPortal: true }}
+        >
+            {/* Configuring an alert is always editing, so the builder is editable */}
+            <FiltersForm isEditMode filters={filters} setFilters={onChange} />
+        </FiltersProvider>
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormParametersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormParametersTab.tsx
@@ -136,6 +136,9 @@ const ParameterItem: FC<SchedulerParameterItemProps> = ({
 
 type SchedulerParametersProps = {
     dashboard?: Dashboard;
+    // Charts (threshold alerts) pass projectUuid directly since they have no
+    // dashboard to source it from.
+    projectUuid?: string;
     currentParameterValues?: ParametersValuesMap;
     onChange: (schedulerParameters: ParametersValuesMap) => void;
     schedulerParameterValues: ParametersValuesMap | undefined;
@@ -145,6 +148,7 @@ type SchedulerParametersProps = {
 
 export const SchedulerFormParametersTab: FC<SchedulerParametersProps> = ({
     dashboard,
+    projectUuid,
     currentParameterValues = {},
     schedulerParameterValues,
     availableParameters,
@@ -233,7 +237,9 @@ export const SchedulerFormParametersTab: FC<SchedulerParametersProps> = ({
                             onChange={handleParameterChange}
                             onRevert={() => handleRevertParameter(paramKey)}
                             hasChanged={hasParameterChanged(paramKey)}
-                            projectUuid={dashboard?.projectUuid || ''}
+                            projectUuid={
+                                projectUuid || dashboard?.projectUuid || ''
+                            }
                             parameterValues={{
                                 ...currentParameterValues,
                                 ...schedulerParameterValues,

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
@@ -1,4 +1,5 @@
 import {
+    isDashboardScheduler,
     SchedulerFormat,
     type CreateSchedulerAndTargetsWithoutIds,
     type Dashboard,
@@ -9,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { Badge, Group, Tabs, Text } from '@mantine-8/core';
 import { type FC } from 'react';
+import { SchedulerFormChartFiltersTab } from './SchedulerFormChartFiltersTab';
 import { useSchedulerFormContext } from './schedulerFormContext';
 import { SchedulerFormCustomizationTab } from './SchedulerFormCustomizationTab';
 import { SchedulerFormFiltersTab } from './SchedulerFormFiltersTab';
@@ -28,6 +30,7 @@ type Props = {
     loading?: boolean;
     confirmText?: string;
     isThresholdAlert?: boolean;
+    projectUuid: string | undefined;
     itemsMap?: ItemsMap;
     currentParameterValues?: ParametersValuesMap;
     availableParameters?: ParameterDefinitions;
@@ -42,6 +45,8 @@ const SchedulerForm: FC<Props> = ({
     savedSchedulerData,
     loading,
     isThresholdAlert,
+    projectUuid,
+    itemsMap,
     currentParameterValues,
     availableParameters,
     dashboard,
@@ -55,8 +60,12 @@ const SchedulerForm: FC<Props> = ({
     const form = useSchedulerFormContext();
 
     const isDashboard = dashboard !== undefined;
+    // Threshold alerts are chart schedulers; expose chart-scoped overrides.
+    const isChartAlert = !!isThresholdAlert && !isDashboard;
 
-    const requiredFiltersWithoutValues = (form.values.filters ?? []).filter(
+    const requiredFiltersWithoutValues = (
+        form.values.dashboardFilters ?? []
+    ).filter(
         (filter) =>
             filter.required && (!filter.values || filter.values.length === 0),
     );
@@ -76,15 +85,18 @@ const SchedulerForm: FC<Props> = ({
                             <Tabs.Tab value="filters">
                                 <Group gap="xs">
                                     Filters
-                                    {form.values.filters &&
-                                    form.values.filters.length > 0 ? (
+                                    {form.values.dashboardFilters &&
+                                    form.values.dashboardFilters.length > 0 ? (
                                         <Badge
                                             color="blue"
                                             size="xs"
                                             variant="light"
                                             radius="sm"
                                         >
-                                            {form.values.filters.length}
+                                            {
+                                                form.values.dashboardFilters
+                                                    .length
+                                            }
                                         </Badge>
                                     ) : (
                                         ''
@@ -97,6 +109,13 @@ const SchedulerForm: FC<Props> = ({
                                     )}
                                 </Group>
                             </Tabs.Tab>
+                            <Tabs.Tab value="parameters">Parameters</Tabs.Tab>
+                        </>
+                    ) : null}
+
+                    {isChartAlert ? (
+                        <>
+                            <Tabs.Tab value="filters">Filters</Tabs.Tab>
                             <Tabs.Tab value="parameters">Parameters</Tabs.Tab>
                         </>
                     ) : null}
@@ -139,17 +158,17 @@ const SchedulerForm: FC<Props> = ({
                         <Tabs.Panel value="filters" p="md">
                             <SchedulerFormFiltersTab
                                 dashboard={dashboard}
-                                draftFilters={form.values.filters}
+                                draftFilters={form.values.dashboardFilters}
                                 isEditMode={savedSchedulerData !== undefined}
                                 savedFilters={
                                     savedSchedulerData &&
-                                    'filters' in savedSchedulerData
+                                    isDashboardScheduler(savedSchedulerData)
                                         ? savedSchedulerData.filters
                                         : []
                                 }
                                 onChange={(schedulerFilters) => {
                                     form.setFieldValue(
-                                        'filters',
+                                        'dashboardFilters',
                                         schedulerFilters,
                                     );
                                 }}
@@ -176,13 +195,49 @@ const SchedulerForm: FC<Props> = ({
                     </>
                 ) : null}
 
+                {isChartAlert ? (
+                    <>
+                        <Tabs.Panel value="filters" p="md">
+                            <SchedulerFormChartFiltersTab
+                                projectUuid={projectUuid}
+                                itemsMap={itemsMap}
+                                filters={form.values.chartFilters ?? {}}
+                                onChange={(chartFilters) => {
+                                    form.setFieldValue(
+                                        'chartFilters',
+                                        chartFilters,
+                                    );
+                                }}
+                            />
+                        </Tabs.Panel>
+
+                        <Tabs.Panel value="parameters" p="md">
+                            <SchedulerFormParametersTab
+                                projectUuid={projectUuid}
+                                currentParameterValues={currentParameterValues}
+                                schedulerParameterValues={
+                                    form.values.parameters
+                                }
+                                availableParameters={availableParameters}
+                                isLoading={!!loading}
+                                onChange={(schedulerParameters) => {
+                                    form.setFieldValue(
+                                        'parameters',
+                                        schedulerParameters,
+                                    );
+                                }}
+                            />
+                        </Tabs.Panel>
+                    </>
+                ) : null}
+
                 <Tabs.Panel value="customization">
                     <SchedulerFormCustomizationTab />
                 </Tabs.Panel>
                 {isDashboard ? (
                     <Tabs.Panel value="preview">
                         <SchedulerFormPreviewTab
-                            schedulerFilters={form.values.filters}
+                            schedulerFilters={form.values.dashboardFilters}
                             dashboard={dashboard}
                             customViewportWidth={
                                 form.values.customViewportWidth

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -1,4 +1,5 @@
 import {
+    isChartScheduler,
     isCreateSchedulerGoogleChatTarget,
     isCreateSchedulerMsTeamsTarget,
     isDashboardScheduler,
@@ -12,6 +13,7 @@ import {
     type CreateSchedulerTarget,
     type Dashboard,
     type DashboardFilterRule,
+    type Filters,
     type ParametersValuesMap,
     type SchedulerAndTargets,
     type SchedulerCsvOptions,
@@ -40,7 +42,8 @@ export interface SchedulerFormValues {
     slackTargets: string[];
     msTeamsTargets: string[];
     googleChatTargets: string[];
-    filters?: DashboardFilterRule[];
+    dashboardFilters?: DashboardFilterRule[];
+    chartFilters?: Filters;
     parameters?: ParametersValuesMap;
     customViewportWidth?: number;
     selectedTabs?: string[] | null;
@@ -77,7 +80,8 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     slackTargets: [],
     msTeamsTargets: [],
     googleChatTargets: [],
-    filters: [],
+    dashboardFilters: [],
+    chartFilters: undefined,
     parameters: undefined,
     customViewportWidth: undefined,
     selectedTabs: null,
@@ -175,10 +179,14 @@ export const getFormValuesFromScheduler = (
         msTeamsTargets: msTeamsTargets,
         googleChatTargets: googleChatTargets,
         ...(isDashboardScheduler(schedulerData) && {
-            filters: schedulerData.filters,
+            dashboardFilters: schedulerData.filters,
             parameters: schedulerData.parameters,
             customViewportWidth: schedulerData.customViewportWidth,
             selectedTabs: schedulerData.selectedTabs,
+        }),
+        ...(isChartScheduler(schedulerData) && {
+            chartFilters: schedulerData.filters,
+            parameters: schedulerData.parameters,
         }),
         thresholds: schedulerData.thresholds,
         notificationFrequency: schedulerData.notificationFrequency,
@@ -256,10 +264,14 @@ export const transformFormValues = (
         appUuid: null,
         appName: null,
         ...(resourceType === 'dashboard' && {
-            filters: values.filters,
+            filters: values.dashboardFilters,
             parameters: values.parameters,
             customViewportWidth: values.customViewportWidth,
             selectedTabs: values.selectedTabs,
+        }),
+        ...(resourceType === 'chart' && {
+            filters: values.chartFilters,
+            parameters: values.parameters,
         }),
         thresholds: values.thresholds,
         enabled: true,

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -181,7 +181,7 @@ const useSchedulerFormModal = ({
                         : null;
                 },
             },
-            filters: (value) => {
+            dashboardFilters: (value) => {
                 if (!value) {
                     // Dashboard filters are undefined/null for charts
                     return null;
@@ -222,7 +222,9 @@ const useSchedulerFormModal = ({
     const isThresholdAlertWithNoFields =
         isThresholdAlert && Object.keys(numericMetrics).length === 0;
 
-    const requiredFiltersWithoutValues = (form.values.filters ?? []).filter(
+    const requiredFiltersWithoutValues = (
+        form.values.dashboardFilters ?? []
+    ).filter(
         (filter) =>
             filter.required && (!filter.values || filter.values.length === 0),
     );
@@ -416,6 +418,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
 }) => {
     // URL param handling is done in SchedulerModal parent component
     const schedulerUuid = schedulerUuidToEdit;
+    const projectUuid = useProjectUuid();
 
     const {
         isLoading,
@@ -567,6 +570,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
                                 resource={formResource}
                                 savedSchedulerData={savedSchedulerData}
                                 isThresholdAlert={isThresholdAlert}
+                                projectUuid={projectUuid}
                                 onSubmit={handleSubmit}
                                 onSendNow={handleSendNow}
                                 loading={isMutating || isLoading}

--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -33,6 +33,7 @@ import { useSendNowSchedulerByUuid } from '../hooks/useScheduler';
 import { useSchedulersEnabledUpdateMutation } from '../hooks/useSchedulersUpdateMutation';
 import ConfirmPauseSchedulerModal from './ConfirmPauseSchedulerModal';
 import ConfirmSendNowModal from './ConfirmSendNowModal';
+import { getSchedulerDeliveryType } from './types';
 
 dayjs.extend(relativeTime);
 
@@ -279,6 +280,7 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                 opened={isConfirmSendNowOpen}
                 onClose={() => setIsConfirmSendNowOpen(false)}
                 schedulerName={scheduler.name}
+                deliveryType={getSchedulerDeliveryType(scheduler)}
                 loading={sendNowMutation.isLoading}
                 onConfirm={() => {
                     sendNowMutation.mutate();

--- a/packages/frontend/src/features/scheduler/components/types.ts
+++ b/packages/frontend/src/features/scheduler/components/types.ts
@@ -1,8 +1,19 @@
+import { type ThresholdOptions } from '@lightdash/common';
+
 export enum Limit {
     TABLE = 'table',
     ALL = 'all',
     CUSTOM = 'custom',
 }
+
+// A scheduler is presented as an "alert" when it has thresholds, otherwise a
+// "scheduled" delivery. Drives copy/labels/icons across scheduler components.
+export type SchedulerDeliveryType = 'scheduled' | 'alert';
+
+export const getSchedulerDeliveryType = (scheduler: {
+    thresholds?: ThresholdOptions[];
+}): SchedulerDeliveryType =>
+    (scheduler.thresholds?.length ?? 0) > 0 ? 'alert' : 'scheduled';
 
 export enum Values {
     FORMATTED = 'formatted',


### PR DESCRIPTION
## Description

Teams running multi-tenant / per-segment alerting need a single shared chart to power many threshold alerts, each scoped to a different subset of data (e.g. a customer or a region) and routed to its own destination. Today that requires cloning the chart once per segment, which doesn't scale.

This adds chart-scoped **filter** and **parameter overrides** to chart threshold alerts — applied on top of the chart's saved query before the threshold is evaluated — mirroring what dashboard scheduled deliveries already support.

Closes: PROD-8247
Closes: #24167
