### PR TITLE
refactor(ai): use jsonSchema helper

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -88,7 +88,7 @@
         "@tsoa/runtime": "6.6.0",
         "@types/async": "3.2.16",
         "@types/sshpk": "1.17.1",
-        "ai": "6.0.198",
+        "ai": "6.0.205",
         "ajv": "8.18.0",
         "ajv-formats": "2.1.1",
         "apache-arrow": "16.1.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@casl/ability": "6.8.0",
     "@types/lodash": "4.14.202",
+    "ai": "6.0.205",
     "ajv": "8.18.0",
     "ajv-errors": "3.0.0",
     "ajv-formats": "2.1.1",

--- a/packages/common/src/ee/AiAgent/schemas/defineTool.ts
+++ b/packages/common/src/ee/AiAgent/schemas/defineTool.ts
@@ -1,3 +1,4 @@
+import { type Schema } from 'ai';
 import { type z } from 'zod';
 import {
     ToolDefinitionWithMcpOutputImpl,
@@ -80,37 +81,6 @@ export type McpToolConfig =
     | McpToolConfigWithoutOutput
     | McpToolConfigWithOutput<McpOutputSchema>;
 
-export type AgentInputSchema<TInput extends z.ZodTypeAny> = {
-    readonly [key: symbol]: true | undefined;
-    readonly _type: z.infer<TInput>;
-    readonly jsonSchema: Record<string, unknown>;
-    readonly validate: (
-        value: unknown,
-    ) =>
-        | { readonly success: true; readonly value: z.infer<TInput> }
-        | { readonly success: false; readonly error: Error };
-    readonly '~standard': {
-        readonly version: 1;
-        readonly vendor: 'lightdash';
-        readonly types: {
-            readonly input: z.input<TInput>;
-            readonly output: z.infer<TInput>;
-        };
-        readonly validate: (value: unknown) =>
-            | { readonly value: z.infer<TInput>; readonly issues?: undefined }
-            | {
-                  readonly issues: ReadonlyArray<{
-                      readonly message: string;
-                      readonly path?: ReadonlyArray<PropertyKey>;
-                  }>;
-              };
-        readonly jsonSchema: {
-            readonly input: () => Record<string, unknown>;
-            readonly output: () => Record<string, unknown>;
-        };
-    };
-};
-
 type AgentToolViewBase<
     TName extends string,
     TInput extends z.ZodObject<z.ZodRawShape>,
@@ -118,7 +88,7 @@ type AgentToolViewBase<
     name: TName;
     title: string;
     description: string;
-    inputSchema: AgentInputSchema<TInput>;
+    inputSchema: Schema<z.infer<TInput>>;
 };
 
 export type AgentToolView<

--- a/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolDefinitionUtils.ts
@@ -1,7 +1,7 @@
+import { jsonSchema, type Schema } from 'ai';
 import { type z } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
-    type AgentInputSchema,
     type AgentToModelOutput,
     type McpErrorResult,
     type McpStructuredResult,
@@ -11,8 +11,6 @@ import {
     type ToolDescription,
     type ToolRuntime,
 } from './defineTool';
-
-const aiSchemaSymbol = Symbol.for('vercel.ai.schema');
 
 export const resolveDescription = (
     description: ToolDescription,
@@ -41,16 +39,13 @@ export const defaultAgentToModelOutput: AgentToModelOutput<
 
 export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
     inputSchema: TInput,
-): AgentInputSchema<TInput> => {
-    const jsonSchema = zodToJsonSchema(inputSchema, {
+): Schema<z.infer<TInput>> => {
+    const agentJsonSchema = zodToJsonSchema(inputSchema, {
         $refStrategy: 'root',
         target: 'jsonSchema7',
-    }) as Record<string, unknown>;
+    }) as Schema<z.infer<TInput>>['jsonSchema'];
 
-    return {
-        [aiSchemaSymbol]: true,
-        _type: undefined as z.infer<TInput>,
-        jsonSchema,
+    return jsonSchema<z.infer<TInput>>(agentJsonSchema, {
         validate: (value) => {
             const result = inputSchema.safeParse(value);
 
@@ -60,33 +55,7 @@ export const createAgentInputSchema = <TInput extends z.ZodTypeAny>(
 
             return { success: false, error: result.error };
         },
-        '~standard': {
-            version: 1,
-            vendor: 'lightdash',
-            types: undefined as unknown as {
-                input: z.input<TInput>;
-                output: z.infer<TInput>;
-            },
-            validate: (value) => {
-                const result = inputSchema.safeParse(value);
-
-                if (result.success) {
-                    return { value: result.data as z.infer<TInput> };
-                }
-
-                return {
-                    issues: result.error.issues.map((issue) => ({
-                        message: issue.message,
-                        path: issue.path,
-                    })),
-                };
-            },
-            jsonSchema: {
-                input: () => jsonSchema,
-                output: () => jsonSchema,
-            },
-        },
-    };
+    });
 };
 
 const text = (textContent: string): McpTextResult => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,7 +216,7 @@ importers:
         version: link:../warehouses
       '@mastra/schema-compat':
         specifier: 0.11.2
-        version: 0.11.2(ai@6.0.198(zod@3.25.55))(zod@3.25.55)
+        version: 0.11.2(ai@6.0.205(zod@3.25.55))(zod@3.25.55)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@3.25.55)
@@ -243,7 +243,7 @@ importers:
         version: 20.1.2
       '@openrouter/ai-sdk-provider':
         specifier: 1.5.4
