### PR TITLE
feat(formatting): render timestamp metrics in the project timezone

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -123,6 +123,25 @@ describe('Formatting', () => {
             ).toBeUndefined();
         });
 
+        test('STRING item carrying a timestamp value does NOT shift', () => {
+            // The by-value fallback is scoped to MIN/MAX; a known non-temporal
+            // type is trusted even when the value looks like an instant.
+            expect(
+                getFormatterTimezone(
+                    { ...dimension, type: DimensionType.STRING },
+                    tsString,
+                    tz,
+                ),
+            ).toBeUndefined();
+            expect(
+                getFormatterTimezone(
+                    { ...dimension, type: DimensionType.STRING },
+                    new Date(tsString),
+                    tz,
+                ),
+            ).toBeUndefined();
+        });
+
         test('DATE table calc does NOT shift even with a midnight-ISO value', () => {
             // The bug: a date-typed table calc whose value arrives as a full
             // timestamp must stay a calendar day (no off-by-one under -ve UTC).
@@ -1236,6 +1255,25 @@ describe('Formatting', () => {
             };
             expect(shouldShiftItemTimezone(dateOverTs)).toBe(true);
             expect(shouldShiftItemTimezone(dateOverTsOptOut)).toBe(false);
+        });
+
+        test('shouldShiftItemTimezone classifies table calcs by type', () => {
+            // Non-field items are keyed off getItemType: a TIMESTAMP table calc
+            // is a real instant (shift), a DATE one is a calendar value (stay).
+            const tsTableCalc = {
+                name: 'ts_tc',
+                displayName: 'ts_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.TIMESTAMP,
+            } as TableCalculation;
+            const dateTableCalc = {
+                name: 'date_tc',
+                displayName: 'date_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.DATE,
+            } as TableCalculation;
+            expect(shouldShiftItemTimezone(tsTableCalc)).toBe(true);
+            expect(shouldShiftItemTimezone(dateTableCalc)).toBe(false);
         });
 
         test('formatItemValue should return the right format when field is Metric', () => {

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -81,6 +81,85 @@ describe('Formatting', () => {
     });
 
     describe('applying CustomFormat to value', () => {
+        describe('timezone threading (GLITCH-498)', () => {
+            const utcInstant = new Date('2025-01-15T17:00:00.000Z'); // 06:00 in Pago_Pago (UTC-11)
+            const tz = 'Pacific/Pago_Pago';
+
+            test('TIMESTAMP format shifts a Date value into the timezone', () => {
+                expect(
+                    applyCustomFormat(
+                        utcInstant,
+                        { type: CustomFormatType.TIMESTAMP },
+                        tz,
+                    ),
+                ).toEqual('2025-01-15, 06:00:00:000 (-11:00)');
+            });
+
+            test('TIMESTAMP format shifts a timestamp string into the timezone', () => {
+                expect(
+                    applyCustomFormat(
+                        '2025-01-15 17:00:00',
+                        { type: CustomFormatType.TIMESTAMP },
+                        tz,
+                    ),
+                ).toEqual('2025-01-15, 06:00:00:000 (-11:00)');
+            });
+
+            test('early Date branch (non-temporal format type) shifts via formatTimestamp', () => {
+                // value is a Date and format.type is PERCENT -> hits the early
+                // `value instanceof Date` branch (formatting.ts:708-715)
+                expect(
+                    applyCustomFormat(
+                        utcInstant,
+                        { type: CustomFormatType.PERCENT },
+                        tz,
+                    ),
+                ).toEqual('2025-01-15, 06:00:00:000 (-11:00)');
+            });
+
+            test('CUSTOM expression on a timestamp string shifts into the timezone', () => {
+                expect(
+                    applyCustomFormat(
+                        '2025-01-15 17:00:00',
+                        {
+                            type: CustomFormatType.CUSTOM,
+                            custom: 'yyyy-mm-dd hh:mm:ss',
+                        },
+                        tz,
+                    ),
+                ).toEqual('2025-01-15 06:00:00');
+            });
+
+            test('DATE format on a date-only string does NOT shift (by-value gate)', () => {
+                // isTimestampString('2025-01-15') === false -> no time component ->
+                // effectiveTimezone is undefined -> calendar day is preserved
+                expect(
+                    applyCustomFormat(
+                        '2025-01-15',
+                        { type: CustomFormatType.DATE },
+                        tz,
+                    ),
+                ).toEqual('2025-01-15');
+            });
+
+            test('numeric formats ignore timezone (no-op)', () => {
+                expect(
+                    applyCustomFormat(
+                        5000,
+                        { type: CustomFormatType.NUMBER },
+                        tz,
+                    ),
+                ).toEqual('5,000');
+                expect(
+                    applyCustomFormat(
+                        0.05,
+                        { type: CustomFormatType.PERCENT },
+                        tz,
+                    ),
+                ).toEqual('5%');
+            });
+        });
+
         describe('when using legacy format', () => {
             test('if Format is legacy distance unit it should return the right format', () => {
                 expect(
@@ -1307,6 +1386,102 @@ describe('Formatting', () => {
         });
     });
     describe('additional metric formatting', () => {
+        describe('timezone shifting for MIN/MAX (GLITCH-498)', () => {
+            // MIN/MAX values arrive from query results as ISO datetime
+            // STRINGS (not Date objects), which is the case the explore table
+            // renders. Each must shift into the project timezone like the
+            // underlying dimension does.
+            test('TIMESTAMP format shifts a string value into the timezone', () => {
+                expect(
+                    formatItemValue(
+                        {
+                            ...additionalMetric,
+                            type: MetricType.MAX,
+                            formatOptions: {
+                                type: CustomFormatType.TIMESTAMP,
+                                timeInterval: TimeFrames.RAW,
+                            },
+                        },
+                        '2025-01-15T17:00:00.000Z',
+                        false,
+                        undefined,
+                        'America/Anchorage', // -09:00 in January
+                    ),
+                ).toEqual('2025-01-15, 08:00:00:000 (-09:00)');
+            });
+
+            test('TIMESTAMP format shifts a Date value into the timezone', () => {
+                expect(
+                    formatItemValue(
+                        {
+                            ...additionalMetric,
+                            type: MetricType.MIN,
+                            formatOptions: { type: CustomFormatType.TIMESTAMP },
+                        },
+                        new Date('2025-01-15T17:00:00.000Z'),
+                        false,
+                        undefined,
+                        'Asia/Tokyo', // +09:00, no DST
+                    ),
+                ).toEqual('2025-01-16, 02:00:00:000 (+09:00)');
+            });
+
+            test('CUSTOM expression shifts a string value into the timezone', () => {
+                expect(
+                    formatItemValue(
+                        {
+                            ...additionalMetric,
+                            type: MetricType.MAX,
+                            formatOptions: {
+                                type: CustomFormatType.CUSTOM,
+                                custom: 'yyyy-mm-dd hh:mm:ss',
+                            },
+                        },
+                        '2025-01-15T17:00:00.000Z',
+                        false,
+                        undefined,
+                        'America/Anchorage',
+                    ),
+                ).toEqual('2025-01-15 08:00:00');
+            });
+
+            test('no timezone is bit-identical to pre-fix behaviour (flag-off parity)', () => {
+                // With no timezone the string still hits the valueIsNaN guard
+                // and renders raw, exactly as before this change.
+                expect(
+                    formatItemValue(
+                        {
+                            ...additionalMetric,
+                            type: MetricType.MAX,
+                            formatOptions: {
+                                type: CustomFormatType.TIMESTAMP,
+                                timeInterval: TimeFrames.RAW,
+                            },
+                        },
+                        '2025-01-15T17:00:00.000Z',
+                    ),
+                ).toEqual('2025-01-15T17:00:00.000Z');
+            });
+
+            test('DATE format over a date-only string is not shifted', () => {
+                // The by-value gate leaves a date-only string alone, so a
+                // MIN/MAX over a real DATE column keeps its calendar day.
+                expect(
+                    formatItemValue(
+                        {
+                            ...additionalMetric,
+                            type: MetricType.MAX,
+                            formatOptions: { type: CustomFormatType.DATE },
+                        },
+                        '2021-03-10',
+                        false,
+                        undefined,
+                        'Pacific/Pago_Pago', // -11:00, would roll the day back
+                    ),
+                ).toEqual('2021-03-10');
+            });
+        });
+
         test('format additional metric with custom format DATE', () => {
             expect(
                 formatItemValue(

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -26,6 +26,7 @@ import {
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     getEffectiveSeparator,
+    getFormatterTimezone,
     isCalendarValueDimension,
     isMomentInput,
     isTimestampString,
@@ -40,6 +41,87 @@ import {
 } from './formatting.mock';
 
 describe('Formatting', () => {
+    describe('getFormatterTimezone (unified shift decision)', () => {
+        const tz = 'America/Anchorage';
+        const tsString = '2025-01-15T17:00:00.000Z';
+        const dateOnly = '2025-01-15';
+
+        test('returns undefined when no project timezone is supplied', () => {
+            expect(
+                getFormatterTimezone(
+                    { ...dimension, type: DimensionType.TIMESTAMP },
+                    tsString,
+                    undefined,
+                ),
+            ).toBeUndefined();
+        });
+
+        test('TIMESTAMP dimension shifts by shape (value-independent)', () => {
+            const item = { ...dimension, type: DimensionType.TIMESTAMP };
+            expect(getFormatterTimezone(item, tsString, tz)).toEqual(tz);
+            // shape says shift even for a value the by-value gate would reject
+            expect(getFormatterTimezone(item, 12345, tz)).toEqual(tz);
+        });
+
+        test('bare DATE dimension never shifts (calendar guard)', () => {
+            expect(
+                getFormatterTimezone(
+                    { ...dimension, type: DimensionType.DATE },
+                    dateOnly,
+                    tz,
+                ),
+            ).toBeUndefined();
+        });
+
+        test('DATE dimension truncated from a TIMESTAMP base shifts', () => {
+            const dateBaseTs: Dimension = {
+                ...dimension,
+                type: DimensionType.DATE,
+                timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+            };
+            expect(getFormatterTimezone(dateBaseTs, tsString, tz)).toEqual(tz);
+        });
+
+        test('skipTimezoneConversion opts out even for a TIMESTAMP', () => {
+            const skipTzDim: Dimension = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+                skipTimezoneConversion: true,
+            };
+            expect(
+                getFormatterTimezone(skipTzDim, tsString, tz),
+            ).toBeUndefined();
+        });
+
+        test('MIN/MAX over a timestamp shifts via the by-value fallback', () => {
+            const maxMetric = { ...additionalMetric, type: MetricType.MAX };
+            expect(getFormatterTimezone(maxMetric, tsString, tz)).toEqual(tz);
+            expect(
+                getFormatterTimezone(maxMetric, new Date(tsString), tz),
+            ).toEqual(tz);
+        });
+
+        test('MIN/MAX over a calendar date does NOT shift (date-only value)', () => {
+            expect(
+                getFormatterTimezone(
+                    { ...additionalMetric, type: MetricType.MAX },
+                    dateOnly,
+                    tz,
+                ),
+            ).toBeUndefined();
+        });
+
+        test('MIN/MAX over a number does NOT shift', () => {
+            expect(
+                getFormatterTimezone(
+                    { ...additionalMetric, type: MetricType.MAX },
+                    42,
+                    tz,
+                ),
+            ).toBeUndefined();
+        });
+    });
+
     describe('convert legacy Format type', () => {
         [Format.KM, Format.MI].forEach((format) => {
             test(`when it is ${format.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -8,9 +8,11 @@ import {
     Format,
     MetricType,
     NumberSeparator,
+    TableCalculationType,
     type CustomFormat,
     type Dimension,
     type Metric,
+    type TableCalculation,
 } from '../types/field';
 import { TimeFrames } from '../types/timeFrames';
 import {
@@ -27,7 +29,7 @@ import {
     getCustomFormatFromLegacy,
     getEffectiveSeparator,
     getFormatterTimezone,
-    isCalendarValueDimension,
+    isCalendarValueItem,
     isMomentInput,
     isTimestampString,
     shouldShiftItemTimezone,
@@ -119,6 +121,30 @@ describe('Formatting', () => {
                     tz,
                 ),
             ).toBeUndefined();
+        });
+
+        test('DATE table calc does NOT shift even with a midnight-ISO value', () => {
+            // The bug: a date-typed table calc whose value arrives as a full
+            // timestamp must stay a calendar day (no off-by-one under -ve UTC).
+            const dateTableCalc = {
+                name: 'date_tc',
+                displayName: 'date_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.DATE,
+            } as TableCalculation;
+            expect(
+                getFormatterTimezone(dateTableCalc, tsString, tz),
+            ).toBeUndefined();
+        });
+
+        test('TIMESTAMP table calc shifts', () => {
+            const tsTableCalc = {
+                name: 'ts_tc',
+                displayName: 'ts_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.TIMESTAMP,
+            } as TableCalculation;
+            expect(getFormatterTimezone(tsTableCalc, tsString, tz)).toEqual(tz);
         });
     });
 
@@ -916,7 +942,7 @@ describe('Formatting', () => {
         });
     });
 
-    describe('isCalendarValueDimension', () => {
+    describe('isCalendarValueItem', () => {
         const dateBaseColumn: Dimension = {
             ...dimension,
             type: DimensionType.DATE,
@@ -956,20 +982,20 @@ describe('Formatting', () => {
 
         test('treats wall-clock DATE values as calendar values', () => {
             // plain DATE column (no interval, base undefined)
-            expect(isCalendarValueDimension(dateBaseColumn)).toBe(true);
+            expect(isCalendarValueItem(dateBaseColumn)).toBe(true);
             // DATE truncated from a DATE base — any grain
-            expect(isCalendarValueDimension(dateOverDateDay)).toBe(true);
-            expect(isCalendarValueDimension(dateOverDateWeek)).toBe(true);
+            expect(isCalendarValueItem(dateOverDateDay)).toBe(true);
+            expect(isCalendarValueItem(dateOverDateWeek)).toBe(true);
             // A date-typed metric (MetricType.DATE) — not a Dimension, still calendar
-            expect(isCalendarValueDimension(dateMetric)).toBe(true);
+            expect(isCalendarValueItem(dateMetric)).toBe(true);
         });
 
         test('treats real instants as non-calendar values', () => {
             // DATE truncated from a TIMESTAMP base is a bucketed instant
-            expect(isCalendarValueDimension(dateOverTimestampDay)).toBe(false);
+            expect(isCalendarValueItem(dateOverTimestampDay)).toBe(false);
             // plain + sub-day TIMESTAMP
-            expect(isCalendarValueDimension(timestampRaw)).toBe(false);
-            expect(isCalendarValueDimension(timestampHour)).toBe(false);
+            expect(isCalendarValueItem(timestampRaw)).toBe(false);
+            expect(isCalendarValueItem(timestampHour)).toBe(false);
         });
 
         test('skipTimezoneConversion does not make a TIMESTAMP a calendar value', () => {
@@ -983,14 +1009,34 @@ describe('Formatting', () => {
                 ...dateOverDateDay,
                 skipTimezoneConversion: true,
             };
-            expect(isCalendarValueDimension(timestampRawOptOut)).toBe(false);
-            expect(isCalendarValueDimension(dateOptOut)).toBe(true);
+            expect(isCalendarValueItem(timestampRawOptOut)).toBe(false);
+            expect(isCalendarValueItem(dateOptOut)).toBe(true);
         });
 
         test('non-temporal items and undefined are not calendar values', () => {
-            expect(isCalendarValueDimension(undefined)).toBe(false);
-            expect(isCalendarValueDimension(dimension)).toBe(false); // STRING
-            expect(isCalendarValueDimension(metric)).toBe(false); // COUNT
+            expect(isCalendarValueItem(undefined)).toBe(false);
+            expect(isCalendarValueItem(dimension)).toBe(false); // STRING
+            expect(isCalendarValueItem(metric)).toBe(false); // COUNT
+        });
+
+        test('classifies table calculations by their declared type', () => {
+            // Table calcs are not fields, but their `type` is reliable, so a
+            // DATE table calc is a calendar value (must not shift) while a
+            // TIMESTAMP one is a real instant.
+            const dateTableCalc = {
+                name: 'date_tc',
+                displayName: 'date_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.DATE,
+            } as TableCalculation;
+            const timestampTableCalc = {
+                name: 'ts_tc',
+                displayName: 'ts_tc',
+                sql: '${orders.order_date_day}',
+                type: TableCalculationType.TIMESTAMP,
+            } as TableCalculation;
+            expect(isCalendarValueItem(dateTableCalc)).toBe(true);
+            expect(isCalendarValueItem(timestampTableCalc)).toBe(false);
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -242,36 +242,25 @@ export const shouldShiftItemTimezone = (
     );
 };
 
-// A calendar value is a bare wall-clock date (year/month/day, no instant) that
-// must never be timezone-shifted or anchored. True for plain DATE columns,
-// DATE-base truncations and DATE metrics; false for any TIMESTAMP (including
-// `skipTimezoneConversion` ones — those are TZ-immune but still real instants)
-// and for a DATE truncated from a TIMESTAMP base, which is a bucketed instant
-// that still anchors and shifts.
-export const isCalendarValueDimension = (
+// A bare wall-clock DATE that must never be shifted. Keyed off getItemType so it
+// also covers DATE metrics and table calcs; a DATE-base-TIMESTAMP dim still shifts.
+export const isCalendarValueItem = (
     item: Item | AdditionalMetric | undefined,
 ): boolean => {
-    if (!isField(item)) return false;
-    if (item.type !== DimensionType.DATE) return false;
+    if (!item) return false;
+    if (getItemType(item) !== DimensionType.DATE) return false;
     return !(
         isDimension(item) &&
         item.timeIntervalBaseDimensionType === DimensionType.TIMESTAMP
     );
 };
 
-// True when a runtime value carries an instant: a Date, or a datetime string
-// with a time component. Date-only strings are deliberately NOT temporal here —
-// they are calendar days that must never be timezone-shifted.
+// A Date or a datetime string (not a date-only string).
 export const isTemporalValue = (value: unknown): boolean =>
     value instanceof Date || isTimestampString(value);
 
-// The single source of truth for which timezone a value FORMATTER should apply.
-// It composes the item-shape predicates with a by-value fallback: a MIN/MAX
-// metric's `type` is its aggregation, not its temporal base, and that base type
-// is not resolvable at the formatter layer (the item only carries an optional
-// base-dimension *name*, not a type, and the explore field map is unavailable).
-// So for type-opaque aggregations the value itself is the only signal. Returns
-// the zone to convert the value into, or undefined to leave it untouched.
+// Which timezone a formatter applies to a value: shape predicates, then a
+// by-value fallback for MIN/MAX (whose type hides its temporal base).
 export const getFormatterTimezone = (
     item: Item | AdditionalMetric | undefined,
     value: unknown,
@@ -279,7 +268,7 @@ export const getFormatterTimezone = (
 ): string | undefined => {
     if (!timezone) return undefined;
     if (isDimension(item) && item.skipTimezoneConversion) return undefined;
-    if (isCalendarValueDimension(item)) return undefined;
+    if (isCalendarValueItem(item)) return undefined;
     if (shouldShiftItemTimezone(item)) return timezone;
     if (isTemporalValue(value)) return timezone;
     return undefined;
@@ -732,12 +721,8 @@ export function applyCustomFormat(
 
     if (value === '') return '';
 
-    // Decide temporality by VALUE, not by format type: a MIN/MAX metric's type
-    // is its aggregation (MAX/MIN), not the underlying TIMESTAMP, so the only
-    // reliable signal is the value itself. isTemporalValue excludes date-only
-    // strings so calendar days are never shifted (off-by-one under -ve offsets).
-    // (applyCustomFormat has no `item`, so it uses the by-value gate directly;
-    // item-aware callers resolve the timezone via getFormatterTimezone first.)
+    // No `item` here, so gate the timezone by value; item-aware callers resolve
+    // it via getFormatterTimezone first.
     const effectiveTimezone = isTemporalValue(value) ? timezone : undefined;
 
     if (
@@ -749,11 +734,8 @@ export function applyCustomFormat(
         return formatTimestamp(value, undefined, false, effectiveTimezone);
     }
 
-    // A timestamp STRING (e.g. a MIN/MAX metric rehydrated from query results)
-    // is `valueIsNaN`, so the guard below would return it raw and drop both the
-    // display format and the timezone. When a timezone is supplied, route the
-    // string through the temporal formatters first so it renders shifted. With
-    // no timezone (flag off) this is skipped and behaviour is unchanged.
+    // Timestamp strings are `valueIsNaN`, so the guard below would return them
+    // raw. When a timezone is supplied, format them first so they render shifted.
     if (effectiveTimezone && isTimestampString(value)) {
         switch (format.type) {
             case CustomFormatType.DATE:
@@ -1102,8 +1084,7 @@ export function formatItemValue(
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (item) {
-        // One decision for every temporal branch below: shape predicates for
-        // dimensions/table-calcs, by-value fallback for type-opaque MIN/MAX.
+        // One timezone decision for every temporal branch below.
         const effectiveTimezone = getFormatterTimezone(item, value, timezone);
 
         if (hasValidFormatExpression(item)) {
@@ -1200,9 +1181,8 @@ export function formatItemValue(
                 case DimensionType.DATE:
                 case MetricType.DATE:
                 case TableCalculationType.DATE: {
-                    // Calendar values (wall-clock dates) have no time component
-                    // — getFormatterTimezone already returns undefined for them
-                    // (off-by-one guard), so effectiveTimezone is safe to use.
+                    // getFormatterTimezone returns undefined for calendar dates,
+                    // so effectiveTimezone is safe to pass here.
                     return isMomentInput(value)
                         ? formatDate(
                               value,
@@ -1226,12 +1206,8 @@ export function formatItemValue(
                         : 'NaT';
                 case MetricType.MAX:
                 case MetricType.MIN: {
-                    // MIN/MAX inherit the aggregated column's type. A temporal
-                    // result must render in the resolved project timezone like
-                    // a dimension does — whether it arrives as a Date (fresh
-                    // query) or an ISO datetime string (rehydrated from cached
-                    // results). The auto-derived numeric format must not
-                    // suppress this; a user-chosen display format still wins.
+                    // A temporal MIN/MAX shifts like a dimension; a user-chosen
+                    // display format wins and falls through to applyCustomFormat.
                     const formatType = customFormat?.type;
                     const userChoseDisplayFormat =
                         formatType === CustomFormatType.DATE ||

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -227,16 +227,19 @@ export const toIsoWithProjectOffset = (
     return m.tz(timezone).toISOString(true);
 };
 
-// TIMESTAMPs and TIMESTAMP-base DATE intervals shift; calendar DATEs and
-// dims with `skipTimezoneConversion` stay put. Used by spreadsheet exports.
+// TIMESTAMPs and TIMESTAMP-base DATE intervals shift; calendar DATEs and dims
+// with `skipTimezoneConversion` stay put. Keyed off getItemType so it classifies
+// non-field items (table calcs, custom dims) by their resolved type too. Used by
+// spreadsheet exports.
 export const shouldShiftItemTimezone = (
     item: Item | AdditionalMetric | undefined,
 ): boolean => {
-    if (!isField(item)) return false;
+    if (!item) return false;
     if (isDimension(item) && item.skipTimezoneConversion) return false;
-    if (item.type === DimensionType.TIMESTAMP) return true;
+    const type = getItemType(item);
+    if (type === DimensionType.TIMESTAMP) return true;
     return (
-        item.type === DimensionType.DATE &&
+        type === DimensionType.DATE &&
         isDimension(item) &&
         item.timeIntervalBaseDimensionType === DimensionType.TIMESTAMP
     );
@@ -259,8 +262,10 @@ export const isCalendarValueItem = (
 export const isTemporalValue = (value: unknown): boolean =>
     value instanceof Date || isTimestampString(value);
 
-// Which timezone a formatter applies to a value: shape predicates, then a
-// by-value fallback for MIN/MAX (whose type hides its temporal base).
+// Which timezone a formatter applies to a value. The shape predicate decides
+// every type-known item (dims, metrics, table calcs, custom dims). MIN/MAX are
+// the one opaque case — their aggregation type hides the temporal base — so only
+// there do we fall back to the value shape.
 export const getFormatterTimezone = (
     item: Item | AdditionalMetric | undefined,
     value: unknown,
@@ -270,7 +275,13 @@ export const getFormatterTimezone = (
     if (isDimension(item) && item.skipTimezoneConversion) return undefined;
     if (isCalendarValueItem(item)) return undefined;
     if (shouldShiftItemTimezone(item)) return timezone;
-    if (isTemporalValue(value)) return timezone;
+    const type = item ? getItemType(item) : undefined;
+    if (
+        (type === MetricType.MIN || type === MetricType.MAX) &&
+        isTemporalValue(value)
+    ) {
+        return timezone;
+    }
     return undefined;
 };
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -259,6 +259,32 @@ export const isCalendarValueDimension = (
     );
 };
 
+// True when a runtime value carries an instant: a Date, or a datetime string
+// with a time component. Date-only strings are deliberately NOT temporal here —
+// they are calendar days that must never be timezone-shifted.
+export const isTemporalValue = (value: unknown): boolean =>
+    value instanceof Date || isTimestampString(value);
+
+// The single source of truth for which timezone a value FORMATTER should apply.
+// It composes the item-shape predicates with a by-value fallback: a MIN/MAX
+// metric's `type` is its aggregation, not its temporal base, and that base type
+// is not resolvable at the formatter layer (the item only carries an optional
+// base-dimension *name*, not a type, and the explore field map is unavailable).
+// So for type-opaque aggregations the value itself is the only signal. Returns
+// the zone to convert the value into, or undefined to leave it untouched.
+export const getFormatterTimezone = (
+    item: Item | AdditionalMetric | undefined,
+    value: unknown,
+    timezone: string | undefined,
+): string | undefined => {
+    if (!timezone) return undefined;
+    if (isDimension(item) && item.skipTimezoneConversion) return undefined;
+    if (isCalendarValueDimension(item)) return undefined;
+    if (shouldShiftItemTimezone(item)) return timezone;
+    if (isTemporalValue(value)) return timezone;
+    return undefined;
+};
+
 // Renders a temporal cell as the wall-clock string Excel and Google Sheets
 // auto-detect as a date. TIMESTAMP → `YYYY-MM-DD HH:mm:ss.SSS`, DATE →
 // `YYYY-MM-DD`. Shifts into the project tz when the item is timezone-
@@ -708,10 +734,11 @@ export function applyCustomFormat(
 
     // Decide temporality by VALUE, not by format type: a MIN/MAX metric's type
     // is its aggregation (MAX/MIN), not the underlying TIMESTAMP, so the only
-    // reliable signal is the value itself. isTimestampString excludes date-only
+    // reliable signal is the value itself. isTemporalValue excludes date-only
     // strings so calendar days are never shifted (off-by-one under -ve offsets).
-    const isTemporal = value instanceof Date || isTimestampString(value);
-    const effectiveTimezone = isTemporal ? timezone : undefined;
+    // (applyCustomFormat has no `item`, so it uses the by-value gate directly;
+    // item-aware callers resolve the timezone via getFormatterTimezone first.)
+    const effectiveTimezone = isTemporalValue(value) ? timezone : undefined;
 
     if (
         value instanceof Date &&
@@ -1075,18 +1102,16 @@ export function formatItemValue(
     if (value === null) return '∅';
     if (value === undefined) return '-';
     if (item) {
+        // One decision for every temporal branch below: shape predicates for
+        // dimensions/table-calcs, by-value fallback for type-opaque MIN/MAX.
+        const effectiveTimezone = getFormatterTimezone(item, value, timezone);
+
         if (hasValidFormatExpression(item)) {
             // A field-level separator localises the ECMA-376 expression, which
             // numfmt otherwise renders with US separators regardless of locale.
             const separatorLocale = separatorToNumfmtLocale(
                 getEffectiveSeparator(item),
             );
-
-            // Only shift genuinely timezone-shiftable temporal fields, so
-            // calendar DATEs and skipTimezoneConversion fields stay put.
-            const expressionTimezone = shouldShiftItemTimezone(item)
-                ? timezone
-                : undefined;
 
             // Check if format uses parameter placeholders
             const hasParameterPlaceholders =
@@ -1108,7 +1133,7 @@ export function formatItemValue(
                             formatExpression,
                             value,
                             separatorLocale,
-                            expressionTimezone,
+                            effectiveTimezone,
                         );
                         return result;
                     } catch (error) {
@@ -1127,7 +1152,7 @@ export function formatItemValue(
                     item.format,
                     value,
                     separatorLocale,
-                    expressionTimezone,
+                    effectiveTimezone,
                 );
                 return result;
             } catch (error) {
@@ -1139,10 +1164,6 @@ export function formatItemValue(
 
         if (isCustomSqlDimension(item) || 'type' in item) {
             const type = getItemType(item);
-            const effectiveTimezone =
-                isDimension(item) && item.skipTimezoneConversion
-                    ? undefined
-                    : timezone;
 
             // Date/Timestamp table calculations may carry a CUSTOM format
             // expression (e.g. "mmmm d, yyyy"). The default switch path
@@ -1155,18 +1176,12 @@ export function formatItemValue(
                 customFormat.custom &&
                 isMomentInput(value)
             ) {
-                // Mirror the default DATE branch: calendar days never shift,
-                // only real instants do. (isCalendarValueDimension is false for
-                // any TIMESTAMP, so this is a no-op there.)
-                const customExpressionTimezone = isCalendarValueDimension(item)
-                    ? undefined
-                    : effectiveTimezone;
                 try {
                     return formatValueWithExpression(
                         customFormat.custom,
                         value,
                         separatorToNumfmtLocale(customFormat.separator),
-                        customExpressionTimezone,
+                        effectiveTimezone,
                     );
                 } catch {
                     // Fall through to the default date/timestamp render.
@@ -1186,17 +1201,14 @@ export function formatItemValue(
                 case MetricType.DATE:
                 case TableCalculationType.DATE: {
                     // Calendar values (wall-clock dates) have no time component
-                    // — applying a display timezone would shift the calendar
-                    // day (off-by-one in negative offsets).
-                    const dateTimezone = isCalendarValueDimension(item)
-                        ? undefined
-                        : effectiveTimezone;
+                    // — getFormatterTimezone already returns undefined for them
+                    // (off-by-one guard), so effectiveTimezone is safe to use.
                     return isMomentInput(value)
                         ? formatDate(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
-                              dateTimezone,
+                              effectiveTimezone,
                           )
                         : 'NaT';
                 }
@@ -1225,9 +1237,7 @@ export function formatItemValue(
                         formatType === CustomFormatType.DATE ||
                         formatType === CustomFormatType.TIMESTAMP ||
                         formatType === CustomFormatType.CUSTOM;
-                    const isTimestampValue =
-                        value instanceof Date || isTimestampString(value);
-                    if (isTimestampValue && !userChoseDisplayFormat) {
+                    if (isTemporalValue(value) && !userChoseDisplayFormat) {
                         return formatTimestamp(
                             value,
                             undefined,
@@ -1251,13 +1261,7 @@ export function formatItemValue(
             }
         }
 
-        return applyCustomFormat(
-            value,
-            customFormat,
-            isDimension(item) && item.skipTimezoneConversion
-                ? undefined
-                : timezone,
-        );
+        return applyCustomFormat(value, customFormat, effectiveTimezone);
     }
 
     return applyDefaultFormat(value);

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -700,10 +700,18 @@ export function formatValueWithExpression(
 export function applyCustomFormat(
     value: unknown,
     format?: CustomFormat | undefined,
+    timezone?: string,
 ): string {
     if (format?.type === undefined) return applyDefaultFormat(value);
 
     if (value === '') return '';
+
+    // Decide temporality by VALUE, not by format type: a MIN/MAX metric's type
+    // is its aggregation (MAX/MIN), not the underlying TIMESTAMP, so the only
+    // reliable signal is the value itself. isTimestampString excludes date-only
+    // strings so calendar days are never shifted (off-by-one under -ve offsets).
+    const isTemporal = value instanceof Date || isTimestampString(value);
+    const effectiveTimezone = isTemporal ? timezone : undefined;
 
     if (
         value instanceof Date &&
@@ -711,7 +719,40 @@ export function applyCustomFormat(
             format.type,
         )
     ) {
-        return formatTimestamp(value, undefined, false);
+        return formatTimestamp(value, undefined, false, effectiveTimezone);
+    }
+
+    // A timestamp STRING (e.g. a MIN/MAX metric rehydrated from query results)
+    // is `valueIsNaN`, so the guard below would return it raw and drop both the
+    // display format and the timezone. When a timezone is supplied, route the
+    // string through the temporal formatters first so it renders shifted. With
+    // no timezone (flag off) this is skipped and behaviour is unchanged.
+    if (effectiveTimezone && isTimestampString(value)) {
+        switch (format.type) {
+            case CustomFormatType.DATE:
+                return formatDate(
+                    value,
+                    format?.timeInterval,
+                    false,
+                    effectiveTimezone,
+                );
+            case CustomFormatType.TIMESTAMP:
+                return formatTimestamp(
+                    value,
+                    format?.timeInterval,
+                    false,
+                    effectiveTimezone,
+                );
+            case CustomFormatType.CUSTOM:
+                return formatValueWithExpression(
+                    format.custom || '',
+                    value,
+                    separatorToNumfmtLocale(format.separator),
+                    effectiveTimezone,
+                );
+            default:
+                break;
+        }
     }
 
     if (valueIsNaN(value) || value === null) {
@@ -737,9 +778,19 @@ export function applyCustomFormat(
 
             return `${currencyFormatted}${compactSuffix}`;
         case CustomFormatType.DATE:
-            return formatDate(value, format?.timeInterval, false);
+            return formatDate(
+                value,
+                format?.timeInterval,
+                false,
+                effectiveTimezone,
+            );
         case CustomFormatType.TIMESTAMP:
-            return formatTimestamp(value, format?.timeInterval, false);
+            return formatTimestamp(
+                value,
+                format?.timeInterval,
+                false,
+                effectiveTimezone,
+            );
         case CustomFormatType.NUMBER:
             const prefix = format.prefix || '';
             const suffix = format.suffix || '';
@@ -767,6 +818,7 @@ export function applyCustomFormat(
                 format.custom || '',
                 value,
                 separatorToNumfmtLocale(format.separator),
+                effectiveTimezone,
             );
         default:
             return assertUnreachable(
@@ -1199,7 +1251,13 @@ export function formatItemValue(
             }
         }
 
-        return applyCustomFormat(value, customFormat);
+        return applyCustomFormat(
+            value,
+            customFormat,
+            isDimension(item) && item.skipTimezoneConversion
+                ? undefined
+                : timezone,
+        );
     }
 
     return applyDefaultFormat(value);

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -1192,6 +1192,8 @@ export const buildCartesianTooltipFormatter =
                     undefined,
                     pivotValuesColumnsMap,
                     parameters,
+                    timezone,
+                    displayTimezone,
                 );
 
                 // For period-over-period series, compute and display the actual previous date

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -38,7 +38,7 @@ import {
     getValueLabelStyle,
     hashFieldReference,
     hasValidFormatExpression,
-    isCalendarValueDimension,
+    isCalendarValueItem,
     isCustomBinDimension,
     isCustomDimension,
     isCustomSqlDimension,
@@ -766,8 +766,7 @@ const seriesValueFormatter = (
                 ? evaluateConditionalFormatExpression(item.format, parameters)
                 : item.format;
 
-        // Resolve the timezone the same way formatItemValue does (shape for
-        // dimensions/table-calcs, by-value for type-opaque MIN/MAX metrics).
+        // Same timezone decision formatItemValue uses.
         const expressionTimezone = getFormatterTimezone(
             item,
             value,
@@ -1617,7 +1616,7 @@ export const getCategoryDateAxisConfig = (
 
     // Calendar values (wall-clock dates) are raw — snap in UTC to match.
     const tz =
-        isCalendarValueDimension(axisField) || !resolvedTimezone
+        isCalendarValueItem(axisField) || !resolvedTimezone
             ? 'UTC'
             : resolvedTimezone;
     // Skip dayjs.tz for UTC: .add() chains drift sub-ms vs fresh .tz() objects

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -26,6 +26,7 @@ import {
     getCustomFormatFromLegacy,
     getDateGroupLabel,
     getFormattedValue,
+    getFormatterTimezone,
     getIndexFromEncode,
     getItemLabelWithoutTableName,
     getItemType,
@@ -48,7 +49,6 @@ import {
     isTableCalculation,
     LightdashParameters,
     MetricType,
-    shouldShiftItemTimezone,
     StackType,
     TableCalculationType,
     TimeFrames,
@@ -766,11 +766,13 @@ const seriesValueFormatter = (
                 ? evaluateConditionalFormatExpression(item.format, parameters)
                 : item.format;
 
-        // Only shift genuinely timezone-shiftable temporal fields, matching
-        // formatItemValue's own format-expression branch.
-        const expressionTimezone = shouldShiftItemTimezone(item)
-            ? resolvedTimezone
-            : undefined;
+        // Resolve the timezone the same way formatItemValue does (shape for
+        // dimensions/table-calcs, by-value for type-opaque MIN/MAX metrics).
+        const expressionTimezone = getFormatterTimezone(
+            item,
+            value,
+            resolvedTimezone,
+        );
         return formatValueWithExpression(
             formatExpression,
             value,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -48,6 +48,7 @@ import {
     isTableCalculation,
     LightdashParameters,
     MetricType,
+    shouldShiftItemTimezone,
     StackType,
     TableCalculationType,
     TimeFrames,
@@ -751,6 +752,7 @@ const seriesValueFormatter = (
     item: Item,
     value: unknown,
     parameters?: ParametersValuesMap,
+    resolvedTimezone?: string,
 ) => {
     if (hasValidFormatExpression(item)) {
         // Check if format uses parameter placeholders
@@ -764,14 +766,30 @@ const seriesValueFormatter = (
                 ? evaluateConditionalFormatExpression(item.format, parameters)
                 : item.format;
 
-        return formatValueWithExpression(formatExpression, value);
+        // Only shift genuinely timezone-shiftable temporal fields, matching
+        // formatItemValue's own format-expression branch.
+        const expressionTimezone = shouldShiftItemTimezone(item)
+            ? resolvedTimezone
+            : undefined;
+        return formatValueWithExpression(
+            formatExpression,
+            value,
+            undefined,
+            expressionTimezone,
+        );
     }
 
     if (isCustomDimension(item)) {
         return value;
     }
     if (isTableCalculation(item)) {
-        return formatItemValue(item, value, false, parameters);
+        return formatItemValue(
+            item,
+            value,
+            false,
+            parameters,
+            resolvedTimezone,
+        );
     } else {
         const defaultFormatOptions = getCustomFormatFromLegacy({
             format: item.format,
@@ -784,7 +802,11 @@ const seriesValueFormatter = (
             isMetric(item) || isDimension(item)
                 ? item.formatOptions
                 : undefined;
-        return applyCustomFormat(value, formatOptions || defaultFormatOptions);
+        return applyCustomFormat(
+            value,
+            formatOptions || defaultFormatOptions,
+            resolvedTimezone,
+        );
     }
 };
 
@@ -1051,6 +1073,7 @@ const getPivotSeries = ({
                                               field,
                                               raw,
                                               parameters,
+                                              resolvedTimezone,
                                           ) ?? '',
                                       );
 
@@ -1240,6 +1263,7 @@ const getSimpleSeries = ({
                                           field,
                                           rawValue,
                                           parameters,
+                                          resolvedTimezone,
                                       ) ?? '',
                                   );
 

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -92,6 +92,7 @@ const formatComparisonValue = (
                           round: metricRoundRaw ?? 2,
                           compact: bigNumberComparisonStyle,
                       }),
+                      timezone,
                   )
                 : formatItemValue(item, value, false, parameters, timezone);
 
@@ -115,6 +116,7 @@ const formatComparisonValue = (
                           round: metricRoundDefault ?? 2,
                           compact: bigNumberComparisonStyle,
                       }),
+                      timezone,
                   )
                 : formatItemValue(item, value, false, parameters, timezone);
     }
@@ -351,11 +353,15 @@ const useBigNumberConfig = (
                         : CustomFormatType.DEFAULT
                     : item.formatOptions?.type;
 
-            return applyCustomFormat(firstRowValueRaw, {
-                ...item.formatOptions,
-                type,
-                compact: bigNumberStyle ?? item.formatOptions?.compact,
-            });
+            return applyCustomFormat(
+                firstRowValueRaw,
+                {
+                    ...item.formatOptions,
+                    type,
+                    compact: bigNumberStyle ?? item.formatOptions?.compact,
+                },
+                resultsData?.resolvedTimezone,
+            );
         } else {
             const metricRound = isField(item) ? item.round : undefined;
             const compactStyleDefault = bigNumberStyle ? 2 : undefined;
@@ -366,6 +372,7 @@ const useBigNumberConfig = (
                     round: metricRound ?? compactStyleDefault,
                     compact: bigNumberStyle,
                 }),
+                resultsData?.resolvedTimezone,
             );
         }
     }, [

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -57,7 +57,6 @@ import {
     selectCustomDimensions,
     selectMetricOverrides,
     selectParameters,
-    selectTimezone,
     selectSorts,
     selectTableCalculations,
     selectTableName,
@@ -485,7 +484,9 @@ export const useColumns = (): TableColumn[] => {
     const resultsFields = query.data?.fields;
 
     const parameters = useExplorerSelector(selectParameters);
-    const timezone = useExplorerSelector(selectTimezone);
+    // Format temporal cells in the flag-gated resolved timezone (null when
+    // timezone support is off), never the chart's unresolved state timezone.
+    const timezone = query.data?.resolvedTimezone ?? undefined;
 
     const { data: exploreData } = useExplore(tableName, {
         refetchOnMount: false,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-498/applycustomformat-drops-the-project-timezone-for-formatted-temporal

## What

Timestamp metrics (a MIN or MAX over a timestamp column) were not being shifted into the project timezone once a display format was applied. They rendered as raw UTC like `2025-01-15T17:00:00.000Z`, while the same column shown as a dimension correctly displayed the project-timezone wall-clock like `2025-01-15, 08:00:00 (-09:00)`.

This affected the explore results table, Big Number tiles, and cartesian chart tooltips.

## Why it happened

A metric's `type` is its aggregation (`max`/`min`), not the underlying temporal type, so the existing shape check (`shouldShiftItemTimezone`) could not tell that a MAX was over a timestamp. The value also comes back from query results as an ISO string, which `applyCustomFormat` treated as non-numeric and returned untouched, dropping both the chosen format and the timezone.

## What changed

* `applyCustomFormat` now takes a `timezone` and shifts timestamp string/Date values through the temporal formatters.
* `formatItemValue` threads the timezone through the MIN/MAX path.
* The cartesian tooltip body formatter now passes the timezone (previously only the tooltip header did).
* New `getFormatterTimezone(item, value, timezone)` is the single source of truth for the "which timezone does this value shift into?" decision. It composes the existing shape predicates with a by-value fallback for type-opaque metrics, and the three formatter call sites now share it. The shape predicates stay as primitives for the value-less callers (exports, filters, pivots, sidebar).

## Flag

Gated behind `EnableTimezoneSupport`. With the flag off (no project timezone resolved) every path is byte-identical to before.

**Before**
Cartesian
<img width="1899" height="1133" alt="before-metric-table-and-tooltip" src="https://github.com/user-attachments/assets/ba714c14-5f81-4cab-af01-90d49a2db459" />

Big number
<img width="1899" height="1133" alt="before-bignumber" src="https://github.com/user-attachments/assets/20fc2969-cc95-4c3e-888d-4168653af741" />

Table calcs
<img width="1899" height="1133" alt="before-tablecalcs" src="https://github.com/user-attachments/assets/443459b3-b767-43eb-abfd-cfdc900742ed" />

**After**
Cartesian
<img width="1899" height="1133" alt="after-metric-table-and-tooltip" src="https://github.com/user-attachments/assets/f15ebd3c-e66a-40b5-8358-c5e14388fb46" />

Big number
<img width="1899" height="1133" alt="after-bignumber" src="https://github.com/user-attachments/assets/e03dfa7f-7457-437c-bd3c-31d9872a25c5" />

Table calcs
<img width="1899" height="1133" alt="after-tablecalcs" src="https://github.com/user-attachments/assets/0c34ff65-d500-4bfb-bf52-fcf8ed659f30" />