### PR TITLE
perf(backend): dedup getSummary in searchFieldUniqueValues

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -2225,6 +2225,7 @@ export class EmbedService extends BaseService {
                 search,
                 limit,
                 filters,
+                organizationUuid: dashboard.organizationUuid,
             });
 
         const useTimezoneAwareDateTrunc =

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5475,6 +5475,7 @@ export class ProjectService extends BaseService {
         search,
         limit,
         filters,
+        organizationUuid: organizationUuidArg,
     }: {
         projectUuid: string;
         table: string;
@@ -5482,9 +5483,11 @@ export class ProjectService extends BaseService {
         search: string;
         limit: unknown;
         filters: AndFilterGroup | undefined;
+        organizationUuid?: string;
     }) {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = organizationUuidArg
+            ? { organizationUuid: organizationUuidArg }
+            : await this.projectModel.getSummary(projectUuid);
         const { maxLimit } = await resolveOrganizationExportLimits(
             this.organizationSettingsModel,
             this.lightdashConfig.query,
@@ -5536,6 +5539,7 @@ export class ProjectService extends BaseService {
                 search,
                 limit,
                 filters,
+                organizationUuid,
             });
 
         const [


### PR DESCRIPTION
Closes: SPK-518

### Description:

For a single `searchFieldUniqueValues` request, `projectModel.getSummary` (a project+organization join) ran twice for the same project — once for the permission check / query tags and again inside `_getFieldValuesMetricQuery` just to derive `organizationUuid`. This threads the already-resolved `organizationUuid` into `_getFieldValuesMetricQuery` as an optional param, so the helper skips the redundant DB round-trip when the caller provides it (and still falls back to `getSummary` when it doesn't). `EmbedService` also passes `dashboard.organizationUuid` to dedup its own path.