### PR TITLE
fix(ai): use referenced agent tool schemas

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -1,6 +1,5 @@
 import { agentToolDefinitions } from '@lightdash/common';
-import type { ZodTypeAny } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { asSchema, type FlexibleSchema } from 'ai';
 import { getDiscoverFields } from '../agents/discoverFields/tool';
 import { getCreateContent } from './createContent';
 import { getDescribeWarehouseTable } from './describeWarehouseTable';
@@ -31,20 +30,18 @@ import { getRunSql } from './runSql';
 import { getSearchFieldValues } from './searchFieldValues';
 import { getSetupPreviewDeploy } from './setupPreviewDeploy';
 
-const schemaToJson = (schema: ZodTypeAny | undefined): unknown => {
+const schemaToJson = (schema: FlexibleSchema | undefined): unknown => {
     if (!schema) {
         return null;
     }
 
-    return zodToJsonSchema(schema, {
-        target: 'jsonSchema7',
-    });
+    return asSchema(schema).jsonSchema;
 };
 
 type SnapshotTool = {
     description?: string;
-    inputSchema?: ZodTypeAny;
-    outputSchema?: ZodTypeAny;
+    inputSchema?: FlexibleSchema;
+    outputSchema?: FlexibleSchema;
 };
 
 const agentToolSnapshot = (name: string, toolDefinition: SnapshotTool) => ({

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,6 +34,7 @@
     "release": "pnpm publish --no-git-checks --access public"
   },
   "dependencies": {
+    "@ai-sdk/provider-utils": "4.0.27",
     "@casl/ability": "6.8.0",
     "@types/lodash": "4.14.202",
     "ajv": "8.18.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,6 @@
     "release": "pnpm publish --no-git-checks --access public"
   },
   "dependencies": {
-    "@ai-sdk/provider-utils": "4.0.27",
     "@casl/ability": "6.8.0",
     "@types/lodash": "4.14.202",
     "ajv": "8.18.0",
@@ -61,7 +60,8 @@
     "type-fest": "4.32.0",
     "uuid": "11.1.1",
     "yaml": "2.8.3",
-    "zod": "3.25.55"
+    "zod": "3.25.55",
+    "zod-to-json-schema": "3.25.1"
   },
   "devDependencies": {
     "@types/handlebars": "4.1.0",

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -45,6 +45,33 @@ describe('defineTool', () => {
         ).toEqual({ type: 'error-text', value: 'Nope' });
     });
 
+    it('wraps agent input schemas with JSON Schema references', () => {
+        const sharedSchema = z.object({ value: z.string() });
+        const inputSchema = z.object({
+            first: sharedSchema,
+            second: sharedSchema,
+        });
+        const tool = defineTool({
+            name: 'referencedSchemaTool',
+            title: 'Referenced schema tool',
+            description: 'Sample',
+            availability: ['agent', 'mcp'],
+            inputSchema,
+            mcp: {
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+            },
+        });
+
+        expect(
+            JSON.stringify(tool.for('agent').inputSchema.jsonSchema),
+        ).toContain('"$ref"');
+        expect(tool.for('mcp').inputSchema).toBe(inputSchema);
+    });
+
     it('builds MCP result helpers', () => {
         const outputSchema = z.object({ count: z.number() });
         const tool = defineTool({

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.ts
@@ -1,4 +1,3 @@
-import { type Schema } from '@ai-sdk/provider-utils';
 import { type z } from 'zod';
 import {
     ToolDefinitionWithMcpOutputImpl,
@@ -81,9 +80,36 @@ export type McpToolConfig =
     | McpToolConfigWithoutOutput
     | McpToolConfigWithOutput<McpOutputSchema>;
 
-export type AgentInputSchema<TInput extends z.ZodTypeAny> = Schema<
-    z.infer<TInput>
->;
+export type AgentInputSchema<TInput extends z.ZodTypeAny> = {
+    readonly [key: symbol]: true | undefined;
+    readonly _type: z.infer<TInput>;
+    readonly jsonSchema: Record<string, unknown>;
+    readonly validate: (
+        value: unknown,
+    ) =>
+        | { readonly success: true; readonly value: z.infer<TInput> }
+        | { readonly success: false; readonly error: Error };
+    readonly '~standard': {
+        readonly version: 1;
+        readonly vendor: 'lightdash';
+        readonly types: {
+            readonly input: z.input<TInput>;
+            readonly output: z.infer<TInput>;
+        };
+        readonly validate: (value: unknown) =>
+            | { readonly value: z.infer<TInput>; readonly issues?: undefined }
+            | {
+                  readonly issues: ReadonlyArray<{
+                      readonly message: string;
+                      readonly path?: ReadonlyArray<PropertyKey>;
+                  }>;
+              };
+        readonly jsonSchema: {
+            readonly input: () => Record<string, unknown>;
+            readonly output: () => Record<string, unknown>;
+        };
+    };
+};
 
 type AgentToolViewBase<
     TName extends string,

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.ts
@@ -1,3 +1,4 @@
+import { type Schema } from '@ai-sdk/provider-utils';
 import { type z } from 'zod';
 import {
     ToolDefinitionWithMcpOutputImpl,
@@ -80,6 +81,10 @@ export type McpToolConfig =
     | McpToolConfigWithoutOutput
     | McpToolConfigWithOutput<McpOutputSchema>;
 
+export type AgentInputSchema<TInput extends z.ZodTypeAny> = Schema<
+    z.infer<TInput>
+>;
+
 type AgentToolViewBase<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
@@ -87,7 +92,7 @@ type AgentToolViewBase<
     name: TName;
     title: string;
     description: string;
-    inputSchema: TInput;
+    inputSchema: AgentInputSchema<TInput>;
 };
 
 export type AgentToolView<

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
@@ -1,4 +1,7 @@
+import { zodSchema } from '@ai-sdk/provider-utils';
+import { type z } from 'zod';
 import {
+    type AgentInputSchema,
     type AgentToModelOutput,
     type McpErrorResult,
     type McpStructuredResult,
@@ -33,6 +36,13 @@ export const defaultAgentToModelOutput: AgentToModelOutput<
     output.metadata.status === 'error'
         ? { type: 'error-text', value: output.result }
         : { type: 'text', value: output.result };
+
+export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
+    inputSchema: TInput,
+): AgentInputSchema<TInput> =>
+    zodSchema(inputSchema, {
+        useReferences: true,
+    });
 
 const text = (textContent: string): McpTextResult => ({
     content: [{ type: 'text', text: textContent }],

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
@@ -1,5 +1,5 @@
-import { zodSchema } from '@ai-sdk/provider-utils';
 import { type z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
     type AgentInputSchema,
     type AgentToModelOutput,
@@ -11,6 +11,8 @@ import {
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
+
+const aiSchemaSymbol = Symbol.for('vercel.ai.schema');
 
 export const resolveDescription = (
     description: ToolDescription,
@@ -39,10 +41,53 @@ export const defaultAgentToModelOutput: AgentToModelOutput<
 
 export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
     inputSchema: TInput,
-): AgentInputSchema<TInput> =>
-    zodSchema(inputSchema, {
-        useReferences: true,
-    });
+): AgentInputSchema<TInput> => {
+    const jsonSchema = zodToJsonSchema(inputSchema, {
+        $refStrategy: 'root',
+        target: 'jsonSchema7',
+    }) as Record<string, unknown>;
+
+    return {
+        [aiSchemaSymbol]: true,
+        _type: undefined as z.infer<TInput>,
+        jsonSchema,
+        validate: (value) => {
+            const result = inputSchema.safeParse(value);
+
+            if (result.success) {
+                return { success: true, value: result.data as z.infer<TInput> };
+            }
+
+            return { success: false, error: result.error };
+        },
+        '~standard': {
+            version: 1,
+            vendor: 'lightdash',
+            types: undefined as unknown as {
+                input: z.input<TInput>;
+                output: z.infer<TInput>;
+            },
+            validate: (value) => {
+                const result = inputSchema.safeParse(value);
+
+                if (result.success) {
+                    return { value: result.data as z.infer<TInput> };
+                }
+
+                return {
+                    issues: result.error.issues.map((issue) => ({
+                        message: issue.message,
+                        path: issue.path,
+                    })),
+                };
+            },
+            jsonSchema: {
+                input: () => jsonSchema,
+                output: () => jsonSchema,
+            },
+        },
+    };
+};
 
 const text = (textContent: string): McpTextResult => ({
     content: [{ type: 'text', text: textContent }],

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
@@ -11,6 +11,7 @@ import {
 } from './defineTool';
 import {
     assertAvailable,
+    createAgentInputSchema,
     createMcpToolResultBuilders,
     defaultAgentToModelOutput,
     resolveDescription,
@@ -68,7 +69,7 @@ export class ToolDefinitionWithMcpOutputImpl<
             name: this.name,
             title: this.title,
             description: this.description,
-            inputSchema: this.inputSchema,
+            inputSchema: createAgentInputSchema(this.inputSchema),
             toModelOutput:
                 this.agentConfig?.toModelOutput ?? defaultAgentToModelOutput,
         };

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
@@ -10,6 +10,7 @@ import {
 } from './defineTool';
 import {
     assertAvailable,
+    createAgentInputSchema,
     createMcpToolResultBuilders,
     defaultAgentToModelOutput,
     resolveDescription,
@@ -66,7 +67,7 @@ export class ToolDefinitionWithoutMcpOutputImpl<
             name: this.name,
             title: this.title,
             description: this.description,
-            inputSchema: this.inputSchema,
+            inputSchema: createAgentInputSchema(this.inputSchema),
             toModelOutput:
                 this.agentConfig?.toModelOutput ?? defaultAgentToModelOutput,
         };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,9 +790,6 @@ importers:
 
   packages/common:
     dependencies:
-      '@ai-sdk/provider-utils':
-        specifier: 4.0.27
-        version: 4.0.27(zod@3.25.55)
       '@casl/ability':
         specifier: 6.8.0
         version: 6.8.0
@@ -874,6 +871,9 @@ importers:
       zod:
         specifier: 3.25.55
         version: 3.25.55
+      zod-to-json-schema:
+        specifier: 3.25.1
+        version: 3.25.1(zod@3.25.55)
     devDependencies:
       '@types/handlebars':
         specifier: 4.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
 
   packages/common:
     dependencies:
+      '@ai-sdk/provider-utils':
+        specifier: 4.0.27
+        version: 4.0.27(zod@3.25.55)
       '@casl/ability':
         specifier: 6.8.0
         version: 6.8.0


### PR DESCRIPTION
## Summary
- Use referenced JSON schemas for AI agent tool inputs
- Keep MCP tool schemas unchanged

## Testing
- pnpm -F common test -- src/ee/AiAgent/schemas/defineTool.test.ts
- pnpm -F backend test -- src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts -u
- pnpm -F common typecheck:fast
- pnpm -F backend typecheck:fast