### PR TITLE
perf(backend): parallelize queryHistory get and getSummary in calculate-total

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4315,14 +4315,10 @@ export class AsyncQueryService extends ProjectService {
         // `get` enforces the query belongs to this project and was created by
         // this account — that ownership authorizes the totals query, so we skip
         // the explore-level CASL gate (which embed JWT callers can't pass).
-        const source = await this.queryHistoryModel.get(
-            queryUuid,
-            projectUuid,
-            account,
-        );
-
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const [source, { organizationUuid }] = await Promise.all([
+            this.queryHistoryModel.get(queryUuid, projectUuid, account),
+            this.projectModel.getSummary(projectUuid),
+        ]);
 
         const sourceInputs = {
             metricQuery: source.metricQuery,


### PR DESCRIPTION
Closes: SPK-525
Relates: SPK-516

### Description:

In `executeAsyncCalculateTotalFromQueryHistory`, the independent `queryHistoryModel.get` and `projectModel.getSummary` calls were awaited sequentially despite having no data dependency. This wraps them in a single `Promise.all` so they run concurrently, shaving one round-trip off the calculate-total path.