### PR TITLE
perf(embed): drop redundant param pre-combination for dashboard-tile

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1265,19 +1265,13 @@ export class EmbedService extends BaseService {
             },
         });
 
-        const dashboardParameters = getDashboardParametersValuesMap(dashboard);
+        // Forward only the gated user parameters; AsyncQueryService combines
+        // them with dashboard/project params, so pre-combining here is redundant.
         const acceptedUserParameters =
             isParameterInteractivityEnabled(account.access.parameters) &&
             parameters
                 ? parameters
                 : {};
-        const combinedParameters = await this.projectService.combineParameters(
-            projectUuid,
-            explore,
-            acceptedUserParameters,
-            dashboardParameters,
-            projectParameters,
-        );
 
         // Execute using AsyncQueryService method with embed context.
         // The session timezone only takes effect when timezone support is
@@ -1296,7 +1290,7 @@ export class EmbedService extends BaseService {
             invalidateCache,
             limit,
             context: QueryExecutionContext.EMBED,
-            parameters: combinedParameters,
+            parameters: acceptedUserParameters,
             pivotResults,
             sessionTimezone: isTimezoneSupportEnabled
                 ? (timezone ?? null)


### PR DESCRIPTION
Closes: SPK-522

### Description:

`EmbedService.executeAsyncDashboardTileQuery` pre-combined parameters via `combineParameters` — an extra `projectParametersModel.find` round-trip plus a dashboard-params map build — only for `AsyncQueryService.executeAsyncDashboardChartQuery` to re-fetch and re-combine everything from scratch. This forwards just the gated `acceptedUserParameters` and lets AsyncQueryService do the single combine, removing the redundant work while keeping the embed-specific `isParameterInteractivityEnabled` gating and identical merge precedence. The timezone-flag hoist and project-params preload from the same Linear ticket already landed via the parent PR (#24368), so this slice is parameters-only.