### PR TITLE
perf(backend): dedup getSummary in searchFieldUniqueValues

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5474,6 +5474,7 @@ export class ProjectService extends BaseService {
         search,
         limit,
         filters,
+        organizationUuid: organizationUuidArg,
     }: {
         projectUuid: string;
         table: string;
@@ -5481,9 +5482,11 @@ export class ProjectService extends BaseService {
         search: string;
         limit: unknown;
         filters: AndFilterGroup | undefined;
+        organizationUuid?: string;
     }) {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = organizationUuidArg
+            ? { organizationUuid: organizationUuidArg }
+            : await this.projectModel.getSummary(projectUuid);
         const { maxLimit } = await resolveOrganizationExportLimits(
             this.organizationSettingsModel,
             this.lightdashConfig.query,
@@ -5535,6 +5538,7 @@ export class ProjectService extends BaseService {
                 search,
                 limit,
                 filters,
+                organizationUuid,
             });
 
         const warehouseCredentials = await this.getWarehouseCredentials({


### PR DESCRIPTION
Closes: SPK-518

### Description:

`searchFieldUniqueValues` was running `projectModel.getSummary(projectUuid)` — a project+organization join query — twice per request: once for the permission check and once inside `_getFieldValuesMetricQuery` just to derive `organizationUuid`. This threads the already-resolved `organizationUuid` into the helper (optional param), removing one redundant DB round-trip per request while leaving the `EmbedService` caller unchanged via the fallback.