### PR TITLE
fix(ai): emit proper agent schemas

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/agentInputSchema.ts
+++ b/packages/common/src/ee/AiAgent/schemas/agentInputSchema.ts
@@ -1,0 +1,24 @@
+import { jsonSchema, type Schema } from 'ai';
+import { type z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
+    inputSchema: TInput,
+): Schema<z.infer<TInput>> => {
+    const agentJsonSchema = zodToJsonSchema(inputSchema, {
+        $refStrategy: 'root',
+        target: 'jsonSchema7',
+    }) as Schema<z.infer<TInput>>['jsonSchema'];
+
+    return jsonSchema<z.infer<TInput>>(agentJsonSchema, {
+        validate: (value) => {
+            const result = inputSchema.safeParse(value);
+
+            if (result.success) {
+                return { success: true, value: result.data as z.infer<TInput> };
+            }
+
+            return { success: false, error: result.error };
+        },
+    });
+};

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.test.ts
@@ -46,7 +46,7 @@ describe('defineTool', () => {
         ).toEqual({ type: 'error-text', value: 'Nope' });
     });
 
-    it('keeps MCP input schemas ref-free', () => {
+    it('builds agent validation and keeps MCP input schemas ref-free', () => {
         const sharedSchema = z.object({ value: z.string() });
         const input = {
             first: { value: 'one' },
@@ -71,9 +71,24 @@ describe('defineTool', () => {
             },
         });
 
+        const agentInputSchema = tool.for('agent').inputSchema;
+        const { jsonSchema, validate } = agentInputSchema;
+        expect(jsonSchema).toEqual(
+            zodToJsonSchema(inputSchema, {
+                $refStrategy: 'root',
+                target: 'jsonSchema7',
+            }),
+        );
+        expect(validate?.(input)).toEqual({
+            success: true,
+            value: input,
+        });
         expect(
-            JSON.stringify(tool.for('agent').inputSchema.jsonSchema),
-        ).toContain('"$ref"');
+            validate?.({
+                first: { value: 1 },
+                second: { value: 'two' },
+            }),
+        ).toMatchObject({ success: false });
 
         const mcpInputSchema = tool.for('mcp').inputSchema;
         expect(mcpInputSchema).not.toBe(inputSchema);

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
@@ -1,6 +1,3 @@
-import { jsonSchema, type Schema } from 'ai';
-import { type z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
     type AgentToModelOutput,
     type McpErrorResult,
@@ -36,27 +33,6 @@ export const defaultAgentToModelOutput: AgentToModelOutput<
     output.metadata.status === 'error'
         ? { type: 'error-text', value: output.result }
         : { type: 'text', value: output.result };
-
-export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
-    inputSchema: TInput,
-): Schema<z.infer<TInput>> => {
-    const agentJsonSchema = zodToJsonSchema(inputSchema, {
-        $refStrategy: 'root',
-        target: 'jsonSchema7',
-    }) as Schema<z.infer<TInput>>['jsonSchema'];
-
-    return jsonSchema<z.infer<TInput>>(agentJsonSchema, {
-        validate: (value) => {
-            const result = inputSchema.safeParse(value);
-
-            if (result.success) {
-                return { success: true, value: result.data as z.infer<TInput> };
-            }
-
-            return { success: false, error: result.error };
-        },
-    });
-};
 
 const text = (textContent: string): McpTextResult => ({
     content: [{ type: 'text', text: textContent }],

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithMcpOutput.ts
@@ -1,5 +1,6 @@
 import snakeCase from 'lodash/snakeCase';
 import { type z } from 'zod';
+import { createAgentInputSchema } from './agentInputSchema';
 import {
     type AgentToolConfig,
     type AgentToolView,
@@ -12,7 +13,6 @@ import {
 import { createMcpCompatibleInputSchema } from './McpSchemaCompatLayer';
 import {
     assertAvailable,
-    createAgentInputSchema,
     createMcpToolResultBuilders,
     defaultAgentToModelOutput,
     resolveDescription,

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionWithoutMcpOutput.ts
@@ -1,5 +1,6 @@
 import snakeCase from 'lodash/snakeCase';
 import { type z } from 'zod';
+import { createAgentInputSchema } from './agentInputSchema';
 import {
     type AgentToolConfig,
     type AgentToolView,
@@ -11,7 +12,6 @@ import {
 import { createMcpCompatibleInputSchema } from './McpSchemaCompatLayer';
 import {
     assertAvailable,
-    createAgentInputSchema,
     createMcpToolResultBuilders,
     defaultAgentToModelOutput,
     resolveDescription,


### PR DESCRIPTION
## Summary
- generate agent tool JSON Schemas from the Zod source schemas via `zod-to-json-schema`
- wrap them with AI SDK `jsonSchema<z.infer<...>>()` and validate with Zod `safeParse`
- normalize path-based local `$ref`s into top-level `$defs` refs so strict tool schemas are accepted
- update agent tool contract snapshots

## Testing
- `pnpm -F common run linter src/ee/AiAgent/schemas/agentInputSchema.ts src/ee/AiAgent/schemas/toolDefinitionUtils.ts src/ee/AiAgent/schemas/defineTool.test.ts`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F common test -- src/ee/AiAgent/schemas/tools/toolRunQueryArgs.test.ts src/ee/AiAgent/schemas/defineTool.test.ts`
- `pnpm -F backend test -- src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts`
- `pnpm -F backend exec tsx /tmp/check-agent-schema.ts` -> `{ refs: 75, nestedRefs: [], hasDefs: true, hasSchema: false }`
- local probe with updated untracked script: strict schemas were accepted; 9/10 cases passed (remaining failure was semantic model output for `jan_2026_range`, not schema rejection)
