### PR TITLE
refactor(ai): give period-comparison metrics their own field

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1517,7 +1517,10 @@ export class AiAgentService extends BaseService {
         );
 
         const populatedCustomMetrics = populateCustomMetricsSQL(
-            metricQuery.customMetrics,
+            [
+                ...metricQuery.additionalMetrics,
+                ...metricQuery.periodComparisonMetrics,
+            ],
             explore,
         );
         const metricQueryWithCustomMetrics = {

--- a/packages/backend/src/ee/services/ai/tools/runContentQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runContentQuery.ts
@@ -108,7 +108,7 @@ export const getRunContentQuery = ({
                     sorts: [],
                     tableCalculations: [],
                     additionalMetrics: [],
-                    customMetrics: null,
+                    periodComparisonMetrics: [],
                     ...rawMetricQuery,
                     exploreName: rawMetricQuery.exploreName ?? source.tableName,
                     filters: (rawMetricQuery.filters ?? {}) as Filters,

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -252,8 +252,9 @@ export const getRunQuery = ({
                         maxLimit,
                     ),
                     filters: queryTool.queryConfig.filters,
+                    // PoP already expanded into additionalMetrics above
                     additionalMetrics: populatedCustomMetrics,
-                    customMetrics: queryTool.queryConfig.customMetrics,
+                    periodComparisonMetrics: [],
                     tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
                         queryTool.queryConfig.tableCalculations,
                     ),

--- a/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSavedChart.ts
@@ -125,7 +125,7 @@ export const getRunSavedChart = ({
                     limit: getValidAiQueryLimit(metricQuery.limit, maxLimit),
                     tableCalculations: metricQuery.tableCalculations,
                     additionalMetrics: metricQuery.additionalMetrics ?? [],
-                    customMetrics: null,
+                    periodComparisonMetrics: [],
                     filters: metricQuery.filters,
                 };
 

--- a/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
+++ b/packages/common/src/ee/AiAgent/schemas/customMetrics.ts
@@ -227,6 +227,11 @@ export const filterAggregationCustomMetrics = (
             !isPeriodComparisonCustomMetric(cm),
     );
 
+export const filterPeriodComparisonCustomMetrics = (
+    cms: TransformedCustomMetric[] | null | undefined,
+): PeriodComparisonCustomMetric[] =>
+    (cms ?? []).filter(isPeriodComparisonCustomMetric);
+
 export const customMetricsSchema = z
     .array(customMetricBaseSchema)
     .nullable()

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/tableViz.ts
@@ -65,6 +65,7 @@ export const metricQueryTableViz = ({
     limit: getValidAiQueryLimit(vizConfig.limit, maxLimit),
     filters,
     additionalMetrics: filterAggregationCustomMetrics(customMetrics),
-    customMetrics: customMetrics ?? null,
+    // viz tools predate period comparisons — never any to carry
+    periodComparisonMetrics: [],
     tableCalculations,
 });

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/timeSeriesViz.ts
@@ -91,7 +91,8 @@ export const metricQueryTimeSeriesViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: filterAggregationCustomMetrics(customMetrics),
-        customMetrics: customMetrics ?? null,
+        // viz tools predate period comparisons — never any to carry
+        periodComparisonMetrics: [],
         tableCalculations,
     };
 };

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/verticalBarViz.ts
@@ -98,7 +98,8 @@ export const metricQueryVerticalBarViz = ({
         exploreName: vizConfig.exploreName,
         filters,
         additionalMetrics: filterAggregationCustomMetrics(customMetrics),
-        customMetrics: customMetrics ?? null,
+        // viz tools predate period comparisons — never any to carry
+        periodComparisonMetrics: [],
         // TODO: add tableCalculations
         tableCalculations,
     };

--- a/packages/common/src/ee/AiAgent/types.ts
+++ b/packages/common/src/ee/AiAgent/types.ts
@@ -1,6 +1,6 @@
 import type { Filters } from '../../types/filter';
 import type { AdditionalMetric, MetricQuery } from '../../types/metricQuery';
-import type { TransformedCustomMetric } from './schemas/customMetrics';
+import type { PeriodComparisonCustomMetric } from './schemas/customMetrics';
 import type {
     ToolRunQueryArgs,
     ToolTableVizArgs,
@@ -28,11 +28,13 @@ export type AiMetricQuery = Pick<
     | 'exploreName'
     | 'tableCalculations'
 > & {
-    // Aggregation custom metrics as additional-metric definitions, used for
-    // field-existence validation.
+    // Aggregation / real metrics — id-addressable (table+name), so they're
+    // safe for field-existence validation, getItemId and FE rendering.
     additionalMetrics: Omit<AdditionalMetric, 'sql'>[];
-    // Full custom-metric set (incl. periodComparison) used to populate SQL.
-    customMetrics: TransformedCustomMetric[] | null;
+    // Period-over-period specs ONLY. They have no table/name until
+    // populateCustomMetricsSQL expands them, so they're kept out of
+    // additionalMetrics (which getItemId would choke on).
+    periodComparisonMetrics: PeriodComparisonCustomMetric[];
 };
 
 export type AiMetricQueryWithFilters = AiMetricQuery & {

--- a/packages/common/src/ee/AiAgent/utils.ts
+++ b/packages/common/src/ee/AiAgent/utils.ts
@@ -2,6 +2,7 @@ import { AI_DEFAULT_MAX_QUERY_LIMIT } from './constants';
 import {
     convertAiTableCalcsSchemaToTableCalcs,
     filterAggregationCustomMetrics,
+    filterPeriodComparisonCustomMetrics,
     metricQueryTableViz,
     metricQueryTimeSeriesViz,
     metricQueryVerticalBarViz,
@@ -99,13 +100,15 @@ export const parseVizConfig = (
                 maxLimit ?? AI_DEFAULT_MAX_QUERY_LIMIT,
             ),
             filters: vizTool.queryConfig.filters,
-            // additionalMetrics is filtered to aggregations (for field
-            // validation); customMetrics keeps the full set incl.
-            // periodComparison for SQL population.
+            // Aggregations and period comparisons live in separate fields:
+            // additionalMetrics is id-addressable (validation/FE),
+            // periodComparisonMetrics holds the specs to expand into SQL.
             additionalMetrics: filterAggregationCustomMetrics(
                 vizTool.queryConfig.customMetrics,
             ),
-            customMetrics: vizTool.queryConfig.customMetrics,
+            periodComparisonMetrics: filterPeriodComparisonCustomMetrics(
+                vizTool.queryConfig.customMetrics,
+            ),
             tableCalculations: convertAiTableCalcsSchemaToTableCalcs(
                 vizTool.queryConfig.tableCalculations,
             ),


### PR DESCRIPTION
Follow-up to #24283. That PR added `AiMetricQuery.customMetrics` (the full custom-metric set) next to `additionalMetrics` — but the name made them look like duplicates and kept raising "are we losing period-over-period (PoP)?".

This splits them into two honest, non-overlapping fields:

```ts
additionalMetrics: Omit<AdditionalMetric, 'sql'>[];      // aggregation/real metrics — id-addressable (validation, FE, getItemId)
periodComparisonMetrics: PeriodComparisonCustomMetric[]; // PoP specs ONLY — expanded server-side by populateCustomMetricsSQL
```

Why this is the right shape:
- `additionalMetrics` is consumed by `getItemId` (FE chart renderer + backend validators), so it can only hold metrics with a `table`/`name`. A `periodComparison` spec has neither, so keeping it out of `additionalMetrics` is what prevents the `getItemId` garbage-id problem.
- PoP is **never stripped** — it lives in its own field and is concatenated back at population time: `populateCustomMetricsSQL([...additionalMetrics, ...periodComparisonMetrics])`.
- The viz builders (bar/timeseries/table) set `periodComparisonMetrics: []` — those tools were removed (#17991, Nov 2025) before PoP shipped (#23229, May 2026), so they can never carry it.

`periodComparisonMetrics` is non-empty only in `parseVizConfig`'s runQuery branch and is consumed only by the artifact re-render path (`executeAsyncAiMetricQuery`); the live `runAsyncQuery` path is untouched.
