### PR TITLE
feat(charts): add min tick interval axis option

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4997,6 +4997,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                minInterval: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 max: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5774,6 +5774,11 @@
                         "type": "string",
                         "description": "Offset from minimum value"
                     },
+                    "minInterval": {
+                        "type": "number",
+                        "format": "double",
+                        "description": "Minimum interval between ticks (e.g. 1 to force integer ticks)"
+                    },
                     "max": {
                         "type": "string",
                         "description": "Maximum value (or 'dataMax' for auto)"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -152,6 +152,11 @@
                     "description": "Minimum value (or 'dataMin' for auto)",
                     "type": "string"
                 },
+                "minInterval": {
+                    "description": "Minimum interval between ticks (e.g. 1 to force integer ticks)",
+                    "format": "double",
+                    "type": "number"
+                },
                 "minOffset": {
                     "description": "Offset from minimum value",
                     "type": "string"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -682,6 +682,8 @@ type Axis = {
     min?: string | undefined;
     /** Maximum value (or 'dataMax' for auto) */
     max?: string | undefined;
+    /** Minimum interval between ticks (e.g. 1 to force integer ticks) */
+    minInterval?: number | undefined;
     /** Offset from minimum value */
     minOffset?: string | undefined;
     /** Offset from maximum value */

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
@@ -1,0 +1,25 @@
+import { Group, NumberInput } from '@mantine-8/core';
+import { type FC } from 'react';
+import { Config } from '../../common/Config';
+
+type Props = {
+    label: string;
+    value: number | undefined;
+    onChange: (value: number | undefined) => void;
+};
+
+export const AxisMinInterval: FC<Props> = ({ label, value, onChange }) => (
+    <Group wrap="nowrap" gap="xs">
+        <Config.Label>{label}</Config.Label>
+        <NumberInput
+            placeholder="Auto"
+            value={value ?? ''}
+            min={0}
+            step={1}
+            w={80}
+            onChange={(newValue) =>
+                onChange(typeof newValue === 'number' ? newValue : undefined)
+            }
+        />
+    </Group>
+);

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinInterval.tsx
@@ -18,7 +18,11 @@ export const AxisMinInterval: FC<Props> = ({ label, value, onChange }) => (
             step={1}
             w={80}
             onChange={(newValue) =>
-                onChange(typeof newValue === 'number' ? newValue : undefined)
+                onChange(
+                    typeof newValue === 'number' && newValue > 0
+                        ? newValue
+                        : undefined,
+                )
             }
         />
     </Group>

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/index.tsx
@@ -34,6 +34,7 @@ import MantineIcon from '../../../common/MantineIcon';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
+import { AxisMinInterval } from './AxisMinInterval';
 import { AxisMinMax } from './AxisMinMax';
 
 const XAxisSortSelectItem = forwardRef<
@@ -67,7 +68,9 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
         setYAxisName,
         setYMinValue,
         setYMaxValue,
+        setYMinInterval,
         setXMinValue,
+        setXMinInterval,
         setXMinOffsetValue,
         setXMaxValue,
         setXMaxOffsetValue,
@@ -171,6 +174,16 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             max={dirtyEchartsConfig?.xAxis?.[0]?.max}
                             setMin={(newValue) => setXMinValue(0, newValue)}
                             setMax={(newValue) => setXMaxValue(0, newValue)}
+                        />
+                    )}
+
+                    {isNumericItem(xAxisField) && (
+                        <AxisMinInterval
+                            label="Min tick interval"
+                            value={dirtyEchartsConfig?.xAxis?.[0]?.minInterval}
+                            onChange={(newValue) =>
+                                setXMinInterval(0, newValue)
+                            }
                         />
                     )}
 
@@ -371,6 +384,15 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             setMax={(newValue) => setYMaxValue(0, newValue)}
                         />
                     )}
+                    {showFirstAxisRange && (
+                        <AxisMinInterval
+                            label="Min tick interval"
+                            value={dirtyEchartsConfig?.yAxis?.[0]?.minInterval}
+                            onChange={(newValue) =>
+                                setYMinInterval(0, newValue)
+                            }
+                        />
+                    )}
                 </Config.Section>
             </Config>
 
@@ -407,6 +429,15 @@ export const Axes: FC<Props> = ({ itemsMap }) => {
                             max={dirtyEchartsConfig?.yAxis?.[1]?.max}
                             setMin={(newValue) => setYMinValue(1, newValue)}
                             setMax={(newValue) => setYMaxValue(1, newValue)}
+                        />
+                    )}
+                    {showSecondAxisRange && (
+                        <AxisMinInterval
+                            label="Min tick interval"
+                            value={dirtyEchartsConfig?.yAxis?.[1]?.minInterval}
+                            onChange={(newValue) =>
+                                setYMinInterval(1, newValue)
+                            }
                         />
                     )}
                 </Config.Section>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.test.ts
