### PR TITLE
feat: add `--auth` flag to diagnostics command

### DIFF
--- a/packages/cli/src/handlers/diagnostics.ts
+++ b/packages/cli/src/handlers/diagnostics.ts
@@ -15,6 +15,7 @@ import { checkLightdashVersion, getUserContext } from './dbt/apiClient';
 import { getDbtVersion } from './dbt/getDbtVersion';
 
 type DiagnosticsOptions = {
+    auth?: boolean;
     dbt?: boolean;
     projectDir?: string;
     profilesDir?: string;
@@ -36,6 +37,25 @@ const getEnvSourceSuffix = (
 
 const formatConfiguredProject = (projectName: string, projectUuid: string) =>
     projectUuid === 'Not set' ? projectName : `${projectName} (${projectUuid})`;
+
+const printAuthDetails = async (configuredProjectUuid?: string) => {
+    const user = await getUserContext();
+
+    console.log(
+        JSON.stringify(
+            {
+                email: user.email,
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid,
+                organizationRole: user.role,
+                configuredProjectUuid,
+                abilityRules: user.abilityRules,
+            },
+            null,
+            2,
+        ),
+    );
+};
 
 const getAuthStatus = async () => {
     try {
@@ -128,9 +148,16 @@ const runDbtDebug = async (
 export const diagnosticsHandler = async (options: DiagnosticsOptions) => {
     const startTime = Date.now();
     let success = true;
-    GlobalState.setVerbose(true); // Always verbose for diagnostics
 
     try {
+        if (options.auth) {
+            const config = await getConfig();
+            await printAuthDetails(config.context?.project);
+            return;
+        }
+
+        GlobalState.setVerbose(true); // Always verbose for diagnostics
+
         console.log(styles.title('⚡️ Lightdash CLI Diagnostics'));
         console.log('');
 
@@ -246,13 +273,15 @@ export const diagnosticsHandler = async (options: DiagnosticsOptions) => {
         success = false;
         throw e;
     } finally {
-        await LightdashAnalytics.track({
-            event: 'command.executed',
-            properties: {
-                command: 'diagnostics',
-                durationMs: Date.now() - startTime,
-                success,
-            },
-        });
+        if (!options.auth) {
+            await LightdashAnalytics.track({
+                event: 'command.executed',
+                properties: {
+                    command: 'diagnostics',
+                    durationMs: Date.now() - startTime,
+                    success,
+                },
+            });
+        }
     }
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1167,6 +1167,11 @@ ${styles.bold('Examples:')}
   )}
   ${styles.title('⚡')}️lightdash ${styles.bold(
       'diagnostics',
+  )} --auth ${styles.secondary(
+      '-- outputs authenticated user and ability rules as JSON',
+  )}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'diagnostics',
   )} --dbt ${styles.secondary('-- includes dbt debug output')}
   ${styles.title('⚡')}️lightdash ${styles.bold(
       'diagnostics',
@@ -1174,6 +1179,11 @@ ${styles.bold('Examples:')}
       '-- runs dbt debug with custom project directory',
   )}
 `,
+    )
+    .option(
+        '--auth',
+        'Output authenticated user and ability rules as JSON',
+        false,
     )
     .option('--dbt', 'Include dbt debug information', false)
     .option(
@@ -1476,6 +1486,12 @@ const errorHandler = (err: Error) => {
 };
 
 const successHandler = () => {
+    if (
+        process.argv.includes('diagnostics') &&
+        process.argv.includes('--auth')
+    ) {
+        process.exit(0);
+    }
     console.error(`Done 🕶`);
     process.exit(0);
 };


### PR DESCRIPTION
Closes:

### Description:
Adds a new `--auth` flag to the `lightdash diagnostics` command that outputs the authenticated user's details and ability rules as JSON. When this flag is used, the command prints the user's email, UUIDs, organization role, configured project, and ability rules, then exits immediately without running the full diagnostics flow or tracking analytics events.