### PR TITLE
feat(slack): polish AI agent cards and image previews

### DIFF
--- a/packages/backend/src/controllers/slackController.ts
+++ b/packages/backend/src/controllers/slackController.ts
@@ -262,6 +262,59 @@ export class SlackController extends BaseController {
         }
     }
 
+    /**
+     * Get a Slack AI agent card image.
+     * Falls back to a placeholder image if the image is not found.
+     * @summary Get Slack card image
+     */
+    @SuccessResponse('200', 'Success')
+    @Get('/card-image/{id}')
+    @OperationId('getSlackCardImage')
+    async getCardImage(
+        @Path() id: string,
+        @Request() req: express.Request,
+    ): Promise<Readable | void> {
+        const NANOID_REGEX = /^[\w-]{21}$/;
+
+        this.setHeader('Cache-Control', 'no-store');
+        this.setHeader('X-Robots-Tag', 'noindex, nofollow');
+
+        if (!NANOID_REGEX.test(id)) {
+            return SlackController.sendPlaceholder(req.res!);
+        }
+
+        try {
+            const stream = await this.services
+                .getUnfurlService()
+                .getPreviewImageStream(id);
+
+            this.setStatus(200);
+            this.setHeader('Content-Type', 'image/png');
+            this.setHeader(
+                'Content-Disposition',
+                `inline; filename="${id}.png"`,
+            );
+            return stream;
+        } catch (e) {
+            if (e instanceof NotFoundError) {
+                Logger.info(
+                    `Slack card image miss, serving placeholder: ${id}`,
+                );
+            } else {
+                Logger.error(
+                    `Slack card image failed, serving placeholder: ${id} ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+                Sentry.captureException(e, {
+                    tags: { feature: 'slack-card-image' },
+                    extra: { previewId: id },
+                });
+            }
+            return SlackController.sendPlaceholder(req.res!);
+        }
+    }
+
     private static sendPlaceholder(res: express.Response): Promise<void> {
         return new Promise((resolve, reject) => {
             const placeholderPath = path.resolve(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -812,7 +812,7 @@ export class AiAgentService extends BaseService {
             });
 
             return new URL(
-                `/api/v1/slack/preview/${previewId}`,
+                `/api/v1/slack/card-image/${previewId}`,
                 this.lightdashConfig.siteUrl,
             ).href;
         }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1528,21 +1528,23 @@ export class ManagedAgentService extends BaseService {
             // Main message: compact summary with CTA
             const mainBlocks: KnownBlock[] = [
                 {
-                    type: 'section',
-                    text: {
-                        type: 'mrkdwn',
-                        text: `:zap: *Autopilot completed a health check*\n${summaryParts.length > 0 ? summaryParts.join('  ·  ') : '_No actions this run_'}`,
-                    },
-                    accessory: {
-                        type: 'button',
-                        text: {
-                            type: 'plain_text',
-                            text: 'View activity',
-                            emoji: true,
+                    type: 'markdown',
+                    text: `### Autopilot health check\n${summaryParts.length > 0 ? summaryParts.join('  ·  ') : '_No actions this run_'}`,
+                } as unknown as KnownBlock,
+                {
+                    type: 'actions',
+                    elements: [
+                        {
+                            type: 'button',
+                            text: {
+                                type: 'plain_text',
+                                text: 'View activity',
+                                emoji: true,
+                            },
+                            url: activityUrl,
                         },
-                        url: activityUrl,
-                    },
-                },
+                    ],
+                } as KnownBlock,
             ];
 
             const mainMessage = await this.slackClient.postMessage({
@@ -1576,12 +1578,9 @@ export class ManagedAgentService extends BaseService {
                         text: chunk,
                         blocks: [
                             {
-                                type: 'section',
-                                text: {
-                                    type: 'mrkdwn',
-                                    text: chunk,
-                                },
-                            },
+                                type: 'markdown',
+                                text: chunk,
+                            } as unknown as KnownBlock,
                         ],
                     });
                 }

