### PR TITLE
refactor(slack): share downvote feedback modal across classic and modern paths

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -96,7 +96,12 @@ import {
     type SuggestionValidationCatalog,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
-import { AllMiddlewareArgs, App, SlackEventMiddlewareArgs } from '@slack/bolt';
+import {
+    AllMiddlewareArgs,
+    App,
+    ModalView,
+    SlackEventMiddlewareArgs,
+} from '@slack/bolt';
 import { Block, KnownBlock, WebClient } from '@slack/web-api';
 import { MessageElement } from '@slack/web-api/dist/response/ConversationsHistoryResponse';
 import {
@@ -8581,6 +8586,76 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         );
     }
 
+    private static buildDownvoteFeedbackModalView(
+        promptUuid: string,
+    ): ModalView {
+        return {
+            type: 'modal',
+            callback_id: 'downvote_feedback_modal',
+            private_metadata: JSON.stringify({ promptUuid }),
+            title: { type: 'plain_text', text: 'Feedback' },
+            submit: { type: 'plain_text', text: 'Submit' },
+            close: { type: 'plain_text', text: 'Skip' },
+            blocks: [
+                {
+                    type: 'section',
+                    text: {
+                        type: 'mrkdwn',
+                        text: 'Help us improve! What went wrong with this answer?',
+                    },
+                },
+                {
+                    type: 'input',
+                    block_id: 'feedback_input',
+                    optional: false,
+                    element: {
+                        type: 'plain_text_input',
+                        action_id: 'feedback_text',
+                        multiline: true,
+                        placeholder: {
+                            type: 'plain_text',
+                            text: 'Your feedback will help improve the AI agent',
+                        },
+                    },
+                    label: { type: 'plain_text', text: 'Feedback' },
+                },
+            ],
+        };
+    }
+
+    public handleDownvoteFeedbackModalSubmit(app: App) {
+        app.view('downvote_feedback_modal', async ({ ack, view, body }) => {
+            await ack();
+
+            const metadata = JSON.parse(view.private_metadata);
+            const { promptUuid } = metadata;
+
+            const feedbackValue =
+                view.state.values.feedback_input?.feedback_text?.value;
+
+            if (feedbackValue) {
+                await this.aiAgentModel.updateHumanScore({
+                    promptUuid,
+                    humanScore: -1,
+                    humanFeedback: feedbackValue,
+                });
+
+                const promptContext =
+                    await this.aiAgentModel.findPromptContext(promptUuid);
+
+                this.enqueueReviewClassifierEvent({
+                    eventType: 'feedback_changed',
+                    organizationUuid: promptContext?.organizationUuid,
+                    projectUuid: promptContext?.projectUuid,
+                    agentUuid: promptContext?.agentUuid,
+                    threadUuid: promptContext?.threadUuid,
+                    promptUuid,
+                    userUuid: body.user.id,
+                });
+            }
+        });
+    }
+
     public handlePromptUpvote(app: App) {
         app.action(
             'prompt_human_score.upvote',
@@ -8733,52 +8808,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 if (score < 0) {
                     await client.views.open({
                         trigger_id: body.trigger_id,
-                        view: {
-                            type: 'modal',
-                            callback_id: 'downvote_feedback_modal',
-                            private_metadata: JSON.stringify({
-                                promptUuid,
-                            }),
-                            title: {
-                                type: 'plain_text',
-                                text: 'Feedback',
-                            },
-                            submit: {
-                                type: 'plain_text',
-                                text: 'Submit',
-                            },
-                            close: {
-                                type: 'plain_text',
-                                text: 'Skip',
-                            },
-                            blocks: [
-                                {
-                                    type: 'section',
-                                    text: {
-                                        type: 'mrkdwn',
-                                        text: 'Help us improve. What went wrong with this answer?',
-                                    },
-                                },
-                                {
-                                    type: 'input',
-                                    block_id: 'feedback_input',
-                                    optional: false,
-                                    element: {
-                                        type: 'plain_text_input',
-                                        action_id: 'feedback_text',
-                                        multiline: true,
-                                        placeholder: {
-                                            type: 'plain_text',
-                                            text: 'Your feedback will help improve the AI agent',
-                                        },
-                                    },
-                                    label: {
-                                        type: 'plain_text',
-                                        text: 'Feedback',
-                                    },
-                                },
-                            ],
-                        },
+                        view: AiAgentService.buildDownvoteFeedbackModalView(
+                            promptUuid,
+                        ),
                     });
                 }
             },
@@ -8850,89 +8882,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
                         await client.views.open({
                             trigger_id: body.trigger_id,
-                            view: {
-                                type: 'modal',
-                                callback_id: 'downvote_feedback_modal',
-                                private_metadata: JSON.stringify({
-                                    promptUuid,
-                                }),
-                                title: {
-                                    type: 'plain_text',
-                                    text: 'Feedback',
-                                },
-                                submit: {
-                                    type: 'plain_text',
-                                    text: 'Submit',
-                                },
-                                close: {
-                                    type: 'plain_text',
-                                    text: 'Skip',
-                                },
-                                blocks: [
-                                    {
-                                        type: 'section',
-                                        text: {
-                                            type: 'mrkdwn',
-                                            text: 'Help us improve! What went wrong with this answer?',
-                                        },
-                                    },
-                                    {
-                                        type: 'input',
-                                        block_id: 'feedback_input',
-                                        optional: false,
-                                        element: {
-                                            type: 'plain_text_input',
-                                            action_id: 'feedback_text',
-                                            multiline: true,
-                                            placeholder: {
-                                                type: 'plain_text',
-                                                text: 'Your feedback will help improve the AI agent (optional)',
-                                            },
-                                        },
-                                        label: {
-                                            type: 'plain_text',
-                                            text: 'Feedback',
-                                        },
-                                    },
-                                ],
-                            },
+                            view: AiAgentService.buildDownvoteFeedbackModalView(
+                                promptUuid,
+                            ),
                         });
                     }
                 }
             },
         );
