### PR TITLE
perf(backend): parallelize setup loads in getAsyncQueryResults

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -866,8 +866,10 @@ export class AsyncQueryService extends ProjectService {
     }: GetAsyncQueryResultsArgs): Promise<ApiGetAsyncQueryResults> {
         assertIsAccountWithOrg(account);
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const [{ organizationUuid }, queryHistory] = await Promise.all([
+            this.projectModel.getSummary(projectUuid),
+            this.queryHistoryModel.get(queryUuid, projectUuid, account),
+        ]);
 
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -877,12 +879,6 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 metadata: { queryUuid },
             }),
-        );
-
-        const queryHistory = await this.queryHistoryModel.get(
-            queryUuid,
-            projectUuid,
-            account,
         );
 
         const isForbidden =


### PR DESCRIPTION
Closes: SPK-510

### Description:

The results-polling endpoint `GET /api/v2/projects/:projectUuid/query/:queryUuid` is the product's second-busiest API call, and `getAsyncQueryResults` awaited `projectModel.getSummary` and `queryHistoryModel.get` sequentially even though they share no data dependency. This change wraps both in a single `Promise.all`, removing one serial Postgres round-trip per poll. Both results are only consumed downstream by the forbidden check, so behaviour is unchanged.