### PR TITLE
feat(slack): add Open in SQL Runner link to AI agent replies

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7180,15 +7180,115 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                   )
                 : [];
 
+        const sqlRunnerBlocks = await this.getSqlRunnerLinkBlocks(
+            user,
+            slackPrompt,
+        );
+
         return [
             ...exploreBlocks,
             ...proposeChangeBlocks,
             ...editDbtProjectBlocks,
             ...referencedArtifactsBlocks,
             ...followUpToolBlocks,
+            ...sqlRunnerBlocks,
             ...feedbackBlocks,
             ...historyBlocks,
         ];
+    }
+
+    // "Open in SQL Runner" link for the latest successful runSql. The SQL only
+    // lives in the browser's nav state on web; persisting it as a share URL lets
+    // the link work from Slack too (task cards can't carry links).
+    private async getSqlRunnerLinkBlocks(
+        user: SessionUser,
+        slackPrompt: SlackPrompt,
+    ): Promise<(Block | KnownBlock)[]> {
+        const toolCalls = await this.aiAgentModel.getToolCallsForPrompt(
+            slackPrompt.promptUuid,
+        );
+        const runSqlCalls = toolCalls.filter(
+            (call) => call.tool_name === 'runSql',
+        );
+        if (runSqlCalls.length === 0) return [];
+
+        const toolResults = await this.aiAgentModel.getToolResultsForPrompt(
+            slackPrompt.promptUuid,
+        );
+        const succeededCallIds = new Set(
+            toolResults
+                .filter(
+                    (result) =>
+                        result.toolName === 'runSql' &&
+                        (result.metadata as { status?: string } | null)
+                            ?.status === 'success',
+                )
+                .map((result) => result.toolCallId),
+        );
+
+        const latestSuccessful = [...runSqlCalls]
+            .reverse()
+            .find((call) => succeededCallIds.has(call.tool_call_id));
+        const sql = (
+            latestSuccessful?.tool_args as { sql?: string } | undefined
+        )?.sql;
+        if (!latestSuccessful || !sql) return [];
+        const limit = (
+            latestSuccessful.tool_args as { limit?: number } | undefined
+        )?.limit;
+
+        let shareUrl: string | undefined;
+        try {
+            shareUrl = await this.createSqlRunnerShareUrl(
+                user,
+                slackPrompt.projectUuid,
+                sql,
+                limit,
+            );
+        } catch (error) {
+            this.logger.warn('Failed to build SQL runner share url', error);
+            return [];
+        }
+
+        return [
+            {
+                type: 'actions',
+                elements: [
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Open in SQL Runner',
+                        },
+                        url: shareUrl,
+                    },
+                ],
+            },
+        ];
+    }
+
+    private async createSqlRunnerShareUrl(
+        user: SessionUser,
+        projectUuid: string,
+        sql: string,
+        limit: number | undefined,
+    ): Promise<string> {
+        const path = `/projects/${projectUuid}/sql-runner`;
+        // `chartConfig` must be present (not undefined, which JSON.stringify
+        // drops) so the frontend hydrates this as a SQL-runner share.
+        const params = JSON.stringify({
+            sqlRunnerState: {
+                sql,
+                ...(typeof limit === 'number' ? { limit } : {}),
+            },
+            chartConfig: null,
+        });
+        const { nanoid } = await this.shareService.createShareUrl(
+            user,
+            path,
+            params,
+        );
+        return `${this.lightdashConfig.siteUrl}${path}?share=${nanoid}`;
     }
 
     private static isSlackModernStreamUnsupported(error: unknown) {
@@ -8045,6 +8145,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             '\n',
         );
 
+        const sqlRunnerBlocks = await this.getSqlRunnerLinkBlocks(
+            user,
+            slackPrompt,
+        );
+
         const blocks = [
             ...getMarkdownBlocks(response),
             ...exploreBlocks,
@@ -8052,6 +8157,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ...editDbtProjectBlocks,
             ...referencedArtifactsBlocks,
             ...followUpToolBlocks,
+            ...sqlRunnerBlocks,
             ...feedbackBlocks,
             ...(historyBlocks || []),
         ];

