### PR TITLE
perf(embed): thread preloaded saved chart across service boundary

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1270,6 +1270,7 @@ export class EmbedService extends BaseService {
             account,
             projectUuid,
             chartUuid: chart.uuid,
+            preloadedSavedChart: chart,
             tileUuid,
             dashboardSorts: dashboardSorts ?? [],
             dashboardUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4961,14 +4961,15 @@ export class AsyncQueryService extends ProjectService {
         parameters,
         pivotResults,
         sessionTimezone,
+        preloadedSavedChart,
     }: ExecuteAsyncDashboardChartQueryArgs): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         assertIsAccountWithOrg(account);
 
-        const savedChart = await this.savedChartModel.get(
-            chartUuid,
-            undefined,
-            { projectUuid },
-        );
+        const savedChart =
+            preloadedSavedChart ??
+            (await this.savedChartModel.get(chartUuid, undefined, {
+                projectUuid,
+            }));
         const { organizationUuid, projectUuid: savedChartProjectUuid } =
             savedChart;
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -16,6 +16,7 @@ import {
     type ResultColumns,
     type ResultsPaginationArgs,
     type RunQueryTags,
+    type SavedChartDAO,
     type SortField,
     type UserAccessControls,
     type UserAttributeValueMap,
@@ -96,6 +97,7 @@ export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {
     limit?: number | null | undefined;
     pivotResults?: boolean;
     sessionTimezone?: string | null;
+    preloadedSavedChart?: SavedChartDAO;
 };
 
 export type ExecuteAsyncUnderlyingDataQueryArgs = CommonAsyncQueryArgs & {


### PR DESCRIPTION
Closes: SPK-521

### Description:

On the embed dashboard-tile path, `savedChartModel.get` ran twice for the same chart — once in `EmbedService._getChartFromDashboardTiles` and again inside `AsyncQueryService.executeAsyncDashboardChartQuery` — each a multi-join query (saved_queries + dashboards + spaces + projects + organizations + lateral version fetch). This threads the already-loaded `SavedChartDAO` through as an optional `preloadedSavedChart` arg, keeping the `savedChartProjectUuid !== projectUuid` ownership guard on the passed object. It's optional so `QueryController` and `SchedulerTask` callers (which have no preloaded chart) keep the DB-fetch path; the field is server-side only and never part of the API request body, so no API regeneration is needed.