### PR TITLE
fix(slack): clear :eyes: ack reaction when a prompt finishes

### DIFF
--- a/packages/backend/src/clients/Slack/SlackClient.ts
+++ b/packages/backend/src/clients/Slack/SlackClient.ts
@@ -311,6 +311,21 @@ export class SlackClient {
         await webClient.reactions.add({ channel, timestamp, name });
     }
 
+    public async removeReaction({
+        organizationUuid,
+        channel,
+        timestamp,
+        name,
+    }: {
+        organizationUuid: string;
+        channel: string;
+        timestamp: string;
+        name: string;
+    }): Promise<void> {
+        const webClient = await this.getWebClient(organizationUuid);
+        await webClient.reactions.remove({ channel, timestamp, name });
+    }
+
     async getWebClient(organizationUuid: string): Promise<WebClient> {
         if (!this.isEnabled) {
             throw new MissingConfigError('Slack is not configured');

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7793,10 +7793,37 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
     // TODO: user permissions
     async replyToSlackPrompt(promptUuid: string): Promise<void> {
-        let slackPrompt = await this.aiAgentModel.findSlackPrompt(promptUuid);
+        const slackPrompt = await this.aiAgentModel.findSlackPrompt(promptUuid);
         if (slackPrompt === undefined) {
             throw new Error('Prompt not found');
         }
+        // Always clear the :eyes: ack (added on app_mention) once we finish —
+        // success or failure — so prompts don't keep a stale reaction forever.
+        try {
+            await this.generateSlackPromptReply(promptUuid, slackPrompt);
+        } finally {
+            await this.cleanupAckReaction(slackPrompt);
+        }
+    }
+
+    private async cleanupAckReaction(slackPrompt: SlackPrompt): Promise<void> {
+        try {
+            await this.slackClient.removeReaction({
+                organizationUuid: slackPrompt.organizationUuid,
+                channel: slackPrompt.slackChannelId,
+                timestamp: slackPrompt.promptSlackTs,
+                name: 'eyes',
+            });
+        } catch (err) {
+            Logger.debug('Failed to remove :eyes: ack reaction:', err);
+        }
+    }
+
+    private async generateSlackPromptReply(
+        promptUuid: string,
+        initialSlackPrompt: SlackPrompt,
+    ): Promise<void> {
+        let slackPrompt: SlackPrompt | undefined = initialSlackPrompt;
 
         const user = await this.userModel.findSessionUserAndOrgByUuid(
             slackPrompt.createdByUserUuid,

--- a/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
@@ -1,0 +1,112 @@
+import { AiAgentService } from './AiAgentService';
+
+// Avoid constructing the real MCP runtime client (and its transitive deps) when
+// we new up the service with mostly-empty mocks below.
+jest.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const buildSlackPrompt = (overrides: Record<string, unknown> = {}) => ({
+    promptUuid: 'prompt-1',
+    organizationUuid: 'org-1',
+    projectUuid: 'proj-1',
+    threadUuid: 'thread-1',
+    slackChannelId: 'C123',
+    promptSlackTs: '1700000000.000100',
+    slackThreadTs: '1700000000.000000',
+    createdByUserUuid: 'user-1',
+    ...overrides,
+});
+
+const buildService = () => {
+    const slackClient = {
+        addReaction: jest.fn().mockResolvedValue(undefined),
+        removeReaction: jest.fn().mockResolvedValue(undefined),
+    };
+    const aiAgentModel = {
+        findSlackPrompt: jest.fn().mockResolvedValue(buildSlackPrompt()),
+    };
+    const service = new AiAgentService({
+        slackClient,
+        aiAgentModel,
+        lightdashConfig: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return { service, slackClient, aiAgentModel };
+};
+
+describe('AiAgentService :eyes: ack reaction lifecycle', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('adds the :eyes: ack reaction on app_mention', async () => {
+        const { service } = buildService();
+        const reactionsAdd = jest.fn().mockResolvedValue({});
+        await service.handleAppMention({
+            event: { channel: 'C123', ts: 'ts-1', text: 'hi', user: 'U1' },
+            // No teamId -> handler returns right after the early ack reaction.
+            context: {},
+            say: jest.fn(),
+            client: { reactions: { add: reactionsAdd } },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        expect(reactionsAdd).toHaveBeenCalledWith({
+            channel: 'C123',
+            timestamp: 'ts-1',
+            name: 'eyes',
+        });
+    });
+
+    it('removes the :eyes: reaction after a successful reply', async () => {
+        const { service, slackClient } = buildService();
+        jest.spyOn(
+            service as unknown as {
+                generateSlackPromptReply: () => Promise<void>;
+            },
+            'generateSlackPromptReply',
+        ).mockResolvedValue(undefined);
+
+        await service.replyToSlackPrompt('prompt-1');
+
+        expect(slackClient.removeReaction).toHaveBeenCalledWith({
+            organizationUuid: 'org-1',
+            channel: 'C123',
+            timestamp: '1700000000.000100',
+            name: 'eyes',
+        });
+    });
+
+    it('removes the :eyes: reaction after a failed reply', async () => {
+        const { service, slackClient } = buildService();
+        jest.spyOn(
+            service as unknown as {
+                generateSlackPromptReply: () => Promise<void>;
+            },
+            'generateSlackPromptReply',
+        ).mockRejectedValue(new Error('boom'));
+
+        await expect(service.replyToSlackPrompt('prompt-1')).rejects.toThrow(
+            'boom',
+        );
+        expect(slackClient.removeReaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fail the prompt when reaction cleanup fails', async () => {
+        const { service, slackClient } = buildService();
+        jest.spyOn(
+            service as unknown as {
+                generateSlackPromptReply: () => Promise<void>;
+            },
+            'generateSlackPromptReply',
+        ).mockResolvedValue(undefined);
+        slackClient.removeReaction.mockRejectedValue(
+            new Error('missing_scope'),
+        );
+
+        await expect(
+            service.replyToSlackPrompt('prompt-1'),
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -5685,6 +5685,12 @@ Table calculations perform row-by-row calculations on query results without coll
         "metadata": {
           "additionalProperties": false,
           "properties": {
+            "chartImageUrl": {
+              "type": [
+                "string",
+                "null",
+              ],
+            },
             "status": {
               "enum": [
                 "success",


### PR DESCRIPTION
Stacked on #24374.

## Problem
We add an `:eyes:` reaction on `app_mention` to ack that the bot saw the message, but never remove it — so every prompt keeps a stale ack reaction forever.

## Fix
- Add `SlackClient.removeReaction` (mirrors `addReaction`; calls `reactions.remove`).
- In `replyToSlackPrompt`, extract the body into `generateSlackPromptReply` and wrap it in a `try/finally` so a `cleanupAckReaction` helper runs on **every** exit: modern-stream success/error and classic success/error.
- Cleanup removes the reaction from the original user prompt message (`slackChannelId` + `promptSlackTs`).
- **Best-effort**: `missing_scope` / `no_reaction` / deleted-message errors are swallowed and logged at debug — reaction cleanup never fails the prompt.
- The early ack add in `handleAppMention` is unchanged (it fires before org resolution for immediate feedback), so the raw Bolt `reactions.add` stays.

## Tests
`ackReactionLifecycle.test.ts` asserts:
- `:eyes:` is still added on mention
- `removeReaction` runs after a successful reply
- `removeReaction` runs after a failed reply
- a cleanup failure does not fail the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
