### PR TITLE
fix(ai): describe filter permutations

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -956,6 +956,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -972,6 +973,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use isNull for missing values, notNull for present values.",
                                             "enum": [
                                               "isNull",
                                               "notNull",
@@ -989,6 +991,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -1005,6 +1008,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use equals/notEquals to match true or false.",
                                             "enum": [
                                               "equals",
                                               "notEquals",
@@ -1012,6 +1016,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "Exactly one boolean value, e.g. [true] or [false].",
                                             "items": {
                                               "type": "boolean",
                                             },
@@ -1035,6 +1040,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1051,6 +1057,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use isNull for missing values, notNull for present values.",
                                             "enum": [
                                               "isNull",
                                               "notNull",
@@ -1068,6 +1075,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1084,6 +1092,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                             "enum": [
                                               "equals",
                                               "notEquals",
@@ -1095,6 +1104,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "String values to match. Do not put natural-language date ranges here.",
                                             "items": {
                                               "type": "string",
                                             },
@@ -1116,6 +1126,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1142,6 +1153,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use isNull for missing values, notNull for present values.",
                                             "enum": [
                                               "isNull",
                                               "notNull",
@@ -1159,6 +1171,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1185,6 +1198,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use equals/notEquals for exact numeric matches.",
                                             "enum": [
                                               "equals",
                                               "notEquals",
@@ -1192,6 +1206,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "One or more exact numeric values to match.",
                                             "items": {
                                               "type": "number",
                                             },
@@ -1209,6 +1224,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1235,6 +1251,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use for threshold comparisons such as greater than 100.",
                                             "enum": [
                                               "lessThan",
                                               "lessThanOrEqual",
@@ -1244,6 +1261,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "Exactly one numeric threshold value.",
                                             "items": {
                                               "type": "number",
                                             },
@@ -1263,6 +1281,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1289,6 +1308,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use for ranges between two numeric bounds.",
                                             "enum": [
                                               "inBetween",
                                               "notInBetween",
@@ -1296,6 +1316,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "Exactly two numeric bounds: [lower, upper].",
                                             "items": {
                                               "type": "number",
                                             },
@@ -1319,6 +1340,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1336,6 +1358,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use isNull for missing dates, notNull for present dates.",
                                             "enum": [
                                               "isNull",
                                               "notNull",
@@ -1353,6 +1376,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1370,6 +1394,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use equals/notEquals for explicit dates or datetimes.",
                                             "enum": [
                                               "equals",
                                               "notEquals",
@@ -1377,6 +1402,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "One or more explicit ISO dates/datetimes.",
                                             "items": {
                                               "anyOf": [
                                                 {
@@ -1388,6 +1414,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                                   "type": "string",
                                                 },
                                               ],
+                                              "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                             },
                                             "type": "array",
                                           },
@@ -1403,6 +1430,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1420,6 +1448,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                             "enum": [
                                               "inThePast",
                                               "notInThePast",
@@ -1429,11 +1458,14 @@ Example B — "Revenue by month with year-over-year comparison"
                                           },
                                           "settings": {
                                             "additionalProperties": false,
+                                            "description": "Relative period settings.",
                                             "properties": {
                                               "completed": {
+                                                "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                                 "type": "boolean",
                                               },
                                               "unitOfTime": {
+                                                "description": "Period unit for the relative date filter.",
                                                 "enum": [
                                                   "days",
                                                   "weeks",
@@ -1451,6 +1483,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "object",
                                           },
                                           "values": {
+                                            "description": "Exactly one positive number of periods, e.g. [2].",
                                             "items": {
                                               "type": "number",
                                             },
@@ -1471,6 +1504,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1488,6 +1522,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use for this/current period or to exclude this/current period.",
                                             "enum": [
                                               "inTheCurrent",
                                               "notInTheCurrent",
@@ -1496,12 +1531,15 @@ Example B — "Revenue by month with year-over-year comparison"
                                           },
                                           "settings": {
                                             "additionalProperties": false,
+                                            "description": "Current-period settings.",
                                             "properties": {
                                               "completed": {
                                                 "const": false,
+                                                "description": "Always false for current-period filters.",
                                                 "type": "boolean",
                                               },
                                               "unitOfTime": {
+                                                "description": "Current period unit, e.g. weeks for this week.",
                                                 "enum": [
                                                   "days",
                                                   "weeks",
@@ -1519,6 +1557,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "object",
                                           },
                                           "values": {
+                                            "description": "Always [1] for current-period filters.",
                                             "items": {
                                               "const": 1,
                                               "type": "number",
@@ -1540,6 +1579,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1557,6 +1597,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "operator": {
+                                            "description": "Use for before/after comparisons against one explicit date or datetime.",
                                             "enum": [
                                               "lessThan",
                                               "lessThanOrEqual",
@@ -1566,6 +1607,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "Exactly one explicit ISO date/datetime threshold.",
                                             "items": {
                                               "anyOf": [
                                                 {
@@ -1577,6 +1619,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                                   "type": "string",
                                                 },
                                               ],
+                                              "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                             },
                                             "maxItems": 1,
                                             "minItems": 1,
@@ -1594,6 +1637,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
+                                        "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1612,9 +1656,11 @@ Example B — "Revenue by month with year-over-year comparison"
                                           },
                                           "operator": {
                                             "const": "inBetween",
+                                            "description": "Use for explicit date ranges between two dates/datetimes.",
                                             "type": "string",
                                           },
                                           "values": {
+                                            "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                             "items": {
                                               "anyOf": [
                                                 {
@@ -1626,6 +1672,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                                   "type": "string",
                                                 },
                                               ],
+                                              "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                             },
                                             "maxItems": 2,
                                             "minItems": 2,
@@ -1771,6 +1818,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -1787,6 +1835,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -1804,6 +1853,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -1820,6 +1870,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals to match true or false.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -1827,6 +1878,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one boolean value, e.g. [true] or [false].",
                                   "items": {
                                     "type": "boolean",
                                   },
@@ -1850,6 +1902,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -1866,6 +1919,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -1883,6 +1937,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -1899,6 +1954,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -1910,6 +1966,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "String values to match. Do not put natural-language date ranges here.",
                                   "items": {
                                     "type": "string",
                                   },
@@ -1931,6 +1988,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -1957,6 +2015,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -1974,6 +2033,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2000,6 +2060,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals for exact numeric matches.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2007,6 +2068,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "One or more exact numeric values to match.",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2024,6 +2086,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2050,6 +2113,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for threshold comparisons such as greater than 100.",
                                   "enum": [
                                     "lessThan",
                                     "lessThanOrEqual",
@@ -2059,6 +2123,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one numeric threshold value.",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2078,6 +2143,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2104,6 +2170,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for ranges between two numeric bounds.",
                                   "enum": [
                                     "inBetween",
                                     "notInBetween",
@@ -2111,6 +2178,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly two numeric bounds: [lower, upper].",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2134,6 +2202,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2151,6 +2220,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing dates, notNull for present dates.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -2168,6 +2238,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2185,6 +2256,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals for explicit dates or datetimes.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2192,6 +2264,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "One or more explicit ISO dates/datetimes.",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -2203,6 +2276,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "type": "array",
                                 },
@@ -2218,6 +2292,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2235,6 +2310,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                   "enum": [
                                     "inThePast",
                                     "notInThePast",
@@ -2244,11 +2320,14 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "settings": {
                                   "additionalProperties": false,
+                                  "description": "Relative period settings.",
                                   "properties": {
                                     "completed": {
+                                      "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                       "type": "boolean",
                                     },
                                     "unitOfTime": {
+                                      "description": "Period unit for the relative date filter.",
                                       "enum": [
                                         "days",
                                         "weeks",
@@ -2266,6 +2345,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "object",
                                 },
                                 "values": {
+                                  "description": "Exactly one positive number of periods, e.g. [2].",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2286,6 +2366,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2303,6 +2384,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for this/current period or to exclude this/current period.",
                                   "enum": [
                                     "inTheCurrent",
                                     "notInTheCurrent",
@@ -2311,12 +2393,15 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "settings": {
                                   "additionalProperties": false,
+                                  "description": "Current-period settings.",
                                   "properties": {
                                     "completed": {
                                       "const": false,
+                                      "description": "Always false for current-period filters.",
                                       "type": "boolean",
                                     },
                                     "unitOfTime": {
+                                      "description": "Current period unit, e.g. weeks for this week.",
                                       "enum": [
                                         "days",
                                         "weeks",
@@ -2334,6 +2419,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "object",
                                 },
                                 "values": {
+                                  "description": "Always [1] for current-period filters.",
                                   "items": {
                                     "const": 1,
                                     "type": "number",
@@ -2355,6 +2441,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2372,6 +2459,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for before/after comparisons against one explicit date or datetime.",
                                   "enum": [
                                     "lessThan",
                                     "lessThanOrEqual",
@@ -2381,6 +2469,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one explicit ISO date/datetime threshold.",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -2392,6 +2481,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "maxItems": 1,
                                   "minItems": 1,
@@ -2409,6 +2499,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2427,9 +2518,11 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "operator": {
                                   "const": "inBetween",
+                                  "description": "Use for explicit date ranges between two dates/datetimes.",
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -2441,6 +2534,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "maxItems": 2,
                                   "minItems": 2,
@@ -2470,6 +2564,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2486,6 +2581,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -2503,6 +2599,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2519,6 +2616,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals to match true or false.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2526,6 +2624,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one boolean value, e.g. [true] or [false].",
                                   "items": {
                                     "type": "boolean",
                                   },
@@ -2549,6 +2648,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2565,6 +2665,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -2582,6 +2683,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2598,6 +2700,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2609,6 +2712,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "String values to match. Do not put natural-language date ranges here.",
                                   "items": {
                                     "type": "string",
                                   },
@@ -2630,6 +2734,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2656,6 +2761,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing values, notNull for present values.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -2673,6 +2779,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2699,6 +2806,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals for exact numeric matches.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2706,6 +2814,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "One or more exact numeric values to match.",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2723,6 +2832,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2749,6 +2859,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for threshold comparisons such as greater than 100.",
                                   "enum": [
                                     "lessThan",
                                     "lessThanOrEqual",
@@ -2758,6 +2869,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one numeric threshold value.",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2777,6 +2889,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2803,6 +2916,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for ranges between two numeric bounds.",
                                   "enum": [
                                     "inBetween",
                                     "notInBetween",
@@ -2810,6 +2924,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly two numeric bounds: [lower, upper].",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2833,6 +2948,7 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2850,6 +2966,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use isNull for missing dates, notNull for present dates.",
                                   "enum": [
                                     "isNull",
                                     "notNull",
@@ -2867,6 +2984,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2884,6 +3002,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use equals/notEquals for explicit dates or datetimes.",
                                   "enum": [
                                     "equals",
                                     "notEquals",
@@ -2891,6 +3010,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "One or more explicit ISO dates/datetimes.",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -2902,6 +3022,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "type": "array",
                                 },
@@ -2917,6 +3038,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2934,6 +3056,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                   "enum": [
                                     "inThePast",
                                     "notInThePast",
@@ -2943,11 +3066,14 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "settings": {
                                   "additionalProperties": false,
+                                  "description": "Relative period settings.",
                                   "properties": {
                                     "completed": {
+                                      "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                       "type": "boolean",
                                     },
                                     "unitOfTime": {
+                                      "description": "Period unit for the relative date filter.",
                                       "enum": [
                                         "days",
                                         "weeks",
@@ -2965,6 +3091,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "object",
                                 },
                                 "values": {
+                                  "description": "Exactly one positive number of periods, e.g. [2].",
                                   "items": {
                                     "type": "number",
                                   },
@@ -2985,6 +3112,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3002,6 +3130,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for this/current period or to exclude this/current period.",
                                   "enum": [
                                     "inTheCurrent",
                                     "notInTheCurrent",
@@ -3010,12 +3139,15 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "settings": {
                                   "additionalProperties": false,
+                                  "description": "Current-period settings.",
                                   "properties": {
                                     "completed": {
                                       "const": false,
+                                      "description": "Always false for current-period filters.",
                                       "type": "boolean",
                                     },
                                     "unitOfTime": {
+                                      "description": "Current period unit, e.g. weeks for this week.",
                                       "enum": [
                                         "days",
                                         "weeks",
@@ -3033,6 +3165,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "object",
                                 },
                                 "values": {
+                                  "description": "Always [1] for current-period filters.",
                                   "items": {
                                     "const": 1,
                                     "type": "number",
@@ -3054,6 +3187,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3071,6 +3205,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "operator": {
+                                  "description": "Use for before/after comparisons against one explicit date or datetime.",
                                   "enum": [
                                     "lessThan",
                                     "lessThanOrEqual",
@@ -3080,6 +3215,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly one explicit ISO date/datetime threshold.",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -3091,6 +3227,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "maxItems": 1,
                                   "minItems": 1,
@@ -3108,6 +3245,7 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3126,9 +3264,11 @@ Example B — "Revenue by month with year-over-year comparison"
                                 },
                                 "operator": {
                                   "const": "inBetween",
+                                  "description": "Use for explicit date ranges between two dates/datetimes.",
                                   "type": "string",
                                 },
                                 "values": {
+                                  "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                   "items": {
                                     "anyOf": [
                                       {
@@ -3140,6 +3280,7 @@ Example B — "Revenue by month with year-over-year comparison"
                                         "type": "string",
                                       },
                                     ],
+                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                   },
                                   "maxItems": 2,
                                   "minItems": 2,
@@ -3167,6 +3308,7 @@ Example B — "Revenue by month with year-over-year comparison"
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3193,6 +3335,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -3210,6 +3353,7 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3236,6 +3380,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals for exact numeric matches.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -3243,6 +3388,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "values": {
+                              "description": "One or more exact numeric values to match.",
                               "items": {
                                 "type": "number",
                               },
@@ -3260,6 +3406,7 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3286,6 +3433,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for threshold comparisons such as greater than 100.",
                               "enum": [
                                 "lessThan",
                                 "lessThanOrEqual",
@@ -3295,6 +3443,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one numeric threshold value.",
                               "items": {
                                 "type": "number",
                               },
@@ -3314,6 +3463,7 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3340,6 +3490,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for ranges between two numeric bounds.",
                               "enum": [
                                 "inBetween",
                                 "notInBetween",
@@ -3347,6 +3498,7 @@ Example B — "Revenue by month with year-over-year comparison"
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly two numeric bounds: [lower, upper].",
                               "items": {
                                 "type": "number",
                               },
@@ -4159,6 +4311,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4175,6 +4328,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4192,6 +4346,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4208,6 +4363,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals to match true or false.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4215,6 +4371,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one boolean value, e.g. [true] or [false].",
                               "items": {
                                 "type": "boolean",
                               },
@@ -4238,6 +4395,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -4254,6 +4412,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4271,6 +4430,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -4287,6 +4447,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4298,6 +4459,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "String values to match. Do not put natural-language date ranges here.",
                               "items": {
                                 "type": "string",
                               },
@@ -4319,6 +4481,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4345,6 +4508,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4362,6 +4526,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4388,6 +4553,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals for exact numeric matches.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4395,6 +4561,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "One or more exact numeric values to match.",
                               "items": {
                                 "type": "number",
                               },
@@ -4412,6 +4579,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4438,6 +4606,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for threshold comparisons such as greater than 100.",
                               "enum": [
                                 "lessThan",
                                 "lessThanOrEqual",
@@ -4447,6 +4616,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one numeric threshold value.",
                               "items": {
                                 "type": "number",
                               },
@@ -4466,6 +4636,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4492,6 +4663,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for ranges between two numeric bounds.",
                               "enum": [
                                 "inBetween",
                                 "notInBetween",
@@ -4499,6 +4671,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly two numeric bounds: [lower, upper].",
                               "items": {
                                 "type": "number",
                               },
@@ -4522,6 +4695,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4539,6 +4713,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing dates, notNull for present dates.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4556,6 +4731,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4573,6 +4749,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals for explicit dates or datetimes.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4580,6 +4757,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "One or more explicit ISO dates/datetimes.",
                               "items": {
                                 "anyOf": [
                                   {
@@ -4591,6 +4769,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "type": "array",
                             },
@@ -4606,6 +4785,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4623,6 +4803,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                               "enum": [
                                 "inThePast",
                                 "notInThePast",
@@ -4632,11 +4813,14 @@ Usage Tips:
                             },
                             "settings": {
                               "additionalProperties": false,
+                              "description": "Relative period settings.",
                               "properties": {
                                 "completed": {
+                                  "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                   "type": "boolean",
                                 },
                                 "unitOfTime": {
+                                  "description": "Period unit for the relative date filter.",
                                   "enum": [
                                     "days",
                                     "weeks",
@@ -4654,6 +4838,7 @@ Usage Tips:
                               "type": "object",
                             },
                             "values": {
+                              "description": "Exactly one positive number of periods, e.g. [2].",
                               "items": {
                                 "type": "number",
                               },
@@ -4674,6 +4859,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4691,6 +4877,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for this/current period or to exclude this/current period.",
                               "enum": [
                                 "inTheCurrent",
                                 "notInTheCurrent",
@@ -4699,12 +4886,15 @@ Usage Tips:
                             },
                             "settings": {
                               "additionalProperties": false,
+                              "description": "Current-period settings.",
                               "properties": {
                                 "completed": {
                                   "const": false,
+                                  "description": "Always false for current-period filters.",
                                   "type": "boolean",
                                 },
                                 "unitOfTime": {
+                                  "description": "Current period unit, e.g. weeks for this week.",
                                   "enum": [
                                     "days",
                                     "weeks",
@@ -4722,6 +4912,7 @@ Usage Tips:
                               "type": "object",
                             },
                             "values": {
+                              "description": "Always [1] for current-period filters.",
                               "items": {
                                 "const": 1,
                                 "type": "number",
@@ -4743,6 +4934,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4760,6 +4952,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for before/after comparisons against one explicit date or datetime.",
                               "enum": [
                                 "lessThan",
                                 "lessThanOrEqual",
@@ -4769,6 +4962,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one explicit ISO date/datetime threshold.",
                               "items": {
                                 "anyOf": [
                                   {
@@ -4780,6 +4974,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "maxItems": 1,
                               "minItems": 1,
@@ -4797,6 +4992,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -4815,9 +5011,11 @@ Usage Tips:
                             },
                             "operator": {
                               "const": "inBetween",
+                              "description": "Use for explicit date ranges between two dates/datetimes.",
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                               "items": {
                                 "anyOf": [
                                   {
@@ -4829,6 +5027,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "maxItems": 2,
                               "minItems": 2,
@@ -4858,6 +5057,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4874,6 +5074,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4891,6 +5092,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4907,6 +5109,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals to match true or false.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4914,6 +5117,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one boolean value, e.g. [true] or [false].",
                               "items": {
                                 "type": "boolean",
                               },
@@ -4937,6 +5141,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -4953,6 +5158,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -4970,6 +5176,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -4986,6 +5193,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -4997,6 +5205,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "String values to match. Do not put natural-language date ranges here.",
                               "items": {
                                 "type": "string",
                               },
@@ -5018,6 +5227,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5044,6 +5254,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing values, notNull for present values.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -5061,6 +5272,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5087,6 +5299,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals for exact numeric matches.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -5094,6 +5307,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "One or more exact numeric values to match.",
                               "items": {
                                 "type": "number",
                               },
@@ -5111,6 +5325,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5137,6 +5352,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for threshold comparisons such as greater than 100.",
                               "enum": [
                                 "lessThan",
                                 "lessThanOrEqual",
@@ -5146,6 +5362,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one numeric threshold value.",
                               "items": {
                                 "type": "number",
                               },
@@ -5165,6 +5382,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5191,6 +5409,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for ranges between two numeric bounds.",
                               "enum": [
                                 "inBetween",
                                 "notInBetween",
@@ -5198,6 +5417,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly two numeric bounds: [lower, upper].",
                               "items": {
                                 "type": "number",
                               },
@@ -5221,6 +5441,7 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5238,6 +5459,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use isNull for missing dates, notNull for present dates.",
                               "enum": [
                                 "isNull",
                                 "notNull",
@@ -5255,6 +5477,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5272,6 +5495,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use equals/notEquals for explicit dates or datetimes.",
                               "enum": [
                                 "equals",
                                 "notEquals",
@@ -5279,6 +5503,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "One or more explicit ISO dates/datetimes.",
                               "items": {
                                 "anyOf": [
                                   {
@@ -5290,6 +5515,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "type": "array",
                             },
@@ -5305,6 +5531,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5322,6 +5549,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                               "enum": [
                                 "inThePast",
                                 "notInThePast",
@@ -5331,11 +5559,14 @@ Usage Tips:
                             },
                             "settings": {
                               "additionalProperties": false,
+                              "description": "Relative period settings.",
                               "properties": {
                                 "completed": {
+                                  "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                   "type": "boolean",
                                 },
                                 "unitOfTime": {
+                                  "description": "Period unit for the relative date filter.",
                                   "enum": [
                                     "days",
                                     "weeks",
@@ -5353,6 +5584,7 @@ Usage Tips:
                               "type": "object",
                             },
                             "values": {
+                              "description": "Exactly one positive number of periods, e.g. [2].",
                               "items": {
                                 "type": "number",
                               },
@@ -5373,6 +5605,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5390,6 +5623,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for this/current period or to exclude this/current period.",
                               "enum": [
                                 "inTheCurrent",
                                 "notInTheCurrent",
@@ -5398,12 +5632,15 @@ Usage Tips:
                             },
                             "settings": {
                               "additionalProperties": false,
+                              "description": "Current-period settings.",
                               "properties": {
                                 "completed": {
                                   "const": false,
+                                  "description": "Always false for current-period filters.",
                                   "type": "boolean",
                                 },
                                 "unitOfTime": {
+                                  "description": "Current period unit, e.g. weeks for this week.",
                                   "enum": [
                                     "days",
                                     "weeks",
@@ -5421,6 +5658,7 @@ Usage Tips:
                               "type": "object",
                             },
                             "values": {
+                              "description": "Always [1] for current-period filters.",
                               "items": {
                                 "const": 1,
                                 "type": "number",
@@ -5442,6 +5680,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5459,6 +5698,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "operator": {
+                              "description": "Use for before/after comparisons against one explicit date or datetime.",
                               "enum": [
                                 "lessThan",
                                 "lessThanOrEqual",
@@ -5468,6 +5708,7 @@ Usage Tips:
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly one explicit ISO date/datetime threshold.",
                               "items": {
                                 "anyOf": [
                                   {
@@ -5479,6 +5720,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "maxItems": 1,
                               "minItems": 1,
@@ -5496,6 +5738,7 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5514,9 +5757,11 @@ Usage Tips:
                             },
                             "operator": {
                               "const": "inBetween",
+                              "description": "Use for explicit date ranges between two dates/datetimes.",
                               "type": "string",
                             },
                             "values": {
+                              "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                               "items": {
                                 "anyOf": [
                                   {
@@ -5528,6 +5773,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                 ],
+                                "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                               },
                               "maxItems": 2,
                               "minItems": 2,
@@ -5555,6 +5801,7 @@ Usage Tips:
                   "anyOf": [
                     {
                       "additionalProperties": false,
+                      "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -5581,6 +5828,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "operator": {
+                          "description": "Use isNull for missing values, notNull for present values.",
                           "enum": [
                             "isNull",
                             "notNull",
@@ -5598,6 +5846,7 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
+                      "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -5624,6 +5873,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "operator": {
+                          "description": "Use equals/notEquals for exact numeric matches.",
                           "enum": [
                             "equals",
                             "notEquals",
@@ -5631,6 +5881,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "values": {
+                          "description": "One or more exact numeric values to match.",
                           "items": {
                             "type": "number",
                           },
@@ -5648,6 +5899,7 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
+                      "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -5674,6 +5926,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "operator": {
+                          "description": "Use for threshold comparisons such as greater than 100.",
                           "enum": [
                             "lessThan",
                             "lessThanOrEqual",
@@ -5683,6 +5936,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "values": {
+                          "description": "Exactly one numeric threshold value.",
                           "items": {
                             "type": "number",
                           },
@@ -5702,6 +5956,7 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
+                      "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -5728,6 +5983,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "operator": {
+                          "description": "Use for ranges between two numeric bounds.",
                           "enum": [
                             "inBetween",
                             "notInBetween",
@@ -5735,6 +5991,7 @@ Usage Tips:
                           "type": "string",
                         },
                         "values": {
+                          "description": "Exactly two numeric bounds: [lower, upper].",
                           "items": {
                             "type": "number",
                           },

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1399,6 +1399,7 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "boolean",
@@ -1415,6 +1416,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "operator": {
+                                                        "description": "Use isNull for missing values, notNull for present values.",
                                                         "enum": [
                                                           "isNull",
                                                           "notNull",
@@ -1432,6 +1434,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -1443,6 +1446,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use equals/notEquals to match true or false.",
                                                         "enum": [
                                                           "equals",
                                                           "notEquals",
@@ -1450,6 +1454,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly one boolean value, e.g. [true] or [false].",
                                                         "items": {
                                                           "type": "boolean",
                                                         },
@@ -1473,6 +1478,7 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "string",
@@ -1489,6 +1495,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "operator": {
+                                                        "description": "Use isNull for missing values, notNull for present values.",
                                                         "enum": [
                                                           "isNull",
                                                           "notNull",
@@ -1506,6 +1513,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -1517,6 +1525,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                                         "enum": [
                                                           "equals",
                                                           "notEquals",
@@ -1528,6 +1537,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "String values to match. Do not put natural-language date ranges here.",
                                                         "items": {
                                                           "type": "string",
                                                         },
@@ -1549,6 +1559,7 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "number",
@@ -1575,6 +1586,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "operator": {
+                                                        "description": "Use isNull for missing values, notNull for present values.",
                                                         "enum": [
                                                           "isNull",
                                                           "notNull",
@@ -1592,6 +1604,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1603,6 +1616,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use equals/notEquals for exact numeric matches.",
                                                         "enum": [
                                                           "equals",
                                                           "notEquals",
@@ -1610,6 +1624,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "One or more exact numeric values to match.",
                                                         "items": {
                                                           "type": "number",
                                                         },
@@ -1627,6 +1642,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1638,6 +1654,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use for threshold comparisons such as greater than 100.",
                                                         "enum": [
                                                           "lessThan",
                                                           "lessThanOrEqual",
@@ -1647,6 +1664,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly one numeric threshold value.",
                                                         "items": {
                                                           "type": "number",
                                                         },
@@ -1666,6 +1684,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1677,6 +1696,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use for ranges between two numeric bounds.",
                                                         "enum": [
                                                           "inBetween",
                                                           "notInBetween",
@@ -1684,6 +1704,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly two numeric bounds: [lower, upper].",
                                                         "items": {
                                                           "type": "number",
                                                         },
@@ -1707,6 +1728,7 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "date",
@@ -1724,6 +1746,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "operator": {
+                                                        "description": "Use isNull for missing dates, notNull for present dates.",
                                                         "enum": [
                                                           "isNull",
                                                           "notNull",
@@ -1741,6 +1764,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1752,6 +1776,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use equals/notEquals for explicit dates or datetimes.",
                                                         "enum": [
                                                           "equals",
                                                           "notEquals",
@@ -1759,6 +1784,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "One or more explicit ISO dates/datetimes.",
                                                         "items": {
                                                           "anyOf": [
                                                             {
@@ -1770,6 +1796,7 @@ Recommended Dashboard Structure:
                                                               "type": "string",
                                                             },
                                                           ],
+                                                          "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                                         },
                                                         "type": "array",
                                                       },
@@ -1785,6 +1812,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1796,6 +1824,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                                         "enum": [
                                                           "inThePast",
                                                           "notInThePast",
@@ -1805,11 +1834,14 @@ Recommended Dashboard Structure:
                                                       },
                                                       "settings": {
                                                         "additionalProperties": false,
+                                                        "description": "Relative period settings.",
                                                         "properties": {
                                                           "completed": {
+                                                            "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                                             "type": "boolean",
                                                           },
                                                           "unitOfTime": {
+                                                            "description": "Period unit for the relative date filter.",
                                                             "enum": [
                                                               "days",
                                                               "weeks",
@@ -1827,6 +1859,7 @@ Recommended Dashboard Structure:
                                                         "type": "object",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly one positive number of periods, e.g. [2].",
                                                         "items": {
                                                           "type": "number",
                                                         },
@@ -1847,6 +1880,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1858,6 +1892,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use for this/current period or to exclude this/current period.",
                                                         "enum": [
                                                           "inTheCurrent",
                                                           "notInTheCurrent",
@@ -1866,12 +1901,15 @@ Recommended Dashboard Structure:
                                                       },
                                                       "settings": {
                                                         "additionalProperties": false,
+                                                        "description": "Current-period settings.",
                                                         "properties": {
                                                           "completed": {
                                                             "const": false,
+                                                            "description": "Always false for current-period filters.",
                                                             "type": "boolean",
                                                           },
                                                           "unitOfTime": {
+                                                            "description": "Current period unit, e.g. weeks for this week.",
                                                             "enum": [
                                                               "days",
                                                               "weeks",
@@ -1889,6 +1927,7 @@ Recommended Dashboard Structure:
                                                         "type": "object",
                                                       },
                                                       "values": {
+                                                        "description": "Always [1] for current-period filters.",
                                                         "items": {
                                                           "const": 1,
                                                           "type": "number",
@@ -1910,6 +1949,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1921,6 +1961,7 @@ Recommended Dashboard Structure:
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                       },
                                                       "operator": {
+                                                        "description": "Use for before/after comparisons against one explicit date or datetime.",
                                                         "enum": [
                                                           "lessThan",
                                                           "lessThanOrEqual",
@@ -1930,6 +1971,7 @@ Recommended Dashboard Structure:
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly one explicit ISO date/datetime threshold.",
                                                         "items": {
                                                           "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
                                                         },
@@ -1949,6 +1991,7 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
+                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1961,9 +2004,11 @@ Recommended Dashboard Structure:
                                                       },
                                                       "operator": {
                                                         "const": "inBetween",
+                                                        "description": "Use for explicit date ranges between two dates/datetimes.",
                                                         "type": "string",
                                                       },
                                                       "values": {
+                                                        "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                                         "items": {
                                                           "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
                                                         },
@@ -4318,6 +4363,7 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "boolean",
@@ -4334,6 +4380,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "operator": {
+                                                  "description": "Use isNull for missing values, notNull for present values.",
                                                   "enum": [
                                                     "isNull",
                                                     "notNull",
@@ -4351,6 +4398,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -4362,6 +4410,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use equals/notEquals to match true or false.",
                                                   "enum": [
                                                     "equals",
                                                     "notEquals",
@@ -4369,6 +4418,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly one boolean value, e.g. [true] or [false].",
                                                   "items": {
                                                     "type": "boolean",
                                                   },
@@ -4392,6 +4442,7 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "string",
@@ -4408,6 +4459,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "operator": {
+                                                  "description": "Use isNull for missing values, notNull for present values.",
                                                   "enum": [
                                                     "isNull",
                                                     "notNull",
@@ -4425,6 +4477,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -4436,6 +4489,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                                   "enum": [
                                                     "equals",
                                                     "notEquals",
@@ -4447,6 +4501,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "String values to match. Do not put natural-language date ranges here.",
                                                   "items": {
                                                     "type": "string",
                                                   },
@@ -4468,6 +4523,7 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "number",
@@ -4494,6 +4550,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "operator": {
+                                                  "description": "Use isNull for missing values, notNull for present values.",
                                                   "enum": [
                                                     "isNull",
                                                     "notNull",
@@ -4511,6 +4568,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4522,6 +4580,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use equals/notEquals for exact numeric matches.",
                                                   "enum": [
                                                     "equals",
                                                     "notEquals",
@@ -4529,6 +4588,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "One or more exact numeric values to match.",
                                                   "items": {
                                                     "type": "number",
                                                   },
@@ -4546,6 +4606,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4557,6 +4618,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use for threshold comparisons such as greater than 100.",
                                                   "enum": [
                                                     "lessThan",
                                                     "lessThanOrEqual",
@@ -4566,6 +4628,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly one numeric threshold value.",
                                                   "items": {
                                                     "type": "number",
                                                   },
@@ -4585,6 +4648,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4596,6 +4660,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use for ranges between two numeric bounds.",
                                                   "enum": [
                                                     "inBetween",
                                                     "notInBetween",
@@ -4603,6 +4668,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly two numeric bounds: [lower, upper].",
                                                   "items": {
                                                     "type": "number",
                                                   },
@@ -4626,6 +4692,7 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "date",
@@ -4643,6 +4710,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "operator": {
+                                                  "description": "Use isNull for missing dates, notNull for present dates.",
                                                   "enum": [
                                                     "isNull",
                                                     "notNull",
@@ -4660,6 +4728,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4671,6 +4740,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use equals/notEquals for explicit dates or datetimes.",
                                                   "enum": [
                                                     "equals",
                                                     "notEquals",
@@ -4678,6 +4748,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "One or more explicit ISO dates/datetimes.",
                                                   "items": {
                                                     "anyOf": [
                                                       {
@@ -4689,6 +4760,7 @@ Notes:
                                                         "type": "string",
                                                       },
                                                     ],
+                                                    "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                                   },
                                                   "type": "array",
                                                 },
@@ -4704,6 +4776,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4715,6 +4788,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                                   "enum": [
                                                     "inThePast",
                                                     "notInThePast",
@@ -4724,11 +4798,14 @@ Notes:
                                                 },
                                                 "settings": {
                                                   "additionalProperties": false,
+                                                  "description": "Relative period settings.",
                                                   "properties": {
                                                     "completed": {
+                                                      "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                                       "type": "boolean",
                                                     },
                                                     "unitOfTime": {
+                                                      "description": "Period unit for the relative date filter.",
                                                       "enum": [
                                                         "days",
                                                         "weeks",
@@ -4746,6 +4823,7 @@ Notes:
                                                   "type": "object",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly one positive number of periods, e.g. [2].",
                                                   "items": {
                                                     "type": "number",
                                                   },
@@ -4766,6 +4844,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4777,6 +4856,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use for this/current period or to exclude this/current period.",
                                                   "enum": [
                                                     "inTheCurrent",
                                                     "notInTheCurrent",
@@ -4785,12 +4865,15 @@ Notes:
                                                 },
                                                 "settings": {
                                                   "additionalProperties": false,
+                                                  "description": "Current-period settings.",
                                                   "properties": {
                                                     "completed": {
                                                       "const": false,
+                                                      "description": "Always false for current-period filters.",
                                                       "type": "boolean",
                                                     },
                                                     "unitOfTime": {
+                                                      "description": "Current period unit, e.g. weeks for this week.",
                                                       "enum": [
                                                         "days",
                                                         "weeks",
@@ -4808,6 +4891,7 @@ Notes:
                                                   "type": "object",
                                                 },
                                                 "values": {
+                                                  "description": "Always [1] for current-period filters.",
                                                   "items": {
                                                     "const": 1,
                                                     "type": "number",
@@ -4829,6 +4913,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4840,6 +4925,7 @@ Notes:
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldType",
                                                 },
                                                 "operator": {
+                                                  "description": "Use for before/after comparisons against one explicit date or datetime.",
                                                   "enum": [
                                                     "lessThan",
                                                     "lessThanOrEqual",
@@ -4849,6 +4935,7 @@ Notes:
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly one explicit ISO date/datetime threshold.",
                                                   "items": {
                                                     "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
                                                   },
@@ -4868,6 +4955,7 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
+                                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4880,9 +4968,11 @@ Notes:
                                                 },
                                                 "operator": {
                                                   "const": "inBetween",
+                                                  "description": "Use for explicit date ranges between two dates/datetimes.",
                                                   "type": "string",
                                                 },
                                                 "values": {
+                                                  "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                                   "items": {
                                                     "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/1/properties/values/items",
                                                   },
@@ -5908,6 +5998,7 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
+                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "boolean",
@@ -5924,6 +6015,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "operator": {
+                                    "description": "Use isNull for missing values, notNull for present values.",
                                     "enum": [
                                       "isNull",
                                       "notNull",
@@ -5941,6 +6033,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -5952,6 +6045,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use equals/notEquals to match true or false.",
                                     "enum": [
                                       "equals",
                                       "notEquals",
@@ -5959,6 +6053,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "Exactly one boolean value, e.g. [true] or [false].",
                                     "items": {
                                       "type": "boolean",
                                     },
@@ -5982,6 +6077,7 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
+                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "string",
@@ -5998,6 +6094,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "operator": {
+                                    "description": "Use isNull for missing values, notNull for present values.",
                                     "enum": [
                                       "isNull",
                                       "notNull",
@@ -6015,6 +6112,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -6026,6 +6124,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "equals/notEquals for exact matches; include/doesNotInclude for contains; startsWith/endsWith for prefixes/suffixes.",
                                     "enum": [
                                       "equals",
                                       "notEquals",
@@ -6037,6 +6136,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "String values to match. Do not put natural-language date ranges here.",
                                     "items": {
                                       "type": "string",
                                     },
@@ -6058,6 +6158,7 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
+                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "number",
@@ -6084,6 +6185,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "operator": {
+                                    "description": "Use isNull for missing values, notNull for present values.",
                                     "enum": [
                                       "isNull",
                                       "notNull",
@@ -6101,6 +6203,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6112,6 +6215,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use equals/notEquals for exact numeric matches.",
                                     "enum": [
                                       "equals",
                                       "notEquals",
@@ -6119,6 +6223,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "One or more exact numeric values to match.",
                                     "items": {
                                       "type": "number",
                                     },
@@ -6136,6 +6241,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6147,6 +6253,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use for threshold comparisons such as greater than 100.",
                                     "enum": [
                                       "lessThan",
                                       "lessThanOrEqual",
@@ -6156,6 +6263,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "Exactly one numeric threshold value.",
                                     "items": {
                                       "type": "number",
                                     },
@@ -6175,6 +6283,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6186,6 +6295,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use for ranges between two numeric bounds.",
                                     "enum": [
                                       "inBetween",
                                       "notInBetween",
@@ -6193,6 +6303,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "Exactly two numeric bounds: [lower, upper].",
                                     "items": {
                                       "type": "number",
                                     },
@@ -6216,6 +6327,7 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
+                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "date",
@@ -6233,6 +6345,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "operator": {
+                                    "description": "Use isNull for missing dates, notNull for present dates.",
                                     "enum": [
                                       "isNull",
                                       "notNull",
@@ -6250,6 +6363,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6261,6 +6375,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use equals/notEquals for explicit dates or datetimes.",
                                     "enum": [
                                       "equals",
                                       "notEquals",
@@ -6268,6 +6383,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "One or more explicit ISO dates/datetimes.",
                                     "items": {
                                       "anyOf": [
                                         {
@@ -6279,6 +6395,7 @@ Usage Tips:
                                           "type": "string",
                                         },
                                       ],
+                                      "description": "ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.",
                                     },
                                     "type": "array",
                                   },
@@ -6294,6 +6411,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6305,6 +6423,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use inThePast for last/past N periods, inTheNext for next N periods, notInThePast to exclude recent periods.",
                                     "enum": [
                                       "inThePast",
                                       "notInThePast",
@@ -6314,11 +6433,14 @@ Usage Tips:
                                   },
                                   "settings": {
                                     "additionalProperties": false,
+                                    "description": "Relative period settings.",
                                     "properties": {
                                       "completed": {
+                                        "description": "false for rolling periods including the current partial period; true for completed periods only.",
                                         "type": "boolean",
                                       },
                                       "unitOfTime": {
+                                        "description": "Period unit for the relative date filter.",
                                         "enum": [
                                           "days",
                                           "weeks",
@@ -6336,6 +6458,7 @@ Usage Tips:
                                     "type": "object",
                                   },
                                   "values": {
+                                    "description": "Exactly one positive number of periods, e.g. [2].",
                                     "items": {
                                       "type": "number",
                                     },
@@ -6356,6 +6479,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6367,6 +6491,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use for this/current period or to exclude this/current period.",
                                     "enum": [
                                       "inTheCurrent",
                                       "notInTheCurrent",
@@ -6375,12 +6500,15 @@ Usage Tips:
                                   },
                                   "settings": {
                                     "additionalProperties": false,
+                                    "description": "Current-period settings.",
                                     "properties": {
                                       "completed": {
                                         "const": false,
+                                        "description": "Always false for current-period filters.",
                                         "type": "boolean",
                                       },
                                       "unitOfTime": {
+                                        "description": "Current period unit, e.g. weeks for this week.",
                                         "enum": [
                                           "days",
                                           "weeks",
@@ -6398,6 +6526,7 @@ Usage Tips:
                                     "type": "object",
                                   },
                                   "values": {
+                                    "description": "Always [1] for current-period filters.",
                                     "items": {
                                       "const": 1,
                                       "type": "number",
@@ -6419,6 +6548,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6430,6 +6560,7 @@ Usage Tips:
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldType",
                                   },
                                   "operator": {
+                                    "description": "Use for before/after comparisons against one explicit date or datetime.",
                                     "enum": [
                                       "lessThan",
                                       "lessThanOrEqual",
@@ -6439,6 +6570,7 @@ Usage Tips:
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "Exactly one explicit ISO date/datetime threshold.",
                                     "items": {
                                       "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/1/properties/values/items",
                                     },
@@ -6458,6 +6590,7 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
+                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6470,9 +6603,11 @@ Usage Tips:
                                   },
                                   "operator": {
                                     "const": "inBetween",
+                                    "description": "Use for explicit date ranges between two dates/datetimes.",
                                     "type": "string",
                                   },
                                   "values": {
+                                    "description": "Exactly two explicit ISO dates/datetimes: [start, end].",
                                     "items": {
                                       "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/1/properties/values/items",
                                     },

--- a/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
+import {
+    filterJsonExamples,
+    filterOperatorList,
+    valuePresenceOperatorDescription,
+} from './filterDescriptionUtils';
 
 const commonBooleanFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -13,19 +18,64 @@ const commonBooleanFilterRuleSchema = z.object({
 });
 
 const booleanFilterSchema = z.union([
-    commonBooleanFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.NULL),
-            z.literal(FilterOperator.NOT_NULL),
-        ]),
-    }),
-    commonBooleanFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.EQUALS),
-            z.literal(FilterOperator.NOT_EQUALS),
-        ]),
-        values: z.array(z.boolean()).length(1),
-    }),
+    commonBooleanFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.NULL),
+                    z.literal(FilterOperator.NOT_NULL),
+                ])
+                .describe(valuePresenceOperatorDescription),
+        })
+        .describe(
+            `Use for boolean fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+                {
+                    fieldId: 'users_is_active',
+                    fieldType: DimensionType.BOOLEAN,
+                    fieldFilterType: FilterType.BOOLEAN,
+                    operator: FilterOperator.NULL,
+                },
+                {
+                    fieldId: 'users_is_active',
+                    fieldType: DimensionType.BOOLEAN,
+                    fieldFilterType: FilterType.BOOLEAN,
+                    operator: FilterOperator.NOT_NULL,
+                },
+            )}`,
+        ),
+    commonBooleanFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.EQUALS),
+                    z.literal(FilterOperator.NOT_EQUALS),
+                ])
+                .describe(
+                    `Use ${filterOperatorList(FilterOperator.EQUALS, FilterOperator.NOT_EQUALS)} to match true or false.`,
+                ),
+            values: z
+                .array(z.boolean())
+                .length(1)
+                .describe('Exactly one boolean value, e.g. [true] or [false].'),
+        })
+        .describe(
+            `Use for boolean fields when matching or excluding true/false values. ${filterJsonExamples(
+                {
+                    fieldId: 'users_is_active',
+                    fieldType: DimensionType.BOOLEAN,
+                    fieldFilterType: FilterType.BOOLEAN,
+                    operator: FilterOperator.EQUALS,
+                    values: [true],
+                },
+                {
+                    fieldId: 'users_is_active',
+                    fieldType: DimensionType.BOOLEAN,
+                    fieldFilterType: FilterType.BOOLEAN,
+                    operator: FilterOperator.NOT_EQUALS,
+                    values: [false],
+                },
+            )}`,
+        ),
 ]);
 
 export default booleanFilterSchema;

--- a/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
@@ -6,11 +6,17 @@ import {
     UnitOfTime,
 } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
+import {
+    datePresenceOperatorDescription,
+    filterJsonExamples,
+    filterOperatorList,
+} from './filterDescriptionUtils';
 
-const dateOrDateTimeSchema = z.union([
-    z.string().date(),
-    z.string().datetime(),
-]);
+const dateOrDateTimeSchema = z
+    .union([z.string().date(), z.string().datetime()])
+    .describe(
+        'ISO date (YYYY-MM-DD) or ISO datetime. Do not use relative phrases like "last 2 weeks" here.',
+    );
 
 const commonDateFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -24,68 +30,272 @@ const commonDateFilterRuleSchema = z.object({
 });
 
 const dateFilterSchema = z.union([
-    commonDateFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.NULL),
-            z.literal(FilterOperator.NOT_NULL),
-        ]),
-    }),
-    commonDateFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.EQUALS),
-            z.literal(FilterOperator.NOT_EQUALS),
-        ]),
-        values: z.array(dateOrDateTimeSchema),
-    }),
-    commonDateFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.IN_THE_PAST),
-            z.literal(FilterOperator.NOT_IN_THE_PAST),
-            z.literal(FilterOperator.IN_THE_NEXT),
-            // NOTE: NOT_IN_THE_NEXT is not supported...
-        ]),
-        values: z.array(z.number()).length(1),
-        settings: z.object({
-            completed: z.boolean(),
-            unitOfTime: z.union([
-                z.literal(UnitOfTime.days),
-                z.literal(UnitOfTime.weeks),
-                z.literal(UnitOfTime.months),
-                z.literal(UnitOfTime.quarters),
-                z.literal(UnitOfTime.years),
-            ]),
-        }),
-    }),
-    commonDateFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.IN_THE_CURRENT),
-            z.literal(FilterOperator.NOT_IN_THE_CURRENT),
-        ]),
-        values: z.array(z.literal(1)).length(1),
-        settings: z.object({
-            completed: z.literal(false),
-            unitOfTime: z.union([
-                z.literal(UnitOfTime.days),
-                z.literal(UnitOfTime.weeks),
-                z.literal(UnitOfTime.months),
-                z.literal(UnitOfTime.quarters),
-                z.literal(UnitOfTime.years),
-            ]),
-        }),
-    }),
-    commonDateFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.LESS_THAN),
-            z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
-            z.literal(FilterOperator.GREATER_THAN),
-            z.literal(FilterOperator.GREATER_THAN_OR_EQUAL),
-        ]),
-        values: z.array(dateOrDateTimeSchema).length(1),
-    }),
-    commonDateFilterRuleSchema.extend({
-        operator: z.literal(FilterOperator.IN_BETWEEN),
-        values: z.array(dateOrDateTimeSchema).length(2),
-    }),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.NULL),
+                    z.literal(FilterOperator.NOT_NULL),
+                ])
+                .describe(datePresenceOperatorDescription),
+        })
+        .describe(
+            `Use for date/timestamp fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.NULL,
+                },
+                {
+                    fieldId: 'orders_created_at',
+                    fieldType: DimensionType.TIMESTAMP,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.NOT_NULL,
+                },
+            )}`,
+        ),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.EQUALS),
+                    z.literal(FilterOperator.NOT_EQUALS),
+                ])
+                .describe(
+                    `Use ${filterOperatorList(FilterOperator.EQUALS, FilterOperator.NOT_EQUALS)} for explicit dates or datetimes.`,
+                ),
+            values: z
+                .array(dateOrDateTimeSchema)
+                .describe('One or more explicit ISO dates/datetimes.'),
+        })
+        .describe(
+            `Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use ${FilterOperator.IN_THE_PAST}. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-01-01'],
+                },
+                {
+                    fieldId: 'orders_created_at',
+                    fieldType: DimensionType.TIMESTAMP,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.NOT_EQUALS,
+                    values: ['2024-01-01T00:00:00Z'],
+                },
+            )}`,
+        ),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.IN_THE_PAST),
+                    z.literal(FilterOperator.NOT_IN_THE_PAST),
+                    z.literal(FilterOperator.IN_THE_NEXT),
+                    // NOTE: NOT_IN_THE_NEXT is not supported...
+                ])
+                .describe(
+                    `Use ${FilterOperator.IN_THE_PAST} for last/past N periods, ${FilterOperator.IN_THE_NEXT} for next N periods, ${FilterOperator.NOT_IN_THE_PAST} to exclude recent periods.`,
+                ),
+            values: z
+                .array(z.number())
+                .length(1)
+                .describe('Exactly one positive number of periods, e.g. [2].'),
+            settings: z
+                .object({
+                    completed: z
+                        .boolean()
+                        .describe(
+                            'false for rolling periods including the current partial period; true for completed periods only.',
+                        ),
+                    unitOfTime: z
+                        .union([
+                            z.literal(UnitOfTime.days),
+                            z.literal(UnitOfTime.weeks),
+                            z.literal(UnitOfTime.months),
+                            z.literal(UnitOfTime.quarters),
+                            z.literal(UnitOfTime.years),
+                        ])
+                        .describe('Period unit for the relative date filter.'),
+                })
+                .describe('Relative period settings.'),
+        })
+        .describe(
+            `Use for relative date requests such as "last 2 weeks" or "next 3 months". ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [2],
+                    settings: {
+                        completed: false,
+                        unitOfTime: UnitOfTime.weeks,
+                    },
+                },
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [3],
+                    settings: {
+                        completed: true,
+                        unitOfTime: UnitOfTime.months,
+                    },
+                },
+                {
+                    fieldId: 'orders_ship_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_THE_NEXT,
+                    values: [14],
+                    settings: {
+                        completed: false,
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.NOT_IN_THE_PAST,
+                    values: [7],
+                    settings: {
+                        completed: false,
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+            )}`,
+        ),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.IN_THE_CURRENT),
+                    z.literal(FilterOperator.NOT_IN_THE_CURRENT),
+                ])
+                .describe(
+                    'Use for this/current period or to exclude this/current period.',
+                ),
+            values: z
+                .array(z.literal(1))
+                .length(1)
+                .describe('Always [1] for current-period filters.'),
+            settings: z
+                .object({
+                    completed: z
+                        .literal(false)
+                        .describe('Always false for current-period filters.'),
+                    unitOfTime: z
+                        .union([
+                            z.literal(UnitOfTime.days),
+                            z.literal(UnitOfTime.weeks),
+                            z.literal(UnitOfTime.months),
+                            z.literal(UnitOfTime.quarters),
+                            z.literal(UnitOfTime.years),
+                        ])
+                        .describe(
+                            'Current period unit, e.g. weeks for this week.',
+                        ),
+                })
+                .describe('Current-period settings.'),
+        })
+        .describe(
+            `Use for current date requests such as "today", "this week", "this month", or "this year". ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_THE_CURRENT,
+                    values: [1],
+                    settings: {
+                        completed: false,
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.NOT_IN_THE_CURRENT,
+                    values: [1],
+                    settings: {
+                        completed: false,
+                        unitOfTime: UnitOfTime.months,
+                    },
+                },
+            )}`,
+        ),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.LESS_THAN),
+                    z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
+                    z.literal(FilterOperator.GREATER_THAN),
+                    z.literal(FilterOperator.GREATER_THAN_OR_EQUAL),
+                ])
+                .describe(
+                    'Use for before/after comparisons against one explicit date or datetime.',
+                ),
+            values: z
+                .array(dateOrDateTimeSchema)
+                .length(1)
+                .describe('Exactly one explicit ISO date/datetime threshold.'),
+        })
+        .describe(
+            `Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                    values: ['2024-01-01'],
+                },
+                {
+                    fieldId: 'orders_created_at',
+                    fieldType: DimensionType.TIMESTAMP,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.LESS_THAN,
+                    values: ['2024-02-01T00:00:00Z'],
+                },
+            )}`,
+        ),
+    commonDateFilterRuleSchema
+        .extend({
+            operator: z
+                .literal(FilterOperator.IN_BETWEEN)
+                .describe(
+                    'Use for explicit date ranges between two dates/datetimes.',
+                ),
+            values: z
+                .array(dateOrDateTimeSchema)
+                .length(2)
+                .describe(
+                    'Exactly two explicit ISO dates/datetimes: [start, end].',
+                ),
+        })
+        .describe(
+            `Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_order_date',
+                    fieldType: DimensionType.DATE,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_BETWEEN,
+                    values: ['2024-01-01', '2024-01-31'],
+                },
+                {
+                    fieldId: 'orders_created_at',
+                    fieldType: DimensionType.TIMESTAMP,
+                    fieldFilterType: FilterType.DATE,
+                    operator: FilterOperator.IN_BETWEEN,
+                    values: ['2024-01-01T00:00:00Z', '2024-01-31T23:59:59Z'],
+                },
+            )}`,
+        ),
 ]);
 
 export default dateFilterSchema;

--- a/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
@@ -1,0 +1,13 @@
+import { FilterOperator } from '../../../../types/filter';
+
+export const filterOperatorList = (...operators: FilterOperator[]): string =>
+    operators.join('/');
+
+export const valuePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing values, ${FilterOperator.NOT_NULL} for present values.`;
+
+export const datePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing dates, ${FilterOperator.NOT_NULL} for present dates.`;
+
+export const filterJsonExamples = (
+    ...examples: Record<string, unknown>[]
+): string =>
+    `Examples: ${examples.map((example) => JSON.stringify(example)).join('; ')}`;

--- a/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
+import {
+    filterJsonExamples,
+    filterOperatorList,
+    valuePresenceOperatorDescription,
+} from './filterDescriptionUtils';
 
 const commonNumberFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -23,35 +28,129 @@ const commonNumberFilterRuleSchema = z.object({
 });
 
 const numberFilterSchema = z.union([
-    commonNumberFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.NULL),
-            z.literal(FilterOperator.NOT_NULL),
-        ]),
-    }),
-    commonNumberFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.EQUALS),
-            z.literal(FilterOperator.NOT_EQUALS),
-        ]),
-        values: z.array(z.number()),
-    }),
-    commonNumberFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.LESS_THAN),
-            z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
-            z.literal(FilterOperator.GREATER_THAN),
-            z.literal(FilterOperator.GREATER_THAN_OR_EQUAL),
-        ]),
-        values: z.array(z.number()).length(1),
-    }),
-    commonNumberFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.IN_BETWEEN),
-            z.literal(FilterOperator.NOT_IN_BETWEEN),
-        ]),
-        values: z.array(z.number()).length(2),
-    }),
+    commonNumberFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.NULL),
+                    z.literal(FilterOperator.NOT_NULL),
+                ])
+                .describe(valuePresenceOperatorDescription),
+        })
+        .describe(
+            `Use for numeric fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_total_revenue',
+                    fieldType: MetricType.SUM,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.NULL,
+                },
+                {
+                    fieldId: 'orders_total_revenue',
+                    fieldType: MetricType.SUM,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.NOT_NULL,
+                },
+            )}`,
+        ),
+    commonNumberFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.EQUALS),
+                    z.literal(FilterOperator.NOT_EQUALS),
+                ])
+                .describe(
+                    `Use ${filterOperatorList(FilterOperator.EQUALS, FilterOperator.NOT_EQUALS)} for exact numeric matches.`,
+                ),
+            values: z
+                .array(z.number())
+                .describe('One or more exact numeric values to match.'),
+        })
+        .describe(
+            `Use for numeric fields that equal or exclude specific values. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_item_count',
+                    fieldType: MetricType.COUNT,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.EQUALS,
+                    values: [1, 2],
+                },
+                {
+                    fieldId: 'orders_discount_percent',
+                    fieldType: DimensionType.NUMBER,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.NOT_EQUALS,
+                    values: [0],
+                },
+            )}`,
+        ),
+    commonNumberFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.LESS_THAN),
+                    z.literal(FilterOperator.LESS_THAN_OR_EQUAL),
+                    z.literal(FilterOperator.GREATER_THAN),
+                    z.literal(FilterOperator.GREATER_THAN_OR_EQUAL),
+                ])
+                .describe(
+                    'Use for threshold comparisons such as greater than 100.',
+                ),
+            values: z
+                .array(z.number())
+                .length(1)
+                .describe('Exactly one numeric threshold value.'),
+        })
+        .describe(
+            `Use for numeric fields with a single comparison threshold. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_total_revenue',
+                    fieldType: MetricType.SUM,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.GREATER_THAN,
+                    values: [1000],
+                },
+                {
+                    fieldId: 'orders_discount_percent',
+                    fieldType: DimensionType.NUMBER,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.LESS_THAN_OR_EQUAL,
+                    values: [0.15],
+                },
+            )}`,
+        ),
+    commonNumberFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.IN_BETWEEN),
+                    z.literal(FilterOperator.NOT_IN_BETWEEN),
+                ])
+                .describe('Use for ranges between two numeric bounds.'),
+            values: z
+                .array(z.number())
+                .length(2)
+                .describe('Exactly two numeric bounds: [lower, upper].'),
+        })
+        .describe(
+            `Use for numeric fields inside or outside a two-value range. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_total_revenue',
+                    fieldType: MetricType.SUM,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.IN_BETWEEN,
+                    values: [100, 500],
+                },
+                {
+                    fieldId: 'orders_margin_percent',
+                    fieldType: DimensionType.NUMBER,
+                    fieldFilterType: FilterType.NUMBER,
+                    operator: FilterOperator.NOT_IN_BETWEEN,
+                    values: [0.2, 0.4],
+                },
+            )}`,
+        ),
 ]);
 
 export default numberFilterSchema;

--- a/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
@@ -2,6 +2,11 @@ import { z } from 'zod';
 import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
+import {
+    filterJsonExamples,
+    filterOperatorList,
+    valuePresenceOperatorDescription,
+} from './filterDescriptionUtils';
 
 const commonStringFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -13,23 +18,83 @@ const commonStringFilterRuleSchema = z.object({
 });
 
 const stringFilterSchema = z.union([
-    commonStringFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.NULL),
-            z.literal(FilterOperator.NOT_NULL),
-        ]),
-    }),
-    commonStringFilterRuleSchema.extend({
-        operator: z.union([
-            z.literal(FilterOperator.EQUALS),
-            z.literal(FilterOperator.NOT_EQUALS),
-            z.literal(FilterOperator.STARTS_WITH),
-            z.literal(FilterOperator.ENDS_WITH),
-            z.literal(FilterOperator.INCLUDE),
-            z.literal(FilterOperator.NOT_INCLUDE),
-        ]),
-        values: z.array(z.string()),
-    }),
+    commonStringFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.NULL),
+                    z.literal(FilterOperator.NOT_NULL),
+                ])
+                .describe(valuePresenceOperatorDescription),
+        })
+        .describe(
+            `Use for string fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_status',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.NULL,
+                },
+                {
+                    fieldId: 'orders_status',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.NOT_NULL,
+                },
+            )}`,
+        ),
+    commonStringFilterRuleSchema
+        .extend({
+            operator: z
+                .union([
+                    z.literal(FilterOperator.EQUALS),
+                    z.literal(FilterOperator.NOT_EQUALS),
+                    z.literal(FilterOperator.STARTS_WITH),
+                    z.literal(FilterOperator.ENDS_WITH),
+                    z.literal(FilterOperator.INCLUDE),
+                    z.literal(FilterOperator.NOT_INCLUDE),
+                ])
+                .describe(
+                    `${filterOperatorList(FilterOperator.EQUALS, FilterOperator.NOT_EQUALS)} for exact matches; ${filterOperatorList(FilterOperator.INCLUDE, FilterOperator.NOT_INCLUDE)} for contains; ${filterOperatorList(FilterOperator.STARTS_WITH, FilterOperator.ENDS_WITH)} for prefixes/suffixes.`,
+                ),
+            values: z
+                .array(z.string())
+                .describe(
+                    'String values to match. Do not put natural-language date ranges here.',
+                ),
+        })
+        .describe(
+            `Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. ${filterJsonExamples(
+                {
+                    fieldId: 'orders_status',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.EQUALS,
+                    values: ['complete', 'paid'],
+                },
+                {
+                    fieldId: 'customers_email',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.INCLUDE,
+                    values: ['@lightdash.com'],
+                },
+                {
+                    fieldId: 'products_sku',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.STARTS_WITH,
+                    values: ['SKU-'],
+                },
+                {
+                    fieldId: 'orders_status',
+                    fieldType: DimensionType.STRING,
+                    fieldFilterType: FilterType.STRING,
+                    operator: FilterOperator.NOT_EQUALS,
+                    values: ['cancelled'],
+                },
+            )}`,
+        ),
 ]);
 
 export default stringFilterSchema;


### PR DESCRIPTION
## Summary

Stacked on #24382.

- add descriptions to filter schema permutations so the agent can choose the right filter shape/operator
- call out relative date filters vs explicit date values to avoid putting phrases like "last 2 weeks" in string/date values
- interpolate filter operator enum values in descriptions instead of hardcoding them
- update agent tool contract snapshots

## Testing

- `pnpm -F common run linter src/ee/AiAgent/schemas/filters/booleanFilters.ts src/ee/AiAgent/schemas/filters/stringFilters.ts src/ee/AiAgent/schemas/filters/numberFilters.ts src/ee/AiAgent/schemas/filters/dateFilters.ts src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts`
- `pnpm -F common typecheck:fast`
- `pnpm -F common test -- src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts src/ee/AiAgent/schemas/defineTool.test.ts`
