### PR TITLE
perf(backend): parallelize setup loads in searchFieldUniqueValues

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5537,11 +5537,26 @@ export class ProjectService extends BaseService {
                 filters,
             });
 
-        const warehouseCredentials = await this.getWarehouseCredentials({
-            projectUuid,
-            userId: user.userUuid,
-            isRegisteredUser: true,
-        });
+        const [
+            warehouseCredentials,
+            { userAttributes, intrinsicUserAttributes },
+            availableParameterDefinitions,
+            combinedParameters,
+            projectTimezone,
+            useTimezoneAwareDateTrunc,
+        ] = await Promise.all([
+            this.getWarehouseCredentials({
+                projectUuid,
+                userId: user.userUuid,
+                isRegisteredUser: true,
+            }),
+            this.getUserAttributes({ user }),
+            this.getAvailableParameters(projectUuid, explore),
+            this.combineParameters(projectUuid, explore, parameters),
+            this.getQueryTimezoneForProject(projectUuid),
+            this.isTimezoneSupportEnabled(user),
+        ]);
+
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             projectUuid,
             warehouseCredentials,
@@ -5550,8 +5565,6 @@ export class ProjectService extends BaseService {
                 databricksCompute: explore.databricksCompute,
             },
         );
-        const { userAttributes, intrinsicUserAttributes } =
-            await this.getUserAttributes({ user });
 
         const mergedUserAttributes = userAttributeOverrides
             ? {
@@ -5560,28 +5573,12 @@ export class ProjectService extends BaseService {
               }
             : userAttributes;
 
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            explore,
-        );
-
-        // Combine request parameters with defaults from parameter definitions
-        const combinedParameters = await this.combineParameters(
-            projectUuid,
-            explore,
-            parameters,
-        );
-
-        const projectTimezone =
-            await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone({
             sessionTimezone: null,
             metricQuery,
             projectTimezone,
             userTimezone: user.timezone,
         });
-        const useTimezoneAwareDateTrunc =
-            await this.isTimezoneSupportEnabled(user);
 
         const { query } = await ProjectService._compileQuery({
             metricQuery,


### PR DESCRIPTION
Closes: SPK-517

### Description:

`searchFieldUniqueValues` ran its setup as six serial `await`s, adding ~5 avoidable serial DB/feature-flag round-trips to a high-traffic autocomplete endpoint. This batches the six independent loads (`getWarehouseCredentials`, `getUserAttributes`, `getAvailableParameters`, `combineParameters`, `getQueryTimezoneForProject`, `isTimezoneSupportEnabled`) into a single `Promise.all`, keeping `_getWarehouseClient` after the credentials resolve. Behaviour and types are unchanged; `pnpm -F backend typecheck:fast` and `pnpm -F backend test:dev:nowatch` (299 tests) pass.