### PR TITLE
feat(data-apps): capture Claude generation token/turn/cost usage in analytics

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1282,6 +1282,17 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         buildFixAttempts: number;
         buildFixGenerationMs: number;
         toolCallCount: number;
+        // Token/turn/cost usage summed across every `claude` invocation in the
+        // build (main generation + build-fix re-runs + metadata). Used to
+        // decompose `generateMs` into output volume vs turn count and to
+        // confirm prompt caching is landing (`cacheReadInputTokens > 0`).
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadInputTokens: number;
+        cacheCreationInputTokens: number;
+        numTurns: number;
+        durationApiMs: number;
+        totalCostUsd: number;
         catalogTableCount: number;
         catalogDimensionCount: number;
         catalogMetricCount: number;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -85,7 +85,12 @@ import {
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
 } from './claudeCodeEnv';
-import { ClaudeStreamProcessor } from './ClaudeStreamProcessor';
+import {
+    addClaudeUsage,
+    ClaudeStreamProcessor,
+    ZERO_CLAUDE_USAGE,
+    type ClaudeGenerationUsage,
+} from './ClaudeStreamProcessor';
 import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
@@ -1401,6 +1406,7 @@ export class AppGenerateService extends BaseService {
         durationMs: number;
         responseText: string | null;
         toolCallCount: number;
+        usage: ClaudeGenerationUsage | null;
     }> {
         const start = performance.now();
 
@@ -1420,6 +1426,7 @@ export class AppGenerateService extends BaseService {
             durationMs: number;
             responseText: string | null;
             toolCallCount: number;
+            usage: ClaudeGenerationUsage | null;
         }> => {
             const sessionFlags =
                 continueSession || forceContinue ? '--continue -p' : '-p';
@@ -1477,8 +1484,10 @@ export class AppGenerateService extends BaseService {
                                         );
                                         break;
                                     }
-                                    case 'result_text':
-                                        responseText = event.text;
+                                    case 'result':
+                                        if (event.text) {
+                                            responseText = event.text;
+                                        }
                                         break;
                                     default:
                                         assertUnreachable(
@@ -1511,9 +1520,10 @@ export class AppGenerateService extends BaseService {
                     };
                 });
             const toolCallCount = processor.totalToolCalls;
+            const usage = processor.lastUsage;
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
-                `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+                `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, turns=${usage?.numTurns ?? 0}, outputTokens=${usage?.outputTokens ?? 0}, cacheReadTokens=${usage?.cacheReadInputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
             );
 
             if (result.exitCode === 0) {
@@ -1522,7 +1532,7 @@ export class AppGenerateService extends BaseService {
                         `App ${appUuid}: Claude generation recovered after ${attempt - 1} retry(ies)`,
                     );
                 }
