### PR TITLE
fix(backend): emit bare YYYY-MM-DD for DATE fields in raw XLSX export (GLITCH-503)

### DIFF
--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -328,6 +328,25 @@ $4.00,value_4,2020-03-16
         expect(csv).toEqual(['value_1', '2020-03-16']);
     });
 
+    it('GLITCH-503: raw mode (onlyRaw) already emits bare YYYY-MM-DD for DATE fields', async () => {
+        // CSV runs formatTemporalCellForSpreadsheet before the onlyRaw check, so
+        // a day-grain DATE is bare in raw mode too (the XLSX gap was Excel-only).
+        const row = {
+            column_string: `value_1`,
+            column_date: '2020-03-16T02:32:55.000Z',
+        };
+
+        const csv = CsvService.convertRowToCsv(
+            row,
+            itemMap,
+            true,
+            ['column_string', 'column_date'],
+            'America/New_York',
+        );
+
+        expect(csv).toEqual(['value_1', '2020-03-16']);
+    });
+
     it('Should generate csv file ids', async () => {
         const time = moment('2023-09-07 12:13:45.123');
         const timestamp = time.format('YYYY-MM-DD-HH-mm-ss-SSSS');

--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -313,6 +313,37 @@ describe('ExcelService', () => {
             expect(result[2]).toBe('test string');
         });
 
+        it('GLITCH-503: raw mode emits bare YYYY-MM-DD for DATE fields when a display tz is resolved', () => {
+            const row = {
+                date_column: '2024-01-15T00:00:00.000Z',
+                date_base_ts_column: '2024-01-15T00:00:00.000Z',
+                timestamp_column: '2024-01-15T09:30:00.000Z',
+            };
+            const result = ExcelService.convertRowToExcel(
+                row,
+                mockItemMapWithFormats,
+                true,
+                ['date_column', 'date_base_ts_column', 'timestamp_column'],
+                'Asia/Tokyo',
+            );
+            // DATE (incl. DATE-base-TS, a real DATE post-452) → bare date, matching the API raw
+            expect(result[0]).toBe('2024-01-15');
+            expect(result[1]).toBe('2024-01-15');
+            // TIMESTAMP raw stays the ISO instant (unchanged)
+            expect(result[2]).toBe('2024-01-15T09:30:00.000Z');
+        });
+
+        it('GLITCH-503: raw mode is byte-identical passthrough when no tz is resolved (flag off)', () => {
+            const row = { date_column: '2024-01-15T00:00:00.000Z' };
+            const result = ExcelService.convertRowToExcel(
+                row,
+                mockItemMapWithFormats,
+                true,
+                ['date_column'],
+            );
+            expect(result[0]).toBe('2024-01-15T00:00:00.000Z');
+        });
+
         it('should handle null and undefined values', () => {
             const row = {
                 number_with_usd_format: null,

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -3,6 +3,7 @@ import {
     DimensionType,
     DownloadFileType,
     formatItemValue,
+    formatRawValue,
     formatRows,
     getErrorMessage,
     getExcelFormatExpression,
@@ -88,7 +89,15 @@ export class ExcelService {
             const rawValue = row[fieldId];
 
             if (onlyRaw) {
-                return rawValue;
+                const item = itemMap[fieldId];
+                // GLITCH-452/503: a day-or-coarser DATE field's raw is a bare
+                // YYYY-MM-DD in tz-aware mode (matching the API `raw`). Flag off
+                // (no timezone) keeps the passthrough — byte-identical.
+                return timezone &&
+                    isField(item) &&
+                    item.type === DimensionType.DATE
+                    ? formatRawValue(item, rawValue, timezone)
+                    : rawValue;
             }
 
             if (rawValue === null || rawValue === undefined) {


### PR DESCRIPTION
### Description

Raw-mode XLSX export returned the stored ISO-midnight instant for day-or-coarser DATE fields (`2024-01-15T00:00:00.000Z`) while the API/grid `raw` is a bare `2024-01-15` (the GLITCH-452 `formatRawValue` change). `ExcelService.convertRowToExcel`'s `onlyRaw` branch returned the value untouched, skipping that formatting.

**Fix:** route the `onlyRaw` branch through the same `formatRawValue` the API uses, gated on a resolved display timezone:
- DATE fields → bare `YYYY-MM-DD` (matches the API raw) under `EnableTimezoneSupport`.
- TIMESTAMP, non-temporal, and **flag-off** output → unchanged passthrough (byte-identical).

**Scope:** the gap was Excel-only. CSV (`formatTemporalCellForSpreadsheet`) and Google Sheets (`formatCell` → `formatDate`) already emit bare dates — added a CSV lock test documenting that.

## Test coverage
- [x] XLSX raw: DATE (incl. DATE-base-TS) → `2024-01-15`; TIMESTAMP → ISO unchanged
- [x] XLSX raw flag-off (no tz): byte-identical passthrough
- [x] CSV raw: already bare (lock test)
- [x] Full ExcelService + CsvService suites (57) green; backend lint/format clean

Closes: GLITCH-503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
