### PR TITLE
perf(backend): preload warehouse config + parallelize explore/creds in metric query

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4130,8 +4130,18 @@ export class AsyncQueryService extends ProjectService {
 
         const metricQueryStart = Date.now();
 
-        const { explore, userAccessControls: preloadedUserAccessControls } =
-            await this.getExploreForMetricQueryExecution({
+        // Load project warehouse config once, shared by warehouse credentials and timezone resolution
+        const { organizationWarehouseCredentialsUuid, queryTimezone } =
+            await this.projectModel.getProjectWarehouseConfig(projectUuid);
+        const projectTimezone =
+            queryTimezone ?? this.lightdashConfig.query.timezone ?? 'UTC';
+
+        // Explore load and warehouse credentials are independent, run them in parallel
+        const [
+            { explore, userAccessControls: preloadedUserAccessControls },
+            warehouseCredentials,
+        ] = await Promise.all([
+            this.getExploreForMetricQueryExecution({
                 account,
                 projectUuid,
                 exploreName: inputMetricQuery.exploreName,
@@ -4141,8 +4151,17 @@ export class AsyncQueryService extends ProjectService {
                     QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
                         ? materializationRole
                         : undefined,
-            });
-        const getExploreMs = Date.now() - metricQueryStart;
+            }),
+            this.getWarehouseCredentials({
+                projectUuid,
+                userId: account.user.id,
+                isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
+                preloadedOrgWarehouseCredentialsUuid:
+                    organizationWarehouseCredentialsUuid,
+            }),
+        ]);
+        const prepLoadMs = Date.now() - metricQueryStart;
 
         // Dashboard filters (e.g. from a data-app tile) are merged once the
         // explore is known so we can drop filters that target fields outside
@@ -4169,15 +4188,6 @@ export class AsyncQueryService extends ProjectService {
                 explore,
             );
         }
-
-        const whCredStart = Date.now();
-        const warehouseCredentials = await this.getWarehouseCredentials({
-            projectUuid,
-            userId: account.user.id,
-            isRegisteredUser: account.isRegisteredUser(),
-            isServiceAccount: account.isServiceAccount(),
-        });
-        const getWarehouseCredentialsMs = Date.now() - whCredStart;
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(
             warehouseCredentials.type,
@@ -4218,6 +4228,7 @@ export class AsyncQueryService extends ProjectService {
             materializationRole,
             columnTimezone: getColumnTimezone(warehouseCredentials),
             preloadedUserAccessControls,
+            preloadedProjectTimezone: projectTimezone,
         });
         const prepareMs = Date.now() - prepareStart;
 
@@ -4236,7 +4247,7 @@ export class AsyncQueryService extends ProjectService {
         });
 
         this.logger.info(
-            `Metric query prep for ${metricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
+            `Metric query prep for ${metricQuery.exploreName}: explore_and_wh_credentials=${prepLoadMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
         );
 
         if (routingDecision.preAggregateMetadata) {


### PR DESCRIPTION
Closes: SPK-524

### Description:
The metric-query execution path (`runAsyncMetricQueryWithoutPermissionCheck`) loaded the explore sequentially before warehouse credentials, and the credentials call re-fetched the project warehouse config internally. This now preloads `getProjectWarehouseConfig` once and runs the explore load and warehouse credentials load in parallel via `Promise.all`, threading the preloaded org-credentials UUID and project timezone to cut redundant Postgres round-trips. This mirrors the optimized dashboard-chart template; behaviour is unchanged. Verified with `pnpm -F backend typecheck:fast` and `pnpm -F backend test:dev:nowatch` (166 tests passing).