### PR TITLE
test(ai): cover filter permutations

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,7 @@
         "test:snapshots:update": "vitest run --config vitest.config.ts src/utils/QueryBuilder/metricQueryBuilderSnapshots -u",
         "test:integration": "vitest run --config vitest.config.integration.ts",
         "test:integration:dev": "vitest run --config vitest.config.integration.ts --watch",
+        "test:ai-filter-permutations": "TZ=UTC LANG=en_US.UTF-8 vitest run --config vitest.config.ai-filter-permutations.ts",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore --rulesdir eslint-rules",
         "formatter": "oxfmt",
         "lint": "pnpm run linter ./src",

--- a/packages/backend/src/ee/services/ai/filterPermutations/aiFilterPermutation.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/filterPermutations/aiFilterPermutation.integration.test.ts
@@ -1,0 +1,47 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+    filterPermutationGroups,
+    formatFilterPermutationResult,
+    getFilterPermutationModelOptions,
+    runLlmFilterPermutationCase,
+} from './llmFilterPermutationRunner';
+
+const describeIfOpenAiConfigured = process.env.OPENAI_API_KEY
+    ? describe
+    : describe.skip;
+
+describeIfOpenAiConfigured('AI filter permutations (unstrict)', () => {
+    let modelOptions: ReturnType<typeof getFilterPermutationModelOptions>;
+
+    beforeAll(() => {
+        modelOptions = getFilterPermutationModelOptions();
+    });
+
+    describe.each(filterPermutationGroups)(
+        '$family $operator',
+        (permutationGroup) => {
+            it('has at least 3 prompt cases', () => {
+                expect(permutationGroup.cases.length).toBeGreaterThanOrEqual(3);
+            });
+
+            it.each(permutationGroup.cases)(
+                'generates $id',
+                async (testCase) => {
+                    const result = await runLlmFilterPermutationCase({
+                        probeCase: testCase,
+                        modelOptions,
+                        toolSchemaMode: 'unstrict',
+                    });
+
+                    if (!result.ok) {
+                        throw new Error(formatFilterPermutationResult(result));
+                    }
+
+                    expect(result.errors).toEqual([]);
+                    expect(result.ok).toBe(true);
+                },
+                120_000,
+            );
+        },
+    );
+});

