### PR TITLE
feat(slack): stream AI agent replies with task progress

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -297,6 +297,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         repository.getAiOrganizationSettingsService(),
                     shareService: repository.getShareService(),
                     fileStorageClient: clients.getFileStorageClient(),
+                    downloadFileModel: models.getDownloadFileModel(),
+                    slackUnfurlImageModel: models.getSlackUnfurlImageModel(),
                     persistentDownloadFileService:
                         repository.getPersistentDownloadFileService(),
                     aiAgentContentValidation: new AiAgentContentValidation(),

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -51,6 +51,7 @@ import {
     ContentType,
     DbtProjectType,
     derivePivotConfigurationFromChart,
+    DownloadFileType,
     Explore,
     FeatureFlags,
     followUpToolsText,
@@ -111,6 +112,7 @@ import {
 } from 'ai';
 import { createCanvas, loadImage } from 'canvas';
 import { EventEmitter } from 'events';
+import fs from 'fs/promises';
 import _ from 'lodash';
 import { nanoid as nanoidGenerator } from 'nanoid';
 import slackifyMarkdown from 'slackify-markdown';
@@ -150,12 +152,14 @@ import {
 } from '../../../models/CatalogModel/CatalogModel';
 import { ChangesetModel } from '../../../models/ChangesetModel';
 import { ContentVerificationModel } from '../../../models/ContentVerificationModel';
+import { DownloadFileModel } from '../../../models/DownloadFileModel';
 import { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
 import { GroupsModel } from '../../../models/GroupsModel';
 import { OpenIdIdentityModel } from '../../../models/OpenIdIdentitiesModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { PullRequestsModel } from '../../../models/PullRequestsModel';
 import { SearchModel } from '../../../models/SearchModel';
+import { SlackUnfurlImageModel } from '../../../models/SlackUnfurlImageModel';
 import { SpaceModel } from '../../../models/SpaceModel';
 import { UserAttributesModel } from '../../../models/UserAttributesModel';
 import { UserModel } from '../../../models/UserModel';
@@ -236,6 +240,8 @@ import {
 import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
 import { getUserFacingErrorMessage } from '../ai/utils/errorMessages';
 import {
+    buildFeedbackContextActions,
+    buildSlackTaskUpdate,
     getAgentConfirmationBlocks,
     getAgentSelectionBlocks,
     getArtifactBlocks,
@@ -244,6 +250,8 @@ import {
     getFeedbackBlocks,
     getFollowUpToolBlocks,
     getMarkdownBlocks,
+    getModernArtifactCardBlocks,
+    getModernPullRequestCardBlocks,
     getProjectSelectionBlocks,
     getProposeChangeBlocks,
     getReferencedArtifactsBlocks,
@@ -333,6 +341,8 @@ type AiAgentServiceDependencies = {
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     shareService: ShareService;
     fileStorageClient: FileStorageClient;
+    downloadFileModel: DownloadFileModel;
+    slackUnfurlImageModel: SlackUnfurlImageModel;
     persistentDownloadFileService: PersistentDownloadFileService;
     aiAgentContentValidation: AiAgentContentValidation;
     aiWritebackService: AiWritebackService;
@@ -574,6 +584,10 @@ export class AiAgentService extends BaseService {
 
     private readonly fileStorageClient: FileStorageClient;
 
+    private readonly downloadFileModel: DownloadFileModel;
+
+    private readonly slackUnfurlImageModel: SlackUnfurlImageModel;
+
     private readonly persistentDownloadFileService: PersistentDownloadFileService;
 
     private readonly aiAgentContentValidation: AiAgentContentValidation;
@@ -758,6 +772,8 @@ export class AiAgentService extends BaseService {
             dependencies.aiOrganizationSettingsService;
         this.shareService = dependencies.shareService;
         this.fileStorageClient = dependencies.fileStorageClient;
+        this.downloadFileModel = dependencies.downloadFileModel;
+        this.slackUnfurlImageModel = dependencies.slackUnfurlImageModel;
         this.persistentDownloadFileService =
             dependencies.persistentDownloadFileService;
         this.aiAgentContentValidation = dependencies.aiAgentContentValidation;
@@ -775,6 +791,45 @@ export class AiAgentService extends BaseService {
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
         });
+    }
+
+    private async uploadSlackAgentCardImage({
+        organizationUuid,
+        image,
+    }: {
+        organizationUuid: string;
+        image: Buffer;
+    }): Promise<string> {
+        const imageId = `slack-ai-agent-chart-${nanoidGenerator()}`;
+
+        if (this.fileStorageClient.isEnabled()) {
+            await this.fileStorageClient.uploadImage(image, imageId);
+            const previewId = nanoidGenerator();
+            await this.slackUnfurlImageModel.create({
+                nanoid: previewId,
+                s3Key: `${imageId}.png`,
+                organizationUuid,
+            });
+
+            return new URL(
+                `/api/v1/slack/preview/${previewId}`,
+                this.lightdashConfig.siteUrl,
+            ).href;
+        }
+
+        const downloadFileId = nanoidGenerator();
+        const filePath = `/tmp/${imageId}.png`;
+        await fs.writeFile(filePath, image);
+        await this.downloadFileModel.createDownloadFile(
+            downloadFileId,
+            filePath,
+            DownloadFileType.IMAGE,
+        );
+
+        return new URL(
+            `/api/v1/slack/image/${downloadFileId}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
     }
 
     private enqueueReviewClassifierEvent(args: {
@@ -1880,7 +1935,10 @@ export class AiAgentService extends BaseService {
                     } catch (error) {
                         this.logger.warn(
                             `Failed to fetch Slack user info for ${userId}`,
-                            { organizationUuid, error },
+                            {
+                                organizationUuid,
+                                error,
+                            },
                         );
                         return null;
                     }
@@ -5177,9 +5235,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // query…", "Starting sandbox…") that Slack overwrites into the
             // pinned "Thinking…" message, along with the tool they belong to
             // so the web client can scope an inline progress row to the active
-            // tool. Only invoked for web prompts; Slack prompts route through
-            // updateSlackResponseWithProgress instead.
-            onStepProgress?: (progress: string, toolName?: string) => void;
+            // tool. Web uses it for transient SSE progress. Modern Slack uses
+            // it for stream task updates. Classic Slack falls back to
+            // updateSlackResponseWithProgress.
+            onStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -5200,8 +5264,22 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const getProjectContextDocument: AiAgentDependencies['getProjectContextDocument'] =
             () => this.projectContextModel.getDocument(projectUuid);
 
-        const updateProgress: UpdateProgressFn = (progress, toolName) => {
+        const updateProgress: UpdateProgressFn = (
+            progress,
+            toolName,
+            progressId,
+            progressStatus,
+        ) => {
             if (isSlackPrompt(prompt)) {
+                if (options?.onStepProgress) {
+                    options.onStepProgress(
+                        progress,
+                        toolName,
+                        progressId,
+                        progressStatus,
+                    );
+                    return Promise.resolve();
+                }
                 return this.updateSlackResponseWithProgress(prompt, progress);
             }
             // Web prompts surface step progress through a transient
@@ -5209,7 +5287,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // generateOrStreamAgentResponse). The callback is wired only
             // when streaming; non-stream responses silently drop these
             // events.
-            options?.onStepProgress?.(progress, toolName);
+            options?.onStepProgress?.(
+                progress,
+                toolName,
+                progressId,
+                progressStatus,
+            );
             return Promise.resolve();
         };
 
@@ -5225,7 +5308,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         };
 
         const sendFile: SendFileFn = (args) =>
-            wrapSentryTransaction('AiAgent.sendFile', args, () =>
+            wrapSentryTransaction('AiAgent.sendFile', args, () => {
+                const isModernSlackImageUpload =
+                    isSlackPrompt(prompt) &&
+                    Boolean(options?.onStepProgress) &&
+                    Buffer.isBuffer(args.file) &&
+                    ((args.fileType ?? '').startsWith('image/') ||
+                        /\.(png|jpe?g|gif|webp)$/i.test(args.filename));
+
+                if (isModernSlackImageUpload) {
+                    return this.uploadSlackAgentCardImage({
+                        organizationUuid: args.organizationUuid,
+                        image: args.file as Buffer,
+                    });
+                }
+
                 //
                 // TODO: https://api.slack.com/methods/files.upload does not support setting custom usernames
                 // support this in the future
@@ -5238,9 +5335,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 //     username = agent.name;
                 // }
                 //
-
-                this.slackClient.postFileToThread(args),
-            );
+                return this.slackClient
+                    .postFileToThread(args)
+                    .then(() => undefined);
+            });
 
         const sendSlackBlocks: SendSlackBlocksFn = async (args) =>
             wrapSentryTransaction(
@@ -5326,7 +5424,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // message, or dropped SSE client must never take down the
             // writeback itself.
             const writebackProgressCallback = (message: string) => {
-                void updateProgress(message, 'editDbtProject').catch((err) => {
+                void updateProgress(
+                    message,
+                    `editDbtProject:${message}`,
+                    args.progressId
+                        ? `${args.progressId}:${message}`
+                        : undefined,
+                    'complete',
+                ).catch((err) => {
                     Logger.debug(
                         `Failed to update progress for writeback (${message}):`,
                         err,
@@ -5437,7 +5542,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             if (result.prUrl) {
                 const preview =
                     await this.writebackPreviewService.createPreviewForPullRequest(
-                        { user, projectUuid, prUrl: result.prUrl },
+                        {
+                            user,
+                            projectUuid,
+                            prUrl: result.prUrl,
+                        },
                     );
                 previewUrl = preview?.previewUrl ?? null;
             }
@@ -5529,6 +5638,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints?: string[];
+            onSlackStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
         },
     ): Promise<AgentResponseStream>;
     async generateOrStreamAgentResponse(
@@ -5541,6 +5656,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints?: string[];
+            onSlackStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
         },
     ): Promise<string>;
     async generateOrStreamAgentResponse(
@@ -5553,6 +5674,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints?: string[];
+            onSlackStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
         },
     ): Promise<string>;
     async generateOrStreamAgentResponse(
@@ -5564,6 +5691,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
             toolHints?: string[];
+            onSlackStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
         } & (
             | {
                   prompt: AiWebAppPrompt;
@@ -5637,13 +5770,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             listProjects,
             getProjectInfo,
         } = await this.getAiAgentDependencies(user, prompt, {
-            onStepProgress: stepProgressEmitter
-                ? (progress, toolName) =>
-                      stepProgressEmitter.emit('stepProgress', {
-                          message: progress,
-                          toolName,
-                      })
-                : undefined,
+            onStepProgress:
+                options.onSlackStepProgress ??
+                (stepProgressEmitter
+                    ? (progress, toolName, progressId, progressStatus) =>
+                          stepProgressEmitter.emit('stepProgress', {
+                              message: progress,
+                              toolName,
+                              progressId,
+                              progressStatus,
+                          })
+                    : undefined),
         });
 
         const enableSqlMode = options.enableSqlMode ?? false;
@@ -5998,7 +6135,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             repoShell,
             listProjects,
             getProjectInfo,
-            updateProgress: (progress: string) => updateProgress(progress),
+            updateProgress: (progress, toolName, progressId, progressStatus) =>
+                updateProgress(progress, toolName, progressId, progressStatus),
             updatePrompt: (
                 update: UpdateSlackResponse | UpdateWebAppResponse,
             ) => {
@@ -6143,12 +6281,23 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 if (stepProgressEmitter) {
                     stepProgressEmitter.on(
                         'stepProgress',
-                        (event: { message: string; toolName?: string }) => {
+                        (event: {
+                            message: string;
+                            toolName?: string;
+                            progressId?: string;
+                            progressStatus?:
+                                | 'in_progress'
+                                | 'complete'
+                                | 'error';
+                        }) => {
                             writer.write({
                                 type: 'data-step-progress',
                                 data: {
                                     message: event.message,
                                     toolName: event.toolName ?? null,
+                                    progressId: event.progressId ?? null,
+                                    progressStatus:
+                                        event.progressStatus ?? null,
                                 },
                                 transient: true,
                             });
@@ -6365,13 +6514,544 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     }
 
     // TODO: user permissions
+    private async getSlackAgentFinalBlocks({
+        user,
+        slackPrompt,
+        agent,
+        useModernFeedback,
+    }: {
+        user: SessionUser;
+        slackPrompt: SlackPrompt;
+        agent: AiAgent | undefined;
+        useModernFeedback: boolean;
+    }): Promise<(Block | KnownBlock)[]> {
+        const referencedArtifactsMap =
+            await this.aiAgentModel.findThreadReferencedArtifacts({
+                promptUuids: [slackPrompt.promptUuid],
+            });
+        const referencedArtifacts =
+            referencedArtifactsMap.get(slackPrompt.promptUuid) ?? [];
+
+        const threadArtifacts =
+            await this.aiAgentModel.findArtifactsByThreadUuid(
+                slackPrompt.threadUuid,
+            );
+
+        const toolResults = await this.aiAgentModel.getToolResultsForPrompt(
+            slackPrompt.promptUuid,
+        );
+
+        const legacyFeedbackBlocks = agent
+            ? getFeedbackBlocks(
+                  slackPrompt,
+                  toolResults,
+                  agent.uuid,
+                  this.lightdashConfig.siteUrl,
+              )
+            : [];
+        const feedbackBlocks =
+            useModernFeedback && legacyFeedbackBlocks.length > 0
+                ? buildFeedbackContextActions(slackPrompt.promptUuid)
+                : legacyFeedbackBlocks;
+        const followUpToolBlocks = getFollowUpToolBlocks(
+            slackPrompt,
+            threadArtifacts,
+        );
+
+        const createShareUrl = async (
+            path: string,
+            params: string,
+        ): Promise<string> => {
+            const result = await this.shareService.createShareUrl(
+                user,
+                path,
+                params,
+            );
+            return `${this.lightdashConfig.siteUrl}/share/${result.nanoid}`;
+        };
+
+        const exploreBlocks = useModernFeedback
+            ? await getModernArtifactCardBlocks(
+                  slackPrompt,
+                  this.lightdashConfig.siteUrl,
+                  this.lightdashConfig.ai.copilot.maxQueryLimit,
+                  createShareUrl,
+                  (exploreName) =>
+                      this.getExplore(
+                          user,
+                          slackPrompt.projectUuid,
+                          null,
+                          exploreName,
+                      ),
+                  agent?.uuid,
+                  threadArtifacts,
+                  toolResults,
+              )
+            : await getArtifactBlocks(
+                  slackPrompt,
+                  this.lightdashConfig.siteUrl,
+                  this.lightdashConfig.ai.copilot.maxQueryLimit,
+                  createShareUrl,
+                  (exploreName) =>
+                      this.getExplore(
+                          user,
+                          slackPrompt.projectUuid,
+                          null,
+                          exploreName,
+                      ),
+                  threadArtifacts,
+              );
+        const proposeChangeBlocks = getProposeChangeBlocks(
+            slackPrompt,
+            this.lightdashConfig.siteUrl,
+            toolResults,
+        );
+        const editDbtProjectBlocks = useModernFeedback
+            ? getModernPullRequestCardBlocks(toolResults)
+            : getEditDbtProjectBlocks(toolResults);
+        const historyBlocks = agent
+            ? getDeepLinkBlocks(
+                  agent.uuid,
+                  slackPrompt,
+                  this.lightdashConfig.siteUrl,
+                  threadArtifacts,
+              )
+            : [];
+
+        const referencedArtifactsBlocks =
+            agent && referencedArtifacts.length > 0
+                ? getReferencedArtifactsBlocks(
+                      agent.uuid,
+                      slackPrompt.projectUuid,
+                      this.lightdashConfig.siteUrl,
+                      referencedArtifacts,
+                      slackPrompt.threadUuid,
+                      slackPrompt.promptUuid,
+                  )
+                : [];
+
+        return [
+            ...exploreBlocks,
+            ...proposeChangeBlocks,
+            ...editDbtProjectBlocks,
+            ...referencedArtifactsBlocks,
+            ...followUpToolBlocks,
+            ...feedbackBlocks,
+            ...historyBlocks,
+        ];
+    }
+
+    private static isSlackModernStreamUnsupported(error: unknown) {
+        const errorCode =
+            typeof error === 'object' && error !== null && 'data' in error
+                ? (error as { data?: { error?: string } }).data?.error
+                : undefined;
+        const message = getErrorMessage(error).toLowerCase();
+        return [
+            errorCode,
+            message.includes('missing_scope') ? 'missing_scope' : undefined,
+            message.includes('unknown_method') ? 'unknown_method' : undefined,
+            message.includes('not_allowed') ? 'not_allowed' : undefined,
+            message.includes('unsupported') ? 'unsupported' : undefined,
+        ].some((code) =>
+            [
+                'missing_scope',
+                'unknown_method',
+                'invalid_arguments',
+                'not_allowed_token_type',
+                'method_not_supported_for_channel_type',
+                'unsupported',
+            ].includes(code ?? ''),
+        );
+    }
+
+    private async postSlackMultiAgentTipIfNeeded(
+        slackPrompt: SlackPrompt,
+        threadMessages: Awaited<ReturnType<AiAgentModel['getThreadMessages']>>,
+        agent: AiAgent | undefined,
+    ) {
+        const slackSettings =
+            await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+                slackPrompt.organizationUuid,
+            );
+
+        const isMultiAgentChannel =
+            slackSettings?.aiMultiAgentChannelId === slackPrompt.slackChannelId;
+        const isFirstMessage = threadMessages.length === 1;
+
+        if (!isMultiAgentChannel || !isFirstMessage || !agent) {
+            return;
+        }
+
+        const slackApp = this.slackClient.getApp();
+        let botMention = 'the app';
+
+        if (slackApp) {
+            try {
+                const authTest = await slackApp.client.auth.test({
+                    token: slackSettings?.token,
+                });
+                if (authTest.user_id) {
+                    botMention = `<@${authTest.user_id}>`;
+                }
+            } catch (error) {
+                Logger.error(
+                    'Failed to get bot user ID for tip message',
+                    error,
+                );
+            }
+        }
+
+        await this.slackClient.postMessage({
+            organizationUuid: slackPrompt.organizationUuid,
+            text: `💬 To continue this conversation, just tag ${botMention} in this thread!`,
+            channel: slackPrompt.slackChannelId,
+            thread_ts: slackPrompt.slackThreadTs,
+            blocks: [
+                {
+                    type: 'context',
+                    elements: [
+                        {
+                            type: 'mrkdwn',
+                            text: `💬 *Tip:* To continue this conversation, just tag ${botMention} in this thread!`,
+                        },
+                    ],
+                },
+            ],
+        });
+    }
+
+    private async replyToSlackPromptWithModernBlocks({
+        user,
+        slackPrompt,
+        threadMessages,
+        agent,
+        chatHistoryMessages,
+        canManageAgent,
+    }: {
+        user: SessionUser;
+        slackPrompt: SlackPrompt;
+        threadMessages: Awaited<ReturnType<AiAgentModel['getThreadMessages']>>;
+        agent: AiAgent | undefined;
+        chatHistoryMessages: ModelMessage[];
+        canManageAgent: boolean;
+    }): Promise<boolean> {
+        const threadTs = slackPrompt.slackThreadTs || slackPrompt.promptSlackTs;
+        let streamTs: string | undefined;
+
+        try {
+            await this.slackClient.setAssistantStatus({
+                organizationUuid: slackPrompt.organizationUuid,
+                channelId: slackPrompt.slackChannelId,
+                threadTs,
+                status: 'thinking...',
+                loadingMessages: [
+                    'Checking the project context...',
+                    'Finding the relevant metrics...',
+                    'Reviewing available content...',
+                    'Preparing the answer...',
+                ],
+            });
+            void this.slackClient
+                .setAssistantTitle({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    title: agent
+                        ? `${agent.name} is working`
+                        : 'Lightdash is working',
+                })
+                .catch((error) => {
+                    Logger.debug('Failed to set Slack assistant title:', error);
+                });
+            if (threadMessages.length <= 1) {
+                void this.slackClient
+                    .setSuggestedPrompts({
+                        organizationUuid: slackPrompt.organizationUuid,
+                        channelId: slackPrompt.slackChannelId,
+                        threadTs,
+                        title: 'Try asking',
+                        prompts: [
+                            {
+                                title: 'Find the right metric',
+                                message:
+                                    'Which metric should I use for this question?',
+                            },
+                            {
+                                title: 'Explain this dashboard',
+                                message:
+                                    'Explain the main takeaways from this dashboard.',
+                            },
+                            {
+                                title: 'Build a chart',
+                                message:
+                                    'Build a chart that answers this question.',
+                            },
+                            {
+                                title: 'Improve project context',
+                                message:
+                                    'What context is missing from this project?',
+                            },
+                        ],
+                    })
+                    .catch((error) => {
+                        Logger.debug(
+                            'Failed to set Slack suggested prompts:',
+                            error,
+                        );
+                    });
+            }
+
+            const stream = await this.slackClient.startAgentStream({
+                organizationUuid: slackPrompt.organizationUuid,
+                channelId: slackPrompt.slackChannelId,
+                threadTs,
+                username: agent?.name,
+                recipientUserId: slackPrompt.slackUserId,
+                chunks: [
+                    {
+                        type: 'plan_update',
+                        title: 'Answering your question',
+                    },
+                ],
+            });
+            streamTs = stream.ts;
+            if (!streamTs) {
+                throw new Error('Slack stream did not return a message ts');
+            }
+        } catch (error) {
+            if (AiAgentService.isSlackModernStreamUnsupported(error)) {
+                Logger.info(
+                    'Slack modern AI stream unavailable, falling back to classic blocks',
+                    error,
+                );
+                return false;
+            }
+            throw error;
+        }
+
+        const taskUpdatePromises: Promise<unknown>[] = [];
+
+        const flushTaskUpdates = async () => {
+            const pending = taskUpdatePromises.splice(0);
+            await Promise.allSettled(pending);
+        };
+
+        const appendTaskUpdate = (
+            progress: string,
+            toolName?: string,
+            progressId?: string,
+            progressStatus?: 'in_progress' | 'complete' | 'error',
+        ) => {
+            if (!streamTs) return;
+            if (!toolName || !progressId) return;
+            const resolvedToolName = toolName ?? 'lightdash_agent';
+            const isComplete =
+                progressStatus === 'complete' || /^finished\s/i.test(progress);
+            taskUpdatePromises.push(
+                this.slackClient
+                    .appendAgentStream({
+                        organizationUuid: slackPrompt.organizationUuid,
+                        channelId: slackPrompt.slackChannelId,
+                        threadTs,
+                        messageTs: streamTs,
+                        chunks: [
+                            buildSlackTaskUpdate({
+                                toolName: resolvedToolName,
+                                taskId: progressId,
+                                status: isComplete ? 'complete' : 'in_progress',
+                                ...(isComplete
+                                    ? { output: progress }
+                                    : { details: progress }),
+                            }),
+                        ],
+                    })
+                    .catch((error) => {
+                        Logger.debug(
+                            'Failed to append Slack AI stream task update:',
+                            error,
+                        );
+                    }),
+            );
+        };
+
+        const persistStreamResponseTsAndDeletePlaceholder = async () => {
+            await this.aiAgentModel.updateSlackResponseTs({
+                promptUuid: slackPrompt.promptUuid,
+                responseSlackTs: streamTs,
+            });
+
+            if (slackPrompt.response_slack_ts !== streamTs) {
+                void this.slackClient
+                    .deleteMessage({
+                        organizationUuid: slackPrompt.organizationUuid,
+                        channelId: slackPrompt.slackChannelId,
+                        messageTs: slackPrompt.response_slack_ts,
+                    })
+                    .catch((error) => {
+                        Logger.debug(
+                            'Failed to delete Slack placeholder:',
+                            error,
+                        );
+                    });
+            }
+        };
+
+        const updatePlanTitle = async (title: string) => {
+            await this.slackClient
+                .appendAgentStream({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    messageTs: streamTs,
+                    chunks: [
+                        {
+                            type: 'plan_update',
+                            title,
+                        },
+                    ],
+                })
+                .catch((error) => {
+                    Logger.debug(
+                        'Failed to update Slack AI plan title:',
+                        error,
+                    );
+                });
+        };
+
+        try {
+            const response = await this.generateOrStreamAgentResponse(
+                user,
+                chatHistoryMessages,
+                {
+                    prompt: slackPrompt,
+                    stream: false,
+                    canManageAgent,
+                    enableSqlMode: true,
+                    onSlackStepProgress: appendTaskUpdate,
+                },
+            );
+
+            if (!response) {
+                await flushTaskUpdates();
+                await updatePlanTitle('No answer generated');
+                await this.slackClient.stopAgentStream({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    messageTs: streamTs,
+                    text: 'No response generated.',
+                    chunks: [
+                        {
+                            type: 'blocks',
+                            blocks: getMarkdownBlocks('No response generated.'),
+                        },
+                    ],
+                });
+                await persistStreamResponseTsAndDeletePlaceholder();
+                return true;
+            }
+
+            const blocks = await this.getSlackAgentFinalBlocks({
+                user,
+                slackPrompt,
+                agent,
+                useModernFeedback: true,
+            });
+            const slackifiedMarkdown = slackifyMarkdown(response).replace(
+                /\\\n/g,
+                '\n',
+            );
+
+            await flushTaskUpdates();
+            await updatePlanTitle('Answered');
+            await this.slackClient.stopAgentStream({
+                organizationUuid: slackPrompt.organizationUuid,
+                channelId: slackPrompt.slackChannelId,
+                threadTs,
+                messageTs: streamTs,
+                text: slackifiedMarkdown,
+                chunks: [
+                    ...getMarkdownBlocks(response).map((block) => ({
+                        type: 'blocks' as const,
+                        blocks: [block],
+                    })),
+                    {
+                        type: 'blocks',
+                        blocks,
+                    },
+                ],
+            });
+
+            await persistStreamResponseTsAndDeletePlaceholder();
+            await this.aiAgentModel.updateModelResponse({
+                promptUuid: slackPrompt.promptUuid,
+                response,
+            });
+
+            await this.postSlackMultiAgentTipIfNeeded(
+                slackPrompt,
+                threadMessages,
+                agent,
+            );
+            return true;
+        } catch (error) {
+            const userFacingMessage = getUserFacingErrorMessage(
+                error,
+                'Co-pilot failed to generate a response. Please try again.',
+            );
+            await flushTaskUpdates();
+            await updatePlanTitle('Could not finish');
+            await this.slackClient.stopAgentStream({
+                organizationUuid: slackPrompt.organizationUuid,
+                channelId: slackPrompt.slackChannelId,
+                threadTs,
+                messageTs: streamTs,
+                text: userFacingMessage,
+                chunks: [
+                    {
+                        type: 'blocks',
+                        blocks: [
+                            {
+                                type: 'section',
+                                text: {
+                                    type: 'mrkdwn',
+                                    text: `:warning: ${userFacingMessage}`,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            });
+            await persistStreamResponseTsAndDeletePlaceholder();
+            Logger.error(
+                'Failed to generate modern Slack agent response',
+                error,
+            );
+            return true;
+        } finally {
+            void this.slackClient
+                .setAssistantStatus({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    status: '',
+                })
+                .catch((error) => {
+                    Logger.debug(
+                        'Failed to clear Slack assistant status:',
+                        error,
+                    );
+                });
+        }
+    }
+
+    // TODO: user permissions
     async replyToSlackPrompt(promptUuid: string): Promise<void> {
         let slackPrompt = await this.aiAgentModel.findSlackPrompt(promptUuid);
         if (slackPrompt === undefined) {
             throw new Error('Prompt not found');
         }
-
-        await this.updateSlackResponseWithProgress(slackPrompt, 'Thinking...');
 
         const user = await this.userModel.findSessionUserAndOrgByUuid(
             slackPrompt.createdByUserUuid,
@@ -6423,6 +7103,31 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     // equivalent persisted marker / summary UX.
                     compaction: null,
                 });
+
+            const { enabled: modernSlackBlocksEnabled } =
+                await this.featureFlagService.get({
+                    user,
+                    featureFlagId: FeatureFlags.AiAgentSlackModernBlocks,
+                });
+            if (modernSlackBlocksEnabled) {
+                const handledByModernSlack =
+                    await this.replyToSlackPromptWithModernBlocks({
+                        user,
+                        slackPrompt,
+                        threadMessages,
+                        agent,
+                        chatHistoryMessages,
+                        canManageAgent,
+                    });
+                if (handledByModernSlack) {
+                    return;
+                }
+            }
+
+            await this.updateSlackResponseWithProgress(
+                slackPrompt,
+                'Thinking...',
+            );
 
             response = await this.generateOrStreamAgentResponse(
                 user,
@@ -6941,6 +7646,79 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         );
     }
 
+    public async handleAssistantThreadStarted({
+        event,
+        context,
+    }: {
+        event: AnyType;
+        context: AnyType;
+    }) {
+        const assistantThread = event?.assistant_thread;
+        const channelId = assistantThread?.channel_id;
+        const threadTs = assistantThread?.thread_ts;
+        const teamId =
+            context?.teamId ??
+            context?.team_id ??
+            assistantThread?.context?.team_id;
+
+        if (!teamId || !channelId || !threadTs) {
+            Logger.debug(
+                'Skipping assistant_thread_started without thread ids',
+                {
+                    teamId,
+                    channelId,
+                    threadTs,
+                },
+            );
+            return;
+        }
+
+        try {
+            const organizationUuid =
+                await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
+                    teamId,
+                );
+            await this.slackClient.setSuggestedPrompts({
+                organizationUuid,
+                channelId,
+                threadTs,
+                title: 'Ask Lightdash',
+                prompts: [
+                    {
+                        title: 'Find the right metric',
+                        message: 'Which metric should I use for this question?',
+                    },
+                    {
+                        title: 'Explain this dashboard',
+                        message:
+                            'Explain the main takeaways from this dashboard.',
+                    },
+                    {
+                        title: 'Build a chart',
+                        message: 'Build a chart that answers this question.',
+                    },
+                    {
+                        title: 'Improve project context',
+                        message: 'What context is missing from this project?',
+                    },
+                ],
+            });
+        } catch (error) {
+            Logger.error('Failed to handle assistant_thread_started', error);
+        }
+    }
+
+    public async handleAssistantThreadContextChanged({
+        event,
+    }: {
+        event: AnyType;
+    }) {
+        this.logger.debug('Slack assistant thread context changed', {
+            channelId: event?.assistant_thread?.context?.channel_id,
+            threadTs: event?.assistant_thread?.thread_ts,
+        });
+    }
+
     // eslint-disable-next-line class-methods-use-this
     public handleClickOAuthButton(app: App) {
         // Match action_id pattern: actions.oauth_button_click:teamId:channelId:messageTs
@@ -7054,6 +7832,143 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             ),
                         });
                     }
+                }
+            },
+        );
+    }
+
+    public handlePromptFeedbackButtons(app: App) {
+        app.action(
+            'prompt_human_score.feedback',
+            async ({ ack, body, respond, context, client }) => {
+                await ack();
+                if (body.type !== 'block_actions') {
+                    return;
+                }
+
+                const action = body.actions[0] as AnyType;
+                const rawValue =
+                    action?.selected_button?.value ??
+                    action?.value ??
+                    action?.selectedButton?.value;
+                if (!rawValue || typeof rawValue !== 'string') {
+                    return;
+                }
+
+                let parsedValue: unknown;
+                try {
+                    parsedValue = JSON.parse(rawValue);
+                } catch (error) {
+                    Logger.error('Invalid Slack feedback button JSON', error);
+                    return;
+                }
+                const parsed = z
+                    .object({
+                        promptUuid: z.string(),
+                        score: z.union([z.literal(1), z.literal(-1)]),
+                    })
+                    .safeParse(parsedValue);
+                if (!parsed.success) {
+                    Logger.error('Invalid Slack feedback button payload', {
+                        error: parsed.error.message,
+                    });
+                    return;
+                }
+
+                const organizationUuid =
+                    await this.getSlackVoteOrganizationUuid({
+                        teamId: context.teamId,
+                        userId: body.user.id,
+                        channelId: body.channel?.id,
+                        messageId: body.message?.ts,
+                        threadTs: body.message?.thread_ts,
+                        client,
+                    });
+
+                if (organizationUuid === null) {
+                    return;
+                }
+
+                const { promptUuid, score } = parsed.data;
+                await this.updateHumanScoreForSlackPrompt(
+                    body.user.id,
+                    organizationUuid,
+                    promptUuid,
+                    score,
+                );
+
+                const newBlock = {
+                    type: 'context',
+                    elements: [
+                        {
+                            type: 'mrkdwn',
+                            text:
+                                score > 0
+                                    ? `<@${body.user.id}> marked this answer helpful :thumbsup:`
+                                    : `<@${body.user.id}> marked this answer unhelpful :thumbsdown:`,
+                        },
+                    ],
+                };
+
+                await respond({
+                    replace_original: true,
+                    blocks: AiAgentService.replaceSlackBlockByBlockId(
+                        body.message?.blocks ?? [],
+                        'prompt_human_score',
+                        newBlock,
+                    ),
+                });
+
+                if (score < 0) {
+                    await client.views.open({
+                        trigger_id: body.trigger_id,
+                        view: {
+                            type: 'modal',
+                            callback_id: 'downvote_feedback_modal',
+                            private_metadata: JSON.stringify({
+                                promptUuid,
+                            }),
+                            title: {
+                                type: 'plain_text',
+                                text: 'Feedback',
+                            },
+                            submit: {
+                                type: 'plain_text',
+                                text: 'Submit',
+                            },
+                            close: {
+                                type: 'plain_text',
+                                text: 'Skip',
+                            },
+                            blocks: [
+                                {
+                                    type: 'section',
+                                    text: {
+                                        type: 'mrkdwn',
+                                        text: 'Help us improve. What went wrong with this answer?',
+                                    },
+                                },
+                                {
+                                    type: 'input',
+                                    block_id: 'feedback_input',
+                                    optional: false,
+                                    element: {
+                                        type: 'plain_text_input',
+                                        action_id: 'feedback_text',
+                                        multiline: true,
+                                        placeholder: {
+                                            type: 'plain_text',
+                                            text: 'Your feedback will help improve the AI agent',
+                                        },
+                                    },
+                                    label: {
+                                        type: 'plain_text',
+                                        text: 'Feedback',
+                                    },
+                                },
+                            ],
+                        },
+                    });
                 }
             },
         );
@@ -7806,6 +8721,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const postedMessage = await say({
             username: agentConfig.name,
             thread_ts: threadTs,
+            text: createdThread
+                ? `Hi <@${userId}>, working on your request now.`
+                : 'Let me check that for you. One moment.',
             blocks: [
                 {
                     type: 'section',
@@ -8449,11 +9367,27 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     // through Slack), so validate its shape before trusting
                     // it. `projectName` round-trips so the confirmation
                     // message can name the project without an extra lookup.
-                    const projectSelectionSchema = z.object({
-                        projectUuid: z.string().uuid(),
-                        channelId: z.string().min(1),
-                        projectName: z.string().min(1),
-                    });
+                    const projectSelectionSchema = z
+                        .object({
+                            projectUuid: z.string().uuid().optional(),
+                            channelId: z.string().min(1).optional(),
+                            projectName: z.string().min(1).optional(),
+                            p: z.string().uuid().optional(),
+                            c: z.string().min(1).optional(),
+                            n: z.string().min(1).optional(),
+                        })
+                        .transform((value) => ({
+                            projectUuid: value.projectUuid ?? value.p,
+                            channelId: value.channelId ?? value.c,
+                            projectName: value.projectName ?? value.n,
+                        }))
+                        .pipe(
+                            z.object({
+                                projectUuid: z.string().uuid(),
+                                channelId: z.string().min(1),
+                                projectName: z.string().min(1),
+                            }),
+                        );
                     const parseResult = projectSelectionSchema.safeParse(
                         JSON.parse(rawValue),
                     );

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -1,3 +1,4 @@
+import { AnyType } from '@lightdash/common';
 import {
     SlackService,
     SlackServiceArguments,
@@ -28,6 +29,16 @@ export class CommercialSlackService extends SlackService {
         slackApp.event('app_mention', (m) =>
             this.aiAgentService.handleAppMention(m),
         );
+        // Bolt's current event typings lag Slack's assistant events, so keep
+        // these registrations typed loosely until the SDK exposes them.
+        (slackApp as AnyType).event('assistant_thread_started', (m: AnyType) =>
+            this.aiAgentService.handleAssistantThreadStarted(m),
+        );
+        (slackApp as AnyType).event(
+            'assistant_thread_context_changed',
+            (m: AnyType) =>
+                this.aiAgentService.handleAssistantThreadContextChanged(m),
+        );
         slackApp.event('message', (m) =>
             this.aiAgentService.handleMultiAgentChannelMessage(m),
         );
@@ -35,6 +46,7 @@ export class CommercialSlackService extends SlackService {
         this.aiAgentService.handleProjectSelection(slackApp);
         this.aiAgentService.handlePromptUpvote(slackApp);
         this.aiAgentService.handlePromptDownvote(slackApp);
+        this.aiAgentService.handlePromptFeedbackButtons(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);
         this.aiAgentService.handleViewArtifact(slackApp);
         this.aiAgentService.handleViewPullRequestButton(slackApp);

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -1,4 +1,9 @@
-import { AgentToolOutput, assertUnreachable, Explore } from '@lightdash/common';
+import {
+    AgentToolOutput,
+    AnyType,
+    assertUnreachable,
+    Explore,
+} from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import {
     generateText,
@@ -62,6 +67,143 @@ const createAiAgentLogger =
     };
 
 const STEP_CAP = 40;
+
+const oneLine = (value: string, maxLength = 180) => {
+    const text = value.replace(/\s+/g, ' ').trim();
+    return text.length > maxLength
+        ? `${text.slice(0, maxLength - 3)}...`
+        : text;
+};
+
+const readString = (input: AnyType, keys: string[]) => {
+    if (!input || typeof input !== 'object') return undefined;
+    for (const key of keys) {
+        const value = input[key];
+        if (typeof value === 'string' && value.trim()) return value;
+        if (Array.isArray(value) && value.length > 0) {
+            return value
+                .filter((item): item is string => typeof item === 'string')
+                .slice(0, 3)
+                .join(', ');
+        }
+    }
+    return undefined;
+};
+
+const summarizeToolCall = (toolName: string, input: AnyType) => {
+    const quoted = (text?: string) => (text ? `“${oneLine(text)}”` : undefined);
+    switch (toolName) {
+        case 'runSql':
+            return 'Checking query';
+        case 'repoShell':
+            return quoted(readString(input, ['command'])) ?? 'Inspecting files';
+        case 'searchSemanticLayer':
+            return (
+                quoted(readString(input, ['searchQuery', 'query'])) ??
+                'Searching semantic layer'
+            );
+        case 'findExplores':
+            return (
+                quoted(readString(input, ['searchQuery'])) ?? 'Finding explores'
+            );
+        case 'findFields':
+            return (
+                quoted(
+                    readString(input, [
+                        'fieldSearchQueries',
+                        'fieldSearchQuery',
+                    ]),
+                ) ?? 'Checking fields'
+            );
+        case 'findContent':
+            return (
+                quoted(readString(input, ['query', 'searchQuery'])) ??
+                'Searching content'
+            );
+        case 'readContent':
+            return (
+                quoted(readString(input, ['contentUuid', 'slug'])) ??
+                'Reading content'
+            );
+        case 'describeWarehouseTable':
+            return (
+                quoted(readString(input, ['table', 'tableName'])) ??
+                'Inspecting table'
+            );
+        case 'loadProjectContext':
+            return 'Reading project context';
+        case 'discoverFields':
+            return 'Finding the fields to answer this';
+        case 'generateVisualization':
+            return 'Building chart';
+        case 'generateDashboard':
+            return 'Building dashboard structure';
+        case 'getProjectInfo':
+            return 'Reading project details';
+        case 'editDbtProject':
+        case 'proposeChange':
+            return 'Preparing change proposal';
+        default:
+            return quoted(
+                readString(input, ['query', 'searchQuery', 'name', 'path']),
+            );
+    }
+};
+
+const summarizeToolResult = (toolName: string, output: AnyType) => {
+    if (!output || typeof output !== 'object') return `Finished ${toolName}`;
+    const metadataStatus =
+        typeof output.metadata === 'object' && output.metadata
+            ? output.metadata.status
+            : undefined;
+    if (typeof metadataStatus === 'string' && metadataStatus !== 'success') {
+        if (toolName === 'runSql') {
+            return 'Skipped restricted SQL; used table metadata instead';
+        }
+        return oneLine(`Skipped: ${metadataStatus}`);
+    }
+    if (toolName === 'getProjectInfo') {
+        return 'Project details loaded';
+    }
+    if (toolName === 'loadProjectContext') {
+        return 'Project context loaded';
+    }
+    if (toolName === 'searchSemanticLayer') {
+        return 'Metric search complete';
+    }
+    if (toolName === 'findFields') {
+        return 'Fields checked';
+    }
+    if (toolName === 'discoverFields') {
+        return 'Fields selected';
+    }
+    if (toolName === 'generateVisualization') {
+        return 'Chart ready';
+    }
+    if (toolName === 'describeWarehouseTable') {
+        return 'Table columns loaded';
+    }
+    if (toolName === 'editDbtProject') {
+        const metadata =
+            typeof output.metadata === 'object' && output.metadata
+                ? output.metadata
+                : {};
+        const action = (metadata as { prAction?: string | null }).prAction;
+        if (action === 'updated') return 'Pull request updated';
+        if (action === 'opened') return 'Pull request opened';
+        return 'Writeback complete';
+    }
+    if (typeof output.rowCount === 'number') {
+        return `Returned ${output.rowCount} rows`;
+    }
+    if (typeof output.result === 'string') {
+        return oneLine(output.result);
+    }
+    if (typeof output.message === 'string') {
+        return oneLine(output.message);
+    }
+    return `Finished ${toolName}`;
+};
 
 const withToolHints = (
     messageHistory: ModelMessage[],
@@ -539,6 +681,23 @@ export const generateAgentResponse = async ({
                                     },
                                 });
 
+                                void dependencies
+                                    .updateProgress(
+                                        summarizeToolCall(
+                                            toolCall.toolName,
+                                            toolCall.input as AnyType,
+                                        ) ?? `Running ${toolCall.toolName}...`,
+                                        toolCall.toolName,
+                                        toolCall.toolCallId,
+                                        'in_progress',
+                                    )
+                                    .catch((error) => {
+                                        Logger.debug(
+                                            '[AiAgent][On Step Finish] Failed to update tool progress:',
+                                            error,
+                                        );
+                                    });
+
                                 await dependencies.storeToolCall({
                                     promptUuid: args.promptUuid,
                                     toolCallId: toolCall.toolCallId,
@@ -578,6 +737,22 @@ export const generateAgentResponse = async ({
                                         toolResult.toolCallId
                                     }) (RESULT: ${JSON.stringify(toolResult.output)})`,
                                 );
+                                void dependencies
+                                    .updateProgress(
+                                        summarizeToolResult(
+                                            toolResult.toolName,
+                                            toolResult.output as AnyType,
+                                        ),
+                                        toolResult.toolName,
+                                        toolResult.toolCallId,
+                                        'complete',
+                                    )
+                                    .catch((error) => {
+                                        Logger.debug(
+                                            '[AiAgent][On Step Finish] Failed to update tool progress:',
+                                            error,
+                                        );
+                                    });
                                 const output = normalizeToolOutput(
                                     toolResult.output,
                                 );
@@ -758,6 +933,23 @@ export const streamAgentResponse = async ({
                         }
 
                         void dependencies
+                            .updateProgress(
+                                summarizeToolCall(
+                                    event.chunk.toolName,
+                                    event.chunk.input as AnyType,
+                                ) ?? `Running ${event.chunk.toolName}...`,
+                                event.chunk.toolName,
+                                event.chunk.toolCallId,
+                                'in_progress',
+                            )
+                            .catch((error) => {
+                                Logger.debug(
+                                    '[AiAgent][Chunk Tool Call] Failed to update tool progress:',
+                                    error,
+                                );
+                            });
+
+                        void dependencies
                             .storeToolCall({
                                 promptUuid: args.promptUuid,
                                 toolCallId: event.chunk.toolCallId,
@@ -800,6 +992,22 @@ export const streamAgentResponse = async ({
                                 event.chunk.toolCallId
                             }) (RESULT: ${JSON.stringify(event.chunk.output)})`,
                         );
+                        void dependencies
+                            .updateProgress(
+                                summarizeToolResult(
+                                    event.chunk.toolName,
+                                    event.chunk.output as AnyType,
+                                ),
+                                event.chunk.toolName,
+                                event.chunk.toolCallId,
+                                'complete',
+                            )
+                            .catch((error) => {
+                                Logger.debug(
+                                    '[AiAgent][Chunk Tool Result] Failed to update tool progress:',
+                                    error,
+                                );
+                            });
                         void dependencies
                             .storeToolResults([
                                 {

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -47,11 +47,10 @@ const toolDefinition = editDbtProjectToolDefinition.for('agent');
 export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
     tool({
         ...toolDefinition,
-        execute: async ({
-            prompt,
-            prUrl: pastedPrUrl,
-            fromActiveChangeset,
-        }) => {
+        execute: async (
+            { prompt, prUrl: pastedPrUrl, fromActiveChangeset },
+            { toolCallId },
+        ) => {
             try {
                 const {
                     prUrl,
@@ -69,6 +68,7 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
                     prompt,
                     prUrl: pastedPrUrl,
                     fromActiveChangeset,
+                    progressId: toolCallId,
                 });
 
                 // Surface which Lightdash project + repo were used so the

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -277,6 +277,8 @@ export type UpdateProgressFn = (
     // ignores it (single pinned message). Omitted by tools that don't need
     // attribution.
     toolName?: string,
+    progressId?: string,
+    progressStatus?: 'in_progress' | 'complete' | 'error',
 ) => Promise<void>;
 
 export type GetPromptFn = () => Promise<SlackPrompt | AiWebAppPrompt>;
@@ -303,7 +305,7 @@ export type RunSavedChartQueryFn = (args: {
 
 export type GetSavedChartFn = (chartUuidOrSlug: string) => Promise<SavedChart>;
 
-export type SendFileFn = (args: PostSlackFile) => Promise<void>;
+export type SendFileFn = (args: PostSlackFile) => Promise<string | undefined>;
 
 export type SendSlackBlocksFn = (args: {
     channelId: string;
@@ -430,6 +432,7 @@ export type EditDbtProjectFn = (args: {
     prompt: string | null;
     prUrl: string | null;
     fromActiveChangeset: boolean;
+    progressId?: string;
 }) => Promise<
     AiWritebackRunResult & {
         previewDeployConfigured: boolean | null;


### PR DESCRIPTION
## Summary
Wires Slack AI-agent conversations to Slack streaming behind the feature flag.

## Changes
- Uses assistant status/loading messages and Slack stream chunks when enabled.
- Streams task progress from tool calls/results and writeback stages.
- Falls back to existing Slack posting behavior when streaming is unavailable or disabled.
- Adds assistant thread event handlers and feedback button action handling.
- Preserves SQL approval behavior.

## Validation
- Backend typecheck passed on the full stack.
- Focused Slack block tests passed on the full stack.