@@ -1028,6 +1028,40 @@ describe('useCartesianChartConfig', () => {
         expect(result.current.validConfig.conditionalFormattings).toEqual([]);
     });
 
+    test('should set and clear y-axis minInterval', () => {
+        const params = getSingleSeriesParams();
+        const { result } = renderHook(() => useCartesianChartConfig(params));
+
+        act(() => {
+            result.current.setYMinInterval(0, 1);
+        });
+
+        expect(result.current.dirtyEchartsConfig?.yAxis?.[0]?.minInterval).toBe(
+            1,
+        );
+
+        act(() => {
+            result.current.setYMinInterval(0, undefined);
+        });
+
+        expect(
+            result.current.dirtyEchartsConfig?.yAxis?.[0]?.minInterval,
+        ).toBeUndefined();
+    });
+
+    test('should set x-axis minInterval', () => {
+        const params = getSingleSeriesParams();
+        const { result } = renderHook(() => useCartesianChartConfig(params));
+
+        act(() => {
+            result.current.setXMinInterval(0, 1);
+        });
+
+        expect(result.current.dirtyEchartsConfig?.xAxis?.[0]?.minInterval).toBe(
+            1,
+        );
+    });
+
     test('should clear custom colors when stacking is enabled', () => {
         const initialParams = getSingleSeriesParams();
         const conditionalFormattings = [

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -342,6 +342,25 @@ const useCartesianChartConfig = ({
         [],
     );
 
+    const setYMinInterval = useCallback(
+        (index: number, value: number | undefined) => {
+            setDirtyEchartsConfig((prevState) => {
+                return {
+                    ...prevState,
+                    yAxis: [
+                        prevState?.yAxis?.[0] || {},
+                        prevState?.yAxis?.[1] || {},
+                    ].map((axis, axisIndex) =>
+                        axisIndex === index
+                            ? { ...axis, minInterval: value }
+                            : axis,
+                    ),
+                };
+            });
+        },
+        [],
+    );
+
     const setXMinValue = useCallback(
         (index: number, value: string | undefined) => {
             setDirtyEchartsConfig((prevState) => {
@@ -352,6 +371,25 @@ const useCartesianChartConfig = ({
                         prevState?.xAxis?.[1] || {},
                     ].map((axis, axisIndex) =>
                         axisIndex === index ? { ...axis, min: value } : axis,
+                    ),
+                };
+            });
+        },
+        [],
+    );
+
+    const setXMinInterval = useCallback(
+        (index: number, value: number | undefined) => {
+            setDirtyEchartsConfig((prevState) => {
+                return {
+                    ...prevState,
+                    xAxis: [
+                        prevState?.xAxis?.[0] || {},
+                        prevState?.xAxis?.[1] || {},
+                    ].map((axis, axisIndex) =>
+                        axisIndex === index
+                            ? { ...axis, minInterval: value }
+                            : axis,
                     ),
                 };
             });
@@ -1320,7 +1358,9 @@ const useCartesianChartConfig = ({
         setFlipAxis,
         setYMinValue,
         setYMaxValue,
+        setYMinInterval,
         setXMinValue,
+        setXMinInterval,
         setXMinOffsetValue,
         setXMaxValue,
         setXMaxOffsetValue,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1999,9 +1999,23 @@ const getEchartAxes = ({
                     ((bottomAxisOffset.maxOffset ?? 0) / 100) * logRange +
                     baselineOffset;
 
+                const offsetMin = minX - minOffset;
+                const offsetMax = maxX + maxOffset;
+
+                // When a min tick interval is set, snap the truncated bounds to
+                // multiples of it so the edge ticks stay clean (e.g. integers)
+                // instead of fractional offsets like 0.45 / 3.55
+                const minInterval = xAxisConfiguration?.[0]?.minInterval;
+                if (minInterval) {
+                    return {
+                        min: Math.floor(offsetMin / minInterval) * minInterval,
+                        max: Math.ceil(offsetMax / minInterval) * minInterval,
+                    };
+                }
+
                 return {
-                    min: minX - minOffset,
-                    max: maxX + maxOffset,
+                    min: offsetMin,
+                    max: offsetMax,
                 };
             }
             return {
@@ -2137,6 +2151,10 @@ const getEchartAxes = ({
                 ...bottomAxisExtraConfig,
                 min: bottomAxisBounds.min,
                 max: maxXAxisValue,
+                ...(bottomAxisType === 'value' &&
+                xAxisConfiguration?.[0]?.minInterval !== undefined
+                    ? { minInterval: xAxisConfiguration[0].minInterval }
+                    : {}),
             },
             {
                 type: topAxisType,
@@ -2173,6 +2191,10 @@ const getEchartAxes = ({
                               allowSecondAxisDefaultRange,
                           )
                         : undefined,
+                ...(topAxisType === 'value' &&
+                xAxisConfiguration?.[1]?.minInterval !== undefined
+                    ? { minInterval: xAxisConfiguration[1].minInterval }
+                    : {}),
                 ...topAxisConfigWithStyle,
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
@@ -2215,6 +2237,10 @@ const getEchartAxes = ({
                     : {}),
                 min: minYAxisValue,
                 max: maxYAxisValue,
+                ...(leftAxisType === 'value' &&
+                yAxisConfiguration?.[0]?.minInterval !== undefined
+                    ? { minInterval: yAxisConfiguration[0].minInterval }
+                    : {}),
                 ...leftAxisConfigWithStyle,
                 // Override formatter for 100% stacking without flipped axes
                 ...(shouldStack100 &&
@@ -2293,6 +2319,10 @@ const getEchartAxes = ({
                               allowSecondAxisDefaultRange,
                           )
                         : undefined,
+                ...(rightAxisType === 'value' &&
+                yAxisConfiguration?.[1]?.minInterval !== undefined
+                    ? { minInterval: yAxisConfiguration[1].minInterval }
+                    : {}),
                 ...rightAxisConfigWithStyle,
                 splitLine: isAxisTheSameForAllSeries
                     ? gridStyle
@@ -2630,6 +2660,17 @@ const useEchartsCartesianConfig = (
         if (!itemsMap) return;
 
         const isHorizontal = Boolean(validCartesianConfig?.layout.flipAxes);
+        // Value-type dimension axes don't reserve band space for bars, so the
+        // end bar gets clipped at the grid edge. clip:false lets it overflow
+        // into the margin. Category/date axes band-space bars and are left as-is.
+        // Excluded when dataZoom is on: clip:false would also let bars outside
+        // the scroll window render past the grid over the slider/labels.
+        const dimensionAxis = isHorizontal ? axes.yAxis[0] : axes.xAxis[0];
+        const enableDataZoom = Boolean(
+            validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom,
+        );
+        const shouldDisableBarClip =
+            dimensionAxis?.type === 'value' && !enableDataZoom;
         const conditionalFormattings =
             validCartesianConfig?.conditionalFormattings;
         const categoryColorOverrides =
@@ -2699,6 +2740,7 @@ const useEchartsCartesianConfig = (
                     const barConfig = {
                         ...baseConfig,
                         ...getBarStyle(),
+                        ...(shouldDisableBarClip ? { clip: false } : {}),
                         // Non-stacked bars get border radius on all bars
                         ...((!serie.stack ||
                             getValidStack(serie) === undefined) && {
@@ -2785,12 +2827,15 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.categoryColorOverrides,
         validCartesianConfig?.layout?.xField,
         validCartesianConfig?.conditionalFormattings,
+        validCartesianConfig?.eChartsConfig?.xAxis,
         series,
         dynamicRadius,
         pivotDimensions,
         getSeriesColor,
         colorPalette,
         theme.colors.background,
+        axes.xAxis,
+        axes.yAxis,
     ]);
     const sortedResults = useMemo(() => {
         const results =


### PR DESCRIPTION
## Problem

On bar/line charts whose value axis holds only small integers (e.g. 0, 1, 2), ECharts auto-scales the axis into 0.5 tick steps. With integer label formatting that renders as duplicate labels (0, 1, 1, 2, 2). Users couldn't fix this with `minInterval: 1` in chart YAML because the `Axis` type never exposed `minInterval`, so the setting was silently dropped.

## Changes

- **`Axis.minInterval`** — added to the `Axis` type (`packages/common/src/types/savedCharts.ts`) and applied to value-type axes (left/right Y, bottom/top X) in the ECharts config builder. Gated to value axes so it never collides with the existing time-axis auto `minInterval`.
- **UI control** — new "Min tick interval" input (`AxisMinInterval`) in the axis config panel for each numeric axis, plus `setYMinInterval`/`setXMinInterval` setters.
- **Truncate x-axis integration** — when a min tick interval is set, the Truncate x-axis (offset) bounds are snapped to multiples of the interval, so the edge ticks stay clean integers (previously e.g. `0.44999999999999996` / `3.55`).
- **Generated schemas** — regenerated OpenAPI (`swagger.json`, `routes.ts`) and the chart-as-code JSON schema so the `lightdash upload` YAML path validates `minInterval`. Scoped to the `minInterval` addition only.

## Testing

- Verified tick output with headless ECharts (SSR): `minInterval: 1` turns `0, 0.5, 1, 1.5, 2, 2.5, 3` into `0, 1, 2, 3`; truncate-snapping turns `0.4499…, 1, 2, 3, 3.55` into `0, 1, 2, 3, 4`.
- Added regression tests for the setters; full `useCartesianChartConfig` suite passes (47/47).
- `pnpm check:chart-as-code-schema` passes; frontend + common typecheck and lint clean.

## Notes

- Separate, pre-existing issue spotted while testing: end bars can clip on a numeric (value) axis because ECharts doesn't reserve band space on value axes. Verified independent of this change (the axis extent is identical with/without `minInterval`); tracked separately for its own focused fix.

Closes: PROD-8333
Closes: #24376
