### PR TITLE
feat(slack): durable SQL approval (suspend/resume) for the AI agent

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5242,6 +5242,45 @@ export class AiAgentModel {
             });
     }
 
+    // A runSql call the agent suspended on awaiting approval: it has no result
+    // (never executed) and no recorded decision yet. Used to detect a suspended
+    // run and to post the approval card.
+    async getPendingSqlApprovalForPrompt(
+        promptUuid: string,
+    ): Promise<{ toolCallId: string; sql: string } | null> {
+        const row = await this.database(AiAgentToolCallTableName)
+            .leftJoin(
+                AiAgentToolResultTableName,
+                `${AiAgentToolCallTableName}.tool_call_id`,
+                `${AiAgentToolResultTableName}.tool_call_id`,
+            )
+            .leftJoin(
+                AiSqlApprovalTableName,
+                `${AiAgentToolCallTableName}.tool_call_id`,
+                `${AiSqlApprovalTableName}.tool_call_id`,
+            )
+            .where(`${AiAgentToolCallTableName}.ai_prompt_uuid`, promptUuid)
+            .where(`${AiAgentToolCallTableName}.tool_name`, 'runSql')
+            .whereNull(
+                `${AiAgentToolResultTableName}.ai_agent_tool_result_uuid`,
+            )
+            .whereNull(`${AiSqlApprovalTableName}.tool_call_id`)
+            .orderBy(`${AiAgentToolCallTableName}.created_at`, 'desc')
+            .first<Pick<DbAiAgentToolCall, 'tool_call_id' | 'tool_args'>>(
+                `${AiAgentToolCallTableName}.tool_call_id`,
+                `${AiAgentToolCallTableName}.tool_args`,
+            );
+
+        if (!row) {
+            return null;
+        }
+        const sql =
+            typeof (row.tool_args as { sql?: unknown })?.sql === 'string'
+                ? (row.tool_args as { sql: string }).sql
+                : '';
+        return { toolCallId: row.tool_call_id, sql };
+    }
+
     async getToolCallsForPrompt(
         promptUuid: string,
     ): Promise<DbAiAgentToolCallWithMcpServer[]> {

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -5168,7 +5168,8 @@ export class AiAgentModel {
     async getToolCallsAndResultsForPrompt(promptUuid: string): Promise<
         Array<{
             toolCall: AiAgentToolCall;
-            toolResult: AiAgentToolResult;
+            toolResult: AiAgentToolResult | null;
+            approvalDecision: AiSqlApprovalDecision | null;
         }>
     > {
         const rows = await this.database(AiAgentToolCallTableName)
@@ -5179,6 +5180,7 @@ export class AiAgentModel {
                         result: string | null;
                         metadata: Record<string, unknown> | null;
                         result_created_at: Date | null;
+                        approval_decision: AiSqlApprovalDecision | null;
                     }
                 >
             >(
@@ -5187,11 +5189,20 @@ export class AiAgentModel {
                 `${AiAgentToolResultTableName}.result`,
                 `${AiAgentToolResultTableName}.metadata`,
                 `${AiAgentToolResultTableName}.created_at as result_created_at`,
+                `${AiSqlApprovalTableName}.decision as approval_decision`,
             )
             .leftJoin(
                 AiAgentToolResultTableName,
                 `${AiAgentToolCallTableName}.tool_call_id`,
                 `${AiAgentToolResultTableName}.tool_call_id`,
+            )
+            // Tool calls awaiting/granted SQL approval may have no result yet —
+            // join the decision so history reconstruction can replay the
+            // native approval request/response parts.
+            .leftJoin(
+                AiSqlApprovalTableName,
+                `${AiAgentToolCallTableName}.tool_call_id`,
+                `${AiSqlApprovalTableName}.tool_call_id`,
             )
             .where(`${AiAgentToolCallTableName}.ai_prompt_uuid`, promptUuid)
             // Subagent children are stored with `parent_tool_call_id` set so the
@@ -5203,24 +5214,30 @@ export class AiAgentModel {
         return rows
             .filter(
                 (row) =>
-                    row.result !== null && isParseableToolName(row.tool_name),
+                    (row.result !== null || row.approval_decision !== null) &&
+                    isParseableToolName(row.tool_name),
             )
             .map((row) => {
                 const toolCall = this.parseToolCall(row);
 
-                const toolResult = this.parseToolResult({
-                    ai_agent_tool_result_uuid: row.ai_agent_tool_result_uuid!,
-                    ai_prompt_uuid: row.ai_prompt_uuid,
-                    tool_call_id: row.tool_call_id,
-                    tool_name: row.tool_name,
-                    result: row.result!,
-                    metadata: row.metadata!,
-                    created_at: row.result_created_at!,
-                });
+                const toolResult =
+                    row.result !== null
+                        ? this.parseToolResult({
+                              ai_agent_tool_result_uuid:
+                                  row.ai_agent_tool_result_uuid!,
+                              ai_prompt_uuid: row.ai_prompt_uuid,
+                              tool_call_id: row.tool_call_id,
+                              tool_name: row.tool_name,
+                              result: row.result,
+                              metadata: row.metadata!,
+                              created_at: row.result_created_at!,
+                          })
+                        : null;
 
                 return {
                     toolCall,
                     toolResult,
+                    approvalDecision: row.approval_decision,
                 };
             });
     }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -213,6 +213,7 @@ import { generateEmbedding } from '../ai/agents/embeddingGenerator';
 import { routeProjectForSlack } from '../ai/agents/projectRouter';
 import { generateArtifactQuestion } from '../ai/agents/questionGenerator';
 import { evaluateAgentReadiness } from '../ai/agents/readinessScorer';
+import { sqlApprovalId } from '../ai/agents/sqlApprovalSuspend';
 import {
     generateAgentSuggestions,
     SUGGESTION_FALLBACK_CHIPS,
@@ -5554,44 +5555,84 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         message.ai_prompt_uuid,
                     );
                 const toolCallmessages = toolCallsAndResults.flatMap(
-                    ({ toolCall, toolResult }) => [
-                        {
-                            role: 'assistant',
-                            content: [
+                    ({ toolCall, toolResult, approvalDecision }) => {
+                        // Native SQL-approval: replay the request on the
+                        // assistant turn and the response on a tool turn so the
+                        // SDK can resume (execute on approve, skip on reject).
+                        const assistantContent: AssistantModelMessage['content'] =
+                            [
                                 {
                                     type: 'tool-call' as const,
                                     toolCallId: toolCall.toolCallId,
                                     toolName: toolCall.toolName,
                                     input: toolCall.toolArgs,
                                 },
-                            ] satisfies ToolCallPart[],
-                        } satisfies AssistantModelMessage,
-                        {
-                            role: 'tool',
-                            content: [
-                                {
-                                    type: 'tool-result',
-                                    toolCallId: toolResult.toolCallId,
-                                    toolName: toolResult.toolName,
-                                    output:
-                                        isToolProposeChangeSuccessResult(
-                                            toolResult,
-                                        ) &&
-                                        toolResult.metadata.userFeedback ===
-                                            'rejected'
-                                            ? {
-                                                  type: 'json',
-                                                  value: `${toolResult.result}\nUser rejected proposed change.`,
-                                              }
-                                            : {
-                                                  type: 'json',
-                                                  // TODO :: based on tool, if there's a need for it we can use the metadata here
-                                                  value: toolResult.result,
-                                              },
-                                },
-                            ],
-                        } satisfies ToolModelMessage,
-                    ],
+                                ...(approvalDecision
+                                    ? [
+                                          {
+                                              type: 'tool-approval-request' as const,
+                                              approvalId: sqlApprovalId(
+                                                  toolCall.toolCallId,
+                                              ),
+                                              toolCallId: toolCall.toolCallId,
+                                          },
+                                      ]
+                                    : []),
+                            ];
+
+                        const toolTurnMessages: ModelMessage[] = [
+                            {
+                                role: 'assistant',
+                                content: assistantContent,
+                            } satisfies AssistantModelMessage,
+                        ];
+
+                        if (approvalDecision) {
+                            toolTurnMessages.push({
+                                role: 'tool',
+                                content: [
+                                    {
+                                        type: 'tool-approval-response' as const,
+                                        approvalId: sqlApprovalId(
+                                            toolCall.toolCallId,
+                                        ),
+                                        approved:
+                                            approvalDecision === 'approved',
+                                    },
+                                ],
+                            } satisfies ToolModelMessage);
+                        }
+
+                        if (toolResult) {
+                            toolTurnMessages.push({
+                                role: 'tool',
+                                content: [
+                                    {
+                                        type: 'tool-result',
+                                        toolCallId: toolResult.toolCallId,
+                                        toolName: toolResult.toolName,
+                                        output:
+                                            isToolProposeChangeSuccessResult(
+                                                toolResult,
+                                            ) &&
+                                            toolResult.metadata.userFeedback ===
+                                                'rejected'
+                                                ? {
+                                                      type: 'json',
+                                                      value: `${toolResult.result}\nUser rejected proposed change.`,
+                                                  }
+                                                : {
+                                                      type: 'json',
+                                                      // TODO :: based on tool, if there's a need for it we can use the metadata here
+                                                      value: toolResult.result,
+                                                  },
+                                    },
+                                ],
+                            } satisfies ToolModelMessage);
+                        }
+
+                        return toolTurnMessages;
+                    },
                 );
 
                 messages.push(...toolCallmessages);

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5638,7 +5638,20 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
                 messages.push(...toolCallmessages);
 
-                if (message.response && !message.error_message) {
+                // A turn suspended mid SQL-approval has a partial `response`
+                // (text emitted before the runSql call). Replaying it would
+                // leave the runSql tool_use without a following tool_result, so
+                // skip it — the resumed run regenerates from the approval.
+                const hasUnresolvedApproval = toolCallsAndResults.some(
+                    ({ toolResult, approvalDecision }) =>
+                        approvalDecision !== null && toolResult === null,
+                );
+
+                if (
+                    message.response &&
+                    !message.error_message &&
+                    !hasUnresolvedApproval
+                ) {
                     messages.push({
                         role: 'assistant',
                         content: message.response,
@@ -7365,11 +7378,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         threadTs: string;
         toolCallId: string;
         sql: string;
+        agentName?: string;
     }): Promise<void> {
         await this.slackClient.postMessage({
             organizationUuid: input.slackPrompt.organizationUuid,
             channel: input.slackPrompt.slackChannelId,
             thread_ts: input.threadTs,
+            username: input.agentName,
             text: 'Awaiting approval to run SQL',
             blocks: renderSqlApprovalBlocks(
                 {
@@ -7864,6 +7879,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     threadTs,
                     toolCallId: pendingApproval.toolCallId,
                     sql: pendingApproval.sql,
+                    agentName: agent?.name,
                 });
                 await persistStreamResponseTsAndDeletePlaceholder();
                 return true;

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5489,6 +5489,108 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         } satisfies UserModelMessage;
     }
 
+    // A turn suspended mid SQL-approval has a tool call with a decision but no
+    // result yet. Its partial `response` text must not be replayed (it would
+    // leave the runSql tool_use without a following tool_result on resume).
+    static hasUnresolvedSqlApproval(
+        toolCallsAndResults: Awaited<
+            ReturnType<
+                typeof AiAgentModel.prototype.getToolCallsAndResultsForPrompt
+            >
+        >,
+    ): boolean {
+        return toolCallsAndResults.some(
+            ({ toolResult, approvalDecision }) =>
+                approvalDecision !== null && toolResult === null,
+        );
+    }
+
+    // Rebuilds the assistant/tool turns for a prompt's tool calls. SQL-approval
+    // calls replay a tool-approval-request (assistant) + tool-approval-response
+    // (tool) so the SDK resumes — executing runSql on approve, skipping on
+    // reject — and the real tool-result is appended once it exists.
+    static buildToolCallTurnMessages(
+        toolCallsAndResults: Awaited<
+            ReturnType<
+                typeof AiAgentModel.prototype.getToolCallsAndResultsForPrompt
+            >
+        >,
+    ): ModelMessage[] {
+        return toolCallsAndResults.flatMap(
+            ({ toolCall, toolResult, approvalDecision }) => {
+                const assistantContent: AssistantModelMessage['content'] = [
+                    {
+                        type: 'tool-call' as const,
+                        toolCallId: toolCall.toolCallId,
+                        toolName: toolCall.toolName,
+                        input: toolCall.toolArgs,
+                    },
+                    ...(approvalDecision
+                        ? [
+                              {
+                                  type: 'tool-approval-request' as const,
+                                  approvalId: sqlApprovalId(
+                                      toolCall.toolCallId,
+                                  ),
+                                  toolCallId: toolCall.toolCallId,
+                              },
+                          ]
+                        : []),
+                ];
+
+                const toolTurnMessages: ModelMessage[] = [
+                    {
+                        role: 'assistant',
+                        content: assistantContent,
+                    } satisfies AssistantModelMessage,
+                ];
+
+                if (approvalDecision) {
+                    toolTurnMessages.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-approval-response' as const,
+                                approvalId: sqlApprovalId(toolCall.toolCallId),
+                                approved: approvalDecision === 'approved',
+                            },
+                        ],
+                    } satisfies ToolModelMessage);
+                }
+
+                if (toolResult) {
+                    toolTurnMessages.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: toolResult.toolCallId,
+                                toolName: toolResult.toolName,
+                                output:
+                                    isToolProposeChangeSuccessResult(
+                                        toolResult,
+                                    ) &&
+                                    toolResult.metadata.userFeedback ===
+                                        'rejected'
+                                        ? {
+                                              type: 'json',
+                                              value: `${toolResult.result}\nUser rejected proposed change.`,
+                                          }
+                                        : {
+                                              type: 'json',
+                                              // TODO :: based on tool, if there's a need for it we can use the metadata here
+                                              value: toolResult.result,
+                                          },
+                            },
+                        ],
+                    } satisfies ToolModelMessage);
+                }
+
+                return toolTurnMessages;
+            },
+        );
+    }
+
     async getChatHistoryFromThreadMessages(
         // TODO: move getThreadMessages to AiAgentModel and improve types
         // also, it should be called through a service method...
@@ -5555,97 +5657,20 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     await this.aiAgentModel.getToolCallsAndResultsForPrompt(
                         message.ai_prompt_uuid,
                     );
-                const toolCallmessages = toolCallsAndResults.flatMap(
-                    ({ toolCall, toolResult, approvalDecision }) => {
-                        // Native SQL-approval: replay the request on the
-                        // assistant turn and the response on a tool turn so the
-                        // SDK can resume (execute on approve, skip on reject).
-                        const assistantContent: AssistantModelMessage['content'] =
-                            [
-                                {
-                                    type: 'tool-call' as const,
-                                    toolCallId: toolCall.toolCallId,
-                                    toolName: toolCall.toolName,
-                                    input: toolCall.toolArgs,
-                                },
-                                ...(approvalDecision
-                                    ? [
-                                          {
-                                              type: 'tool-approval-request' as const,
-                                              approvalId: sqlApprovalId(
-                                                  toolCall.toolCallId,
-                                              ),
-                                              toolCallId: toolCall.toolCallId,
-                                          },
-                                      ]
-                                    : []),
-                            ];
-
-                        const toolTurnMessages: ModelMessage[] = [
-                            {
-                                role: 'assistant',
-                                content: assistantContent,
-                            } satisfies AssistantModelMessage,
-                        ];
-
-                        if (approvalDecision) {
-                            toolTurnMessages.push({
-                                role: 'tool',
-                                content: [
-                                    {
-                                        type: 'tool-approval-response' as const,
-                                        approvalId: sqlApprovalId(
-                                            toolCall.toolCallId,
-                                        ),
-                                        approved:
-                                            approvalDecision === 'approved',
-                                    },
-                                ],
-                            } satisfies ToolModelMessage);
-                        }
-
-                        if (toolResult) {
-                            toolTurnMessages.push({
-                                role: 'tool',
-                                content: [
-                                    {
-                                        type: 'tool-result',
-                                        toolCallId: toolResult.toolCallId,
-                                        toolName: toolResult.toolName,
-                                        output:
-                                            isToolProposeChangeSuccessResult(
-                                                toolResult,
-                                            ) &&
-                                            toolResult.metadata.userFeedback ===
-                                                'rejected'
-                                                ? {
-                                                      type: 'json',
-                                                      value: `${toolResult.result}\nUser rejected proposed change.`,
-                                                  }
-                                                : {
-                                                      type: 'json',
-                                                      // TODO :: based on tool, if there's a need for it we can use the metadata here
-                                                      value: toolResult.result,
-                                                  },
-                                    },
-                                ],
-                            } satisfies ToolModelMessage);
-                        }
-
-                        return toolTurnMessages;
-                    },
+                messages.push(
+                    ...AiAgentService.buildToolCallTurnMessages(
+                        toolCallsAndResults,
+                    ),
                 );
-
-                messages.push(...toolCallmessages);
 
                 // A turn suspended mid SQL-approval has a partial `response`
                 // (text emitted before the runSql call). Replaying it would
                 // leave the runSql tool_use without a following tool_result, so
                 // skip it — the resumed run regenerates from the approval.
-                const hasUnresolvedApproval = toolCallsAndResults.some(
-                    ({ toolResult, approvalDecision }) =>
-                        approvalDecision !== null && toolResult === null,
-                );
+                const hasUnresolvedApproval =
+                    AiAgentService.hasUnresolvedSqlApproval(
+                        toolCallsAndResults,
+                    );
 
                 if (
                     message.response &&

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7859,20 +7859,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 finalizeToolTasksForSuccess();
                 await flushTaskUpdates();
                 await updatePlanTitle('Waiting for SQL approval');
+                // Finalize the task card without extra copy — its header plus
+                // the approval card below already say we're waiting.
                 await this.slackClient.stopAgentStream({
                     organizationUuid: slackPrompt.organizationUuid,
                     channelId: slackPrompt.slackChannelId,
                     threadTs,
                     messageTs: streamTs,
                     text: 'Waiting for approval to run SQL.',
-                    chunks: [
-                        {
-                            type: 'blocks',
-                            blocks: getMarkdownBlocks(
-                                '_Waiting for approval to run SQL…_',
-                            ),
-                        },
-                    ],
+                    chunks: [],
                 });
                 await this.postSqlApprovalCard({
                     slackPrompt,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -241,6 +241,7 @@ import {
     MountingRepoFileSystem,
 } from '../ai/repoFs/mountingRepoFileSystem';
 import { RepoFs } from '../ai/repoFs/RepoFs';
+import { renderBlocks as renderSqlApprovalBlocks } from '../ai/tools/slackSqlAggregate';
 import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
@@ -7357,6 +7358,33 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         );
     }
 
+    // Posts the SQL approval card as its own message after the task-list card
+    // so the run can suspend and resume on the user's decision.
+    private async postSqlApprovalCard(input: {
+        slackPrompt: SlackPrompt;
+        threadTs: string;
+        toolCallId: string;
+        sql: string;
+    }): Promise<void> {
+        await this.slackClient.postMessage({
+            organizationUuid: input.slackPrompt.organizationUuid,
+            channel: input.slackPrompt.slackChannelId,
+            thread_ts: input.threadTs,
+            text: 'Awaiting approval to run SQL',
+            blocks: renderSqlApprovalBlocks(
+                {
+                    kind: 'pending',
+                    sql: input.sql,
+                    toolCallId: input.toolCallId,
+                    threadUuid: input.slackPrompt.threadUuid,
+                    native: true,
+                },
+                this.lightdashConfig.siteUrl,
+            ),
+            unfurl_links: false,
+        });
+    }
+
     private async postSlackMultiAgentTipIfNeeded(
         slackPrompt: SlackPrompt,
         threadMessages: Awaited<ReturnType<AiAgentModel['getThreadMessages']>>,
@@ -7804,6 +7832,42 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     onSlackStepProgress: appendTaskUpdate,
                 },
             );
+
+            // Native SQL approval: the loop halted awaiting approval. Finalize
+            // the task card and post the approval card below it; the run resumes
+            // via a re-enqueued reply job once the user decides.
+            const pendingApproval =
+                await this.aiAgentModel.getPendingSqlApprovalForPrompt(
+                    slackPrompt.promptUuid,
+                );
+            if (pendingApproval) {
+                finalizeToolTasksForSuccess();
+                await flushTaskUpdates();
+                await updatePlanTitle('Waiting for SQL approval');
+                await this.slackClient.stopAgentStream({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    messageTs: streamTs,
+                    text: 'Waiting for approval to run SQL.',
+                    chunks: [
+                        {
+                            type: 'blocks',
+                            blocks: getMarkdownBlocks(
+                                '_Waiting for approval to run SQL…_',
+                            ),
+                        },
+                    ],
+                });
+                await this.postSqlApprovalCard({
+                    slackPrompt,
+                    threadTs,
+                    toolCallId: pendingApproval.toolCallId,
+                    sql: pendingApproval.sql,
+                });
+                await persistStreamResponseTsAndDeletePlaceholder();
+                return true;
+            }
 
             if (!response) {
                 await flushTaskUpdates();
@@ -8519,12 +8583,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 }
                 const actionId = 'action_id' in action ? action.action_id : '';
                 const parts = actionId.split(':');
-                if (parts.length !== 4) {
+                if (parts.length !== 4 && parts.length !== 5) {
                     return;
                 }
                 const toolCallId = parts[1];
                 const threadUuid = parts[2];
                 const rawDecision = parts[3];
+                // Native approval cards carry a trailing ':native' segment;
+                // those runs are suspended and resume via a re-enqueued reply.
+                const isNative = parts.length === 5 && parts[4] === 'native';
 
                 const isApprovedAlways = rawDecision === 'approved_always';
                 const decision: 'approved' | 'rejected' =
@@ -8546,11 +8613,34 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 // here (no direct join exists), so the audit trail records
                 // the decision without a user reference. The Slack user id
                 // is available via body.user.id if we want to enrich later.
-                await this.aiAgentModel.recordSqlApproval(
+                const recorded = await this.aiAgentModel.recordSqlApproval(
                     toolCallId,
                     decision,
                     null,
                 );
+
+                // Resume the suspended run once, on the first recorded decision.
+                // The reply job rebuilds history with the approval response, so
+                // the SDK executes runSql (approve) or skips it (reject).
+                if (isNative && recorded) {
+                    const context =
+                        await this.aiAgentModel.findSqlApprovalContext(
+                            toolCallId,
+                        );
+                    const resumePrompt = context
+                        ? await this.aiAgentModel.findSlackPrompt(
+                              context.promptUuid,
+                          )
+                        : undefined;
+                    if (resumePrompt) {
+                        await this.schedulerClient.slackAiPrompt({
+                            slackPromptUuid: resumePrompt.promptUuid,
+                            userUuid: resumePrompt.createdByUserUuid,
+                            projectUuid: resumePrompt.projectUuid,
+                            organizationUuid: resumePrompt.organizationUuid,
+                        });
+                    }
+                }
 
                 const emoji =
                     decision === 'approved'

--- a/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
@@ -1,0 +1,139 @@
+import { AiAgentService } from './AiAgentService';
+
+type Row = Parameters<
+    typeof AiAgentService.buildToolCallTurnMessages
+>[0][number];
+
+const call = (toolCallId: string, sql: string) =>
+    ({ toolCallId, toolName: 'runSql', toolArgs: { sql } }) as Row['toolCall'];
+
+const result = (toolCallId: string, value: string) =>
+    ({
+        toolCallId,
+        toolName: 'runSql',
+        result: value,
+        metadata: {},
+    }) as Row['toolResult'];
+
+const content = (msg: { content: unknown }) => msg.content as Array<AnyType>;
+
+type AnyType = Record<string, unknown> & { type: string };
+
+describe('AiAgentService SQL-approval history reconstruction', () => {
+    it('a normal tool call emits assistant(call) + tool(result), no approval parts', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages([
+            {
+                toolCall: call('tc1', 'SELECT 1'),
+                toolResult: result('tc1', '3 rows'),
+                approvalDecision: null,
+            },
+        ]);
+
+        expect(msgs).toHaveLength(2);
+        expect(msgs[0].role).toBe('assistant');
+        expect(content(msgs[0])).toEqual([
+            {
+                type: 'tool-call',
+                toolCallId: 'tc1',
+                toolName: 'runSql',
+                input: { sql: 'SELECT 1' },
+            },
+        ]);
+        expect(msgs[1].role).toBe('tool');
+        expect(content(msgs[1])[0].type).toBe('tool-result');
+    });
+
+    it('approved-but-unexecuted call emits request + response and NO result (the resume input)', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages([
+            {
+                toolCall: call('tc1', 'SELECT 1'),
+                toolResult: null,
+                approvalDecision: 'approved',
+            },
+        ]);
+
+        expect(msgs).toHaveLength(2);
+        expect(content(msgs[0])).toEqual([
+            {
+                type: 'tool-call',
+                toolCallId: 'tc1',
+                toolName: 'runSql',
+                input: { sql: 'SELECT 1' },
+            },
+            {
+                type: 'tool-approval-request',
+                approvalId: 'sql-approval:tc1',
+                toolCallId: 'tc1',
+            },
+        ]);
+        expect(content(msgs[1])).toEqual([
+            {
+                type: 'tool-approval-response',
+                approvalId: 'sql-approval:tc1',
+                approved: true,
+            },
+        ]);
+    });
+
+    it('rejected call emits an approval-response with approved=false', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages([
+            {
+                toolCall: call('tc1', 'SELECT 1'),
+                toolResult: null,
+                approvalDecision: 'rejected',
+            },
+        ]);
+
+        expect(content(msgs[1])[0]).toEqual({
+            type: 'tool-approval-response',
+            approvalId: 'sql-approval:tc1',
+            approved: false,
+        });
+    });
+
+    it('a completed approved call emits request + response + result', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages([
+            {
+                toolCall: call('tc1', 'SELECT 1'),
+                toolResult: result('tc1', '3 rows'),
+                approvalDecision: 'approved',
+            },
+        ]);
+
+        expect(msgs).toHaveLength(3);
+        expect(content(msgs[1])[0].type).toBe('tool-approval-response');
+        expect(content(msgs[2])[0].type).toBe('tool-result');
+    });
+
+    it('hasUnresolvedSqlApproval is true only for a decided, result-less call', () => {
+        expect(
+            AiAgentService.hasUnresolvedSqlApproval([
+                {
+                    toolCall: call('tc1', 'x'),
+                    toolResult: null,
+                    approvalDecision: 'approved',
+                },
+            ]),
+        ).toBe(true);
+
+        expect(
+            AiAgentService.hasUnresolvedSqlApproval([
+                {
+                    toolCall: call('tc1', 'x'),
+                    toolResult: result('tc1', 'y'),
+                    approvalDecision: 'approved',
+                },
+            ]),
+        ).toBe(false);
+
+        expect(
+            AiAgentService.hasUnresolvedSqlApproval([
+                {
+                    toolCall: call('tc1', 'x'),
+                    toolResult: null,
+                    approvalDecision: null,
+                },
+            ]),
+        ).toBe(false);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -242,6 +242,7 @@ const getAgentTools = (
               siteUrl: args.siteUrl,
               waitForSqlApproval: dependencies.waitForSqlApproval,
               recordSqlApproval: dependencies.recordSqlApproval,
+              storeToolResults: dependencies.storeToolResults,
               maxQueryLimit: args.runSqlMaxLimit,
               autoApproveSql: args.autoApproveSql,
               autoApproveSqlUserUuid: args.autoApproveSqlUserUuid,

--- a/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.test.ts
@@ -1,0 +1,40 @@
+import {
+    extractPendingSqlApprovals,
+    sqlApprovalId,
+} from './sqlApprovalSuspend';
+
+const approvalRequest = (toolCallId: string, sql: string) => ({
+    type: 'tool-approval-request' as const,
+    approvalId: sqlApprovalId(toolCallId),
+    toolCall: { toolCallId, toolName: 'runSql', input: { sql } },
+});
+
+describe('SQL approval (native needsApproval)', () => {
+    it('derives a deterministic approvalId from the toolCallId', () => {
+        expect(sqlApprovalId('tc1')).toBe('sql-approval:tc1');
+        expect(sqlApprovalId('tc1')).toBe(sqlApprovalId('tc1'));
+    });
+
+    it('extracts pending approvals from step content', () => {
+        const steps = [
+            { content: [{ type: 'text' }] },
+            { content: [approvalRequest('tc1', 'SELECT 1')] },
+        ];
+        expect(extractPendingSqlApprovals(steps)).toEqual([
+            {
+                approvalId: 'sql-approval:tc1',
+                toolCallId: 'tc1',
+                toolName: 'runSql',
+                input: { sql: 'SELECT 1' },
+            },
+        ]);
+    });
+
+    it('returns empty when no approval request is present', () => {
+        expect(
+            extractPendingSqlApprovals([{ content: [{ type: 'tool-call' }] }]),
+        ).toEqual([]);
+        expect(extractPendingSqlApprovals([{ content: null }])).toEqual([]);
+        expect(extractPendingSqlApprovals([])).toEqual([]);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.ts
+++ b/packages/backend/src/ee/services/ai/agents/sqlApprovalSuspend.ts
@@ -1,0 +1,58 @@
+// Native AI-SDK human-in-the-loop for SQL approval. runSql declares
+// `needsApproval` on the modern Slack path: the SDK halts before executing and
+// emits a `tool-approval-request`, ending the run so the worker can be released.
+// A resume job rebuilds history with a matching `tool-approval-response` and the
+// SDK executes runSql itself.
+//
+// Because we reconstruct the message history ourselves, the approvalId is
+// derived deterministically from the toolCallId — request and response always
+// match without persisting the SDK's original id.
+
+export const sqlApprovalId = (toolCallId: string): string =>
+    `sql-approval:${toolCallId}`;
+
+type ApprovalRequestPart = {
+    type: 'tool-approval-request';
+    approvalId: string;
+    toolCall: {
+        toolCallId: string;
+        toolName: string;
+        input?: unknown;
+    };
+};
+
+type StepLike = {
+    content?: ReadonlyArray<{ type?: string } | null> | null;
+};
+
+export type PendingSqlApproval = {
+    approvalId: string;
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+};
+
+const isApprovalRequestPart = (
+    part: { type?: string } | null,
+): part is ApprovalRequestPart => part?.type === 'tool-approval-request';
+
+// Pulls pending tool-approval-requests out of a generateText result's steps.
+// When non-empty, the run suspended awaiting approval rather than finishing.
+export const extractPendingSqlApprovals = (
+    steps: ReadonlyArray<StepLike>,
+): PendingSqlApproval[] => {
+    const pending: PendingSqlApproval[] = [];
+    for (const step of steps) {
+        for (const part of step.content ?? []) {
+            if (isApprovalRequestPart(part)) {
+                pending.push({
+                    approvalId: part.approvalId,
+                    toolCallId: part.toolCall.toolCallId,
+                    toolName: part.toolCall.toolName,
+                    input: part.toolCall.input,
+                });
+            }
+        }
+    }
+    return pending;
+};

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -177,6 +177,7 @@ const makeAgentTools = () => {
         runSql: getRunSql({
             getPrompt: noop,
             recordSqlApproval: noop,
+            storeToolResults: noop,
             runSqlJob: noop,
             sendFile: noop,
             siteUrl: 'https://lightdash.example',

--- a/packages/backend/src/ee/services/ai/tools/runSql.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.test.ts
@@ -62,6 +62,7 @@ const makeTool = ({
         siteUrl: 'https://lightdash.example',
         waitForSqlApproval,
         recordSqlApproval,
+        storeToolResults: jest.fn().mockResolvedValue(undefined),
         autoApproveSql,
         autoApproveSqlUserUuid,
         maxQueryLimit,

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -145,17 +145,20 @@ export const getRunSql = ({
             const isNativeApprovalPath =
                 useSlackStreamCard && isSlack && !shouldAutoApprove;
 
-            // On the native path execute runs during resume, where onStepFinish
-            // does not persist the result (the tool call was made in a prior
-            // run). Persist it here so the call isn't left result-less — which
-            // would re-trigger execution on later turns and show a stale
-            // approval card on the web.
-            const persistResultIfNative = async <
+            // When execute runs as a RESUME of a previously-suspended approval,
+            // onStepFinish won't persist the result (the tool call was made in a
+            // prior run), so we persist it here. Otherwise the call is left
+            // result-less — which re-triggers execution on later turns and
+            // shows a stale approval card on the web. A resume is identified
+            // either by the native path, or (when "don't ask again" flipped the
+            // thread to auto-approve) by the decision already being recorded.
+            let isResumeExecution = isNativeApprovalPath;
+            const persistResumeResult = async <
                 T extends { result: string; metadata: AnyType },
             >(
                 output: T,
             ): Promise<T> => {
-                if (isNativeApprovalPath) {
+                if (isResumeExecution) {
                     await storeToolResults([
                         {
                             promptUuid: prompt.promptUuid,
@@ -193,11 +196,16 @@ export const getRunSql = ({
                     if (isSlack) {
                         await renderState({ kind: 'approved', sql });
                     }
-                    await recordSqlApproval(
+                    const recorded = await recordSqlApproval(
                         toolCallId,
                         'approved',
                         autoApproveSql ? autoApproveSqlUserUuid : null,
                     );
+                    // A pre-existing decision means this is a resume (the button
+                    // recorded it), so onStepFinish won't persist the result.
+                    if (!recorded) {
+                        isResumeExecution = true;
+                    }
                 } else if (isNativeApprovalPath) {
                     // Approval already handled by the SDK before this call.
                 } else if (isSlack) {
@@ -250,7 +258,7 @@ export const getRunSql = ({
                         inlineCsv: '',
                         truncated: false,
                     });
-                    return await persistResultIfNative({
+                    return await persistResumeResult({
                         result: `Query returned 0 rows.${
                             columns.length > 0
                                 ? ` Columns: ${columns.join(', ')}`
@@ -324,7 +332,7 @@ export const getRunSql = ({
                         ? `\n(Showing first ${PREVIEW_ROW_LIMIT} of ${rowCount} rows.)`
                         : '';
 
-                return await persistResultIfNative({
+                return await persistResumeResult({
                     result: `${rowCount} rows. Columns: ${columns.join(
                         ', ',
                     )}.${truncatedNote}\n${serializeData(previewCsv, 'csv')}`,
@@ -339,7 +347,7 @@ export const getRunSql = ({
                 await renderState({ kind: 'error', sql, message }).catch(() => {
                     /* don't shadow the original error if rendering fails */
                 });
-                return persistResultIfNative({
+                return persistResumeResult({
                     result: toolErrorHandler(e, 'Error running SQL query.'),
                     metadata: { status: 'error' },
                 });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -12,6 +12,7 @@ import type {
     RecordSqlApprovalFn,
     RunSqlJobFn,
     SendFileFn,
+    StoreToolResultsFn,
     UpdateProgressFn,
     UpdateSlackMessageFn,
     WaitForSqlApprovalFn,
@@ -30,6 +31,7 @@ type Dependencies = {
     siteUrl: string;
     waitForSqlApproval: WaitForSqlApprovalFn;
     recordSqlApproval: RecordSqlApprovalFn;
+    storeToolResults: StoreToolResultsFn;
     maxQueryLimit: number;
     autoApproveSql?: boolean;
     autoApproveSqlUserUuid?: string | null;
@@ -81,6 +83,7 @@ export const getRunSql = ({
     siteUrl,
     waitForSqlApproval,
     recordSqlApproval,
+    storeToolResults,
     maxQueryLimit,
     autoApproveSql = false,
     autoApproveSqlUserUuid = null,
@@ -141,6 +144,32 @@ export const getRunSql = ({
             // already recorded.
             const isNativeApprovalPath =
                 useSlackStreamCard && isSlack && !shouldAutoApprove;
+
+            // On the native path execute runs during resume, where onStepFinish
+            // does not persist the result (the tool call was made in a prior
+            // run). Persist it here so the call isn't left result-less — which
+            // would re-trigger execution on later turns and show a stale
+            // approval card on the web.
+            const persistResultIfNative = async <
+                T extends { result: string; metadata: AnyType },
+            >(
+                output: T,
+            ): Promise<T> => {
+                if (isNativeApprovalPath) {
+                    await storeToolResults([
+                        {
+                            promptUuid: prompt.promptUuid,
+                            toolCallId,
+                            toolName: 'runSql',
+                            result: output.result,
+                            metadata: output.metadata,
+                        },
+                    ]).catch(() => {
+                        // Best-effort; the model already has the result.
+                    });
+                }
+                return output;
+            };
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -221,14 +250,14 @@ export const getRunSql = ({
                         inlineCsv: '',
                         truncated: false,
                     });
-                    return {
+                    return await persistResultIfNative({
                         result: `Query returned 0 rows.${
                             columns.length > 0
                                 ? ` Columns: ${columns.join(', ')}`
                                 : ''
                         }`,
                         metadata: { status: 'success', rowCount: 0 },
-                    };
+                    });
                 }
 
                 const csv = stringify(
@@ -295,12 +324,12 @@ export const getRunSql = ({
                         ? `\n(Showing first ${PREVIEW_ROW_LIMIT} of ${rowCount} rows.)`
                         : '';
 
-                return {
+                return await persistResultIfNative({
                     result: `${rowCount} rows. Columns: ${columns.join(
                         ', ',
                     )}.${truncatedNote}\n${serializeData(previewCsv, 'csv')}`,
                     metadata: { status: 'success', rowCount },
-                };
+                });
             } catch (e) {
                 // Post-section errors (runSqlJob threw, Slack call failed,
                 // etc.). Reflect the error in the living Slack block so the
@@ -310,10 +339,10 @@ export const getRunSql = ({
                 await renderState({ kind: 'error', sql, message }).catch(() => {
                     /* don't shadow the original error if rendering fails */
                 });
-                return {
+                return persistResultIfNative({
                     result: toolErrorHandler(e, 'Error running SQL query.'),
                     metadata: { status: 'error' },
-                };
+                });
             }
         },
     });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -92,11 +92,25 @@ export const getRunSql = ({
         maxLimit: maxQueryLimit,
     });
 
+    // Modern Slack path uses the AI SDK's native tool approval: the loop halts
+    // on a tool-approval-request and the worker job ends; a resume job re-runs
+    // generation and the SDK re-invokes execute once approved. Auto-approve and
+    // "don't ask again" threads bypass approval entirely.
+    const usesNativeApproval = async () => {
+        if (!useSlackStreamCard || autoApproveSql) return false;
+        const prompt = await getPrompt();
+        return (
+            isSlackPrompt(prompt) &&
+            !isSlackThreadAutoApproved(prompt.threadUuid)
+        );
+    };
+
     return tool({
         description: buildRunSqlDescription(500, maxQueryLimit),
         inputSchema,
         outputSchema: toolDefinition.outputSchema,
         toModelOutput: toolDefinition.toModelOutput,
+        needsApproval: usesNativeApproval,
         execute: async ({ sql, limit }, { toolCallId }) => {
             if (sqlApprovalTimedOut) {
                 return {
@@ -121,6 +135,12 @@ export const getRunSql = ({
             const slackAutoApproved =
                 isSlack && isSlackThreadAutoApproved(prompt.threadUuid);
             const shouldAutoApprove = autoApproveSql || slackAutoApproved;
+            // When native approval gated this call, execute only runs after the
+            // user approved (or auto-approve). No blocking wait, no pending card
+            // — the reply flow posted the approval card and the decision is
+            // already recorded.
+            const isNativeApprovalPath =
+                useSlackStreamCard && isSlack && !shouldAutoApprove;
 
             // Render a runSql state INTO the bot's existing progress message
             // (the bolt-gif "Thinking…" message at response_slack_ts). One
@@ -149,6 +169,8 @@ export const getRunSql = ({
                         'approved',
                         autoApproveSql ? autoApproveSqlUserUuid : null,
                     );
+                } else if (isNativeApprovalPath) {
+                    // Approval already handled by the SDK before this call.
                 } else if (isSlack) {
                     await renderState({
                         kind: 'pending',
@@ -160,9 +182,10 @@ export const getRunSql = ({
                     await updateProgress('Awaiting approval to run SQL...');
                 }
 
-                const decision = shouldAutoApprove
-                    ? 'approved'
-                    : await waitForSqlApproval(toolCallId);
+                const decision =
+                    shouldAutoApprove || isNativeApprovalPath
+                        ? 'approved'
+                        : await waitForSqlApproval(toolCallId);
                 if (decision === 'rejected') {
                     await renderState({ kind: 'rejected', sql });
                     return {

--- a/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
+++ b/packages/backend/src/ee/services/ai/tools/slackSqlAggregate.ts
@@ -11,7 +11,15 @@ import type { AnyType } from '@lightdash/common';
 import { getThinkingBlocks } from '../utils/getSlackBlocks';
 
 export type SectionState =
-    | { kind: 'pending'; sql: string; toolCallId: string; threadUuid: string }
+    | {
+          kind: 'pending';
+          sql: string;
+          toolCallId: string;
+          threadUuid: string;
+          // Native AI-SDK approval cards carry a `:native` action suffix so the
+          // button handler enqueues a resume job (vs the legacy blocking poll).
+          native?: boolean;
+      }
     | { kind: 'approved'; sql: string }
     | { kind: 'running'; sql: string }
     | {
@@ -59,6 +67,9 @@ export const renderBlocks = (
     siteUrl: string,
 ): AnyType[] => {
     if (state.kind === 'pending') {
+        const suffix = state.native ? ':native' : '';
+        const actionId = (decision: string) =>
+            `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:${decision}${suffix}`;
         // Prominent block — user action required, can't be a context block
         // (Slack disallows buttons in context blocks).
         return [
@@ -82,7 +93,7 @@ export const renderBlocks = (
                     {
                         type: 'button',
                         text: { type: 'plain_text', text: 'Approve' },
-                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:approved`,
+                        action_id: actionId('approved'),
                         value: state.toolCallId,
                         style: 'primary',
                     },
@@ -92,13 +103,13 @@ export const renderBlocks = (
                             type: 'plain_text',
                             text: "Approve & don't ask again",
                         },
-                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:approved_always`,
+                        action_id: actionId('approved_always'),
                         value: state.toolCallId,
                     },
                     {
                         type: 'button',
                         text: { type: 'plain_text', text: 'Reject' },
-                        action_id: `actions.sql_approval:${state.toolCallId}:${state.threadUuid}:rejected`,
+                        action_id: actionId('rejected'),
                         value: state.toolCallId,
                         style: 'danger',
                     },


### PR DESCRIPTION
## Problem

When the Slack AI agent proposes a SQL query that needs approval, the run **blocked a Graphile worker** polling for the decision for up to 5 minutes, then **timed out and lost the in-progress answer** if no one responded in time. The timeout existed only to stop abandoned approvals from starving the worker pool — not as a product choice.

## What this does

Replaces the blocking wait with **suspend / resume** on the modern Slack card path:

- `runSql` declares the AI SDK's native **`needsApproval`** → the agent loop halts on a `tool-approval-request` and **the worker job ends** (no worker held while waiting).
- The reply flow detects the suspended call, finalizes the task card, and posts the **approval card as its own message after it** (also a small UX win — approval used to render above the task list).
- On Approve/Reject, the button handler records the decision and **re-enqueues the reply job once**. Resume rebuilds history from the DB — now including the `tool-approval-response` — and the SDK **re-executes `runSql` itself** (or skips it on reject) and streams the answer in a fresh card below the approval.

Net effect: the approval window is now **effectively unbounded** (approve minutes or hours later — Slack buttons don't expire), and no worker is held while waiting. There is **no timeout** anymore, because a suspended run costs nothing.

## How resume works without new persistence

Everything resume needs is already stored: `sql`/`limit` in `ai_agent_tool_call.tool_args`, the decision in `ai_sql_approval`, prompt/thread via existing lookups. Because we reconstruct the message history ourselves, the SDK approval id is derived deterministically (`sql-approval:<toolCallId>`), so request/response always match — **no new table, no migration**.

## Scope / regression analysis

- **Affected:** only the **modern Slack card path** (`AiAgentSlackModernBlocks` on) for **non-auto-approved** SQL. That's the only path where `needsApproval` returns true.
- **Unchanged:**
  - **Classic Slack path** (flag off) → still the blocking `waitForSqlApproval` poll + emoji/legacy card.
  - **Web UI** → `needsApproval` is false for web prompts, so it keeps its existing blocking approval behaviour (web holds a cheap HTTP/SSE connection, not a worker — not the problem this solves).
  - **Auto-approve / "don't ask again" threads** → bypass approval entirely, as before.
- **No DB changes.** `ai_sql_approval` stays as the decision record (now read by resume instead of a poll); `waitForSqlApproval` is simply bypassed on the modern path.

## Testing

- Validated **live end-to-end** on the Jaffle dev Slack agent: suspend → worker released → approve after a delay → resume → SDK executes the SQL → answer posted. Reject and "don't ask again" also exercised.
- Unit tests for the history reconstruction (`buildToolCallTurnMessages` / `hasUnresolvedSqlApproval`) covering the resume case that must not regress (approved-but-unexecuted call → request + response, no `tool-result`), and for the suspend-detection helpers.

## Follow-ups (not in this PR)

- Web-UI parity (the reconstruction is already shared; needs a web suspend state + a resume endpoint).
- An end-to-end integration test now that the working message shape is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)