-        version: 1.5.4(ai@6.0.198(zod@3.25.55))(zod@3.25.55)
+        version: 1.5.4(ai@6.0.205(zod@3.25.55))(zod@3.25.55)
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
         version: 2.1.1(tslib@2.8.1)
@@ -275,8 +275,8 @@ importers:
         specifier: 1.17.1
         version: 1.17.1
       ai:
-        specifier: 6.0.198
-        version: 6.0.198(zod@3.25.55)
+        specifier: 6.0.205
+        version: 6.0.205(zod@3.25.55)
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -796,6 +796,9 @@ importers:
       '@types/lodash':
         specifier: 4.14.202
         version: 4.14.202
+      ai:
+        specifier: 6.0.205
+        version: 6.0.205(zod@3.25.55)
       ajv:
         specifier: 8.18.0
         version: 8.18.0
@@ -1811,6 +1814,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.131':
+    resolution: {integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/mcp@1.0.41':
     resolution: {integrity: sha512-AfA0jb6tTnfcieLx1d6breTmuae0fz67UNcBrCgZqPqaZ1NIlJT5uyXx+78pgYOuDHo0GtHECVhI1a9lkZnzgA==}
     engines: {node: '>=18'}
@@ -1837,6 +1846,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.29':
+    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7585,6 +7600,12 @@ packages:
 
   ai@6.0.198:
     resolution: {integrity: sha512-NEXlYGu3n7VTG6cn3SAeimfy60FLH/R5uRpl7zqDu0BLtIuoY1lALBGoJzltoVqd/iFQH1asIy/VqZqLPDWv0w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.205:
+    resolution: {integrity: sha512-F4akEGF41UdgJO3L4v+D5noVD1/czhJy6x0k9R/i1EXfxqrkBh/PdYSgRSLPiGFvrw76dzI8h4w3NYmLrTb8dw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -16812,6 +16833,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 3.25.55
 
+  '@ai-sdk/gateway@3.0.131(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.29(zod@3.25.55)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.55
+
   '@ai-sdk/mcp@1.0.41(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -16839,6 +16867,13 @@ snapshots:
       zod: 3.25.55
 
   '@ai-sdk/provider-utils@4.0.27(zod@3.25.55)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 3.25.55
+
+  '@ai-sdk/provider-utils@4.0.29(zod@3.25.55)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
@@ -20075,9 +20110,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mastra/schema-compat@0.11.2(ai@6.0.198(zod@3.25.55))(zod@3.25.55)':
+  '@mastra/schema-compat@0.11.2(ai@6.0.205(zod@3.25.55))(zod@3.25.55)':
     dependencies:
-      ai: 6.0.198(zod@3.25.55)
+      ai: 6.0.205(zod@3.25.55)
       json-schema: 0.4.0
       zod: 3.25.55
       zod-from-json-schema: 0.5.0
@@ -20490,10 +20525,10 @@ snapshots:
       '@octokit/webhooks-types': 7.3.2
       aggregate-error: 3.1.0
 
-  '@openrouter/ai-sdk-provider@1.5.4(ai@6.0.198(zod@3.25.55))(zod@3.25.55)':
+  '@openrouter/ai-sdk-provider@1.5.4(ai@6.0.205(zod@3.25.55))(zod@3.25.55)':
     dependencies:
       '@openrouter/sdk': 0.1.27
-      ai: 6.0.198(zod@3.25.55)
+      ai: 6.0.205(zod@3.25.55)
       zod: 3.25.55
 
   '@openrouter/sdk@0.1.27':
@@ -24227,6 +24262,14 @@ snapshots:
       '@ai-sdk/gateway': 3.0.126(zod@3.25.55)
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@3.25.55)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.55
+
+  ai@6.0.205(zod@3.25.55):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.131(zod@3.25.55)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.29(zod@3.25.55)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.55
 


### PR DESCRIPTION
Use the AI SDK jsonSchema helper for agent tool input schemas while preserving Zod validation.