### PR TITLE
fix(totals): show pivot totals when a value column is a non-totalable table calc

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.test.ts
@@ -365,6 +365,49 @@ describe('getColumnTotalQueryFromSource', () => {
             ).toEqual(['rev_per_customer']);
         });
 
+        it('drops non-totalable value columns so the pivot query never aggregates a dropped column', () => {
+            const result = getColumnTotalQueryFromSource({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [
+                        {
+                            name: 'rev_per_customer',
+                            displayName: 'Rev per customer',
+                            sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                        } as never,
+                        {
+                            name: 'prev_revenue',
+                            displayName: 'Prev revenue',
+                            sql: 'lag(${orders.total_revenue}) over(order by ${orders.created_at})',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    valuesColumns: [
+                        {
+                            reference: 'orders_total_revenue',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                        {
+                            reference: 'rev_per_customer',
+                            aggregation: VizAggregationOptions.ANY,
+                        },
+                        {
+                            reference: 'prev_revenue',
+                            aggregation: VizAggregationOptions.ANY,
+                        },
+                    ],
+                },
+            });
+
+            expect(
+                result.pivotConfiguration?.valuesColumns.map(
+                    (col) => col.reference,
+                ),
+            ).toEqual(['orders_total_revenue', 'rev_per_customer']);
+        });
+
         it('throws when groupByColumns reference dimensions not in the source query', () => {
             expect(() =>
                 getColumnTotalQueryFromSource({
@@ -510,6 +553,49 @@ describe('getRowTotalQueryFromSource', () => {
             expect(
                 result.metricQuery.tableCalculations.map((tc) => tc.name),
             ).toEqual(['rev_per_customer']);
+        });
+
+        it('drops non-totalable value columns so the pivot query never aggregates a dropped column', () => {
+            const result = getRowTotalQueryFromSource({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    tableCalculations: [
+                        {
+                            name: 'rev_per_customer',
+                            displayName: 'Rev per customer',
+                            sql: '${orders.total_revenue} / ${orders.unique_customer_count}',
+                        } as never,
+                        {
+                            name: 'prev_revenue',
+                            displayName: 'Prev revenue',
+                            sql: 'lag(${orders.total_revenue}) over(order by ${orders.created_at})',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration: {
+                    ...pivotConfiguration,
+                    valuesColumns: [
+                        {
+                            reference: 'orders_total_revenue',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                        {
+                            reference: 'rev_per_customer',
+                            aggregation: VizAggregationOptions.ANY,
+                        },
+                        {
+                            reference: 'prev_revenue',
+                            aggregation: VizAggregationOptions.ANY,
+                        },
+                    ],
+                },
+            });
+
+            expect(
+                result.pivotConfiguration?.valuesColumns.map(
+                    (col) => col.reference,
+                ),
+            ).toEqual(['orders_total_revenue', 'rev_per_customer']);
         });
 
         it('handles an indexColumn array by expanding all references into dimensions', () => {

--- a/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
+++ b/packages/backend/src/services/AsyncQueryService/getTotalsQueryFromSource.ts
@@ -92,6 +92,22 @@ const getTotalableTableCalculations = (
         );
     });
 
+// Drop value columns that reference fields not present in the totals query:
+// PoP metrics and non-totalable table calcs are stripped from the metric query,
+// but the pivot still lists them. Keeping them makes PivotQueryBuilder aggregate
+// a column that was never selected, failing the whole totals SQL.
+const filterTotalsValuesColumns = (
+    valuesColumns: PivotConfiguration['valuesColumns'],
+    keptMetricIds: Set<string>,
+    totalableCalcs: TableCalculation[],
+): PivotConfiguration['valuesColumns'] => {
+    const allowed = new Set<string>([
+        ...keptMetricIds,
+        ...totalableCalcs.map((calc) => calc.name),
+    ]);
+    return valuesColumns.filter((col) => allowed.has(col.reference));
+};
+
 const assertNoBlockingFilters = (
     metricQuery: MetricQuery,
     errorMessage: string,
@@ -181,15 +197,17 @@ export const getColumnTotalQueryFromSource = (
     const keptMetrics = source.metricQuery.metrics.filter(
         (id) => !popMetricIds.has(id),
     );
+    const keptMetricIds = new Set(keptMetrics);
+    const totalableCalcs = getTotalableTableCalculations(
+        source.metricQuery,
+        keptMetricIds,
+    );
 
     const totalsMetricQuery: MetricQuery = {
         ...source.metricQuery,
         dimensions: groupByFieldIds,
         sorts: [],
-        tableCalculations: getTotalableTableCalculations(
-            source.metricQuery,
-            new Set(keptMetrics),
-        ),
+        tableCalculations: totalableCalcs,
         metrics: keptMetrics,
         additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
@@ -207,6 +225,11 @@ export const getColumnTotalQueryFromSource = (
         // once the pivot collapses to a single wide row.
         indexColumn: undefined,
         sortOnlyDimensions: undefined,
+        valuesColumns: filterTotalsValuesColumns(
+            source.pivotConfiguration!.valuesColumns,
+            keptMetricIds,
+            totalableCalcs,
+        ),
     };
 
     return {
@@ -330,15 +353,17 @@ export const getRowTotalQueryFromSource = (
     const keptMetrics = source.metricQuery.metrics.filter(
         (id) => !popMetricIds.has(id),
     );
+    const keptMetricIds = new Set(keptMetrics);
+    const totalableCalcs = getTotalableTableCalculations(
+        source.metricQuery,
+        keptMetricIds,
+    );
 
     const totalsMetricQuery: MetricQuery = {
         ...source.metricQuery,
         dimensions: indexFieldIds,
         sorts: [],
-        tableCalculations: getTotalableTableCalculations(
-            source.metricQuery,
-            new Set(keptMetrics),
-        ),
+        tableCalculations: totalableCalcs,
         metrics: keptMetrics,
         additionalMetrics: (source.metricQuery.additionalMetrics ?? []).filter(
             (am) => !isPeriodOverPeriodAdditionalMetric(am),
@@ -366,6 +391,11 @@ export const getRowTotalQueryFromSource = (
         ),
         sortOnlyDimensions: undefined,
         passthroughDimensions: undefined,
+        valuesColumns: filterTotalsValuesColumns(
+            source.pivotConfiguration!.valuesColumns,
+            keptMetricIds,
+            totalableCalcs,
+        ),
     };
 
     return {


### PR DESCRIPTION
Closes: PROD-8331
Closes: #24367

### Description:
Pivot table totals silently failed to render when a pivot **value column** was a non-totalable table calculation (window function, template, or aggregate/window formula). Such calcs were dropped from the totals `MetricQuery` but left in `pivotConfiguration.valuesColumns`, so `PivotQueryBuilder` aggregated a column the totals base query never selected — failing the entire totals SQL and hiding *all* totals, not just that column's. The totals transforms now filter `valuesColumns` down to the references that survive into the totals query (kept non-PoP metrics + retained totalable table calcs), in both the column- and row-total paths. Added unit tests covering both.
