### PR TITLE
fix(ai): keep mcp schemas ref-free

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -68,7 +68,6 @@
         "@lightdash/common": "workspace:*",
         "@lightdash/formula": "workspace:*",
         "@lightdash/warehouses": "workspace:*",
-        "@mastra/schema-compat": "0.11.2",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@node-oauth/oauth2-server": "5.3.0",
         "@octokit/app": "14.0.2",

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -12,6 +12,7 @@ import {
     convertAiTableCalcsSchemaToTableCalcs,
     convertFieldRefToFieldId,
     createContentToolDefinition,
+    createMcpCompatibleInputShape,
     createToolRunSqlArgsSchema,
     editContentToolDefinition,
     Explore,
@@ -80,7 +81,7 @@ import * as Sentry from '@sentry/node';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs/promises';
 import path from 'path';
-import { z, ZodRawShape } from 'zod';
+import { z } from 'zod';
 import {
     LightdashAnalytics,
     McpToolCallEvent,
@@ -139,7 +140,6 @@ import {
     registerAppTool,
     RESOURCE_MIME_TYPE,
 } from './mcpAppHelpers';
-import { McpSchemaCompatLayer } from './McpSchemaCompatLayer';
 
 export enum McpToolName {
     GET_LIGHTDASH_VERSION = 'get_lightdash_version',
@@ -306,8 +306,6 @@ export class McpService extends BaseService {
 
     private mcpServer: McpServer;
 
-    private mcpCompatLayer: McpSchemaCompatLayer;
-
     constructor({
         lightdashConfig,
         analytics,
@@ -347,7 +345,6 @@ export class McpService extends BaseService {
         this.aiAgentToolsService = aiAgentToolsService;
         this.aiRouterService = aiRouterService;
         this.aiWritebackService = aiWritebackService;
-        this.mcpCompatLayer = new McpSchemaCompatLayer();
         try {
             this.mcpServer = Sentry.wrapMcpServerWithSentry(
                 new McpServer({
@@ -1067,12 +1064,6 @@ export class McpService extends BaseService {
         );
     }
 
-    private getMcpCompatibleSchema<TShape extends ZodRawShape>(
-        schema: z.ZodObject<TShape>,
-    ): TShape {
-        return this.mcpCompatLayer.processZodType(schema).shape;
-    }
-
     /**
      * Registers the run_ai_writeback tool on the current server. Kept separate
      * so setupHandlers can register it conditionally (dark launch — see the
@@ -1084,9 +1075,7 @@ export class McpService extends BaseService {
             {
                 title: mcpRunAiWritebackTool.title,
                 description: mcpRunAiWritebackTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpRunAiWritebackTool.inputSchema,
-                ),
+                inputSchema: mcpRunAiWritebackTool.inputSchema.shape,
                 outputSchema: mcpRunAiWritebackTool.outputSchema.shape,
                 annotations: mcpRunAiWritebackTool.annotations,
             },
@@ -1147,9 +1136,7 @@ export class McpService extends BaseService {
             {
                 title: mcpCreateContentTool.title,
                 description: mcpCreateContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpCreateContentTool.inputSchema,
-                ),
+                inputSchema: mcpCreateContentTool.inputSchema.shape,
                 annotations: mcpCreateContentTool.annotations,
             },
             async (args, extra) => {
@@ -1193,9 +1180,7 @@ export class McpService extends BaseService {
             {
                 title: mcpEditContentTool.title,
                 description: mcpEditContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpEditContentTool.inputSchema,
-                ),
+                inputSchema: mcpEditContentTool.inputSchema.shape,
                 annotations: mcpEditContentTool.annotations,
             },
             async (args, extra) => {
@@ -1244,9 +1229,7 @@ export class McpService extends BaseService {
             {
                 title: mcpGetLightdashVersionTool.title,
                 description: mcpGetLightdashVersionTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpGetLightdashVersionTool.inputSchema,
-                ),
+                inputSchema: mcpGetLightdashVersionTool.inputSchema.shape,
                 annotations: mcpGetLightdashVersionTool.annotations,
             },
             async (_args, extra) => {
@@ -1269,9 +1252,7 @@ export class McpService extends BaseService {
             {
                 title: mcpListExploresTool.title,
                 description: mcpListExploresTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpListExploresTool.inputSchema,
-                ),
+                inputSchema: mcpListExploresTool.inputSchema.shape,
                 annotations: mcpListExploresTool.annotations,
             },
             async (_args, extra) => {
@@ -1324,9 +1305,7 @@ export class McpService extends BaseService {
             {
                 title: mcpFindExploresTool.title,
                 description: mcpFindExploresTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpFindExploresTool.inputSchema,
-                ),
+                inputSchema: mcpFindExploresTool.inputSchema.shape,
                 annotations: mcpFindExploresTool.annotations,
             },
             async (args, extra) => {
@@ -1397,9 +1376,7 @@ export class McpService extends BaseService {
             {
                 title: mcpFindFieldsTool.title,
                 description: mcpFindFieldsTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpFindFieldsTool.inputSchema,
-                ),
+                inputSchema: mcpFindFieldsTool.inputSchema.shape,
                 annotations: mcpFindFieldsTool.annotations,
             },
             async (args, extra) => {
@@ -1440,9 +1417,7 @@ export class McpService extends BaseService {
             {
                 title: mcpFindContentTool.title,
                 description: mcpFindContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpFindContentTool.inputSchema,
-                ),
+                inputSchema: mcpFindContentTool.inputSchema.shape,
                 annotations: mcpFindContentTool.annotations,
             },
             async (args, extra) => {
@@ -1482,9 +1457,7 @@ export class McpService extends BaseService {
             {
                 title: mcpListContentTool.title,
                 description: mcpListContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpListContentTool.inputSchema,
-                ),
+                inputSchema: mcpListContentTool.inputSchema.shape,
                 annotations: mcpListContentTool.annotations,
             },
             async (args, extra) => {
@@ -1522,9 +1495,7 @@ export class McpService extends BaseService {
             {
                 title: mcpReadContentTool.title,
                 description: mcpReadContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpReadContentTool.inputSchema,
-                ),
+                inputSchema: mcpReadContentTool.inputSchema.shape,
                 annotations: mcpReadContentTool.annotations,
             },
             async (args, extra) => {
@@ -1570,9 +1541,7 @@ export class McpService extends BaseService {
                 {
                     title: mcpListProjectsTool.title,
                     description: mcpListProjectsTool.description,
-                    inputSchema: this.getMcpCompatibleSchema(
-                        mcpListProjectsTool.inputSchema,
-                    ),
+                    inputSchema: mcpListProjectsTool.inputSchema.shape,
                     annotations: mcpListProjectsTool.annotations,
                 },
                 async (
@@ -1629,9 +1598,7 @@ export class McpService extends BaseService {
                 {
                     title: mcpSetProjectTool.title,
                     description: mcpSetProjectTool.description,
-                    inputSchema: this.getMcpCompatibleSchema(
-                        mcpSetProjectTool.inputSchema,
-                    ),
+                    inputSchema: mcpSetProjectTool.inputSchema.shape,
                     annotations: mcpSetProjectTool.annotations,
                 },
                 async (
@@ -1718,9 +1685,7 @@ export class McpService extends BaseService {
             {
                 title: mcpGetCurrentProjectTool.title,
                 description: mcpGetCurrentProjectTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpGetCurrentProjectTool.inputSchema,
-                ),
+                inputSchema: mcpGetCurrentProjectTool.inputSchema.shape,
                 annotations: mcpGetCurrentProjectTool.annotations,
             },
             async (_args, extra) => {
@@ -1778,9 +1743,7 @@ export class McpService extends BaseService {
             {
                 title: mcpListAgentsTool.title,
                 description: mcpListAgentsTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpListAgentsTool.inputSchema,
-                ),
+                inputSchema: mcpListAgentsTool.inputSchema.shape,
                 annotations: mcpListAgentsTool.annotations,
             },
             async (args, extra) => {
@@ -1825,9 +1788,7 @@ export class McpService extends BaseService {
             {
                 title: mcpRouteAgentTool.title,
                 description: mcpRouteAgentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpRouteAgentTool.inputSchema,
-                ),
+                inputSchema: mcpRouteAgentTool.inputSchema.shape,
                 annotations: mcpRouteAgentTool.annotations,
                 outputSchema: mcpRouteAgentTool.outputSchema.shape,
             },
@@ -1904,9 +1865,7 @@ export class McpService extends BaseService {
             {
                 title: mcpSetAgentTool.title,
                 description: mcpSetAgentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpSetAgentTool.inputSchema,
-                ),
+                inputSchema: mcpSetAgentTool.inputSchema.shape,
                 annotations: mcpSetAgentTool.annotations,
             },
             async (args, extra) => {
@@ -1964,9 +1923,7 @@ export class McpService extends BaseService {
             {
                 title: mcpClearAgentTool.title,
                 description: mcpClearAgentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpClearAgentTool.inputSchema,
-                ),
+                inputSchema: mcpClearAgentTool.inputSchema.shape,
                 annotations: mcpClearAgentTool.annotations,
             },
             async (_args, extra) => {
@@ -2016,9 +1973,7 @@ export class McpService extends BaseService {
             {
                 title: mcpGetCurrentAgentTool.title,
                 description: mcpGetCurrentAgentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpGetCurrentAgentTool.inputSchema,
-                ),
+                inputSchema: mcpGetCurrentAgentTool.inputSchema.shape,
                 annotations: mcpGetCurrentAgentTool.annotations,
             },
             async (_args, extra) => {
@@ -2106,9 +2061,7 @@ export class McpService extends BaseService {
             {
                 title: mcpRunMetricQueryTool.title,
                 description: mcpRunMetricQueryTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpRunMetricQueryTool.inputSchema,
-                ),
+                inputSchema: mcpRunMetricQueryTool.inputSchema.shape,
                 outputSchema: mcpRunMetricQueryTool.outputSchema,
                 annotations: mcpRunMetricQueryTool.annotations,
             },
@@ -2216,9 +2169,7 @@ export class McpService extends BaseService {
             {
                 title: mcpRenderChartTool.title,
                 description: mcpRenderChartTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpRenderChartTool.inputSchema,
-                ),
+                inputSchema: mcpRenderChartTool.inputSchema.shape,
                 outputSchema: mcpRenderChartTool.outputSchema,
                 annotations: mcpRenderChartTool.annotations,
                 _meta: { ui: { resourceUri: chartResourceUri } },
@@ -2310,9 +2261,7 @@ export class McpService extends BaseService {
             {
                 title: mcpSearchFieldValuesTool.title,
                 description: mcpSearchFieldValuesTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpSearchFieldValuesTool.inputSchema,
-                ),
+                inputSchema: mcpSearchFieldValuesTool.inputSchema.shape,
                 annotations: mcpSearchFieldValuesTool.annotations,
             },
             async (args, extra) => {
@@ -2366,7 +2315,7 @@ export class McpService extends BaseService {
                     500,
                     this.lightdashConfig.mcp.runSqlMaxLimit,
                 ),
-                inputSchema: this.getMcpCompatibleSchema(runSqlArgsSchema),
+                inputSchema: createMcpCompatibleInputShape(runSqlArgsSchema),
                 outputSchema: mcpRunSqlTool.outputSchema,
                 annotations: mcpRunSqlTool.annotations,
             },
@@ -2449,9 +2398,7 @@ export class McpService extends BaseService {
             {
                 title: mcpGetQueryResultTool.title,
                 description: mcpGetQueryResultTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpGetQueryResultTool.inputSchema,
-                ),
+                inputSchema: mcpGetQueryResultTool.inputSchema.shape,
                 outputSchema: mcpGetQueryResultTool.outputSchema,
                 annotations: mcpGetQueryResultTool.annotations,
             },
@@ -2612,9 +2559,7 @@ export class McpService extends BaseService {
             {
                 title: mcpListVerifiedContentTool.title,
                 description: mcpListVerifiedContentTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpListVerifiedContentTool.inputSchema,
-                ),
+                inputSchema: mcpListVerifiedContentTool.inputSchema.shape,
                 annotations: mcpListVerifiedContentTool.annotations,
             },
             async (_args, extra) => {
@@ -3043,9 +2988,7 @@ export class McpService extends BaseService {
             {
                 title: mcpListSkillsTool.title,
                 description: mcpListSkillsTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpListSkillsTool.inputSchema,
-                ),
+                inputSchema: mcpListSkillsTool.inputSchema.shape,
                 outputSchema: mcpListSkillsTool.outputSchema.shape,
                 annotations: mcpListSkillsTool.annotations,
             },
@@ -3066,9 +3009,7 @@ export class McpService extends BaseService {
             {
                 title: mcpReadSkillTool.title,
                 description: mcpReadSkillTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpReadSkillTool.inputSchema,
-                ),
+                inputSchema: mcpReadSkillTool.inputSchema.shape,
                 outputSchema: mcpReadSkillTool.outputSchema.shape,
                 annotations: mcpReadSkillTool.annotations,
             },
@@ -3098,9 +3039,7 @@ export class McpService extends BaseService {
             {
                 title: mcpReadSkillResourceTool.title,
                 description: mcpReadSkillResourceTool.description,
-                inputSchema: this.getMcpCompatibleSchema(
-                    mcpReadSkillResourceTool.inputSchema,
-                ),
+                inputSchema: mcpReadSkillResourceTool.inputSchema.shape,
                 outputSchema: mcpReadSkillResourceTool.outputSchema.shape,
                 annotations: mcpReadSkillResourceTool.annotations,
             },

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -127,26 +127,33 @@ describe('MCP tool contracts', () => {
         mockRegisteredMcpPrompts.length = 0;
         await mcpService.createServer({ aiWritebackEnabled: true });
 
-        expect({
-            prompts: mockRegisteredMcpPrompts.map(({ name, config }) => ({
-                name,
-                title: config.title,
-                description: config.description,
-                argsSchema: schemaToJson(config.argsSchema),
-                prompt:
-                    name === 'lightdash-analyst' ? MCP_ANALYST_PROMPT : null,
-            })),
-            tools: mockRegisteredMcpTools.map(({ name, config }) => ({
-                name,
-                agentName:
-                    name === McpToolName.RUN_METRIC_QUERY ? 'runQuery' : null,
-                title: config.title,
-                description: config.description,
-                inputSchema: schemaToJson(config.inputSchema),
-                ...(config.outputSchema
-                    ? { outputSchema: schemaToJson(config.outputSchema) }
-                    : {}),
-            })),
-        }).toMatchSnapshot();
+        const prompts = mockRegisteredMcpPrompts.map(({ name, config }) => ({
+            name,
+            title: config.title,
+            description: config.description,
+            argsSchema: schemaToJson(config.argsSchema),
+            prompt: name === 'lightdash-analyst' ? MCP_ANALYST_PROMPT : null,
+        }));
+        const tools = mockRegisteredMcpTools.map(({ name, config }) => ({
+            name,
+            agentName:
+                name === McpToolName.RUN_METRIC_QUERY ? 'runQuery' : null,
+            title: config.title,
+            description: config.description,
+            inputSchema: schemaToJson(config.inputSchema),
+            ...(config.outputSchema
+                ? { outputSchema: schemaToJson(config.outputSchema) }
+                : {}),
+        }));
+
+        expect(
+            tools
+                .filter(({ inputSchema }) =>
+                    JSON.stringify(inputSchema).includes('"$ref"'),
+                )
+                .map(({ name }) => name),
+        ).toEqual([]);
+
+        expect({ prompts, tools }).toMatchSnapshot();
     });
 });

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@casl/ability": "6.8.0",
+    "@mastra/schema-compat": "0.11.2",
     "@types/lodash": "4.14.202",
     "ai": "6.0.205",
     "ajv": "8.18.0",

--- a/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.test.ts
@@ -1,13 +1,15 @@
+import z, { type ZodSchema } from 'zod';
+import { McpSchemaCompatLayer } from './McpSchemaCompatLayer';
 import {
-    ToolFindFieldsArgs,
     toolFindFieldsArgsSchema,
     toolFindFieldsArgsSchemaTransformed,
-    ToolRunMetricQueryArgs,
+    type ToolFindFieldsArgs,
+} from './tools/toolFindFieldsArgs';
+import {
     toolRunMetricQueryArgsSchema,
     toolRunMetricQueryArgsSchemaTransformed,
-} from '@lightdash/common';
-import z, { ZodSchema } from 'zod';
-import { McpSchemaCompatLayer } from './McpSchemaCompatLayer';
+    type ToolRunMetricQueryArgs,
+} from './tools/toolRunMetricQueryArgs';
 
 const mcpSchemaCompatLayer = new McpSchemaCompatLayer();
 

--- a/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.ts
+++ b/packages/common/src/ee/AiAgent/schemas/McpSchemaCompatLayer.ts
@@ -1,5 +1,4 @@
-/* eslint-disable class-methods-use-this */
-import { AnyType } from '@lightdash/common';
+/* eslint-disable class-methods-use-this, no-underscore-dangle, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import {
     isArr,
     isNumber,
@@ -13,10 +12,11 @@ import {
 import {
     z,
     ZodDefault,
-    ZodDiscriminatedUnion,
-    ZodNullable,
+    type ZodDiscriminatedUnion,
+    type ZodNullable,
     type ZodTypeAny,
 } from 'zod';
+import { type AnyType } from '../../../types/any';
 
 const isNullable = (v: ZodTypeAny): v is ZodNullable<AnyType> =>
     v._def.typeName === 'ZodNullable';
@@ -85,7 +85,7 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
             return z.preprocess((val) => Number(val), v);
         }
 
-        // Identical to packages/backend/node_modules/@mastra/schema-compat/src/provider-compats/anthropic.ts
+        // Identical to @mastra/schema-compat/src/provider-compats/anthropic.ts
         if (isOptional(v)) {
             const handleTypes: AllZodType[] = [
                 'ZodObject',
@@ -130,3 +130,30 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
         ]);
     }
 }
+
+const mcpSchemaCompatLayer = new McpSchemaCompatLayer();
+
+export type McpCompatibleInputSchema<
+    TInput extends z.ZodObject<z.ZodRawShape>,
+> = z.ZodObject<
+    TInput['shape'],
+    z.UnknownKeysParam,
+    z.ZodTypeAny,
+    z.output<TInput>,
+    z.input<TInput>
+>;
+
+export const createMcpCompatibleInputSchema = <
+    TInput extends z.ZodObject<z.ZodRawShape>,
+>(
+    inputSchema: TInput,
+): McpCompatibleInputSchema<TInput> =>
+    mcpSchemaCompatLayer.processZodType(
+        inputSchema,
+    ) as McpCompatibleInputSchema<TInput>;
+
+export const createMcpCompatibleInputShape = <
+    TInput extends z.ZodObject<z.ZodRawShape>,
+>(
+    inputSchema: TInput,
+): TInput['shape'] => createMcpCompatibleInputSchema(inputSchema).shape;

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { defineTool } from './defineTool';
 import {
     agentToolNames,
@@ -45,8 +46,12 @@ describe('defineTool', () => {
         ).toEqual({ type: 'error-text', value: 'Nope' });
     });
 
-    it('wraps agent input schemas with JSON Schema references', () => {
+    it('keeps MCP input schemas ref-free', () => {
         const sharedSchema = z.object({ value: z.string() });
+        const input = {
+            first: { value: 'one' },
+            second: { value: 'two' },
+        };
         const inputSchema = z.object({
             first: sharedSchema,
             second: sharedSchema,
@@ -69,7 +74,13 @@ describe('defineTool', () => {
         expect(
             JSON.stringify(tool.for('agent').inputSchema.jsonSchema),
         ).toContain('"$ref"');
-        expect(tool.for('mcp').inputSchema).toBe(inputSchema);
+
+        const mcpInputSchema = tool.for('mcp').inputSchema;
+        expect(mcpInputSchema).not.toBe(inputSchema);
+        expect(JSON.stringify(zodToJsonSchema(mcpInputSchema))).not.toContain(
+            '"$ref"',
+        );
+        expect(mcpInputSchema.parse(input)).toEqual(input);
     });
 
     it('builds MCP result helpers', () => {

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.ts
@@ -1,5 +1,6 @@
 import { type Schema } from 'ai';
 import { type z } from 'zod';
+import { type McpCompatibleInputSchema } from './McpSchemaCompatLayer';
 import {
     ToolDefinitionWithMcpOutputImpl,
     ToolDefinitionWithoutMcpOutputImpl,
@@ -108,7 +109,7 @@ type McpToolViewBase<
     canonicalName: TName;
     title: string;
     description: string;
-    inputSchema: TInput;
+    inputSchema: McpCompatibleInputSchema<TInput>;
     annotations: McpToolAnnotations;
     meta: Record<string, unknown> | undefined;
     result: McpToolResultBuilders;

--- a/packages/common/src/ee/AiAgent/schemas/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/index.ts
@@ -32,6 +32,7 @@ import {
 export * from './customMetrics';
 export * from './defineTool';
 export * from './filters';
+export * from './McpSchemaCompatLayer';
 export * from './outputMetadata';
 export * from './sortField';
 export * from './tableCalcs/tableCalcs';

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
@@ -9,6 +9,7 @@ import {
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
+import { createMcpCompatibleInputSchema } from './McpSchemaCompatLayer';
 import {
     assertAvailable,
     createAgentInputSchema,
@@ -107,7 +108,7 @@ export class ToolDefinitionWithMcpOutputImpl<
             canonicalName: this.name,
             title: this.title,
             description: resolveDescription(this.descriptionConfig, mcpName),
-            inputSchema: this.inputSchema,
+            inputSchema: createMcpCompatibleInputSchema(this.inputSchema),
             annotations: this.mcpConfig.annotations,
             outputSchema: this.outputSchema,
             meta: this.mcpConfig.meta,

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
@@ -8,6 +8,7 @@ import {
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
+import { createMcpCompatibleInputSchema } from './McpSchemaCompatLayer';
 import {
     assertAvailable,
     createAgentInputSchema,
@@ -105,7 +106,7 @@ export class ToolDefinitionWithoutMcpOutputImpl<
             canonicalName: this.name,
             title: this.title,
             description: resolveDescription(this.descriptionConfig, mcpName),
-            inputSchema: this.inputSchema,
+            inputSchema: createMcpCompatibleInputSchema(this.inputSchema),
             annotations: this.mcpConfig.annotations,
             meta: this.mcpConfig.meta,
             result: createMcpToolResultBuilders(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,8 @@ overrides:
   ajv@>=8.0.0 <8.18.0: 8.18.0
   postcss@<8.5.10: 8.5.10
 
+packageExtensionsChecksum: sha256-dssFMdNh289VAmJNNfz2Un2yyQ65P87lDvF3ZdZoc94=
+
 pnpmfileChecksum: sha256-eQZaSN8dBqsURx9Y0qj3HqXggTVV5DtL6B15n8AQ53E=
 
 importers:
@@ -214,9 +216,6 @@ importers:
       '@lightdash/warehouses':
         specifier: workspace:*
         version: link:../warehouses
-      '@mastra/schema-compat':
-        specifier: 0.11.2
-        version: 0.11.2(ai@6.0.205(zod@3.25.55))(zod@3.25.55)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@3.25.55)
@@ -246,7 +245,7 @@ importers:
         version: 1.5.4(ai@6.0.205(zod@3.25.55))(zod@3.25.55)
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
-        version: 2.1.1(tslib@2.8.1)
+        version: 2.1.1(tslib@2.6.2)
       '@sentry/core':
         specifier: 9.31.0
         version: 9.31.0
@@ -522,7 +521,7 @@ importers:
         version: 8.3.2
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
       winston:
         specifier: 3.13.0
         version: 3.13.0
@@ -640,7 +639,7 @@ importers:
         version: 3.1.9
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(typescript@6.0.3)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -716,7 +715,7 @@ importers:
         version: 9.15.1(encoding@0.1.13)
       inquirer:
         specifier: 8.2.7
-        version: 8.2.7(@types/node@22.13.1)
+        version: 8.2.7(@types/node@24.3.1)
       js-yaml:
         specifier: 4.2.0
         version: 4.2.0
@@ -783,7 +782,7 @@ importers:
         version: 6.7.0(encoding@0.1.13)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@22.13.1)(typescript@6.0.3)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -793,6 +792,9 @@ importers:
       '@casl/ability':
         specifier: 6.8.0
         version: 6.8.0
+      '@mastra/schema-compat':
+        specifier: 0.11.2
+        version: 0.11.2(ai@6.0.205(zod@3.25.55))(zod@3.25.55)
       '@types/lodash':
         specifier: 4.14.202
         version: 4.14.202
@@ -4073,6 +4075,9 @@ packages:
     peerDependencies:
       ai: ^4.0.0 || ^5.0.0
       zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      ai:
+        optional: true
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -13957,7 +13962,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.15.2:
@@ -15651,6 +15655,9 @@ packages:
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -19647,12 +19654,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.13.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.3.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.13.1
+      '@types/node': 24.3.1
 
   '@ioredis/commands@1.2.0':
     optional: true
@@ -20112,12 +20119,13 @@ snapshots:
 
   '@mastra/schema-compat@0.11.2(ai@6.0.205(zod@3.25.55))(zod@3.25.55)':
     dependencies:
-      ai: 6.0.205(zod@3.25.55)
       json-schema: 0.4.0
       zod: 3.25.55
       zod-from-json-schema: 0.5.0
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.1(zod@3.25.55)
+    optionalDependencies:
+      ai: 6.0.205(zod@3.25.55)
 
   '@mdx-js/react@3.1.0(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
@@ -21486,7 +21494,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.8.1)':
+  '@rudderstack/rudder-sdk-node@2.1.1(tslib@2.6.2)':
     dependencies:
       axios: 1.16.0
       axios-retry: 4.5.0(axios@1.16.0)
@@ -21498,7 +21506,7 @@ snapshots:
       ms: 2.1.3
       remove-trailing-slash: 0.1.1
       serialize-javascript: 6.0.2
-      tslib: 2.8.1
+      tslib: 2.6.2
       uuid: 11.0.2
     optionalDependencies:
       bull: 4.16.4
@@ -23384,7 +23392,6 @@ snapshots:
   '@types/node@24.3.1':
     dependencies:
       undici-types: 7.10.0
-    optional: true
 
   '@types/nodemailer@7.0.9':
     dependencies:
@@ -24016,14 +24023,6 @@ snapshots:
       '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.6(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.6(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))':
     dependencies:
@@ -28385,9 +28384,9 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  inquirer@8.2.7(@types/node@22.13.1):
+  inquirer@8.2.7(@types/node@24.3.1):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@22.13.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.3.1)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -34149,6 +34148,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.3):
     dependencies:
@@ -34169,7 +34169,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
-    optional: true
 
   ts-unused-exports@9.0.4(typescript@6.0.3):
     dependencies:
@@ -34193,6 +34192,8 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.3.0: {}
+
+  tslib@2.6.2: {}
 
   tslib@2.8.1: {}
 
@@ -34353,8 +34354,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.10.0:
-    optional: true
+  undici-types@7.10.0: {}
 
   undici@6.24.1: {}
 
@@ -34973,24 +34973,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.13.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      sugarss: 5.0.1(postcss@8.5.10)
-      terser: 5.46.1
-      tsx: 4.19.4
-      yaml: 2.8.3
-
   vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -35028,35 +35010,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
-
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@22.13.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 22.13.1
-      jsdom: 24.0.0(canvas@3.2.1)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@24.0.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,3 +51,9 @@ minimumReleaseAgeExclude:
   - js-yaml@4.2.0
   # Renovate security update: vite@7.3.5
   - vite@7.3.5
+
+packageExtensions:
+  '@mastra/schema-compat@0.11.2':
+    peerDependenciesMeta:
+      ai:
+        optional: true


### PR DESCRIPTION
## Summary

Stacked on #24378.

- move the MCP schema compatibility layer into common AI agent schemas
- apply MCP-compatible input schema cloning in `defineTool().for('mcp')`
- keep backend MCP registration using those preprocessed schemas, with dynamic `run_sql` schemas wrapped via the common helper
- move `@mastra/schema-compat` from backend to common

## Testing

- `pnpm -F common run linter src/ee/AiAgent/schemas/McpSchemaCompatLayer.ts src/ee/AiAgent/schemas/McpSchemaCompatLayer.test.ts src/ee/AiAgent/schemas/defineTool.test.ts src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts src/ee/AiAgent/schemas/index.ts`
- `pnpm -F backend run linter src/ee/services/McpService/McpService.ts`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F common test -- src/ee/AiAgent/schemas/McpSchemaCompatLayer.test.ts src/ee/AiAgent/schemas/defineTool.test.ts`
- `pnpm -F backend test -- src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts`
