### PR TITLE
feat(slack): add gated AI agent stream foundation

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -18,16 +18,17 @@ import {
 } from '@lightdash/common';
 import {
     App,
-    Block,
     ExpressReceiver,
     LogLevel as SlackLogLevel,
     type InstallationStore,
 } from '@slack/bolt';
 import { InstallProvider } from '@slack/oauth';
 import {
+    Block,
     ChatPostMessageArguments,
     ChatUpdateArguments,
     FilesCompleteUploadExternalResponse,
+    KnownBlock,
     WebAPICallResult,
     WebClient,
     type FilesUploadV2Arguments,
@@ -42,6 +43,36 @@ import Logger from '../../logging/logger';
 import { SlackAuthenticationModel } from '../../models/SlackAuthenticationModel';
 import { SlackChannelCacheModel } from '../../models/SlackChannelCacheModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
+
+export type SlackStreamChunk =
+    | {
+          type: 'markdown_text';
+          text: string;
+      }
+    | {
+          type: 'task_update';
+          id: string;
+          title: string;
+          status: 'pending' | 'in_progress' | 'complete' | 'error';
+          details?: string;
+          output?: string;
+          sources?: Array<{ type: 'url'; text: string; url: string }>;
+      }
+    | {
+          type: 'plan_update';
+          title: string;
+      }
+    | {
+          type: 'blocks';
+          blocks: SlackBlock[];
+      };
+
+export type SlackStreamResponse = WebAPICallResult & {
+    ts?: string;
+    channel?: string;
+};
+
+export type SlackBlock = Block | KnownBlock;
 
 const DEFAULT_CACHE_TIME = 1000 * 60 * 10; // 10 minutes
 const CHANNELS_LIMIT = 200;
@@ -152,6 +183,10 @@ export type PostSlackFile = {
     fileType?: string;
 };
 
+export type SlackScopeOptions = {
+    includeAiAgentSlackModernScopes?: boolean;
+};
+
 export type SlackClientArguments = {
     slackAuthenticationModel: SlackAuthenticationModel;
     slackChannelCacheModel: SlackChannelCacheModel;
@@ -215,7 +250,7 @@ export class SlackClient {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public getRequiredScopes() {
+    public getRequiredScopes(_options: SlackScopeOptions = {}) {
         return [
             'links:read',
             'links:write',
@@ -236,7 +271,7 @@ export class SlackClient {
         ];
     }
 
-    public getSlackOptions() {
+    public getSlackOptions(options: SlackScopeOptions = {}) {
         return {
             signingSecret: this.lightdashConfig.slack?.signingSecret || '',
             clientId: this.lightdashConfig.slack?.clientId || '',
@@ -250,12 +285,15 @@ export class SlackClient {
                 redirectUriPath: '/api/v1/slack/oauth_redirect',
                 userScopes: [],
             },
-            scopes: this.getRequiredScopes(),
+            scopes: this.getRequiredScopes(options),
         };
     }
 
-    public hasRequiredScopes(installationScopes: string[]) {
-        const requiredScopes = this.getRequiredScopes();
+    public hasRequiredScopes(
+        installationScopes: string[],
+        options: SlackScopeOptions = {},
+    ) {
+        const requiredScopes = this.getRequiredScopes(options);
         return without(requiredScopes, ...installationScopes).length === 0;
     }
 
@@ -1008,7 +1046,7 @@ export class SlackClient {
     }: {
         organizationUuid: string;
         text: string;
-        blocks?: Block[];
+        blocks?: SlackBlock[];
     }): Promise<void> {
         try {
             const channelId =
@@ -1057,6 +1095,179 @@ export class SlackClient {
             text,
             blocks,
             ts: messageTs,
+        });
+    }
+
+    async setAssistantStatus({
+        organizationUuid,
+        channelId,
+        threadTs,
+        status,
+        loadingMessages,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        status: string;
+        loadingMessages?: string[];
+    }) {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        return webClient.apiCall('assistant.threads.setStatus', {
+            channel_id: resolvedChannel,
+            thread_ts: threadTs,
+            status,
+            ...(loadingMessages ? { loading_messages: loadingMessages } : {}),
+        });
+    }
+
+    async setAssistantTitle({
+        organizationUuid,
+        channelId,
+        threadTs,
+        title,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        title: string;
+    }) {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        return webClient.apiCall('assistant.threads.setTitle', {
+            channel_id: resolvedChannel,
+            thread_ts: threadTs,
+            title,
+        });
+    }
+
+    async setSuggestedPrompts({
+        organizationUuid,
+        channelId,
+        threadTs,
+        title,
+        prompts,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        title: string;
+        prompts: Array<{ title: string; message: string }>;
+    }) {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        return webClient.apiCall('assistant.threads.setSuggestedPrompts', {
+            channel_id: resolvedChannel,
+            thread_ts: threadTs,
+            title,
+            prompts,
+        });
+    }
+
+    async startAgentStream({
+        organizationUuid,
+        channelId,
+        threadTs,
+        username,
+        recipientUserId,
+        chunks,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        username?: string;
+        recipientUserId?: string;
+        chunks?: SlackStreamChunk[];
+    }): Promise<SlackStreamResponse> {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        const recipientArgs =
+            recipientUserId && !resolvedChannel.startsWith('D')
+                ? {
+                      recipient_user_id: recipientUserId,
+                      recipient_team_id:
+                          await this.slackAuthenticationModel.getSlackTeamIdFromOrganizationUuid(
+                              organizationUuid,
+                          ),
+                  }
+                : {};
+        return webClient.apiCall('chat.startStream', {
+            channel: resolvedChannel,
+            thread_ts: threadTs,
+            task_display_mode: 'plan',
+            ...recipientArgs,
+            ...(username ? { username } : {}),
+            ...(chunks ? { chunks } : {}),
+        });
+    }
+
+    async appendAgentStream({
+        organizationUuid,
+        channelId,
+        threadTs,
+        messageTs,
+        chunks,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        messageTs: string;
+        chunks: SlackStreamChunk[];
+    }): Promise<SlackStreamResponse> {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        return webClient.apiCall('chat.appendStream', {
+            channel: resolvedChannel,
+            thread_ts: threadTs,
+            ts: messageTs,
+            chunks,
+        });
+    }
+
+    async stopAgentStream({
+        organizationUuid,
+        channelId,
+        threadTs,
+        messageTs,
+        text,
+        blocks,
+        chunks,
+    }: {
+        organizationUuid: string;
+        channelId: string;
+        threadTs: string;
+        messageTs: string;
+        text?: string;
+        blocks?: SlackBlock[];
+        chunks?: SlackStreamChunk[];
+    }): Promise<SlackStreamResponse> {
+        const webClient = await this.getWebClient(organizationUuid);
+        const resolvedChannel = await this.resolveChannelToId(
+            organizationUuid,
+            channelId,
+        );
+        return webClient.apiCall('chat.stopStream', {
+            channel: resolvedChannel,
+            thread_ts: threadTs,
+            ts: messageTs,
+            ...(text && !chunks ? { markdown_text: text } : {}),
+            ...(blocks && !chunks ? { blocks } : {}),
+            ...(chunks ? { chunks } : {}),
         });
     }
 

--- a/packages/backend/src/ee/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/ee/clients/Slack/SlackClient.ts
@@ -19,11 +19,50 @@ export class CommercialSlackClient extends SlackClient {
         this.slackAuthenticationModel = args.slackAuthenticationModel;
     }
 
-    public getRequiredScopes() {
-        return [
+    public getRequiredScopes({
+        includeAiAgentSlackModernScopes = false,
+    }: {
+        includeAiAgentSlackModernScopes?: boolean;
+    } = {}) {
+        const scopes = [
             ...super.getRequiredScopes(),
             'channels:history',
             'groups:history',
         ];
+
+        if (includeAiAgentSlackModernScopes) {
+            scopes.push('assistant:write', 'im:history');
+        }
+
+        return scopes;
+    }
+
+    public getSlackOptions({
+        includeAiAgentSlackModernScopes = false,
+    }: {
+        includeAiAgentSlackModernScopes?: boolean;
+    } = {}) {
+        return {
+            ...super.getSlackOptions(),
+            scopes: this.getRequiredScopes({
+                includeAiAgentSlackModernScopes,
+            }),
+        };
+    }
+
+    public hasRequiredScopes(
+        installationScopes: string[],
+        {
+            includeAiAgentSlackModernScopes = false,
+        }: {
+            includeAiAgentSlackModernScopes?: boolean;
+        } = {},
+    ) {
+        const requiredScopes = this.getRequiredScopes({
+            includeAiAgentSlackModernScopes,
+        });
+        return requiredScopes.every((scope) =>
+            installationScopes.includes(scope),
+        );
     }
 }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -415,6 +415,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     slackClient: clients.getSlackClient(),
                     aiAgentModel: models.getAiAgentModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                 }),
             supportService: ({ models, context, repository, clients }) =>
                 new SupportService({

--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -1,9 +1,11 @@
 import {
     Account,
+    FeatureFlags,
     ForbiddenError,
     SessionUser,
     SlackSettings,
 } from '@lightdash/common';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import {
     SlackIntegrationService,
     SlackIntegrationServiceArguments,
@@ -14,15 +16,48 @@ import { CommercialSlackAuthenticationModel } from '../models/CommercialSlackAut
 export class CommercialSlackIntegrationService extends SlackIntegrationService<CommercialSlackAuthenticationModel> {
     private readonly aiAgentModel: AiAgentModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     constructor({
         aiAgentModel,
+        featureFlagModel,
         ...rest
     }: SlackIntegrationServiceArguments<CommercialSlackAuthenticationModel> & {
         aiAgentModel: AiAgentModel;
+        featureFlagModel: FeatureFlagModel;
     }) {
         super(rest);
 
         this.aiAgentModel = aiAgentModel;
+        this.featureFlagModel = featureFlagModel;
+    }
+
+    private async isModernSlackAiAgentEnabled(user: SessionUser) {
+        const flag = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.AiAgentSlackModernBlocks,
+        });
+
+        return flag.enabled;
+    }
+
+    async getSlackInstallOptions(user: SessionUser) {
+        const includeAiAgentSlackModernScopes =
+            await this.isModernSlackAiAgentEnabled(user);
+
+        const { slackOptions, metadata } = await super.getSlackInstallOptions(
+            user,
+        );
+
+        return {
+            slackOptions: {
+                ...slackOptions,
+                scopes: this.slackClient.getRequiredScopes({
+                    includeAiAgentSlackModernScopes,
+                }),
+            },
+            metadata,
+        };
     }
 
     async getInstallationFromOrganizationUuid(user: SessionUser) {
@@ -50,6 +85,10 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
             appProfilePhotoUrl: installation.appProfilePhotoUrl,
             hasRequiredScopes: this.slackClient.hasRequiredScopes(
                 installation.scopes,
+                {
+                    includeAiAgentSlackModernScopes:
+                        await this.isModernSlackAiAgentEnabled(user),
+                },
             ),
             slackChannelProjectMappings:
                 installation.slackChannelProjectMappings,

--- a/packages/backend/src/models/SlackAuthenticationModel.ts
+++ b/packages/backend/src/models/SlackAuthenticationModel.ts
@@ -94,6 +94,23 @@ export class SlackAuthenticationModel {
         return row.installation.user.id;
     }
 
+    async getSlackTeamIdFromOrganizationUuid(organizationUuid: string) {
+        const [row] = await this.database(SlackAuthTokensTableName)
+            .leftJoin(
+                'organizations',
+                'slack_auth_tokens.organization_id',
+                'organizations.organization_id',
+            )
+            .select<DbSlackAuthTokens[]>('slack_team_id')
+            .where('organizations.organization_uuid', organizationUuid);
+        if (row === undefined) {
+            throw new NotFoundError(
+                `Could not find slack team for organization ${organizationUuid}`,
+            );
+        }
+        return row.slack_team_id;
+    }
+
     async getUserUuid(teamId: string) {
         const [row] = await this.database(SlackAuthTokensTableName)
             .leftJoin(

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -108,6 +108,14 @@ export enum FeatureFlags {
     AiAgentRevamp = 'ai-agent-revamp',
 
     /**
+     * Use Slack's modern AI-agent message primitives for Lightdash AI agent
+     * replies: assistant status, streamed markdown, task updates, and
+     * context-action feedback. Falls back to classic Slack blocks when the
+     * workspace has not re-authorized the required Slack scopes.
+     */
+    AiAgentSlackModernBlocks = 'ai-agent-slack-modern-blocks',
+
+    /**
      * Enable the Hexbin (H3 hexagonal binning) layer type for Map charts.
      * Gates the option in the Map Type segmented control. Existing charts
      * already saved with the hexbin layer continue to render either way.


### PR DESCRIPTION
## Summary
Adds the gated Slack AI-agent foundation without changing runtime behavior while the flag is off.

## Changes
- Adds `AiAgentSlackModernBlocks`.
- Adds Slack stream helper methods for assistant status/title/prompts and chat stream start/append/stop.
- Gates new AI-agent OAuth scopes behind the feature flag for commercial Slack installs.
- Adds Slack team lookup needed for channel streaming recipients.

## Validation
- Backend typecheck passed on the full stack.
- Focused Slack block tests passed on the full stack.
