### PR TITLE
fix: disable "Explore from here" in embed mode

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -380,13 +380,17 @@ export const AiChartQuickOptions = ({
                         </>
                     )}
 
-                    <Menu.Item
-                        leftSection={<MantineIcon icon={IconExternalLink} />}
-                        disabled={isDisabled}
-                        onClick={handleExploreFromHere}
-                    >
-                        Explore from here
-                    </Menu.Item>
+                    {!isEmbed && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconExternalLink} />
+                            }
+                            disabled={isDisabled}
+                            onClick={handleExploreFromHere}
+                        >
+                            Explore from here
+                        </Menu.Item>
+                    )}
 
                     {!!compiledSql && (
                         <HoverCard


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-543/hide-explore-from-here-on-embed-ai-agent

<img width="599" height="283" alt="CleanShot 2026-06-17 at 12 43 56" src="https://github.com/user-attachments/assets/4cba2ef2-697e-410a-8323-78cab05d22c9" />

### Description:
Disables the "Explore from here" menu item in the AI Chart Quick Options when the user is in an embed context, preventing access to the explore view from embedded charts.