--- a/packages/backend/src/ee/services/ai/filterPermutations/filterPermutationCases.test.ts
+++ b/packages/backend/src/ee/services/ai/filterPermutations/filterPermutationCases.test.ts
@@ -1,0 +1,86 @@
+import {
+    filtersSchemaTransformed,
+    filtersSchemaV2,
+    FilterType,
+    getFilterExamples,
+} from '@lightdash/common';
+import {
+    filterPermutationCases,
+    filterPermutationGroups,
+} from './filterPermutationCases';
+
+describe('filter permutation cases', () => {
+    it('has unique case IDs', () => {
+        const ids = filterPermutationCases.map((testCase) => testCase.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('has at least 3 cases for each available family/operator group', () => {
+        const expectedGroupKeys = [
+            { family: 'boolean', fieldFilterType: FilterType.BOOLEAN },
+            { family: 'string', fieldFilterType: FilterType.STRING },
+            { family: 'number', fieldFilterType: FilterType.NUMBER },
+            { family: 'date', fieldFilterType: FilterType.DATE },
+        ].flatMap(({ family, fieldFilterType }) =>
+            Array.from(
+                new Set(
+                    getFilterExamples({
+                        fieldId: 'field_id',
+                        fieldType: fieldFilterType,
+                        fieldFilterType,
+                    }).map((example) => example.operator),
+                ),
+            ).map((operator) => `${family}.${operator}`),
+        );
+        const actualGroupKeys = filterPermutationGroups.map(
+            (group) => `${group.family}.${group.operator}`,
+        );
+
+        expect(new Set(actualGroupKeys)).toEqual(new Set(expectedGroupKeys));
+        filterPermutationGroups.forEach((group) => {
+            expect(group.cases.length).toBeGreaterThanOrEqual(3);
+        });
+    });
+
+    it('defines valid expected filter payloads', () => {
+        filterPermutationCases.forEach((testCase) => {
+            const parseResult = filtersSchemaV2.safeParse({
+                type: 'and',
+                dimensions: [
+                    {
+                        fieldId: testCase.expected.fieldId,
+                        fieldType: testCase.expected.fieldType,
+                        fieldFilterType: testCase.expected.fieldFilterType,
+                        operator: testCase.expected.operator,
+                        ...(testCase.expected.values
+                            ? { values: testCase.expected.values }
+                            : {}),
+                        ...(testCase.expected.settings
+                            ? { settings: testCase.expected.settings }
+                            : {}),
+                    },
+                ],
+                metrics: null,
+                tableCalculations: null,
+            });
+
+            if (!parseResult.success) {
+                throw new Error(
+                    `${testCase.id} failed schema validation: ${parseResult.error.message}`,
+                );
+            }
+
+            const transformedParseResult = filtersSchemaTransformed.safeParse(
+                parseResult.data,
+            );
+            if (!transformedParseResult.success) {
+                throw new Error(
+                    `${testCase.id} failed transformed schema validation: ${transformedParseResult.error.message}`,
+                );
+            }
+
+            expect(parseResult.success).toBe(true);
+            expect(transformedParseResult.success).toBe(true);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/filterPermutations/filterPermutationCases.ts
+++ b/packages/backend/src/ee/services/ai/filterPermutations/filterPermutationCases.ts
@@ -1,0 +1,828 @@
+import {
+    assertUnreachable,
+    DimensionType,
+    FilterOperator,
+    FilterType,
+    MetricType,
+    UnitOfTime,
+} from '@lightdash/common';
+
+export type FilterFamily = 'boolean' | 'string' | 'number' | 'date';
+
+export type FieldCatalogEntry = {
+    label: string;
+    fieldType: DimensionType | MetricType;
+    fieldFilterType: FilterType;
+};
+
+export type ExpectedFilter = {
+    fieldId: string;
+    fieldType: DimensionType | MetricType;
+    fieldFilterType: FilterType;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: {
+        completed?: boolean;
+        unitOfTime?: UnitOfTime;
+    };
+};
+
+export type LlmPermutationCase = {
+    id: string;
+    family: FilterFamily;
+    permutation: string;
+    prompt: string;
+    expected: ExpectedFilter;
+};
+
+export const fieldCatalog = {
+    users_name: {
+        label: 'User name',
+        fieldType: DimensionType.STRING,
+        fieldFilterType: FilterType.STRING,
+    },
+    users_status: {
+        label: 'User status',
+        fieldType: DimensionType.STRING,
+        fieldFilterType: FilterType.STRING,
+    },
+    users_segment_metric: {
+        label: 'User segment metric',
+        fieldType: MetricType.STRING,
+        fieldFilterType: FilterType.STRING,
+    },
+    orders_created_date: {
+        label: 'Order created date',
+        fieldType: DimensionType.DATE,
+        fieldFilterType: FilterType.DATE,
+    },
+    orders_created_timestamp: {
+        label: 'Order created timestamp',
+        fieldType: DimensionType.TIMESTAMP,
+        fieldFilterType: FilterType.DATE,
+    },
+    orders_paid_at_metric: {
+        label: 'Order paid at metric',
+        fieldType: MetricType.TIMESTAMP,
+        fieldFilterType: FilterType.DATE,
+    },
+    orders_total_amount: {
+        label: 'Order total amount',
+        fieldType: DimensionType.NUMBER,
+        fieldFilterType: FilterType.NUMBER,
+    },
+    orders_count: {
+        label: 'Order count',
+        fieldType: MetricType.COUNT,
+        fieldFilterType: FilterType.NUMBER,
+    },
+    orders_average_amount: {
+        label: 'Average order amount',
+        fieldType: MetricType.AVERAGE,
+        fieldFilterType: FilterType.NUMBER,
+    },
+    users_is_active: {
+        label: 'User is active',
+        fieldType: DimensionType.BOOLEAN,
+        fieldFilterType: FilterType.BOOLEAN,
+    },
+    users_has_discount_metric: {
+        label: 'User has discount metric',
+        fieldType: MetricType.BOOLEAN,
+        fieldFilterType: FilterType.BOOLEAN,
+    },
+} as const satisfies Record<string, FieldCatalogEntry>;
+
+type FieldId = keyof typeof fieldCatalog;
+
+type CaseSeed = {
+    id: string;
+    family: FilterFamily;
+    fieldId: FieldId;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: ExpectedFilter['settings'];
+    prompt: string;
+};
+
+const caseFromSeed = (seed: CaseSeed): LlmPermutationCase => {
+    const field = fieldCatalog[seed.fieldId];
+    const valueKey = seed.values
+        ? JSON.stringify(seed.values)
+        : 'values omitted';
+    const settingsKey = seed.settings
+        ? JSON.stringify(seed.settings)
+        : 'settings omitted';
+
+    return {
+        id: `${seed.family}.${seed.operator}.${seed.id}`,
+        family: seed.family,
+        permutation: `${seed.family} + ${seed.operator} + ${valueKey} + ${settingsKey}`,
+        prompt: seed.prompt,
+        expected: {
+            fieldId: seed.fieldId,
+            fieldType: field.fieldType,
+            fieldFilterType: field.fieldFilterType,
+            operator: seed.operator,
+            ...(seed.values ? { values: seed.values } : {}),
+            ...(seed.settings ? { settings: seed.settings } : {}),
+        },
+    };
+};
+
+const booleanSeeds: CaseSeed[] = [
+    {
+        id: 'dimension_missing',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users where the active flag is missing.',
+    },
+    {
+        id: 'metric_missing',
+        family: 'boolean',
+        fieldId: 'users_has_discount_metric',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users where the discount metric flag is null.',
+    },
+    {
+        id: 'active_unknown',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users with no value recorded for whether they are active.',
+    },
+    {
+        id: 'dimension_present',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where the active flag is present.',
+    },
+    {
+        id: 'metric_present',
+        family: 'boolean',
+        fieldId: 'users_has_discount_metric',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where the discount metric flag has a value.',
+    },
+    {
+        id: 'active_known',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where whether they are active is known.',
+    },
+    {
+        id: 'true_dimension',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.EQUALS,
+        values: [true],
+        prompt: 'Find users where is active equals true.',
+    },
+    {
+        id: 'false_dimension',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.EQUALS,
+        values: [false],
+        prompt: 'Find users where is active equals false.',
+    },
+    {
+        id: 'true_metric',
+        family: 'boolean',
+        fieldId: 'users_has_discount_metric',
+        operator: FilterOperator.EQUALS,
+        values: [true],
+        prompt: 'Find users where the discount metric flag equals true.',
+    },
+    {
+        id: 'not_true_dimension',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NOT_EQUALS,
+        values: [true],
+        prompt: 'Find users where is active is not true.',
+    },
+    {
+        id: 'not_false_dimension',
+        family: 'boolean',
+        fieldId: 'users_is_active',
+        operator: FilterOperator.NOT_EQUALS,
+        values: [false],
+        prompt: 'Find users where is active is not false.',
+    },
+    {
+        id: 'not_false_metric',
+        family: 'boolean',
+        fieldId: 'users_has_discount_metric',
+        operator: FilterOperator.NOT_EQUALS,
+        values: [false],
+        prompt: 'Find users where the discount metric flag is not false.',
+    },
+];
+
+const stringValueExamples = [
+    {
+        id: 'single_value',
+        fieldId: 'users_status' as const,
+        value: ['active'],
+        phrase: 'status value active',
+    },
+    {
+        id: 'multiple_values',
+        fieldId: 'users_status' as const,
+        value: ['active', 'pending'],
+        phrase: 'status values active or pending',
+    },
+    {
+        id: 'metric_punctuation',
+        fieldId: 'users_segment_metric' as const,
+        value: ['Enterprise - West'],
+        phrase: 'segment metric value Enterprise - West',
+    },
+];
+
+const stringOperatorPhrases: Record<
+    | FilterOperator.EQUALS
+    | FilterOperator.NOT_EQUALS
+    | FilterOperator.STARTS_WITH
+    | FilterOperator.ENDS_WITH
+    | FilterOperator.INCLUDE
+    | FilterOperator.NOT_INCLUDE,
+    string
+> = {
+    [FilterOperator.EQUALS]: 'equals',
+    [FilterOperator.NOT_EQUALS]: 'does not equal',
+    [FilterOperator.STARTS_WITH]: 'starts with',
+    [FilterOperator.ENDS_WITH]: 'ends with',
+    [FilterOperator.INCLUDE]: 'contains',
+    [FilterOperator.NOT_INCLUDE]: 'does not contain',
+};
+
+const stringSeeds: CaseSeed[] = [
+    {
+        id: 'name_missing',
+        family: 'string',
+        fieldId: 'users_name',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users where the user name is missing.',
+    },
+    {
+        id: 'status_missing',
+        family: 'string',
+        fieldId: 'users_status',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users where status is null.',
+    },
+    {
+        id: 'metric_missing',
+        family: 'string',
+        fieldId: 'users_segment_metric',
+        operator: FilterOperator.NULL,
+        prompt: 'Find users where the segment metric has no value.',
+    },
+    {
+        id: 'name_present',
+        family: 'string',
+        fieldId: 'users_name',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where the user name is present.',
+    },
+    {
+        id: 'status_present',
+        family: 'string',
+        fieldId: 'users_status',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where status is not null.',
+    },
+    {
+        id: 'metric_present',
+        family: 'string',
+        fieldId: 'users_segment_metric',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find users where the segment metric has a value.',
+    },
+    ...(
+        [
+            FilterOperator.EQUALS,
+            FilterOperator.NOT_EQUALS,
+            FilterOperator.STARTS_WITH,
+            FilterOperator.ENDS_WITH,
+            FilterOperator.INCLUDE,
+            FilterOperator.NOT_INCLUDE,
+        ] as const
+    ).flatMap((operator) =>
+        stringValueExamples.map<CaseSeed>((example) => ({
+            id: `${operator}_${example.id}`,
+            family: 'string',
+            fieldId: example.fieldId,
+            operator,
+            values: example.value,
+            prompt: `Find users where ${example.phrase} ${stringOperatorPhrases[operator]}.`,
+        })),
+    ),
+];
+
+const numberValueExamples = [
+    {
+        id: 'single_integer',
+        fieldId: 'orders_total_amount' as const,
+        values: [100],
+        phrase: 'order total amount 100',
+    },
+    {
+        id: 'multiple_values',
+        fieldId: 'orders_count' as const,
+        values: [1, 2, 3],
+        phrase: 'order count values 1, 2, or 3',
+    },
+    {
+        id: 'decimal_metric',
+        fieldId: 'orders_average_amount' as const,
+        values: [42.75],
+        phrase: 'average order amount 42.75',
+    },
+];
+
+const numberComparisonExamples = [
+    {
+        id: 'positive_dimension',
+        fieldId: 'orders_total_amount' as const,
+        values: [100],
+        phrase: 'order total amount 100',
+    },
+    {
+        id: 'negative_dimension',
+        fieldId: 'orders_total_amount' as const,
+        values: [-5],
+        phrase: 'order total amount negative 5',
+    },
+    {
+        id: 'decimal_metric',
+        fieldId: 'orders_average_amount' as const,
+        values: [42.75],
+        phrase: 'average order amount 42.75',
+    },
+];
+
+const numberRangeExamples = [
+    {
+        id: 'normal_range',
+        fieldId: 'orders_total_amount' as const,
+        values: [10, 100],
+        phrase: 'order total amount from 10 to 100',
+    },
+    {
+        id: 'negative_to_positive',
+        fieldId: 'orders_total_amount' as const,
+        values: [-10, 10],
+        phrase: 'order total amount from negative 10 to 10',
+    },
+    {
+        id: 'decimal_metric_range',
+        fieldId: 'orders_average_amount' as const,
+        values: [1.5, 9.75],
+        phrase: 'average order amount from 1.5 to 9.75',
+    },
+];
+
+const numberOperatorPhrases: Record<
+    | FilterOperator.EQUALS
+    | FilterOperator.NOT_EQUALS
+    | FilterOperator.LESS_THAN
+    | FilterOperator.LESS_THAN_OR_EQUAL
+    | FilterOperator.GREATER_THAN
+    | FilterOperator.GREATER_THAN_OR_EQUAL
+    | FilterOperator.IN_BETWEEN
+    | FilterOperator.NOT_IN_BETWEEN,
+    string
+> = {
+    [FilterOperator.EQUALS]: 'equals',
+    [FilterOperator.NOT_EQUALS]: 'does not equal',
+    [FilterOperator.LESS_THAN]: 'is less than',
+    [FilterOperator.LESS_THAN_OR_EQUAL]: 'is less than or equal to',
+    [FilterOperator.GREATER_THAN]: 'is greater than',
+    [FilterOperator.GREATER_THAN_OR_EQUAL]: 'is greater than or equal to',
+    [FilterOperator.IN_BETWEEN]: 'is between',
+    [FilterOperator.NOT_IN_BETWEEN]: 'is outside the range',
+};
+
+const numberSeeds: CaseSeed[] = [
+    {
+        id: 'amount_missing',
+        family: 'number',
+        fieldId: 'orders_total_amount',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where total amount is missing.',
+    },
+    {
+        id: 'count_missing',
+        family: 'number',
+        fieldId: 'orders_count',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where order count is null.',
+    },
+    {
+        id: 'average_missing',
+        family: 'number',
+        fieldId: 'orders_average_amount',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where average order amount has no value.',
+    },
+    {
+        id: 'amount_present',
+        family: 'number',
+        fieldId: 'orders_total_amount',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where total amount is present.',
+    },
+    {
+        id: 'count_present',
+        family: 'number',
+        fieldId: 'orders_count',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where order count is not null.',
+    },
+    {
+        id: 'average_present',
+        family: 'number',
+        fieldId: 'orders_average_amount',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where average order amount has a value.',
+    },
+    ...([FilterOperator.EQUALS, FilterOperator.NOT_EQUALS] as const).flatMap(
+        (operator) =>
+            numberValueExamples.map<CaseSeed>((example) => ({
+                id: `${operator}_${example.id}`,
+                family: 'number',
+                fieldId: example.fieldId,
+                operator,
+                values: example.values,
+                prompt: `Find orders where ${example.phrase} ${numberOperatorPhrases[operator]}.`,
+            })),
+    ),
+    ...(
+        [
+            FilterOperator.LESS_THAN,
+            FilterOperator.LESS_THAN_OR_EQUAL,
+            FilterOperator.GREATER_THAN,
+            FilterOperator.GREATER_THAN_OR_EQUAL,
+        ] as const
+    ).flatMap((operator) =>
+        numberComparisonExamples.map<CaseSeed>((example) => ({
+            id: `${operator}_${example.id}`,
+            family: 'number',
+            fieldId: example.fieldId,
+            operator,
+            values: example.values,
+            prompt: `Find orders where ${example.phrase} ${numberOperatorPhrases[operator]}.`,
+        })),
+    ),
+    ...(
+        [FilterOperator.IN_BETWEEN, FilterOperator.NOT_IN_BETWEEN] as const
+    ).flatMap((operator) =>
+        numberRangeExamples.map<CaseSeed>((example) => ({
+            id: `${operator}_${example.id}`,
+            family: 'number',
+            fieldId: example.fieldId,
+            operator,
+            values: example.values,
+            prompt: `Find orders where ${example.phrase} ${numberOperatorPhrases[operator]}.`,
+        })),
+    ),
+];
+
+const explicitDateExamples = [
+    {
+        id: 'date_only',
+        fieldId: 'orders_created_date' as const,
+        values: ['2026-01-15'],
+        phrase: 'created date 2026-01-15',
+    },
+    {
+        id: 'datetime_only',
+        fieldId: 'orders_created_timestamp' as const,
+        values: ['2026-01-15T10:30:00Z'],
+        phrase: 'created timestamp 2026-01-15T10:30:00Z',
+    },
+    {
+        id: 'multiple_dates_metric',
+        fieldId: 'orders_paid_at_metric' as const,
+        values: ['2026-01-15', '2026-02-20T09:00:00Z'],
+        phrase: 'paid-at metric values 2026-01-15 or 2026-02-20T09:00:00Z',
+    },
+];
+
+const dateComparisonExamples = [
+    {
+        id: 'date_threshold',
+        fieldId: 'orders_created_date' as const,
+        values: ['2026-03-01'],
+        phrase: 'created date 2026-03-01',
+    },
+    {
+        id: 'datetime_threshold',
+        fieldId: 'orders_created_timestamp' as const,
+        values: ['2026-03-01T12:45:00Z'],
+        phrase: 'created timestamp 2026-03-01T12:45:00Z',
+    },
+    {
+        id: 'metric_datetime_threshold',
+        fieldId: 'orders_paid_at_metric' as const,
+        values: ['2026-04-05T08:00:00Z'],
+        phrase: 'paid-at metric 2026-04-05T08:00:00Z',
+    },
+];
+
+const dateRangeExamples = [
+    {
+        id: 'date_to_date',
+        fieldId: 'orders_created_date' as const,
+        values: ['2026-01-01', '2026-01-31'],
+        phrase: 'created date between 2026-01-01 and 2026-01-31',
+    },
+    {
+        id: 'datetime_to_datetime',
+        fieldId: 'orders_created_timestamp' as const,
+        values: ['2026-02-01T00:00:00Z', '2026-02-28T23:59:59Z'],
+        phrase: 'created timestamp between 2026-02-01T00:00:00Z and 2026-02-28T23:59:59Z',
+    },
+    {
+        id: 'date_to_datetime_metric',
+        fieldId: 'orders_paid_at_metric' as const,
+        values: ['2026-03-01', '2026-03-31T23:59:59Z'],
+        phrase: 'paid-at metric between 2026-03-01 and 2026-03-31T23:59:59Z',
+    },
+];
+
+const dateOperatorPhrases: Record<
+    | FilterOperator.EQUALS
+    | FilterOperator.NOT_EQUALS
+    | FilterOperator.LESS_THAN
+    | FilterOperator.LESS_THAN_OR_EQUAL
+    | FilterOperator.GREATER_THAN
+    | FilterOperator.GREATER_THAN_OR_EQUAL,
+    string
+> = {
+    [FilterOperator.EQUALS]: 'equals',
+    [FilterOperator.NOT_EQUALS]: 'does not equal',
+    [FilterOperator.LESS_THAN]: 'is before',
+    [FilterOperator.LESS_THAN_OR_EQUAL]: 'is on or before',
+    [FilterOperator.GREATER_THAN]: 'is after',
+    [FilterOperator.GREATER_THAN_OR_EQUAL]: 'is on or after',
+};
+
+const unitOfTimeExamples: Record<UnitOfTime, { value: number; label: string }> =
+    {
+        [UnitOfTime.milliseconds]: { value: 3, label: 'milliseconds' },
+        [UnitOfTime.seconds]: { value: 3, label: 'seconds' },
+        [UnitOfTime.minutes]: { value: 3, label: 'minutes' },
+        [UnitOfTime.hours]: { value: 3, label: 'hours' },
+        [UnitOfTime.days]: { value: 3, label: 'days' },
+        [UnitOfTime.weeks]: { value: 3, label: 'weeks' },
+        [UnitOfTime.months]: { value: 3, label: 'months' },
+        [UnitOfTime.quarters]: { value: 3, label: 'quarters' },
+        [UnitOfTime.years]: { value: 3, label: 'years' },
+    };
+
+const aiDateUnits = [
+    UnitOfTime.days,
+    UnitOfTime.weeks,
+    UnitOfTime.months,
+    UnitOfTime.quarters,
+    UnitOfTime.years,
+] as const;
+
+const relativeDatePrompts = [
+    {
+        id: 'plain_dimension',
+        fieldId: 'orders_created_date' as const,
+        phrase: 'created date',
+    },
+    {
+        id: 'timestamp_dimension',
+        fieldId: 'orders_created_timestamp' as const,
+        phrase: 'created timestamp',
+    },
+    {
+        id: 'metric_timestamp',
+        fieldId: 'orders_paid_at_metric' as const,
+        phrase: 'paid-at metric',
+    },
+];
+
+const relativeOperatorPhrase = (
+    operator:
+        | FilterOperator.IN_THE_PAST
+        | FilterOperator.NOT_IN_THE_PAST
+        | FilterOperator.IN_THE_NEXT,
+    completed: boolean,
+    value: number,
+    unit: UnitOfTime,
+): string => {
+    const period = `${value} ${unitOfTimeExamples[unit].label}`;
+    switch (operator) {
+        case FilterOperator.IN_THE_PAST:
+            return completed
+                ? `in the last ${period}, completed periods only`
+                : `in the past ${period}, including the current partial period`;
+        case FilterOperator.NOT_IN_THE_PAST:
+            return completed
+                ? `not in the last ${period}, completed periods only`
+                : `not in the past ${period}, including the current partial period`;
+        case FilterOperator.IN_THE_NEXT:
+            return completed
+                ? `in the next ${period}, completed periods only`
+                : `in the next ${period}, including the current partial period`;
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported relative date operator: ${operator}`,
+            );
+    }
+};
+
+const currentOperatorPhrase = (
+    operator: FilterOperator.IN_THE_CURRENT | FilterOperator.NOT_IN_THE_CURRENT,
+    unit: UnitOfTime,
+): string => {
+    switch (operator) {
+        case FilterOperator.IN_THE_CURRENT:
+            return `in the current ${unitOfTimeExamples[unit].label.slice(0, -1)}`;
+        case FilterOperator.NOT_IN_THE_CURRENT:
+            return `not in the current ${unitOfTimeExamples[unit].label.slice(0, -1)}`;
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported current date operator: ${operator}`,
+            );
+    }
+};
+
+const dateSeeds: CaseSeed[] = [
+    {
+        id: 'date_missing',
+        family: 'date',
+        fieldId: 'orders_created_date',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where created date is missing.',
+    },
+    {
+        id: 'timestamp_missing',
+        family: 'date',
+        fieldId: 'orders_created_timestamp',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where created timestamp is null.',
+    },
+    {
+        id: 'metric_missing',
+        family: 'date',
+        fieldId: 'orders_paid_at_metric',
+        operator: FilterOperator.NULL,
+        prompt: 'Find orders where paid-at metric has no value.',
+    },
+    {
+        id: 'date_present',
+        family: 'date',
+        fieldId: 'orders_created_date',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where created date is present.',
+    },
+    {
+        id: 'timestamp_present',
+        family: 'date',
+        fieldId: 'orders_created_timestamp',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where created timestamp is not null.',
+    },
+    {
+        id: 'metric_present',
+        family: 'date',
+        fieldId: 'orders_paid_at_metric',
+        operator: FilterOperator.NOT_NULL,
+        prompt: 'Find orders where paid-at metric has a value.',
+    },
+    ...([FilterOperator.EQUALS, FilterOperator.NOT_EQUALS] as const).flatMap(
+        (operator) =>
+            explicitDateExamples.map<CaseSeed>((example) => ({
+                id: `${operator}_${example.id}`,
+                family: 'date',
+                fieldId: example.fieldId,
+                operator,
+                values: example.values,
+                prompt: `Find orders where ${example.phrase} ${dateOperatorPhrases[operator]}.`,
+            })),
+    ),
+    ...(
+        [
+            FilterOperator.IN_THE_PAST,
+            FilterOperator.NOT_IN_THE_PAST,
+            FilterOperator.IN_THE_NEXT,
+        ] as const
+    ).flatMap((operator) =>
+        aiDateUnits.flatMap((unit) =>
+            [true, false].flatMap((completed) =>
+                relativeDatePrompts.map<CaseSeed>((example) => ({
+                    id: `${operator}_${completed ? 'completed' : 'rolling'}_${unit}_${example.id}`,
+                    family: 'date',
+                    fieldId: example.fieldId,
+                    operator,
+                    values: [unitOfTimeExamples[unit].value],
+                    settings: {
+                        completed,
+                        unitOfTime: unit,
+                    },
+                    prompt: `Find orders where ${example.phrase} is ${relativeOperatorPhrase(
+                        operator,
+                        completed,
+                        unitOfTimeExamples[unit].value,
+                        unit,
+                    )}.`,
+                })),
+            ),
+        ),
+    ),
+    ...(
+        [
+            FilterOperator.IN_THE_CURRENT,
+            FilterOperator.NOT_IN_THE_CURRENT,
+        ] as const
+    ).flatMap((operator) =>
+        aiDateUnits.flatMap((unit) =>
+            relativeDatePrompts.map<CaseSeed>((example) => ({
+                id: `${operator}_${unit}_${example.id}`,
+                family: 'date',
+                fieldId: example.fieldId,
+                operator,
+                values: [1],
+                settings: {
+                    completed: false,
+                    unitOfTime: unit,
+                },
+                prompt: `Find orders where ${example.phrase} is ${currentOperatorPhrase(
+                    operator,
+                    unit,
+                )}.`,
+            })),
+        ),
+    ),
+    ...(
+        [
+            FilterOperator.LESS_THAN,
+            FilterOperator.LESS_THAN_OR_EQUAL,
+            FilterOperator.GREATER_THAN,
+            FilterOperator.GREATER_THAN_OR_EQUAL,
+        ] as const
+    ).flatMap((operator) =>
+        dateComparisonExamples.map<CaseSeed>((example) => ({
+            id: `${operator}_${example.id}`,
+            family: 'date',
+            fieldId: example.fieldId,
+            operator,
+            values: example.values,
+            prompt: `Find orders where ${example.phrase} ${dateOperatorPhrases[operator]}.`,
+        })),
+    ),
+    ...dateRangeExamples.map<CaseSeed>((example) => ({
+        id: `inBetween_${example.id}`,
+        family: 'date',
+        fieldId: example.fieldId,
+        operator: FilterOperator.IN_BETWEEN,
+        values: example.values,
+        prompt: `Find orders where ${example.phrase}.`,
+    })),
+];
+
+export const filterPermutationCases: LlmPermutationCase[] = [
+    ...booleanSeeds,
+    ...stringSeeds,
+    ...numberSeeds,
+    ...dateSeeds,
+].map(caseFromSeed);
+
+export const filterPermutationGroups = Object.values(
+    filterPermutationCases.reduce<
+        Record<
+            string,
+            {
+                family: FilterFamily;
+                operator: FilterOperator;
+                permutation: string;
+                cases: LlmPermutationCase[];
+            }
+        >
+    >((acc, testCase) => {
+        const key = `${testCase.family}.${testCase.expected.operator}`;
+        return {
+            ...acc,
+            [key]: {
+                family: testCase.family,
+                operator: testCase.expected.operator,
+                permutation: testCase.permutation,
+                cases: [...(acc[key]?.cases ?? []), testCase],
+            },
+        };
+    }, {}),
+);

--- a/packages/backend/src/ee/services/ai/filterPermutations/llmFilterPermutationRunner.ts
+++ b/packages/backend/src/ee/services/ai/filterPermutations/llmFilterPermutationRunner.ts
@@ -1,0 +1,420 @@
+import {
+    defineTool,
+    filtersSchemaTransformed,
+    filtersSchemaV2,
+    getErrorMessage,
+} from '@lightdash/common';
+import { generateText, stepCountIs, tool } from 'ai';
+import isEqual from 'lodash/isEqual';
+import { type z } from 'zod';
+import { aiCopilotConfigSchema } from '../../../../config/aiConfigSchema';
+import { getAiConfig } from '../../../../config/parseConfig';
+import { getModel } from '../models';
+import {
+    fieldCatalog,
+    filterPermutationCases,
+    filterPermutationGroups,
+    type ExpectedFilter,
+    type LlmPermutationCase,
+} from './filterPermutationCases';
+
+export type FiltersInput = z.infer<typeof filtersSchemaV2>;
+type FilterRuleInput = NonNullable<FiltersInput['dimensions']>[number];
+
+type FilterPermutationModelOptions = ReturnType<typeof getModel>;
+export type FilterPermutationToolSchemaMode = 'strict' | 'unstrict';
+
+export type FilterPermutationResult = {
+    caseId: string;
+    permutation: string;
+    prompt: string;
+    ok: boolean;
+    errors: string[];
+    filters: FiltersInput | null;
+    text: string;
+};
+
+const MODEL_NAME = 'gpt-5.4-nano';
+const TODAY = new Date().toISOString();
+
+const fieldCatalogText = Object.entries(fieldCatalog)
+    .map(
+        ([fieldId, field]) =>
+            `- ${fieldId}: label="${field.label}", fieldType=${field.fieldType}, fieldFilterType=${field.fieldFilterType}`,
+    )
+    .join('\n');
+
+const submitFiltersInputSchema = defineTool({
+    name: 'submitFilters',
+    title: 'Submit filters',
+    description:
+        'Submit the final Lightdash filters object. The input must match the Lightdash AI filters schema.',
+    availability: ['agent'],
+    inputSchema: filtersSchemaV2,
+}).for('agent').inputSchema;
+
+const systemPrompt = `You are a Lightdash metric-query filter builder.
+
+Given a user request, call submitFilters exactly once with a complete filters object:
+{
+  type: "and",
+  dimensions: [exactly one filter rule],
+  metrics: null,
+  tableCalculations: null
+}
+
+Today is ${TODAY}.
+
+Available fields:
+${fieldCatalogText}
+
+Rules:
+- Put the generated filter rule in dimensions.
+- Use field IDs exactly as listed above.
+- Use fieldType and fieldFilterType exactly as listed above for the chosen field.
+- Use the requested operator exactly.
+- Use the requested values exactly when provided.
+- Use the requested settings exactly when provided.
+- For isNull/notNull operators, omit values and settings entirely.
+- Never encode null, missing, or present checks as equals/notEquals/include with values like "null", "missing", "", or true.
+- Do not add extra filters.
+- Do not use natural-language phrases as values.
+- Use ISO dates/datetimes for explicit date values.`;
+
+const getProviderOptions = (
+    providerOptions: Record<string, Record<string, unknown>> | undefined,
+) => ({
+    ...providerOptions,
+    openai: {
+        ...providerOptions?.openai,
+        parallelToolCalls: false,
+    },
+});
+
+const hasProperty = <TProperty extends string>(
+    value: unknown,
+    property: TProperty,
+): value is Record<TProperty, unknown> =>
+    typeof value === 'object' && value !== null && property in value;
+
+const getRuleValues = (rule: FilterRuleInput): unknown[] =>
+    hasProperty(rule, 'values') && Array.isArray(rule.values)
+        ? rule.values
+        : [];
+
+const getRuleSettings = (
+    rule: FilterRuleInput,
+): Record<string, unknown> | undefined =>
+    hasProperty(rule, 'settings') &&
+    typeof rule.settings === 'object' &&
+    rule.settings !== null
+        ? rule.settings
+        : undefined;
+
+const valuesEqual = (actual: unknown, expected: unknown): boolean =>
+    isEqual(actual, expected);
+
+export const summarizeRule = (rule: FilterRuleInput): string =>
+    JSON.stringify({
+        fieldId: rule.fieldId,
+        fieldType: rule.fieldType,
+        fieldFilterType: rule.fieldFilterType,
+        operator: rule.operator,
+        values: getRuleValues(rule),
+        settings: getRuleSettings(rule),
+    });
+
+const validateExpectedFilter = (
+    rule: FilterRuleInput,
+    expected: ExpectedFilter,
+): string[] => {
+    const errors: string[] = [];
+
+    if (rule.fieldId !== expected.fieldId) {
+        errors.push(
+            `used fieldId=${rule.fieldId}; expected ${expected.fieldId}`,
+        );
+    }
+    if (rule.fieldType !== expected.fieldType) {
+        errors.push(
+            `used fieldType=${rule.fieldType}; expected ${expected.fieldType}`,
+        );
+    }
+    if (rule.fieldFilterType !== expected.fieldFilterType) {
+        errors.push(
+            `used fieldFilterType=${rule.fieldFilterType}; expected ${expected.fieldFilterType}`,
+        );
+    }
+    if (rule.operator !== expected.operator) {
+        errors.push(
+            `used operator=${rule.operator}; expected ${expected.operator}`,
+        );
+    }
+
+    const actualValues = getRuleValues(rule);
+    const expectedValues = expected.values ?? [];
+    if (!valuesEqual(actualValues, expectedValues)) {
+        errors.push(
+            `used values=${JSON.stringify(actualValues)}; expected ${JSON.stringify(expectedValues)}`,
+        );
+    }
+
+    const actualSettings = getRuleSettings(rule);
+    if (expected.settings) {
+        if (!valuesEqual(actualSettings, expected.settings)) {
+            errors.push(
+                `used settings=${JSON.stringify(actualSettings)}; expected ${JSON.stringify(expected.settings)}`,
+            );
+        }
+    } else if (actualSettings !== undefined) {
+        errors.push(
+            `used settings=${JSON.stringify(actualSettings)}; expected settings omitted`,
+        );
+    }
+
+    return errors;
+};
+
+const validateTransformedFilters = (
+    filters: FiltersInput,
+    expected: ExpectedFilter,
+): string[] => {
+    const transformed = filtersSchemaTransformed.parse(filters);
+    const { dimensions } = transformed;
+    const errors: string[] = [];
+
+    if (!dimensions) {
+        return ['transformed filters missing dimensions group'];
+    }
+
+    const dimensionItems = 'and' in dimensions ? dimensions.and : dimensions.or;
+    const transformedRule = dimensionItems[0];
+
+    if (!transformedRule || !hasProperty(transformedRule, 'target')) {
+        return ['transformed filter missing first dimension rule'];
+    }
+
+    const { target } = transformedRule;
+    if (!hasProperty(target, 'fieldId')) {
+        errors.push('transformed target missing fieldId');
+    } else if (target.fieldId !== expected.fieldId) {
+        errors.push(
+            `transformed target.fieldId=${String(target.fieldId)}; expected ${expected.fieldId}`,
+        );
+    }
+
+    if (!hasProperty(target, 'fieldFilterType')) {
+        errors.push('transformed target missing fieldFilterType');
+    } else if (target.fieldFilterType !== expected.fieldFilterType) {
+        errors.push(
+            `transformed target.fieldFilterType=${String(target.fieldFilterType)}; expected ${expected.fieldFilterType}`,
+        );
+    }
+
+    if (!hasProperty(transformedRule, 'id')) {
+        errors.push('transformed rule missing id');
+    }
+    if (!hasProperty(transformedRule, 'operator')) {
+        errors.push('transformed rule missing operator');
+    } else if (transformedRule.operator !== expected.operator) {
+        errors.push(
+            `transformed operator=${String(transformedRule.operator)}; expected ${expected.operator}`,
+        );
+    }
+
+    const expectedValues = expected.values ?? [];
+    const actualValues = hasProperty(transformedRule, 'values')
+        ? transformedRule.values
+        : [];
+    if (!valuesEqual(actualValues, expectedValues)) {
+        errors.push(
+            `transformed values=${JSON.stringify(actualValues)}; expected ${JSON.stringify(expectedValues)}`,
+        );
+    }
+
+    const actualSettings = hasProperty(transformedRule, 'settings')
+        ? transformedRule.settings
+        : undefined;
+    if (expected.settings) {
+        if (!valuesEqual(actualSettings, expected.settings)) {
+            errors.push(
+                `transformed settings=${JSON.stringify(actualSettings)}; expected ${JSON.stringify(expected.settings)}`,
+            );
+        }
+    } else if (actualSettings !== undefined) {
+        errors.push(
+            `transformed settings=${JSON.stringify(actualSettings)}; expected settings omitted`,
+        );
+    }
+
+    return errors;
+};
+
+export const getFilterPermutationModelOptions =
+    (): FilterPermutationModelOptions => {
+        const config = aiCopilotConfigSchema.parse(getAiConfig());
+        if (!config.providers.openai) {
+            throw new Error(
+                'OpenAI provider is not configured. Set existing OPENAI_API_KEY.',
+            );
+        }
+
+        return getModel(config, {
+            provider: 'openai',
+            modelName: MODEL_NAME,
+            enableReasoning: false,
+        });
+    };
+
+export const runLlmFilterPermutationCase = async ({
+    probeCase,
+    modelOptions,
+    toolSchemaMode = 'strict',
+}: {
+    probeCase: LlmPermutationCase;
+    modelOptions: FilterPermutationModelOptions;
+    toolSchemaMode?: FilterPermutationToolSchemaMode;
+}): Promise<FilterPermutationResult> => {
+    let submittedFilters: FiltersInput | null = null;
+    let toolCallCount = 0;
+
+    try {
+        const result = await generateText({
+            ...modelOptions.callOptions,
+            providerOptions: getProviderOptions(
+                modelOptions.providerOptions as
+                    | Record<string, Record<string, unknown>>
+                    | undefined,
+            ),
+            model: modelOptions.model,
+            maxRetries: 0,
+            stopWhen: stepCountIs(1),
+            toolChoice: 'required',
+            system: systemPrompt,
+            tools: {
+                submitFilters: tool({
+                    description:
+                        'Submit the final Lightdash filters object. The input must match the Lightdash AI filters schema.',
+                    inputSchema: submitFiltersInputSchema,
+                    strict: toolSchemaMode === 'strict',
+                    execute: async (input) => {
+                        toolCallCount += 1;
+                        submittedFilters = input;
+                        return { ok: true };
+                    },
+                }),
+            },
+            messages: [{ role: 'user', content: probeCase.prompt }],
+        });
+
+        const filters = submittedFilters;
+        if (!filters) {
+            return {
+                caseId: probeCase.id,
+                permutation: probeCase.permutation,
+                prompt: probeCase.prompt,
+                ok: false,
+                errors: ['model did not call submitFilters'],
+                filters: null,
+                text: result.text,
+            };
+        }
+
+        const errors: string[] = [];
+        if (toolCallCount !== 1) {
+            errors.push(
+                `submitFilters called ${toolCallCount} times; expected 1`,
+            );
+        }
+
+        const schemaParse = filtersSchemaV2.safeParse(filters);
+        if (!schemaParse.success) {
+            return {
+                caseId: probeCase.id,
+                permutation: probeCase.permutation,
+                prompt: probeCase.prompt,
+                ok: false,
+                errors: [
+                    `filtersSchemaV2 failed: ${schemaParse.error.message}`,
+                ],
+                filters,
+                text: result.text,
+            };
+        }
+
+        const rules = schemaParse.data.dimensions ?? [];
+        if (rules.length !== 1) {
+            errors.push(
+                `emitted ${rules.length} dimension filters; expected 1`,
+            );
+        }
+
+        const rule = rules[0];
+        if (!rule) {
+            errors.push('missing first dimension filter');
+        } else {
+            errors.push(...validateExpectedFilter(rule, probeCase.expected));
+        }
+
+        try {
+            errors.push(
+                ...validateTransformedFilters(
+                    schemaParse.data,
+                    probeCase.expected,
+                ),
+            );
+        } catch (error) {
+            errors.push(
+                `filtersSchemaTransformed failed: ${getErrorMessage(error)}`,
+            );
+        }
+
+        return {
+            caseId: probeCase.id,
+            permutation: probeCase.permutation,
+            prompt: probeCase.prompt,
+            ok: errors.length === 0,
+            errors,
+            filters: schemaParse.data,
+            text: result.text,
+        };
+    } catch (error) {
+        return {
+            caseId: probeCase.id,
+            permutation: probeCase.permutation,
+            prompt: probeCase.prompt,
+            ok: false,
+            errors: [getErrorMessage(error)],
+            filters: submittedFilters,
+            text: '',
+        };
+    }
+};
+
+export const formatFilterPermutationResult = (
+    result: FilterPermutationResult,
+): string => {
+    const lines = [
+        `[${result.ok ? 'PASS' : 'FAIL'}] ${result.caseId}`,
+        `Permutation: ${result.permutation}`,
+        `Prompt: ${result.prompt}`,
+    ];
+
+    if (result.errors.length > 0) {
+        lines.push(`Errors:\n- ${result.errors.join('\n- ')}`);
+    }
+    if (result.filters) {
+        lines.push(`Filters: ${JSON.stringify(result.filters)}`);
+        const firstRule = result.filters.dimensions?.[0];
+        if (firstRule) {
+            lines.push(`Rule: ${summarizeRule(firstRule)}`);
+        }
+    }
+    if (result.text.trim()) {
+        lines.push(`Text: ${result.text.trim()}`);
+    }
+
+    return lines.join('\n');
+};
+
+export { filterPermutationCases, filterPermutationGroups };

--- a/packages/backend/vitest.config.ai-filter-permutations.ts
+++ b/packages/backend/vitest.config.ai-filter-permutations.ts
@@ -1,0 +1,33 @@
+import * as path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        name: 'ai-filter-permutations',
+        include: [
+            'src/ee/services/ai/filterPermutations/*.integration.test.ts',
+        ],
+        exclude: ['node_modules', 'dist'],
+        environment: 'node',
+        reporters: ['verbose'],
+        testTimeout: 120_000,
+        hookTimeout: 120_000,
+        fileParallelism: true,
+        env: {
+            TZ: 'UTC',
+            NODE_ENV: 'test',
+        },
+    },
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './src'),
+            '@lightdash/common/src': path.resolve(__dirname, '../common/src'),
+            '@lightdash/common': path.resolve(__dirname, '../common/src'),
+            '@lightdash/formula': path.resolve(__dirname, '../formula/src'),
+            '@lightdash/warehouses': path.resolve(
+                __dirname,
+                '../warehouses/src',
+            ),
+        },
+    },
+});

--- a/packages/backend/vitest.config.integration.ts
+++ b/packages/backend/vitest.config.integration.ts
@@ -6,7 +6,11 @@ export default defineConfig({
     test: {
         name: 'integration-tests',
         include: ['src/ee/**/*integration.test.ts'],
-        exclude: ['node_modules', 'dist'],
+        exclude: [
+            'node_modules',
+            'dist',
+            'src/ee/services/ai/filterPermutations/*.integration.test.ts',
+        ],
         environment: 'node',
         testTimeout: 120000,
         hookTimeout: 60000,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:
- Adds backend-owned filter permutation coverage for boolean, string, number, and date filters.
- Covers each available filter family/operator group with at least three valid expected payloads.
- Includes both dimension and metric field types, including numeric metrics such as `count` where `fieldType="count"` and `fieldFilterType="number"`.
- Derives expected operator groups from shared filter examples instead of hard-coding a magic count.
- Validates each expected payload through both `filtersSchemaV2` and `filtersSchemaTransformed`.
- Adds an optional LLM permutation runner that uses natural-language prompts and deep equality for settings.
- Adds a dedicated `test:ai-filter-permutations` Vitest config/script so LLM tests do not run under the DB-backed backend integration config.

### Testing:
- `pnpm -F backend exec jest --config jest.config.js src/ee/services/ai/filterPermutations/filterPermutationCases.test.ts`
- `OPENAI_API_KEY= ANTHROPIC_API_KEY= pnpm -F backend test:ai-filter-permutations`
- `pnpm -F backend typecheck:fast`
