### PR TITLE
perf(content-as-code): reduce redundant reloads on chart upsert

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    AlreadyExistsError,
     ApiChartAsCodeListResponse,
     ApiDashboardAsCodeListResponse,
     assertUnreachable,
@@ -1256,14 +1257,20 @@ export class CoderService extends BaseService {
 
         // Create mode treats the requested slug as a base for a new unique
         // slug instead of updating content that already owns it.
-        const [chart] = shouldUpdateExistingContent
+        const existingCharts = shouldUpdateExistingContent
             ? await this.savedChartModel.find({
                   slug,
                   projectUuid,
                   excludeChartsSavedInDashboard: false,
                   includeOrphanChartsWithinDashboard: true,
               })
-            : [undefined];
+            : [];
+        if (existingCharts.length > 1) {
+            throw new AlreadyExistsError(
+                `There are multiple charts with the same identifier ${slug}`,
+            );
+        }
+        const [chart] = existingCharts;
 
         // If chart does not exist, we can't use promoteService,
         // since it relies on information that's not available in ChartAsCode, and other uuids
@@ -1395,6 +1402,7 @@ export class CoderService extends BaseService {
                 projectUuid, // We use the same projectUuid for both promoted and upstream
                 chart.uuid,
                 true, // includeOrphanChartsWithinDashboard
+                chart, // upstream === promoted project, reuse the chart we already loaded
             );
         const updatedChart = {
             ...promotedChart,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -204,6 +204,7 @@ export class PromoteService extends BaseService {
         upstreamProjectUuid: string,
         chartUuid: string,
         includeOrphanChartsWithinDashboard?: boolean,
+        cachedUpstreamChart?: UpstreamChart['chart'],
     ): Promise<{
         promotedChart: PromotedChart;
         upstreamChart: UpstreamChart;
@@ -227,18 +228,23 @@ export class PromoteService extends BaseService {
                   })
                 : [];
 
-        const upstreamCharts = await this.savedChartModel.find({
-            projectUuid: upstreamProjectUuid,
-            slug: savedChart.slug,
-            includeOrphanChartsWithinDashboard,
-        });
-        if (upstreamCharts.length > 1) {
-            throw new AlreadyExistsError(
-                `There are multiple charts with the same identifier ${savedChart.slug}`,
-            );
+        let upstreamChart: UpstreamChart['chart'];
+        if (cachedUpstreamChart !== undefined) {
+            upstreamChart = cachedUpstreamChart;
+        } else {
+            const upstreamCharts = await this.savedChartModel.find({
+                projectUuid: upstreamProjectUuid,
+                slug: savedChart.slug,
+                includeOrphanChartsWithinDashboard,
+            });
+            if (upstreamCharts.length > 1) {
+                throw new AlreadyExistsError(
+                    `There are multiple charts with the same identifier ${savedChart.slug}`,
+                );
+            }
+            upstreamChart =
+                upstreamCharts.length === 1 ? upstreamCharts[0] : undefined;
         }
-        const upstreamChart =
-            upstreamCharts.length === 1 ? upstreamCharts[0] : undefined;
 
         const upstreamSpaces = await this.spaceModel.find({
             projectUuid: upstreamProjectUuid,
@@ -257,12 +263,20 @@ export class PromoteService extends BaseService {
                 user.userUuid,
                 promotedSpace.uuid,
             );
-        const upstreamCtx = upstreamSpace
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  upstreamSpace.uuid,
-              )
-            : undefined;
+        let upstreamCtx: SpaceAccessContextForCasl | undefined;
+        if (upstreamSpace === undefined) {
+            upstreamCtx = undefined;
+        } else if (upstreamSpace.uuid === promotedSpace.uuid) {
+            // Same project upsert resolves promoted and upstream to the same
+            // space, so the access context is identical — skip the re-query.
+            upstreamCtx = promotedCtx;
+        } else {
+            upstreamCtx =
+                await this.spacePermissionService.getSpaceAccessContext(
+                    user.userUuid,
+                    upstreamSpace.uuid,
+                );
+        }
 
         return {
             promotedChart: {


### PR DESCRIPTION
Closes: SPK-515

### Description:

The `POST /charts/:slug/code` upsert endpoint is high-volume and drives `PromoteService` with the same project as both promoted and upstream, so it re-fetches chart/space context the caller already loaded. This passes the already-loaded chart into `getPromoteCharts` as `cachedUpstreamChart` (skipping a duplicate `savedChartModel.find`, with the duplicate-slug guard moved up to `CoderService` to preserve behavior), and reuses the promoted space's access context for the upstream space when both resolve to the same space uuid (skipping a redundant permission query). Cross-project promotion behavior is unchanged since those callers pass no cached chart and only hit the uuid-equality dedup when the spaces are genuinely identical.