### PR TITLE
feat(data-apps): add per-turn timeline (TTFT + slowest turn) to generation telemetry

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1293,6 +1293,11 @@ export type DataAppVersionCompletedEvent = BaseTrack & {
         numTurns: number;
         durationApiMs: number;
         totalCostUsd: number;
+        // Latency shape of the main generation call: time-to-first-token and
+        // the slowest single turn. Captured from the main generation only
+        // (per-call metrics, not summed across build-fix / metadata).
+        timeToFirstTokenMs: number;
+        slowestTurnMs: number;
         catalogTableCount: number;
         catalogDimensionCount: number;
         catalogMetricCount: number;

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1408,6 +1408,8 @@ export class AppGenerateService extends BaseService {
         responseText: string | null;
         toolCallCount: number;
         usage: ClaudeGenerationUsage | null;
+        timeToFirstTokenMs: number | null;
+        turnDurationsMs: number[];
     }> {
         const start = performance.now();
 
@@ -1428,6 +1430,8 @@ export class AppGenerateService extends BaseService {
             responseText: string | null;
             toolCallCount: number;
             usage: ClaudeGenerationUsage | null;
+            timeToFirstTokenMs: number | null;
+            turnDurationsMs: number[];
         }> => {
             const sessionFlags =
                 continueSession || forceContinue ? '--continue -p' : '-p';
@@ -1522,9 +1526,13 @@ export class AppGenerateService extends BaseService {
                 });
             const toolCallCount = processor.totalToolCalls;
             const usage = processor.lastUsage;
+            const { timeToFirstTokenMs, turnDurationsMs } = processor;
             const durationMs = AppGenerateService.elapsed(start);
             this.logger.info(
                 `App ${appUuid}: Claude code generation completed (model=${claudeModel}, exit=${result.exitCode}, toolCalls=${toolCallCount}, turns=${usage?.numTurns ?? 0}, outputTokens=${usage?.outputTokens ?? 0}, cacheReadTokens=${usage?.cacheReadInputTokens ?? 0}, ${durationMs}ms, attempt ${attempt}/${AppGenerateService.MAX_GENERATION_ATTEMPTS})`,
+            );
+            this.logger.info(
+                `App ${appUuid}: claude turn timeline (ttft=${timeToFirstTokenMs ?? 'n/a'}ms, turnsMs=[${turnDurationsMs.join(', ')}])`,
             );
 
             if (result.exitCode === 0) {
@@ -1533,7 +1541,14 @@ export class AppGenerateService extends BaseService {
                         `App ${appUuid}: Claude generation recovered after ${attempt - 1} retry(ies)`,
                     );
                 }
-                return { durationMs, responseText, toolCallCount, usage };
+                return {
+                    durationMs,
+                    responseText,
+                    toolCallCount,
+                    usage,
+                    timeToFirstTokenMs,
+                    turnDurationsMs,
+                };
             }
 
             const stderrTail = AppGenerateService.truncateEnd(
@@ -2341,6 +2356,11 @@ export class AppGenerateService extends BaseService {
         // build (main generation + build-fix re-runs + metadata). Reported on
         // the completion analytics event to decompose `generateMs`.
         let generationUsage: ClaudeGenerationUsage = ZERO_CLAUDE_USAGE;
+        // Time-to-first-token and slowest single turn, captured from the main
+        // generation call only (a per-call latency shape; not meaningful to
+        // sum across the build-fix and metadata calls).
+        let timeToFirstTokenMs: number | null = null;
+        let slowestTurnMs = 0;
 
         // --- Stage: catalog ---
         if (shouldRun('catalog')) {
@@ -2430,6 +2450,10 @@ export class AppGenerateService extends BaseService {
                     generationUsage,
                     generation.usage,
                 );
+                timeToFirstTokenMs = generation.timeToFirstTokenMs;
+                slowestTurnMs = generation.turnDurationsMs.length
+                    ? Math.max(...generation.turnDurationsMs)
+                    : 0;
             } catch (error) {
                 const totalMs = AppGenerateService.elapsed(overallStart);
                 this.logger.error(
@@ -2695,6 +2719,8 @@ export class AppGenerateService extends BaseService {
                 numTurns: generationUsage.numTurns,
                 durationApiMs: generationUsage.durationApiMs,
                 totalCostUsd: generationUsage.costUsd,
+                timeToFirstTokenMs: timeToFirstTokenMs ?? 0,
+                slowestTurnMs,
                 catalogTableCount: catalogStats.tableCount,
                 catalogDimensionCount: catalogStats.dimensionCount,
                 catalogMetricCount: catalogStats.metricCount,

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.test.ts
@@ -91,6 +91,35 @@ describe('ClaudeStreamProcessor result parsing', () => {
     });
 });
 
+describe('ClaudeStreamProcessor turn timeline', () => {
+    const messageStart = () =>
+        line({ type: 'stream_event', event: { type: 'message_start' } });
+
+    test('measures time-to-first-token and per-turn durations with an injected clock', () => {
+        const clock = { t: 0 };
+        // createdAt = 0
+        const processor = new ClaudeStreamProcessor(() => clock.t);
+
+        clock.t = 100;
+        processor.feedChunk(messageStart()); // turn 1 starts at 100 → ttft 100
+        clock.t = 250;
+        processor.feedChunk(messageStart()); // turn 2 starts → turn 1 = 150ms
+        clock.t = 400;
+        processor.feedChunk(resultLine()); // result → turn 2 = 150ms
+
+        expect(processor.timeToFirstTokenMs).toBe(100);
+        expect(processor.turnDurationsMs).toEqual([150, 150]);
+    });
+
+    test('reports null ttft and no turns when the model never started', () => {
+        const processor = new ClaudeStreamProcessor(() => 0);
+        processor.feedChunk(line({ type: 'system', subtype: 'init' }));
+
+        expect(processor.timeToFirstTokenMs).toBeNull();
+        expect(processor.turnDurationsMs).toEqual([]);
+    });
+});
+
 describe('addClaudeUsage', () => {
     const usage = (n: number): ClaudeGenerationUsage => ({
         inputTokens: n,

--- a/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/ClaudeStreamProcessor.ts
@@ -254,14 +254,24 @@ export class ClaudeStreamProcessor {
 
     private lastUsageValue: ClaudeGenerationUsage | null = null;
 
+    private firstMessageStartAt: number | null = null;
+
+    private lastTurnStartAt: number | null = null;
+
+    private readonly turnDurations: number[] = [];
+
     private readonly now: () => number;
 
+    private readonly createdAt: number;
+
     /**
-     * `now` is injectable purely for future testability — defaults to
-     * `Date.now`. Not used in production code paths.
+     * `now` is injectable for testing the time-based outputs (snippet
+     * throttling, time-to-first-token, per-turn durations) — defaults to
+     * `Date.now`.
      */
     constructor(now: () => number = () => Date.now()) {
         this.now = now;
+        this.createdAt = now();
     }
 
     /**
@@ -279,6 +289,26 @@ export class ClaudeStreamProcessor {
      */
     get lastUsage(): ClaudeGenerationUsage | null {
         return this.lastUsageValue;
+    }
+
+    /**
+     * Wall-clock ms from processor creation to the first assistant turn — a
+     * proxy for time-to-first-token (how long Claude took to start
+     * responding). `null` if the model never produced a turn.
+     */
+    get timeToFirstTokenMs(): number | null {
+        return this.firstMessageStartAt === null
+            ? null
+            : this.firstMessageStartAt - this.createdAt;
+    }
+
+    /**
+     * Per-turn wall-clock durations in ms, in turn order. A turn spans from
+     * its `message_start` to the next turn's start (or to the final `result`
+     * event for the last turn).
+     */
+    get turnDurationsMs(): number[] {
+        return [...this.turnDurations];
     }
 
     /**
@@ -301,6 +331,14 @@ export class ClaudeStreamProcessor {
     private consumeLine(line: string, events: ClaudeStreamEvent[]): void {
         const partialKind = parsePartialStreamEventKind(line);
         if (partialKind === 'message_start') {
+            const turnStart = this.now();
+            if (this.firstMessageStartAt === null) {
+                this.firstMessageStartAt = turnStart;
+            }
+            if (this.lastTurnStartAt !== null) {
+                this.turnDurations.push(turnStart - this.lastTurnStartAt);
+            }
+            this.lastTurnStartAt = turnStart;
             this.turnCount += 1;
             this.thinkingStartedThisTurn = false;
             this.thinkingTextBuffer = '';
@@ -348,6 +386,10 @@ export class ClaudeStreamProcessor {
 
         const result = parseResult(line);
         if (result) {
+            if (this.lastTurnStartAt !== null) {
+                this.turnDurations.push(this.now() - this.lastTurnStartAt);
+                this.lastTurnStartAt = null;
+            }
             this.lastUsageValue = result.usage;
             events.push({ kind: 'result', text: result.text ?? '' });
         }


### PR DESCRIPTION
### Description:

Adds finer granularity inside the generation stage: time-to-first-token and
per-turn durations, so we can tell a slow *start* from a slow *turn* from many
turns.
