### PR TITLE
feat(slack): stream agent cards without assistant scopes

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -183,10 +183,6 @@ export type PostSlackFile = {
     fileType?: string;
 };
 
-export type SlackScopeOptions = {
-    includeAiAgentSlackModernScopes?: boolean;
-};
-
 export type SlackClientArguments = {
     slackAuthenticationModel: SlackAuthenticationModel;
     slackChannelCacheModel: SlackChannelCacheModel;
@@ -250,7 +246,7 @@ export class SlackClient {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    public getRequiredScopes(_options: SlackScopeOptions = {}) {
+    public getRequiredScopes() {
         return [
             'links:read',
             'links:write',
@@ -271,7 +267,7 @@ export class SlackClient {
         ];
     }
 
-    public getSlackOptions(options: SlackScopeOptions = {}) {
+    public getSlackOptions() {
         return {
             signingSecret: this.lightdashConfig.slack?.signingSecret || '',
             clientId: this.lightdashConfig.slack?.clientId || '',
@@ -285,15 +281,12 @@ export class SlackClient {
                 redirectUriPath: '/api/v1/slack/oauth_redirect',
                 userScopes: [],
             },
-            scopes: this.getRequiredScopes(options),
+            scopes: this.getRequiredScopes(),
         };
     }
 
-    public hasRequiredScopes(
-        installationScopes: string[],
-        options: SlackScopeOptions = {},
-    ) {
-        const requiredScopes = this.getRequiredScopes(options);
+    public hasRequiredScopes(installationScopes: string[]) {
+        const requiredScopes = this.getRequiredScopes();
         return without(requiredScopes, ...installationScopes).length === 0;
     }
 

--- a/packages/backend/src/ee/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/ee/clients/Slack/SlackClient.ts
@@ -19,48 +19,23 @@ export class CommercialSlackClient extends SlackClient {
         this.slackAuthenticationModel = args.slackAuthenticationModel;
     }
 
-    public getRequiredScopes({
-        includeAiAgentSlackModernScopes = false,
-    }: {
-        includeAiAgentSlackModernScopes?: boolean;
-    } = {}) {
-        const scopes = [
+    public getRequiredScopes() {
+        return [
             ...super.getRequiredScopes(),
             'channels:history',
             'groups:history',
         ];
-
-        if (includeAiAgentSlackModernScopes) {
-            scopes.push('assistant:write', 'im:history');
-        }
-
-        return scopes;
     }
 
-    public getSlackOptions({
-        includeAiAgentSlackModernScopes = false,
-    }: {
-        includeAiAgentSlackModernScopes?: boolean;
-    } = {}) {
+    public getSlackOptions() {
         return {
             ...super.getSlackOptions(),
-            scopes: this.getRequiredScopes({
-                includeAiAgentSlackModernScopes,
-            }),
+            scopes: this.getRequiredScopes(),
         };
     }
 
-    public hasRequiredScopes(
-        installationScopes: string[],
-        {
-            includeAiAgentSlackModernScopes = false,
-        }: {
-            includeAiAgentSlackModernScopes?: boolean;
-        } = {},
-    ) {
-        const requiredScopes = this.getRequiredScopes({
-            includeAiAgentSlackModernScopes,
-        });
+    public hasRequiredScopes(installationScopes: string[]) {
+        const requiredScopes = this.getRequiredScopes();
         return requiredScopes.every((scope) =>
             installationScopes.includes(scope),
         );

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6740,18 +6740,25 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         let streamTs: string | undefined;
 
         try {
-            await this.slackClient.setAssistantStatus({
-                organizationUuid: slackPrompt.organizationUuid,
-                channelId: slackPrompt.slackChannelId,
-                threadTs,
-                status: 'thinking...',
-                loadingMessages: [
-                    'Checking the project context...',
-                    'Finding the relevant metrics...',
-                    'Reviewing available content...',
-                    'Preparing the answer...',
-                ],
-            });
+            void this.slackClient
+                .setAssistantStatus({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    status: 'thinking...',
+                    loadingMessages: [
+                        'Checking the project context...',
+                        'Finding the relevant metrics...',
+                        'Reviewing available content...',
+                        'Preparing the answer...',
+                    ],
+                })
+                .catch((error) => {
+                    Logger.debug(
+                        'Failed to set Slack assistant status:',
+                        error,
+                    );
+                });
             void this.slackClient
                 .setAssistantTitle({
                     organizationUuid: slackPrompt.organizationUuid,

--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -42,9 +42,6 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
     }
 
     async getSlackInstallOptions(user: SessionUser) {
-        const includeAiAgentSlackModernScopes =
-            await this.isModernSlackAiAgentEnabled(user);
-
         const { slackOptions, metadata } = await super.getSlackInstallOptions(
             user,
         );
@@ -52,9 +49,7 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
         return {
             slackOptions: {
                 ...slackOptions,
-                scopes: this.slackClient.getRequiredScopes({
-                    includeAiAgentSlackModernScopes,
-                }),
+                scopes: this.slackClient.getRequiredScopes(),
             },
             metadata,
         };
@@ -85,10 +80,6 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
             appProfilePhotoUrl: installation.appProfilePhotoUrl,
             hasRequiredScopes: this.slackClient.hasRequiredScopes(
                 installation.scopes,
-                {
-                    includeAiAgentSlackModernScopes:
-                        await this.isModernSlackAiAgentEnabled(user),
-                },
             ),
             slackChannelProjectMappings:
                 installation.slackChannelProjectMappings,


### PR DESCRIPTION
## Summary\n- removes assistant:write / im:history from required Slack scopes\n- keeps modern Slack streaming/cards behind the feature flag\n- makes assistant status/title/prompt APIs best-effort so missing assistant scope does not block streaming\n\n## Tests\n- pnpm -F backend typecheck --pretty false\n- pnpm -F backend test -- --runTestsByPath src/ee/services/ai/utils/getSlackBlocks.test.ts --runInBand