-
-        // Handle modal submission
-        app.view('downvote_feedback_modal', async ({ ack, view, body }) => {
-            await ack();
-
-            const metadata = JSON.parse(view.private_metadata);
-            const { promptUuid } = metadata;
-
-            const feedbackValue =
-                view.state.values.feedback_input?.feedback_text?.value;
-
-            if (feedbackValue) {
-                await this.aiAgentModel.updateHumanScore({
-                    promptUuid,
-                    humanScore: -1,
-                    humanFeedback: feedbackValue,
-                });
-
-                const promptContext =
-                    await this.aiAgentModel.findPromptContext(promptUuid);
-
-                this.enqueueReviewClassifierEvent({
-                    eventType: 'feedback_changed',
-                    organizationUuid: promptContext?.organizationUuid,
-                    projectUuid: promptContext?.projectUuid,
-                    agentUuid: promptContext?.agentUuid,
-                    threadUuid: promptContext?.threadUuid,
-                    promptUuid,
-                    userUuid: body.user.id,
-                });
-            }
-        });
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -36,6 +36,7 @@ export class CommercialSlackService extends SlackService {
         this.aiAgentService.handlePromptUpvote(slackApp);
         this.aiAgentService.handlePromptDownvote(slackApp);
         this.aiAgentService.handlePromptFeedbackButtons(slackApp);
+        this.aiAgentService.handleDownvoteFeedbackModalSubmit(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);
         this.aiAgentService.handleViewArtifact(slackApp);
         this.aiAgentService.handleViewPullRequestButton(slackApp);


### PR DESCRIPTION
## Summary

The modern Slack AI-agent feedback buttons (behind `AiAgentSlackModernBlocks`) and the classic emoji upvote/downvote buttons both open a downvote feedback modal. Previously each path defined that modal inline — two near-duplicate definitions with drifting copy — and the modal's `app.view('downvote_feedback_modal')` submission handler was registered _inside_ `handlePromptDownvote`, so the modern path silently depended on the classic handler being registered to function.

This is a pure refactor; runtime behavior is unchanged.

## Changes

- Add `AiAgentService.buildDownvoteFeedbackModalView(promptUuid)` — single source for the modal view. Both paths now call it.
- Extract the modal submission handler into a standalone `handleDownvoteFeedbackModalSubmit(app)`, registered independently in `SlackService`.
- Unify the modal copy and drop the misleading `(optional)` placeholder (the input is `optional: false`).

## Verification

- `pnpm -F backend typecheck:fast` — clean for the touched files (pre-existing unrelated `analyzeFieldImpact`/`hidden` errors come from in-flight common work, not this change).
- Both feedback paths converge on the shared `updateHumanScoreForSlackPrompt` (analytics + model update + classifier enqueue) and the shared modal — same scoring, modal flow, and submission handling as before.

No Linear ticket — small internal cleanup. Happy to attach one if there's a tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)