-                return { durationMs, responseText, toolCallCount };
+                return { durationMs, responseText, toolCallCount, usage };
             }
 
             const stderrTail = AppGenerateService.truncateEnd(
@@ -1619,6 +1629,7 @@ export class AppGenerateService extends BaseService {
         name: string;
         description: string;
         durationMs: number;
+        usage: ClaudeGenerationUsage | null;
     } | null> {
         const start = performance.now();
         const metadataPrompt =
@@ -1676,7 +1687,12 @@ export class AppGenerateService extends BaseService {
                 );
                 return null;
             }
-            return { name, description: description ?? '', durationMs };
+            return {
+                name,
+                description: description ?? '',
+                durationMs,
+                usage: generation.usage,
+            };
         } catch {
             const safeLog = generation.responseText
                 .replace(/[\n\r]/g, ' ')
@@ -1764,10 +1780,12 @@ export class AppGenerateService extends BaseService {
         buildMs: number;
         fixAttempts: number;
         fixGenerationMs: number;
+        fixUsage: ClaudeGenerationUsage;
     }> {
         let buildMs = 0;
         let fixGenerationMs = 0;
         let fixAttempts = 0;
+        let fixUsage: ClaudeGenerationUsage = ZERO_CLAUDE_USAGE;
 
         let lastResult = await this.runBuild(sandbox, appUuid);
         buildMs += lastResult.durationMs;
@@ -1849,6 +1867,7 @@ export class AppGenerateService extends BaseService {
                 claudeModel,
             );
             fixGenerationMs += generation.durationMs;
+            fixUsage = addClaudeUsage(fixUsage, generation.usage);
 
             try {
                 await this.appModel.updateStatusMessage(
@@ -1889,7 +1908,7 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        return { buildMs, fixAttempts, fixGenerationMs };
+        return { buildMs, fixAttempts, fixGenerationMs, fixUsage };
     }
 
     // Heading text rendered by the shipped src/App.jsx stub. The blank-app
@@ -2317,6 +2336,10 @@ export class AppGenerateService extends BaseService {
         let buildFixGenerationMs = 0;
         let distBytes = 0;
         let sourceBytes = 0;
+        // Token/turn/cost usage summed across every `claude` invocation in the
+        // build (main generation + build-fix re-runs + metadata). Reported on
+        // the completion analytics event to decompose `generateMs`.
+        let generationUsage: ClaudeGenerationUsage = ZERO_CLAUDE_USAGE;
 
         // --- Stage: catalog ---
         if (shouldRun('catalog')) {
@@ -2402,6 +2425,10 @@ export class AppGenerateService extends BaseService {
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
                 toolCallCount = generation.toolCallCount;
+                generationUsage = addClaudeUsage(
+                    generationUsage,
+                    generation.usage,
+                );
             } catch (error) {
                 const totalMs = AppGenerateService.elapsed(overallStart);
                 this.logger.error(
@@ -2464,6 +2491,10 @@ export class AppGenerateService extends BaseService {
                 durations.buildMs = buildResult.buildMs;
                 buildFixAttempts = buildResult.fixAttempts;
                 buildFixGenerationMs = buildResult.fixGenerationMs;
+                generationUsage = addClaudeUsage(
+                    generationUsage,
+                    buildResult.fixUsage,
+                );
                 if (buildResult.fixAttempts > 0) {
                     durations.buildFixMs = buildResult.fixGenerationMs;
                     durations.buildFixAttempts = buildResult.fixAttempts;
@@ -2519,6 +2550,10 @@ export class AppGenerateService extends BaseService {
                         `App ${appUuid}: auto-named "${metadata.name}"`,
                     );
                     durations.metadataMs = metadata.durationMs;
+                    generationUsage = addClaudeUsage(
+                        generationUsage,
+                        metadata.usage,
+                    );
                 }
             } catch (error) {
                 // Non-fatal — the app works fine without a name
@@ -2623,7 +2658,9 @@ export class AppGenerateService extends BaseService {
                 durations,
             )
                 .map(([k, v]) => `${k}=${v}ms`)
-                .join(', ')})`,
+                .join(
+                    ', ',
+                )}, numTurns=${generationUsage.numTurns}, inputTokens=${generationUsage.inputTokens}, outputTokens=${generationUsage.outputTokens}, cacheReadTokens=${generationUsage.cacheReadInputTokens}, cacheCreationTokens=${generationUsage.cacheCreationInputTokens}, costUsd=${generationUsage.costUsd})`,
         );
 
         this.analytics.track({
@@ -2649,6 +2686,14 @@ export class AppGenerateService extends BaseService {
                 buildFixAttempts,
                 buildFixGenerationMs,
                 toolCallCount,
+                inputTokens: generationUsage.inputTokens,
+                outputTokens: generationUsage.outputTokens,
+                cacheReadInputTokens: generationUsage.cacheReadInputTokens,
+                cacheCreationInputTokens:
+                    generationUsage.cacheCreationInputTokens,
+                numTurns: generationUsage.numTurns,
+                durationApiMs: generationUsage.durationApiMs,
+                totalCostUsd: generationUsage.costUsd,
                 catalogTableCount: catalogStats.tableCount,
                 catalogDimensionCount: catalogStats.dimensionCount,
                 catalogMetricCount: catalogStats.metricCount,

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
@@ -1,0 +1,115 @@
+import {
+    addClaudeUsage,
+    ClaudeStreamProcessor,
+    ZERO_CLAUDE_USAGE,
+    type ClaudeGenerationUsage,
+} from './ClaudeStreamProcessor';
+
+// Lines are only consumed once a newline arrives, so every fixture ends in \n.
+const line = (obj: unknown) => `${JSON.stringify(obj)}\n`;
+
+const resultLine = (overrides: Record<string, unknown> = {}) =>
+    line({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        duration_ms: 380_000,
+        duration_api_ms: 350_000,
+        num_turns: 42,
+        result: 'Done building the dashboard.',
+        total_cost_usd: 1.23,
+        usage: {
+            input_tokens: 1_000,
+            output_tokens: 5_000,
+            cache_creation_input_tokens: 2_000,
+            cache_read_input_tokens: 40_000,
+        },
+        ...overrides,
+    });
+
+describe('ClaudeStreamProcessor result parsing', () => {
+    test('emits a result event with text and captures full usage', () => {
+        const processor = new ClaudeStreamProcessor();
+        const events = processor.feedChunk(resultLine());
+
+        expect(events).toEqual([
+            { kind: 'result', text: 'Done building the dashboard.' },
+        ]);
+        expect(processor.lastUsage).toEqual({
+            inputTokens: 1_000,
+            outputTokens: 5_000,
+            cacheCreationInputTokens: 2_000,
+            cacheReadInputTokens: 40_000,
+            numTurns: 42,
+            durationApiMs: 350_000,
+            costUsd: 1.23,
+        });
+    });
+
+    test('defaults missing numeric fields to 0 and absent text to empty string', () => {
+        const processor = new ClaudeStreamProcessor();
+        const events = processor.feedChunk(
+            line({ type: 'result', subtype: 'success' }),
+        );
+
+        expect(events).toEqual([{ kind: 'result', text: '' }]);
+        expect(processor.lastUsage).toEqual(ZERO_CLAUDE_USAGE);
+    });
+
+    test('ignores non-JSON and non-result lines, leaving usage null', () => {
+        const processor = new ClaudeStreamProcessor();
+        expect(processor.feedChunk('not json\n')).toEqual([]);
+        expect(processor.feedChunk(line({ type: 'system' }))).toEqual([]);
+        expect(processor.lastUsage).toBeNull();
+    });
+
+    test('still counts tool_use calls from assistant events', () => {
+        const processor = new ClaudeStreamProcessor();
+        const events = processor.feedChunk(
+            line({
+                type: 'assistant',
+                message: {
+                    content: [
+                        {
+                            type: 'tool_use',
+                            name: 'Write',
+                            input: { file_path: '/app/src/App.tsx' },
+                        },
+                    ],
+                },
+            }),
+        );
+
+        expect(events).toEqual([
+            {
+                kind: 'tool_use',
+                index: 1,
+                description: 'Write /app/src/App.tsx',
+            },
+        ]);
+        expect(processor.totalToolCalls).toBe(1);
+    });
+});
+
+describe('addClaudeUsage', () => {
+    const usage = (n: number): ClaudeGenerationUsage => ({
+        inputTokens: n,
+        outputTokens: n,
+        cacheReadInputTokens: n,
+        cacheCreationInputTokens: n,
+        numTurns: n,
+        durationApiMs: n,
+        costUsd: n,
+    });
+
+    test('sums two usage records field-by-field', () => {
+        expect(addClaudeUsage(usage(1), usage(2))).toEqual(usage(3));
+    });
+
+    test('treats null as all-zero', () => {
+        expect(addClaudeUsage(usage(5), null)).toEqual(usage(5));
+        expect(addClaudeUsage(ZERO_CLAUDE_USAGE, null)).toEqual(
+            ZERO_CLAUDE_USAGE,
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -9,11 +9,59 @@
  * react to events.
  */
 
+/**
+ * Usage summary for a single `claude` run, extracted from the stream-json
+ * `result` event. Token counts, turn count, API time, and cost — the pieces
+ * needed to decompose `generateMs` into "too much output" vs "too many turns"
+ * and to confirm prompt caching is landing (`cacheReadInputTokens > 0`).
+ */
+export type ClaudeGenerationUsage = {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+    numTurns: number;
+    durationApiMs: number;
+    costUsd: number;
+};
+
+export const ZERO_CLAUDE_USAGE: ClaudeGenerationUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    numTurns: 0,
+    durationApiMs: 0,
+    costUsd: 0,
+};
+
+/**
+ * Sum two usage records field-by-field. One build can invoke `claude` several
+ * times (main generation, build-fix re-runs, metadata), so the pipeline totals
+ * them. Treats `null` as all-zero.
+ */
+export function addClaudeUsage(
+    a: ClaudeGenerationUsage,
+    b: ClaudeGenerationUsage | null,
+): ClaudeGenerationUsage {
+    if (!b) return a;
+    return {
+        inputTokens: a.inputTokens + b.inputTokens,
+        outputTokens: a.outputTokens + b.outputTokens,
+        cacheReadInputTokens: a.cacheReadInputTokens + b.cacheReadInputTokens,
+        cacheCreationInputTokens:
+            a.cacheCreationInputTokens + b.cacheCreationInputTokens,
+        numTurns: a.numTurns + b.numTurns,
+        durationApiMs: a.durationApiMs + b.durationApiMs,
+        costUsd: a.costUsd + b.costUsd,
+    };
+}
+
 export type ClaudeStreamEvent =
     | { kind: 'thinking_started'; turn: number }
     | { kind: 'thinking_snippet'; snippet: string }
     | { kind: 'tool_use'; index: number; description: string }
-    | { kind: 'result_text'; text: string };
+    | { kind: 'result'; text: string };
 
 const STATUS_THROTTLE_MS = 3000;
 const SNIPPET_SENTENCES = 1;
@@ -151,10 +199,20 @@ function parsePartialDeltaText(
     return undefined;
 }
 
+function asFiniteNumber(value: unknown): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
 /**
- * Parse a stream-json `result` event and return the final response text.
+ * Parse a stream-json `result` event: the final response text plus the run's
+ * usage summary (token counts, turn count, API time, cost). Returns
+ * `undefined` for non-result lines. Missing numeric fields default to 0 —
+ * the `result` event is emitted once per run and always carries usage, but
+ * we parse defensively in case a field is absent on older CLI versions.
  */
-function parseResultText(line: string): string | undefined {
+function parseResult(
+    line: string,
+): { text: string | null; usage: ClaudeGenerationUsage } | undefined {
     let event: Record<string, unknown>;
     try {
         event = JSON.parse(line);
@@ -162,7 +220,21 @@ function parseResultText(line: string): string | undefined {
         return undefined;
     }
     if (event.type !== 'result') return undefined;
-    return typeof event.result === 'string' ? event.result : undefined;
+    const usage = (event.usage ?? {}) as Record<string, unknown>;
+    return {
+        text: typeof event.result === 'string' ? event.result : null,
+        usage: {
+            inputTokens: asFiniteNumber(usage.input_tokens),
+            outputTokens: asFiniteNumber(usage.output_tokens),
+            cacheReadInputTokens: asFiniteNumber(usage.cache_read_input_tokens),
+            cacheCreationInputTokens: asFiniteNumber(
+                usage.cache_creation_input_tokens,
+            ),
+            numTurns: asFiniteNumber(event.num_turns),
+            durationApiMs: asFiniteNumber(event.duration_api_ms),
+            costUsd: asFiniteNumber(event.total_cost_usd),
+        },
+    };
 }
 
 export class ClaudeStreamProcessor {
@@ -180,6 +252,8 @@ export class ClaudeStreamProcessor {
 
     private lastEmittedSnippet = '';
 
+    private lastUsageValue: ClaudeGenerationUsage | null = null;
+
     private readonly now: () => number;
 
     /**
@@ -196,6 +270,15 @@ export class ClaudeStreamProcessor {
      */
     get totalToolCalls(): number {
         return this.toolCallCount;
+    }
+
+    /**
+     * Usage summary from the run's `result` event, or `null` if no result
+     * event was seen (e.g. the CLI died before finishing). Read after the
+     * run completes — same pattern as `totalToolCalls`.
+     */
+    get lastUsage(): ClaudeGenerationUsage | null {
+        return this.lastUsageValue;
     }
 
     /**
@@ -263,9 +346,10 @@ export class ClaudeStreamProcessor {
             return;
         }
 
-        const resultText = parseResultText(line);
-        if (resultText) {
-            events.push({ kind: 'result_text', text: resultText });
+        const result = parseResult(line);
+        if (result) {
+            this.lastUsageValue = result.usage;
+            events.push({ kind: 'result', text: result.text ?? '' });
         }
     }
 }


### PR DESCRIPTION
### Description:

Adds finer grained events for app generation.

Decomposes the data-app pipeline's dominant `generateMs`. We already time every
stage, but inside the generation stage we only knew wall-clock + tool-call count
— the Claude CLI's `result` event carried token/turn/cost data and we discarded
all but the final text.

This parses that `result` event and sums usage across every `claude` invocation
in a build (main generation + build-fix re-runs + metadata).