--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -273,6 +273,8 @@ export const getRunQuery = ({
 
                 await createOrUpdateArtifactHook();
 
+                let chartImageUrl: string | undefined;
+
                 // Render chart as image for Slack, or send CSV for tables
                 if (isSlackPrompt(prompt)) {
                     const echartsOptions = await getSlackAiEchartsConfig({
@@ -286,7 +288,7 @@ export const getRunQuery = ({
 
                     if (echartsOptions) {
                         const chartImage = await renderEcharts(echartsOptions);
-                        await sendFile({
+                        chartImageUrl = await sendFile({
                             channelId: prompt.slackChannelId,
                             threadTs: prompt.slackThreadTs,
                             organizationUuid: prompt.organizationUuid,
@@ -317,14 +319,14 @@ export const getRunQuery = ({
                 if (!enableDataAccess) {
                     return {
                         result: `Success.`,
-                        metadata: { status: 'success' },
+                        metadata: { status: 'success', chartImageUrl },
                     };
                 }
 
                 const csv = convertQueryResultsToCsv(queryResults);
                 return {
                     result: serializeData(csv, 'csv'),
-                    metadata: { status: 'success' },
+                    metadata: { status: 'success', chartImageUrl },
                 };
             } catch (e) {
                 return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -57130,6 +57130,60 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsSlackController_getCardImage: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        id: { in: 'path', name: 'id', required: true, dataType: 'string' },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/slack/card-image/:id',
+        ...fetchMiddlewares<RequestHandler>(SlackController),
+        ...fetchMiddlewares<RequestHandler>(
+            SlackController.prototype.getCardImage,
+        ),
+
+        async function SlackController_getCardImage(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsSlackController_getCardImage,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<SlackController>(SlackController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getCardImage',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsSlackController_deleteInstallation: Record<
         string,
         TsoaRoute.ParameterSchema

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -50365,6 +50365,40 @@
                 ]
             }
         },
+        "/api/v1/slack/card-image/{id}": {
+            "get": {
+                "operationId": "getSlackCardImage",
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get a Slack AI agent card image.\nFalls back to a placeholder image if the image is not found.",
+                "summary": "Get Slack card image",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v1/slack/install": {
             "get": {
                 "operationId": "installSlack",

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -44,6 +44,7 @@ import { uniq } from 'lodash';
 import { nanoid as useNanoid } from 'nanoid';
 import fetch from 'node-fetch';
 import playwright, { type ElementHandle, type Page } from 'playwright';
+import { type Readable } from 'stream';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import { SlackClient } from '../../clients/Slack/SlackClient';
@@ -373,6 +374,31 @@ export class UnfurlService extends BaseService {
         }
 
         return this.fileStorageClient.getFileUrl(record.s3_key, 300);
+    }
+
+    // AI agent card images need a stable Lightdash URL; classic Slack unfurls
+    // keep using signed-url redirects.
+    async getPreviewImageStream(previewId: string): Promise<Readable> {
+        const record = await this.slackUnfurlImageModel.get(previewId);
+
+        const exists = await this.fileStorageClient.objectExists(record.s3_key);
+        if (!exists) {
+            this.logger.info(
+                `Slack unfurl preview object missing from storage: ${previewId}`,
+            );
+            await this.slackUnfurlImageModel
+                .delete(previewId)
+                .catch((deleteError) => {
+                    this.logger.warn(
+                        `Failed to delete orphan slack_unfurl_images row ${previewId}: ${getErrorMessage(
+                            deleteError,
+                        )}`,
+                    );
+                });
+            throw new NotFoundError('Slack unfurl image object missing');
+        }
+
+        return this.fileStorageClient.getFileStream(record.s3_key);
     }
 
     async getTitleAndDescription(

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -320,7 +320,9 @@ export type ToolRenderChartArgsTransformed = z.infer<
 
 export const toolRunQueryOutputSchema = z.object({
     result: z.string(),
-    metadata: baseOutputMetadataSchema,
+    metadata: baseOutputMetadataSchema.extend({
+        chartImageUrl: z.string().nullish(),
+    }),
 });
 
 export type ToolRunQueryOutput = z.infer<typeof toolRunQueryOutputSchema>;


### PR DESCRIPTION
## Summary
Polishes the Slack AI-agent output cards and chart image delivery.

## Changes
- Captures chart image URLs from `runQuery`/visualization results.
- Serves Slack preview images directly from Lightdash so Slack can render them reliably with S3 enabled.
- Adds chart card actions for opening the image and exploring in Lightdash.
- Modernizes managed-agent digest Slack blocks without streaming scheduled digests.

## Validation
- Backend typecheck passed on the full stack.
- Focused Slack block tests passed on the full stack.