--- a/packages/backend/src/ee/services/AiAgentService/sqlRunnerLinkBlocks.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlRunnerLinkBlocks.test.ts
@@ -1,0 +1,104 @@
+import { AiAgentService } from './AiAgentService';
+
+jest.mock('../ai/AiAgentMcpRuntimeClient', () => ({
+    AiAgentMcpRuntimeClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const SITE_URL = 'https://app.example.com';
+
+const buildService = (overrides: {
+    toolCalls: unknown[];
+    toolResults: unknown[];
+}) => {
+    const createShareUrl = jest.fn().mockResolvedValue({ nanoid: 'share123' });
+    const aiAgentModel = {
+        getToolCallsForPrompt: jest.fn().mockResolvedValue(overrides.toolCalls),
+        getToolResultsForPrompt: jest
+            .fn()
+            .mockResolvedValue(overrides.toolResults),
+    };
+    const service = new AiAgentService({
+        aiAgentModel,
+        shareService: { createShareUrl },
+        lightdashConfig: { siteUrl: SITE_URL },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    return { service, createShareUrl };
+};
+
+const runSqlCall = (toolCallId: string, sql: string, limit?: number) => ({
+    tool_call_id: toolCallId,
+    tool_name: 'runSql',
+    tool_args: { sql, ...(limit !== undefined ? { limit } : {}) },
+});
+
+const runSqlResult = (toolCallId: string, status: string) => ({
+    toolCallId,
+    toolName: 'runSql',
+    metadata: { status },
+});
+
+const slackPrompt = { promptUuid: 'prompt-1', projectUuid: 'proj-1' };
+
+const callHelper = (service: AiAgentService) =>
+    (
+        service as unknown as {
+            getSqlRunnerLinkBlocks: (
+                u: unknown,
+                p: unknown,
+            ) => Promise<unknown[]>;
+        }
+    ).getSqlRunnerLinkBlocks({ userUuid: 'user-1' }, slackPrompt);
+
+describe('AiAgentService.getSqlRunnerLinkBlocks', () => {
+    it('renders an Open in SQL Runner link for the latest successful runSql', async () => {
+        const { service, createShareUrl } = buildService({
+            toolCalls: [
+                runSqlCall('a', 'SELECT 1', 10),
+                runSqlCall('b', 'SELECT 2', 20),
+            ],
+            toolResults: [
+                runSqlResult('a', 'success'),
+                runSqlResult('b', 'success'),
+            ],
+        });
+
+        const blocks = (await callHelper(service)) as Array<{
+            type: string;
+            elements: Array<{
+                type: string;
+                url: string;
+                text: { text: string };
+            }>;
+        }>;
+
+        expect(blocks).toHaveLength(1);
+        const button = blocks[0].elements[0];
+        expect(button.text.text).toBe('Open in SQL Runner');
+        expect(button.url).toBe(
+            `${SITE_URL}/projects/proj-1/sql-runner?share=share123`,
+        );
+
+        // Latest successful query (b) is the one shared, with chartConfig present.
+        const [, path, params] = createShareUrl.mock.calls[0];
+        expect(path).toBe('/projects/proj-1/sql-runner');
+        const parsed = JSON.parse(params);
+        expect(parsed).toEqual({
+            sqlRunnerState: { sql: 'SELECT 2', limit: 20 },
+            chartConfig: null,
+        });
+    });
+
+    it('returns no blocks when there is no runSql tool call', async () => {
+        const { service } = buildService({ toolCalls: [], toolResults: [] });
+        expect(await callHelper(service)).toEqual([]);
+    });
+
+    it('returns no blocks when the runSql did not succeed', async () => {
+        const { service } = buildService({
+            toolCalls: [runSqlCall('a', 'SELECT 1')],
+            toolResults: [runSqlResult('a', 'error')],
+        });
+        expect(await callHelper(service)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Problem
When the AI agent runs `runSql`, the "Open in SQL Runner" link works on **web** (it rides on browser navigation state holding the query) but is **missing/broken in Slack** — Slack has no client to carry that state.

## Fix
Persist the query as a **SQL Runner share URL** and render an "Open in SQL Runner" button in the Slack reply (both the modern streaming-card path and the classic path).

- New `createSqlRunnerShareUrl` mints a share with `{ sqlRunnerState: { sql, limit }, chartConfig: null }` params and returns `{siteUrl}/projects/{uuid}/sql-runner?share={nanoid}` — mirroring the frontend `useCreateSqlRunnerShareUrl` so `useSqlRunnerShareUrl` hydrates it on load. (`chartConfig: null` is required — `undefined` gets dropped by `JSON.stringify`, which would break the frontend's share-shape check.)
- `getSqlRunnerLinkBlocks` reads the prompt's `runSql` tool calls + results and links to the **latest successful** query (matching web's behavior).
- The link is a plain URL, so it works from Slack.

## Scope
Slack-only. Web already works via nav state; switching web to the same share URL is a separate follow-up.

## Tests
`sqlRunnerLinkBlocks.test.ts`: renders the button with the correct URL + share params for a successful runSql; no blocks when there's no runSql or it didn't succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
