### PR TITLE
perf(embed): preload project/org context for dashboard-tile query

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1195,9 +1195,6 @@ export class EmbedService extends BaseService {
         | 'parameters'
         | 'limit'
     >): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
-        const { dashboardUuids, allowAllDashboards, user } =
-            await this.embedModel.get(projectUuid);
-
         const { dashboardUuid } = account.access.content;
 
         if (!dashboardUuid) {
@@ -1206,10 +1203,13 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const dashboard = await this.dashboardModel.getByIdOrSlug(
-            dashboardUuid,
-            { projectUuid },
-        );
+        const [{ dashboardUuids, allowAllDashboards, user }, dashboard] =
+            await Promise.all([
+                this.embedModel.get(projectUuid),
+                this.dashboardModel.getByIdOrSlug(dashboardUuid, {
+                    projectUuid,
+                }),
+            ]);
 
         const chart = await this._getChartFromDashboardTiles(
             dashboard,
@@ -1217,22 +1217,30 @@ export class EmbedService extends BaseService {
         );
 
         const { organizationUuid } = chart;
-        await this.isFeatureEnabled({
-            userUuid: user?.userUuid ?? account.user.id,
-            organizationUuid,
-        });
+        const userUuid = user?.userUuid ?? account.user.id;
 
-        await this._permissionsGetChartAndResults(
-            { allowAllDashboards, dashboardUuids },
-            projectUuid,
-            chart.uuid,
-            dashboardUuid,
-        );
+        // Resolve feature/permission/explore/org-context in parallel — these
+        // are independent once the chart is known.
+        const [, , explore, isTimezoneSupportEnabled, projectParameters] =
+            await Promise.all([
+                this.isFeatureEnabled({ userUuid, organizationUuid }),
+                this._permissionsGetChartAndResults(
+                    { allowAllDashboards, dashboardUuids },
+                    projectUuid,
+                    chart.uuid,
+                    dashboardUuid,
+                ),
+                this.projectModel.getExploreFromCache(
+                    projectUuid,
+                    chart.tableName,
+                ),
+                this.projectService.isTimezoneSupportEnabled({
+                    userUuid,
+                    organizationUuid,
+                }),
+                this.projectService.projectParametersModel.find(projectUuid),
+            ]);
 
-        const explore = await this.projectModel.getExploreFromCache(
-            projectUuid,
-            chart.tableName,
-        );
         if (isExploreError(explore)) {
             throw new ForbiddenError(
                 `Explore ${chart.tableName} on project ${projectUuid} has errors : ${explore.errors}`,
@@ -1268,22 +1276,18 @@ export class EmbedService extends BaseService {
             explore,
             acceptedUserParameters,
             dashboardParameters,
+            projectParameters,
         );
 
+        // Execute using AsyncQueryService method with embed context.
         // The session timezone only takes effect when timezone support is
         // enabled for the org; otherwise it is dropped so the param is inert.
-        const isTimezoneSupportEnabled =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: user?.userUuid ?? account.user.id,
-                organizationUuid,
-            });
-
-        // Execute using AsyncQueryService method with embed context
         return this.asyncQueryService.executeAsyncDashboardChartQuery({
             account,
             projectUuid,
             chartUuid: chart.uuid,
             preloadedSavedChart: chart,
+            preloadedProjectParameters: projectParameters,
             tileUuid,
             dashboardSorts: dashboardSorts ?? [],
             dashboardUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4961,6 +4961,7 @@ export class AsyncQueryService extends ProjectService {
         pivotResults,
         sessionTimezone,
         preloadedSavedChart,
+        preloadedProjectParameters,
     }: ExecuteAsyncDashboardChartQueryArgs): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -5121,7 +5122,8 @@ export class AsyncQueryService extends ProjectService {
                 resolvedDashboardUuid,
                 projectUuid,
             ),
-            this.projectParametersModel.find(projectUuid),
+            preloadedProjectParameters ??
+                this.projectParametersModel.find(projectUuid),
         ]);
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -21,6 +21,7 @@ import {
     type UserAccessControls,
     type UserAttributeValueMap,
 } from '@lightdash/common';
+import type { DbProjectParameter } from '../../database/entities/projectParameters';
 
 export type CommonAsyncQueryArgs = {
     account: Account;
@@ -98,6 +99,7 @@ export type ExecuteAsyncDashboardChartQueryArgs = CommonAsyncQueryArgs & {
     pivotResults?: boolean;
     sessionTimezone?: string | null;
     preloadedSavedChart?: SavedChartDAO;
+    preloadedProjectParameters?: DbProjectParameter[];
 };
 
 export type ExecuteAsyncUnderlyingDataQueryArgs = CommonAsyncQueryArgs & {


### PR DESCRIPTION
Closes: SPK-514

### Description:

Reduces redundant project/org context loads on `POST /embed/:projectUuid/query/dashboard-tile`. `EmbedService.executeAsyncDashboardTileQuery` previously ran its context loads sequentially; this batches the independent ones into two `Promise.all` groups (embed config + dashboard, then feature/permission checks + explore + timezone-support + project parameters once the chart is known) and threads the single project-parameters fetch through to `AsyncQueryService` via a new optional `preloadedProjectParameters` arg so it is no longer re-fetched across the service boundary. Behaviour is unchanged — the explore re-resolution in `AsyncQueryService` is left intact since it returns the user-attribute-filtered explore, which differs from the unfiltered one the embed wrapper uses.