### PR TITLE
feat(ai): admin-only access control for AI agents

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgent.ts
+++ b/packages/backend/src/ee/database/entities/aiAgent.ts
@@ -15,6 +15,7 @@ export type DbAiAgent = {
     enable_data_access: boolean;
     enable_self_improvement: boolean;
     enable_content_tools: boolean;
+    admin_only: boolean;
     /**
      * @deprecated Per-agent reasoning toggle was removed. The gating feature flag
      * `agent-reasoning` was never enabled so this column was effectively

--- a/packages/backend/src/ee/database/migrations/20260616134916_add_admin_only_state_to_ai_agents.ts
+++ b/packages/backend/src/ee/database/migrations/20260616134916_add_admin_only_state_to_ai_agents.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const AiAgentTableName = 'ai_agent';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.boolean('admin_only').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(AiAgentTableName, (table) => {
+        table.dropColumn('admin_only');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -409,6 +409,7 @@ export class AiAgentModel {
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
+                adminOnly: `${AiAgentTableName}.admin_only`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -544,6 +545,7 @@ export class AiAgentModel {
                 enableDataAccess: `${AiAgentTableName}.enable_data_access`,
                 enableSelfImprovement: `${AiAgentTableName}.enable_self_improvement`,
                 enableContentTools: `${AiAgentTableName}.enable_content_tools`,
+                adminOnly: `${AiAgentTableName}.admin_only`,
                 version: `${AiAgentTableName}.version`,
                 groupAccess: this.database.raw(`
                     COALESCE(
@@ -1702,6 +1704,7 @@ export class AiAgentModel {
             | 'enableDataAccess'
             | 'enableSelfImprovement'
             | 'enableContentTools'
+            | 'adminOnly'
             | 'version'
             | 'mcpServerUuids'
         > & {
@@ -1729,6 +1732,7 @@ export class AiAgentModel {
                     enable_data_access: args.enableDataAccess,
                     enable_self_improvement: args.enableSelfImprovement,
                     enable_content_tools: args.enableContentTools ?? false,
+                    admin_only: args.adminOnly ?? false,
                     version: args.version,
                     is_system: args.isSystem ?? false,
                 })
@@ -1830,6 +1834,7 @@ export class AiAgentModel {
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
+                adminOnly: agent.admin_only,
                 version: agent.version,
             };
         });
@@ -1941,6 +1946,9 @@ export class AiAgentModel {
                         : {}),
                     ...(args.enableContentTools !== undefined
                         ? { enable_content_tools: args.enableContentTools }
+                        : {}),
+                    ...(args.adminOnly !== undefined
+                        ? { admin_only: args.adminOnly }
                         : {}),
                     ...(args.version !== undefined
                         ? { version: args.version }
@@ -2109,6 +2117,7 @@ export class AiAgentModel {
                 enableDataAccess: agent.enable_data_access,
                 enableSelfImprovement: agent.enable_self_improvement,
                 enableContentTools: agent.enable_content_tools,
+                adminOnly: agent.admin_only,
                 version: agent.version,
             };
         });

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -921,6 +921,13 @@ export class AiAgentService extends BaseService {
             return true;
         }
 
+        // Admin-only agents are visible to admins/developers only (granted by
+        // the manage check above); everyone else is denied regardless of the
+        // user/group access lists below.
+        if (agent.adminOnly) {
+            return false;
+        }
+
         // Check if open access (no restrictions)
         const hasGroupAccess =
             agent.groupAccess && agent.groupAccess.length > 0;
@@ -2485,14 +2492,17 @@ export class AiAgentService extends BaseService {
             tags: body.tags,
             integrations: body.integrations,
             instruction: body.instruction,
-            groupAccess: body.groupAccess,
-            userAccess: body.userAccess,
+            // Admin-only agents ignore the user/group lists; clear them so the
+            // contradictory "admin-only + specific users" state never persists.
+            groupAccess: body.adminOnly ? [] : body.groupAccess,
+            userAccess: body.adminOnly ? [] : body.userAccess,
             spaceAccess: body.spaceAccess,
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
             enableSelfImprovement: body.enableSelfImprovement,
             enableContentTools:
                 body.enableDataAccess && (body.enableContentTools ?? false),
+            adminOnly: body.adminOnly ?? false,
             version: body.version,
         });
 
@@ -3389,8 +3399,10 @@ export class AiAgentService extends BaseService {
             instruction: body.instruction,
             imageUrl: body.imageUrl,
             imageUrlSource: nextImageUrlSource,
-            groupAccess: body.groupAccess,
-            userAccess: body.userAccess,
+            // Admin-only agents ignore the user/group lists; clear them so the
+            // contradictory "admin-only + specific users" state never persists.
+            groupAccess: body.adminOnly ? [] : body.groupAccess,
+            userAccess: body.adminOnly ? [] : body.userAccess,
             spaceAccess: body.spaceAccess,
             mcpServerUuids: body.mcpServerUuids,
             enableDataAccess: body.enableDataAccess,
@@ -3398,6 +3410,7 @@ export class AiAgentService extends BaseService {
             enableContentTools: nextEnableDataAccess
                 ? body.enableContentTools
                 : false,
+            adminOnly: body.adminOnly,
             version: body.version,
         });
 
@@ -7744,7 +7757,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         let filteredAgents: AiAgentSummary[];
 
         if (!slackSettings?.aiRequireOAuth) {
-            filteredAgents = allAgents;
+            // Without OAuth there is no per-user enforcement, so exclude
+            // admin-only agents to avoid leaking them to non-admin users.
+            // (With OAuth, checkAgentAccess below handles admin-only correctly.)
+            filteredAgents = allAgents.filter((agent) => !agent.adminOnly);
         } else {
             filteredAgents = await Promise.all(
                 allAgents.map(async (agent) => {

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -62,6 +62,7 @@ const createCandidate = (
     enableDataAccess: true,
     enableSelfImprovement: true,
     enableContentTools: true,
+    adminOnly: false,
     version: 1,
     context: overrides.context ?? {
         uuid: overrides.uuid,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -92,6 +92,7 @@ const selectedAgent: AiAgentWithContext = {
     enableDataAccess: true,
     enableSelfImprovement: true,
     enableContentTools: true,
+    adminOnly: false,
     version: 1,
     context: {
         uuid: 'agent-uuid',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10689,7 +10689,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_':
+    'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -10784,6 +10784,7 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     enableContentTools: { dataType: 'boolean', required: true },
+                    adminOnly: { dataType: 'boolean', required: true },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -10793,7 +10794,7 @@ const models: TsoaRoute.Models = {
     AiAgentSummary: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_',
+            ref: 'Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_',
             validators: {},
         },
     },
@@ -11314,7 +11315,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_':
+    'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_':
         {
             dataType: 'refAlias',
             type: {
@@ -11409,6 +11410,7 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     enableContentTools: { dataType: 'boolean', required: true },
+                    adminOnly: { dataType: 'boolean', required: true },
                     version: { dataType: 'double', required: true },
                 },
                 validators: {},
@@ -11418,7 +11420,7 @@ const models: TsoaRoute.Models = {
     AiAgent: {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_',
+            ref: 'Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_',
             validators: {},
         },
     },
@@ -12006,6 +12008,7 @@ const models: TsoaRoute.Models = {
                             dataType: 'array',
                             array: { dataType: 'string' },
                         },
+                        adminOnly: { dataType: 'boolean' },
                         enableContentTools: { dataType: 'boolean' },
                     },
                 },
@@ -12014,7 +12017,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__':
+    'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version__':
         {
             dataType: 'refAlias',
             type: {
@@ -12143,6 +12146,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    adminOnly: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     version: {
                         dataType: 'union',
                         subSchemas: [
@@ -12161,7 +12171,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__',
+                    ref: 'Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version__',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -12711,11 +12721,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14024,11 +14034,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14089,11 +14099,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14270,11 +14280,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14289,11 +14299,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14308,11 +14318,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12319,7 +12319,7 @@
                 "required": ["content", "mimeType", "originalFilename", "name"],
                 "type": "object"
             },
-            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_": {
+            "Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -12409,6 +12409,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "adminOnly": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -12433,13 +12436,14 @@
                     "enableDataAccess",
                     "enableSelfImprovement",
                     "enableContentTools",
+                    "adminOnly",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgentSummary": {
-                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_"
+                "$ref": "#/components/schemas/Pick_AiAgent.uuid-or-name-or-description-or-integrations-or-tags-or-projectUuid-or-organizationUuid-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_"
             },
             "ApiAiAgentSummaryResponse": {
                 "properties": {
@@ -12928,7 +12932,7 @@
             "ApiAiAgentProjectThreadSummaryListResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_KnexPaginatedData_AiAgentProjectThreadSummary-Array__"
             },
-            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_": {
+            "Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -13018,6 +13022,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "adminOnly": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -13042,13 +13049,14 @@
                     "enableDataAccess",
                     "enableSelfImprovement",
                     "enableContentTools",
+                    "adminOnly",
                     "version"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "AiAgent": {
-                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version_"
+                "$ref": "#/components/schemas/Pick_BaseAiAgent.uuid-or-projectUuid-or-organizationUuid-or-integrations-or-tags-or-name-or-description-or-createdAt-or-updatedAt-or-instruction-or-imageUrl-or-imageUrlSource-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version_"
             },
             "ApiAiAgentResponse": {
                 "properties": {
@@ -13641,6 +13649,9 @@
                                 },
                                 "type": "array"
                             },
+                            "adminOnly": {
+                                "type": "boolean"
+                            },
                             "enableContentTools": {
                                 "type": "boolean"
                             }
@@ -13649,7 +13660,7 @@
                     }
                 ]
             },
-            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__": {
+            "Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version__": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -13720,6 +13731,9 @@
                     "enableContentTools": {
                         "type": "boolean"
                     },
+                    "adminOnly": {
+                        "type": "boolean"
+                    },
                     "version": {
                         "type": "number",
                         "format": "double"
@@ -13731,7 +13745,7 @@
             "ApiUpdateAiAgent": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-version__"
+                        "$ref": "#/components/schemas/Partial_Pick_AiAgent.projectUuid-or-integrations-or-tags-or-name-or-description-or-instruction-or-imageUrl-or-groupAccess-or-userAccess-or-spaceAccess-or-enableDataAccess-or-enableSelfImprovement-or-enableContentTools-or-adminOnly-or-version__"
                     },
                     {
                         "properties": {
@@ -14284,6 +14298,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -39589,7 +39616,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3170.1",
+        "version": "0.3173.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -143,6 +143,7 @@ export const baseAgentSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    adminOnly: z.boolean(),
     version: z.number(),
 });
 
@@ -168,6 +169,7 @@ export type AiAgent = Pick<
     | 'enableDataAccess'
     | 'enableSelfImprovement'
     | 'enableContentTools'
+    | 'adminOnly'
     | 'version'
 >;
 
@@ -191,6 +193,7 @@ export type AiAgentSummary = Pick<
     | 'enableDataAccess'
     | 'enableSelfImprovement'
     | 'enableContentTools'
+    | 'adminOnly'
     | 'version'
 >;
 
@@ -327,6 +330,7 @@ export type ApiCreateAiAgent = Pick<
     | 'version'
 > & {
     enableContentTools?: boolean;
+    adminOnly?: boolean;
     mcpServerUuids?: string[];
 };
 
@@ -346,6 +350,7 @@ export type ApiUpdateAiAgent = Partial<
         | 'enableDataAccess'
         | 'enableSelfImprovement'
         | 'enableContentTools'
+        | 'adminOnly'
         | 'version'
     >
 > & {

--- a/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AgentSelector/AgentSelectorUtils.tsx
@@ -1,10 +1,10 @@
 import { type AiAgent } from '@lightdash/common';
-import { Group, Text, type ComboboxItem } from '@mantine-8/core';
+import { Badge, Group, Text, type ComboboxItem } from '@mantine-8/core';
 import { IconCheck } from '@tabler/icons-react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 
-export type Agent = Pick<AiAgent, 'name' | 'uuid' | 'imageUrl'>;
+export type Agent = Pick<AiAgent, 'name' | 'uuid' | 'imageUrl' | 'adminOnly'>;
 
 /**
  * Marks an explicit "Auto" selection on the `/ai-agents` index URL so it shows
@@ -16,6 +16,7 @@ export const AI_ROUTING_AUTO_VALUE = 'auto';
 
 export interface AgentSelectOption extends ComboboxItem {
     imageUrl?: AiAgent['imageUrl'];
+    adminOnly?: boolean;
 }
 
 export const renderSelectOption = ({
@@ -35,16 +36,23 @@ export const renderSelectOption = ({
             {option.label}
         </Text>
 
+        {option.adminOnly && (
+            <Badge size="xs" color="gray" variant="light" radius="sm">
+                Admins only
+            </Badge>
+        )}
+
         {checked && <MantineIcon icon={IconCheck} size="sm" color="violet" />}
     </Group>
 );
 
 export const getAgentOptions = (agents: Agent[]) =>
     agents.map(
-        ({ name, uuid, imageUrl }) =>
+        ({ name, uuid, imageUrl, adminOnly }) =>
             ({
                 label: name,
                 value: uuid,
                 imageUrl: imageUrl,
+                adminOnly: adminOnly,
             }) satisfies AgentSelectOption,
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -13,6 +13,7 @@ import {
     LoadingOverlay,
     MultiSelect,
     Paper,
+    Radio,
     Stack,
     Switch,
     TagsInput,
@@ -35,6 +36,7 @@ import {
     IconSparkles,
     IconTrash,
     IconUpload,
+    IconUsers,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState } from 'react';
 import { z } from 'zod';
@@ -74,6 +76,7 @@ const formSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    adminOnly: z.boolean(),
     version: z.number(),
 });
 
@@ -200,6 +203,38 @@ export const AiAgentFormSetup = ({
                 label: group.name,
             })) ?? [],
         [groups],
+    );
+
+    // UI-only: keeps "Specific users & groups" selected after the user picks it
+    // but before they add anyone (otherwise empty lists would read as "Everyone").
+    const [showSpecificAccess, setShowSpecificAccess] = useState(false);
+
+    const accessMode: 'everyone' | 'admins' | 'specific' = form.values.adminOnly
+        ? 'admins'
+        : showSpecificAccess ||
+            form.values.userAccess.length > 0 ||
+            form.values.groupAccess.length > 0
+          ? 'specific'
+          : 'everyone';
+
+    const handleAccessModeChange = useCallback(
+        (mode: string) => {
+            if (mode === 'admins') {
+                setShowSpecificAccess(false);
+                form.setFieldValue('adminOnly', true);
+                form.setFieldValue('userAccess', []);
+                form.setFieldValue('groupAccess', []);
+            } else if (mode === 'specific') {
+                setShowSpecificAccess(true);
+                form.setFieldValue('adminOnly', false);
+            } else {
+                setShowSpecificAccess(false);
+                form.setFieldValue('adminOnly', false);
+                form.setFieldValue('userAccess', []);
+                form.setFieldValue('groupAccess', []);
+            }
+        },
+        [form],
     );
 
     return (
@@ -352,6 +387,120 @@ export const AiAgentFormSetup = ({
                                     )}
                                 </Group>
                             </Box>
+                        </Stack>
+                    </Paper>
+
+                    <Paper p="xl">
+                        <Group align="center" gap="xs" mb="md">
+                            <Paper p="xxs" withBorder radius="sm">
+                                <MantineIcon icon={IconUsers} size="md" />
+                            </Paper>
+                            <Title order={5} c="ldGray.9" fw={700}>
+                                Access control
+                            </Title>
+                        </Group>
+                        <Stack>
+                            <Radio.Group
+                                value={accessMode}
+                                onChange={handleAccessModeChange}
+                            >
+                                <Stack gap="sm">
+                                    <Radio
+                                        value="everyone"
+                                        label="Everyone in the project"
+                                        description="All project members can see and use this agent."
+                                    />
+                                    <Radio
+                                        value="admins"
+                                        label="Admins & developers only"
+                                        description="Hidden from everyone else — useful while setting up or testing the agent."
+                                    />
+                                    <Radio
+                                        value="specific"
+                                        label={`Specific users ${isGroupsEnabled ? ' & groups' : ''}`}
+                                        description={`Only the users${isGroupsEnabled ? ' and groups ' : ' '}you choose. Admins and developers always have access.`}
+                                    />
+                                </Stack>
+                            </Radio.Group>
+
+                            {accessMode === 'specific' && (
+                                <Stack pl="xl">
+                                    <UserAccessMultiSelect
+                                        projectUuid={projectUuid!}
+                                        isGroupsEnabled={isGroupsEnabled}
+                                        value={form.values.userAccess}
+                                        onChange={(value) => {
+                                            form.setFieldValue(
+                                                'userAccess',
+                                                value,
+                                            );
+                                        }}
+                                    />
+
+                                    {isGroupsEnabled && (
+                                        <MultiSelect
+                                            variant="subtle"
+                                            label={
+                                                <Group gap="xs">
+                                                    <Text fz="sm" fw={500}>
+                                                        Group Access
+                                                    </Text>
+                                                    <Tooltip
+                                                        label="Admins and developers will always have access to this agent."
+                                                        withArrow
+                                                        withinPortal
+                                                        multiline
+                                                        position="right"
+                                                        maw="250px"
+                                                    >
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconInfoCircle
+                                                            }
+                                                        />
+                                                    </Tooltip>
+                                                </Group>
+                                            }
+                                            description="Select groups that can access this agent."
+                                            placeholder={
+                                                isLoadingGroups
+                                                    ? 'Loading groups...'
+                                                    : groupOptions.length === 0
+                                                      ? 'No groups available'
+                                                      : 'Select groups or leave empty for all users'
+                                            }
+                                            data={groupOptions}
+                                            disabled={
+                                                isLoadingGroups ||
+                                                groupOptions.length === 0
+                                            }
+                                            comboboxProps={{
+                                                transitionProps: {
+                                                    transition: 'pop',
+                                                    duration: 200,
+                                                },
+                                            }}
+                                            clearable
+                                            {...form.getInputProps(
+                                                'groupAccess',
+                                            )}
+                                            value={
+                                                form.getInputProps(
+                                                    'groupAccess',
+                                                ).value ?? []
+                                            }
+                                            onChange={(value) => {
+                                                form.setFieldValue(
+                                                    'groupAccess',
+                                                    value.length > 0
+                                                        ? value
+                                                        : [],
+                                                );
+                                            }}
+                                        />
+                                    )}
+                                </Stack>
+                            )}
                         </Stack>
                     </Paper>
 
@@ -556,77 +705,10 @@ export const AiAgentFormSetup = ({
                                 <MantineIcon icon={IconLock} size="md" />
                             </Paper>
                             <Title order={5} c="ldGray.9" fw={700}>
-                                Access control
+                                Data access
                             </Title>
                         </Group>
                         <Stack>
-                            <UserAccessMultiSelect
-                                projectUuid={projectUuid!}
-                                isGroupsEnabled={isGroupsEnabled}
-                                value={form.values.userAccess}
-                                onChange={(value) => {
-                                    form.setFieldValue('userAccess', value);
-                                }}
-                            />
-
-                            {isGroupsEnabled && (
-                                <Stack gap="xs">
-                                    <MultiSelect
-                                        variant="subtle"
-                                        label={
-                                            <Group gap="xs">
-                                                <Text fz="sm" fw={500}>
-                                                    Group Access
-                                                </Text>
-                                                <Tooltip
-                                                    label="Admins and developers will always have access to this agent."
-                                                    withArrow
-                                                    withinPortal
-                                                    multiline
-                                                    position="right"
-                                                    maw="250px"
-                                                >
-                                                    <MantineIcon
-                                                        icon={IconInfoCircle}
-                                                    />
-                                                </Tooltip>
-                                            </Group>
-                                        }
-                                        description="Select groups that can access this agent."
-                                        placeholder={
-                                            isLoadingGroups
-                                                ? 'Loading groups...'
-                                                : groupOptions.length === 0
-                                                  ? 'No groups available'
-                                                  : 'Select groups or leave empty for all users'
-                                        }
-                                        data={groupOptions}
-                                        disabled={
-                                            isLoadingGroups ||
-                                            groupOptions.length === 0
-                                        }
-                                        comboboxProps={{
-                                            transitionProps: {
-                                                transition: 'pop',
-                                                duration: 200,
-                                            },
-                                        }}
-                                        clearable
-                                        {...form.getInputProps('groupAccess')}
-                                        value={
-                                            form.getInputProps('groupAccess')
-                                                .value ?? []
-                                        }
-                                        onChange={(value) => {
-                                            form.setFieldValue(
-                                                'groupAccess',
-                                                value.length > 0 ? value : [],
-                                            );
-                                        }}
-                                    />
-                                </Stack>
-                            )}
-
                             <SpaceAccessSelect
                                 projectUuid={projectUuid}
                                 value={form.values.spaceAccess}

--- a/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/ProjectAiAgentEditPage.tsx
@@ -96,6 +96,7 @@ const formSchema = z.object({
     enableDataAccess: z.boolean(),
     enableSelfImprovement: z.boolean(),
     enableContentTools: z.boolean(),
+    adminOnly: z.boolean(),
     version: z.number(),
 });
 
@@ -149,6 +150,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
             enableDataAccess: true,
             enableSelfImprovement: false,
             enableContentTools: true,
+            adminOnly: false,
             version: 2, // INFO: Default to v2 for now
         },
         validate: zodResolver(formSchema),
@@ -180,6 +182,7 @@ const ProjectAiAgentEditPage: FC<Props> = ({ isCreateMode = false }) => {
                 enableContentTools:
                     (agent.enableDataAccess ?? false) &&
                     (agent.enableContentTools ?? false),
+                adminOnly: agent.adminOnly ?? false,
                 version: agent.version ?? 2, // INFO: Default to v2 for now
             };
             form.setValues(values);


### PR DESCRIPTION
Adds an admin-only access mode for AI agents, so an agent can be kept visible to admins & developers only while it's being set up — before opening it to the wider team.

Access control becomes an explicit choice: Everyone / Admins & developers only / Specific users & groups.

Closes: PROD-8221
Closes: #24102