### PR TITLE
feat(ai): support GitLab repos in the read-only repo VFS

### DIFF
--- a/packages/backend/src/clients/gitlab/Gitlab.test.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.test.ts
@@ -1,5 +1,21 @@
 import fetchMock from 'jest-fetch-mock';
-import { getMergeRequestComments } from './Gitlab';
+import {
+    getGitlabRepoTree,
+    getMergeRequestComments,
+    isGitlabRateLimitError,
+} from './Gitlab';
+
+// One GitLab Trees API page: `entries` are raw {type, path} items (blobs AND
+// trees); `nextPage` populates the x-next-page header GitLab uses for offset
+// pagination (empty string ⇒ last page).
+const treePage = (
+    entries: Array<{ type: string; path: string }>,
+    nextPage: string,
+) =>
+    [
+        JSON.stringify(entries),
+        { headers: { 'x-next-page': nextPage } },
+    ] as const;
 
 describe('GitlabClient.getMergeRequestComments', () => {
     afterEach(() => {
@@ -63,5 +79,90 @@ describe('GitlabClient.getMergeRequestComments', () => {
         expect(url).toBe(
             'https://gitlab.internal.acme.com/api/v4/projects/my-group%2Fmy-repo/merge_requests/7/notes?order_by=created_at&sort=desc&per_page=100',
         );
+    });
+});
+
+describe('GitlabClient.getGitlabRepoTree', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    const args = {
+        owner: 'my-group',
+        repo: 'my-repo',
+        branch: 'main',
+        token: 'glpat-xxx',
+    };
+
+    it('follows x-next-page across pages and returns only blobs (size 0)', async () => {
+        fetchMock.mockResponseOnce(
+            ...treePage(
+                [
+                    { type: 'tree', path: 'models' },
+                    { type: 'blob', path: 'models/orders.sql' },
+                ],
+                '2', // more pages
+            ),
+        );
+        fetchMock.mockResponseOnce(
+            ...treePage(
+                [{ type: 'blob', path: 'dbt_project.yml' }],
+                '', // last page
+            ),
+        );
+
+        const { files, truncated } = await getGitlabRepoTree(args);
+
+        expect(fetchMock.mock.calls).toHaveLength(2);
+        // directory ('tree') entries dropped; blobs from both pages combined
+        expect(files).toEqual([
+            { path: 'models/orders.sql', size: 0 },
+            { path: 'dbt_project.yml', size: 0 },
+        ]);
+        expect(truncated).toBe(false);
+        // page params requested in order
+        expect(fetchMock.mock.calls[0][0]).toContain('page=1');
+        expect(fetchMock.mock.calls[1][0]).toContain('page=2');
+    });
+
+    it('stops at maxPages and reports truncated when more pages remain', async () => {
+        fetchMock.mockResponseOnce(
+            ...treePage([{ type: 'blob', path: 'a.sql' }], '2'),
+        );
+        // A second page exists, but maxPages=1 means we must not fetch it.
+        fetchMock.mockResponseOnce(
+            ...treePage([{ type: 'blob', path: 'b.sql' }], ''),
+        );
+
+        const { files, truncated } = await getGitlabRepoTree({
+            ...args,
+            maxPages: 1,
+        });
+
+        expect(fetchMock.mock.calls).toHaveLength(1);
+        expect(files).toEqual([{ path: 'a.sql', size: 0 }]);
+        expect(truncated).toBe(true);
+    });
+
+    it('does not set truncated when the single page is the last page', async () => {
+        fetchMock.mockResponseOnce(
+            ...treePage([{ type: 'blob', path: 'only.sql' }], ''),
+        );
+
+        const { files, truncated } = await getGitlabRepoTree({
+            ...args,
+            maxPages: 1,
+        });
+
+        expect(fetchMock.mock.calls).toHaveLength(1);
+        expect(files).toEqual([{ path: 'only.sql', size: 0 }]);
+        expect(truncated).toBe(false);
+    });
+
+    it('throws a recoverable GitlabRateLimitError on HTTP 429', async () => {
+        fetchMock.mockResponseOnce('rate limited', { status: 429 });
+
+        const error = await getGitlabRepoTree(args).catch((e) => e);
+        expect(isGitlabRateLimitError(error)).toBe(true);
     });
 });

--- a/packages/backend/src/clients/gitlab/Gitlab.test.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.test.ts
@@ -1,5 +1,6 @@
 import fetchMock from 'jest-fetch-mock';
 import {
+    getFileContent,
     getGitlabRepoTree,
     getMergeRequestComments,
     isGitlabRateLimitError,
@@ -163,6 +164,32 @@ describe('GitlabClient.getGitlabRepoTree', () => {
         fetchMock.mockResponseOnce('rate limited', { status: 429 });
 
         const error = await getGitlabRepoTree(args).catch((e) => e);
+        expect(isGitlabRateLimitError(error)).toBe(true);
+    });
+});
+
+describe('GitlabClient.getFileContent rate limiting', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    // Regression for M1: file reads go through makeGitlabRequest, which must map
+    // a 429 to the recoverable GitlabRateLimitError (not UnexpectedGitError) so
+    // the VFS degrades gracefully under a real rate limit, same as the tree path.
+    it('maps a 429 to a recoverable GitlabRateLimitError', async () => {
+        fetchMock.mockResponseOnce(
+            'Rate limit exceeded; see https://docs.gitlab.com/...',
+            { status: 429 },
+        );
+
+        const error = await getFileContent({
+            owner: 'my-group',
+            repo: 'my-repo',
+            branch: 'main',
+            fileName: 'dbt/dbt_project.yml',
+            token: 'glpat-xxx',
+        }).catch((e) => e);
+
         expect(isGitlabRateLimitError(error)).toBe(true);
     });
 });

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -3,6 +3,7 @@ import {
     AnyType,
     ForbiddenError,
     getErrorMessage,
+    LightdashError,
     NotFoundError,
     ParameterError,
     PullRequestState,
@@ -62,9 +63,20 @@ const getApiUrl = (hostDomain: string, endpoint: string) =>
  * GitLab returns 429 when an org's token exceeds its API rate limit. The
  * read-only repo VFS reads many files per command, so surface this distinctly:
  * {@link gitlabRepoSource} maps it to an agent-recoverable error instead of a
- * hard failure. Mirrors `isGithubRateLimitError` for the GitHub path.
+ * hard failure. Mirrors `isGithubRateLimitError` for the GitHub path. Extends
+ * LightdashError (statusCode 429) so it flows through the project's error
+ * categorisation/Sentry filtering rather than bypassing it as a bare Error.
  */
-export class GitlabRateLimitError extends Error {}
+export class GitlabRateLimitError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'GitlabRateLimitError',
+            statusCode: 429,
+            data: {},
+        });
+    }
+}
 
 export const isGitlabRateLimitError = (error: unknown): boolean =>
     error instanceof GitlabRateLimitError;

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -58,6 +58,17 @@ const getProjectId = (owner: string, repo: string) =>
 const getApiUrl = (hostDomain: string, endpoint: string) =>
     `https://${hostDomain}/api/v4${endpoint}`;
 
+/**
+ * GitLab returns 429 when an org's token exceeds its API rate limit. The
+ * read-only repo VFS reads many files per command, so surface this distinctly:
+ * {@link gitlabRepoSource} maps it to an agent-recoverable error instead of a
+ * hard failure. Mirrors `isGithubRateLimitError` for the GitHub path.
+ */
+export class GitlabRateLimitError extends Error {}
+
+export const isGitlabRateLimitError = (error: unknown): boolean =>
+    error instanceof GitlabRateLimitError;
+
 const makeGitlabRequest = async (
     url: string,
     token: string,
@@ -87,6 +98,13 @@ const makeGitlabRequest = async (
         }
         if (response.status === 404) {
             throw new NotFoundError('GitLab resource not found');
+        }
+        // Surface rate limits distinctly so callers (e.g. the repo VFS) can
+        // degrade gracefully instead of treating a transient 429 as a fault.
+        if (response.status === 429) {
+            throw new GitlabRateLimitError(
+                `GitLab API rate limit reached: ${errorText}`,
+            );
         }
         throw new UnexpectedGitError(
             `GitLab API error: ${response.status} ${errorText}`,
@@ -523,17 +541,6 @@ export const getDirectoryContents = async ({
         throw error;
     }
 };
-
-/**
- * GitLab returns 429 when an org's token exceeds its API rate limit. The
- * read-only repo VFS reads many files per command, so surface this distinctly:
- * {@link gitlabRepoSource} maps it to an agent-recoverable error instead of a
- * hard failure. Mirrors `isGithubRateLimitError` for the GitHub path.
- */
-export class GitlabRateLimitError extends Error {}
-
-export const isGitlabRateLimitError = (error: unknown): boolean =>
-    error instanceof GitlabRateLimitError;
 
 // Offset pagination cap for the recursive tree walk: 50 pages × 100 = 5000
 // files. Beyond this we report `truncated` (same contract as the GitHub tree)

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -524,6 +524,100 @@ export const getDirectoryContents = async ({
     }
 };
 
+/**
+ * GitLab returns 429 when an org's token exceeds its API rate limit. The
+ * read-only repo VFS reads many files per command, so surface this distinctly:
+ * {@link gitlabRepoSource} maps it to an agent-recoverable error instead of a
+ * hard failure. Mirrors `isGithubRateLimitError` for the GitHub path.
+ */
+export class GitlabRateLimitError extends Error {}
+
+export const isGitlabRateLimitError = (error: unknown): boolean =>
+    error instanceof GitlabRateLimitError;
+
+// Offset pagination cap for the recursive tree walk: 50 pages × 100 = 5000
+// files. Beyond this we report `truncated` (same contract as the GitHub tree)
+// rather than walk unbounded — dbt repos are well under this.
+const MAX_TREE_PAGES = 50;
+
+/**
+ * Recursive listing of every blob path in a repo via the GitLab Trees API
+ * (`recursive=true`, offset-paginated). Returns file paths only (tree entries
+ * are dropped) with `size: 0` — GitLab's tree API does not return blob sizes,
+ * so size is unknown here (used only for `ls -l` display, never to gate reads).
+ * `truncated` signals the page cap was hit. Backs `listAllPaths` in the VFS.
+ */
+export const getGitlabRepoTree = async ({
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
+}: GitlabApiParams & { branch: string }): Promise<{
+    files: Array<{ path: string; size: number }>;
+    truncated: boolean;
+}> => {
+    const projectId = getProjectId(owner, repo);
+    const files: Array<{ path: string; size: number }> = [];
+    let page = 1;
+    let truncated = false;
+
+    for (;;) {
+        const url = getApiUrl(
+            hostDomain,
+            `/projects/${projectId}/repository/tree?ref=${encodeURIComponent(
+                branch,
+            )}&recursive=true&per_page=100&page=${page}`,
+        );
+        // eslint-disable-next-line no-await-in-loop
+        const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (response.status === 429) {
+            throw new GitlabRateLimitError(
+                'GitLab API rate limit reached while listing repository files',
+            );
+        }
+        if (!response.ok) {
+            // eslint-disable-next-line no-await-in-loop
+            const errorText = await response.text();
+            if (response.status === 401 || response.status === 403) {
+                throw new ForbiddenError('Invalid GitLab access token');
+            }
+            if (response.status === 404) {
+                throw new NotFoundError(
+                    `GitLab repository tree not found for ${owner}/${repo}@${branch}`,
+                );
+            }
+            throw new UnexpectedGitError(
+                `GitLab API error: ${response.status} ${errorText}`,
+            );
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        const items = (await response.json()) as Array<{
+            type: string;
+            path: string;
+        }>;
+        for (const item of items) {
+            if (item.type === 'blob') {
+                files.push({ path: item.path, size: 0 });
+            }
+        }
+
+        const nextPage = response.headers.get('x-next-page');
+        if (!nextPage) break;
+        if (page >= MAX_TREE_PAGES) {
+            truncated = true;
+            break;
+        }
+        page = Number(nextPage);
+    }
+
+    return { files, truncated };
+};
+
 export const deleteFile = async ({
     owner,
     repo,

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -553,7 +553,8 @@ export const getGitlabRepoTree = async ({
     branch,
     token,
     hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
-}: GitlabApiParams & { branch: string }): Promise<{
+    maxPages = MAX_TREE_PAGES,
+}: GitlabApiParams & { branch: string; maxPages?: number }): Promise<{
     files: Array<{ path: string; size: number }>;
     truncated: boolean;
 }> => {
@@ -608,7 +609,7 @@ export const getGitlabRepoTree = async ({
 
         const nextPage = response.headers.get('x-next-page');
         if (!nextPage) break;
-        if (page >= MAX_TREE_PAGES) {
+        if (page >= maxPages) {
             truncated = true;
             break;
         }

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -235,6 +235,7 @@ import {
     rethrowAsRecoverable,
     type RepoFsTimingEvent,
 } from '../ai/repoFs/githubRepoSource';
+import { createGitlabRepoSource } from '../ai/repoFs/gitlabRepoSource';
 import {
     DBT_MOUNT,
     MountingRepoFileSystem,
@@ -6011,9 +6012,17 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 user,
                 projectUuid,
             });
-            return new RepoFs(
-                createGithubRepoSource({ ...access, onTiming: onRepoFsTiming }),
-            );
+            const source =
+                access.provider === 'gitlab'
+                    ? createGitlabRepoSource({
+                          ...access,
+                          onTiming: onRepoFsTiming,
+                      })
+                    : createGithubRepoSource({
+                          ...access,
+                          onTiming: onRepoFsTiming,
+                      });
+            return new RepoFs(source);
         };
         const buildRepoFs = async (
             owner: string,
@@ -6042,11 +6051,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const getMountFs = () => {
             if (!mountFsPromise) {
                 mountFsPromise = (async () => {
-                    // /dbt is only mountable when the project's dbt repo is on
-                    // GitHub (getRepoReadAccess is GitHub-only).
+                    // /dbt is mountable when the project's dbt repo is on a
+                    // host the VFS can read read-only (GitHub or GitLab); other
+                    // connection types have no repo source.
                     const project = await this.projectModel.get(projectUuid);
                     const hasDbtMount =
-                        project.dbtConnection.type === DbtProjectType.GITHUB;
+                        project.dbtConnection.type === DbtProjectType.GITHUB ||
+                        project.dbtConnection.type === DbtProjectType.GITLAB;
                     return MountingRepoFileSystem.create({
                         listRepos: async () => {
                             this.prometheusMetrics?.incrementRepoFsGithubRequest(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5980,19 +5980,42 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         // descent and a per-run budget bounds an unscoped recursive walk. The
         // tool's `target` just picks the starting directory, so a repo target
         // reads exactly as before while absolute paths can cross repos.
-        const onRepoFsTiming = (event: RepoFsTimingEvent) => {
-            this.prometheusMetrics?.incrementRepoFsGithubRequest(event.kind);
-            if (event.kind === 'tree') {
-                this.prometheusMetrics?.observeRepoFsGithubTreeDuration(
-                    event.durationMs,
+        // Record repo-VFS latency/requests against the metrics for the repo's
+        // host, so GitLab activity isn't mislabelled as GitHub.
+        const makeRepoFsTiming =
+            (provider: 'github' | 'gitlab') => (event: RepoFsTimingEvent) => {
+                if (provider === 'gitlab') {
+                    this.prometheusMetrics?.incrementRepoFsGitlabRequest(
+                        event.kind,
+                    );
+                    if (event.kind === 'tree') {
+                        this.prometheusMetrics?.observeRepoFsGitlabTreeDuration(
+                            event.durationMs,
+                        );
+                    } else if (event.kind === 'file') {
+                        this.prometheusMetrics?.observeRepoFsGitlabFileDuration(
+                            event.durationMs,
+                            event.outcome,
+                        );
+                    }
+                    return;
+                }
+                this.prometheusMetrics?.incrementRepoFsGithubRequest(
+                    event.kind,
                 );
-            } else if (event.kind === 'file') {
-                this.prometheusMetrics?.observeRepoFsGithubFileDuration(
-                    event.durationMs,
-                    event.outcome,
-                );
-            }
-        };
+                if (event.kind === 'tree') {
+                    this.prometheusMetrics?.observeRepoFsGithubTreeDuration(
+                        event.durationMs,
+                    );
+                } else if (event.kind === 'file') {
+                    this.prometheusMetrics?.observeRepoFsGithubFileDuration(
+                        event.durationMs,
+                        event.outcome,
+                    );
+                }
+            };
+        // The installation-browse path (buildRepoFs) is GitHub-App-only.
+        const onRepoFsTiming = makeRepoFsTiming('github');
         let installationAccessPromise: ReturnType<
             typeof this.aiWritebackService.getInstallationRepoReadAccess
         > | null = null;
@@ -6016,11 +6039,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 access.provider === 'gitlab'
                     ? createGitlabRepoSource({
                           ...access,
-                          onTiming: onRepoFsTiming,
+                          onTiming: makeRepoFsTiming('gitlab'),
                       })
                     : createGithubRepoSource({
                           ...access,
-                          onTiming: onRepoFsTiming,
+                          onTiming: makeRepoFsTiming('github'),
                       });
             return new RepoFs(source);
         };

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -682,6 +682,21 @@ describe('AiWritebackService repo read access', () => {
         dbtVersion: SupportedDbtVersions.V1_9,
     });
 
+    const gitlabProject = (): AnyType => ({
+        organizationUuid: ORG,
+        name: 'Analytics',
+        dbtConnection: {
+            type: DbtProjectType.GITLAB,
+            personal_access_token: 'pat',
+            repository: 'acme/analytics',
+            branch: 'main',
+            project_sub_path: 'transform/dbt',
+            host_domain: 'gitlab.acme.com',
+        },
+        warehouseConnection: { type: WarehouseTypes.POSTGRES },
+        dbtVersion: SupportedDbtVersions.V1_9,
+    });
+
     const buildWithInstallation = (project: AnyType = githubProject()) => {
         const githubAppService = {
             getValidUserToken: jest.fn().mockResolvedValue(undefined),
@@ -711,8 +726,8 @@ describe('AiWritebackService repo read access', () => {
         jest.clearAllMocks();
     });
 
-    describe('getRepoReadAccess (dbt project repo, unchanged contract)', () => {
-        it('returns the dbt repo owner/repo/branch/token/subPath', async () => {
+    describe('getRepoReadAccess (dbt project repo, provider-tagged)', () => {
+        it('returns github-tagged access for a GitHub dbt connection', async () => {
             const { service } = buildWithInstallation();
             await expect(
                 service.getRepoReadAccess({
@@ -720,6 +735,7 @@ describe('AiWritebackService repo read access', () => {
                     projectUuid: 'p1',
                 }),
             ).resolves.toEqual({
+                provider: 'github',
                 owner: 'acme',
                 repo: 'analytics',
                 branch: 'main',
@@ -728,6 +744,33 @@ describe('AiWritebackService repo read access', () => {
             });
             // Branch came from the connection; no default-branch lookup.
             expect(getRepoDefaultBranch).not.toHaveBeenCalled();
+        });
+
+        it('returns gitlab-tagged access (with hostDomain) for a GitLab dbt connection', async () => {
+            const { service } = buildWithInstallation(gitlabProject());
+            jest.spyOn(
+                (service as AnyType).gitlabProvider,
+                'resolveInstallation',
+            ).mockResolvedValue({
+                provider: PullRequestProvider.GITLAB,
+                token: 'gitlab-install-token',
+                instanceUrl: 'https://gitlab.acme.com',
+                commitAuthor: { name: 'n', email: 'e' },
+            } as AnyType);
+            await expect(
+                service.getRepoReadAccess({
+                    user: userWithOrg(true),
+                    projectUuid: 'p1',
+                }),
+            ).resolves.toEqual({
+                provider: 'gitlab',
+                owner: 'acme',
+                repo: 'analytics',
+                branch: 'main',
+                token: 'gitlab-install-token',
+                hostDomain: 'gitlab.acme.com',
+                subPath: 'transform/dbt',
+            });
         });
 
         it('rejects a user without view:SourceCode', async () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -93,6 +93,7 @@ import {
     formatWritebackStep,
     interpretAgentEvent,
     parseGithubConnection,
+    parseGitlabConnection,
     parsePullNumber,
     progressTextForStage,
     resolvePrMetadataValue,
@@ -135,6 +136,31 @@ export type SourceCodeRepoAccess = {
     private: boolean;
     token: string;
 };
+
+/**
+ * Resolved read-only access to a project's dbt repo for the agent's `exploreRepo`
+ * VFS, discriminated by `provider`. The `repoFs` layer creates the matching
+ * {@link RepoSource} (GitHub Trees+Contents, or GitLab Trees+Files) from this.
+ * GitLab adds `hostDomain` for self-hosted instances; GitHub has none.
+ */
+export type RepoReadAccess =
+    | {
+          provider: 'github';
+          owner: string;
+          repo: string;
+          branch: string;
+          token: string;
+          subPath: string;
+      }
+    | {
+          provider: 'gitlab';
+          owner: string;
+          repo: string;
+          branch: string;
+          token: string;
+          hostDomain: string;
+          subPath: string;
+      };
 
 type RepoListing = {
     owner: string;
@@ -263,16 +289,20 @@ export class AiWritebackService extends BaseService {
      * {@link getInstallationRepoReadAccess} (any accessible repo): org check →
      * view:SourceCode ability gate → installation token. GitHub-only for now.
      */
-    private async resolveSourceCodeInstallation({
+    /**
+     * Org membership + view:SourceCode gate shared by every read-only source
+     * access path, independent of git provider. Returns the project (so callers
+     * can branch on its dbt connection type) and the org uuid (narrowed here).
+     */
+    private async assertSourceCodeAccess({
         user,
         projectUuid,
     }: {
         user: SessionUser;
         projectUuid: string;
     }): Promise<{
-        installationId: string;
-        token: string;
         project: Awaited<ReturnType<ProjectModel['get']>>;
+        organizationUuid: string;
     }> {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
@@ -294,9 +324,28 @@ export class AiWritebackService extends BaseService {
                 'You do not have permission to view this project source code',
             );
         }
-        const installation = await this.githubProvider.resolveInstallation(
-            user.organizationUuid,
+        return { project, organizationUuid: user.organizationUuid };
+    }
+
+    private async resolveSourceCodeInstallation({
+        user,
+        projectUuid,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+    }): Promise<{
+        installationId: string;
+        token: string;
+        project: Awaited<ReturnType<ProjectModel['get']>>;
+    }> {
+        const { project, organizationUuid } = await this.assertSourceCodeAccess(
+            {
+                user,
+                projectUuid,
+            },
         );
+        const installation =
+            await this.githubProvider.resolveInstallation(organizationUuid);
         if (installation.provider !== PullRequestProvider.GITHUB) {
             throw new WritebackGitNotConnectedError(
                 PullRequestProvider.GITHUB,
@@ -316,43 +365,73 @@ export class AiWritebackService extends BaseService {
     }: {
         user: SessionUser;
         projectUuid: string;
-    }): Promise<{
-        owner: string;
-        repo: string;
-        branch: string;
-        token: string;
-        subPath: string;
-    }> {
-        const { installationId, token, project } =
-            await this.resolveSourceCodeInstallation({ user, projectUuid });
-        const provider = this.getGitProvider(project.dbtConnection.type);
-        if (provider.provider !== PullRequestProvider.GITHUB) {
-            throw new WritebackGitNotConnectedError(
-                provider.provider,
-                'Repository read access is currently only supported for GitHub dbt connections',
-            );
-        }
-        const connection = parseGithubConnection(project.dbtConnection);
-        // Read the project's configured dbt branch so the shell inspects the
-        // same source the Lightdash project compiles from. Only fall back to the
-        // repo's default branch when the project left the branch unset.
-        const branch =
-            connection.branch ||
-            (await getRepoDefaultBranch({
+    }): Promise<RepoReadAccess> {
+        const { project, organizationUuid } = await this.assertSourceCodeAccess(
+            {
+                user,
+                projectUuid,
+            },
+        );
+        const { dbtConnection } = project;
+
+        // Scope the read-only VFS to the dbt project subdirectory so it can't
+        // expose secrets/other files elsewhere in the repo. '.' (repo root)
+        // means no scoping. Read the project's configured dbt branch so the
+        // shell inspects the same source the Lightdash project compiles from.
+        if (dbtConnection.type === DbtProjectType.GITHUB) {
+            const installation =
+                await this.githubProvider.resolveInstallation(organizationUuid);
+            if (installation.provider !== PullRequestProvider.GITHUB) {
+                throw new WritebackGitNotConnectedError(
+                    PullRequestProvider.GITHUB,
+                    'GitHub App is not installed for this organization',
+                );
+            }
+            const connection = parseGithubConnection(dbtConnection);
+            const branch =
+                connection.branch ||
+                (await getRepoDefaultBranch({
+                    owner: connection.owner,
+                    repo: connection.repo,
+                    installationId: installation.installationId,
+                }));
+            return {
+                provider: 'github',
                 owner: connection.owner,
                 repo: connection.repo,
-                installationId,
-            }));
-        return {
-            owner: connection.owner,
-            repo: connection.repo,
-            branch,
-            token,
-            // Scope the read-only VFS to the dbt project subdirectory so it
-            // can't expose secrets/other files elsewhere in the repo. '.' (repo
-            // root) means no scoping.
-            subPath: connection.projectSubPath,
-        };
+                branch,
+                token: installation.token,
+                subPath: connection.projectSubPath,
+            };
+        }
+
+        if (dbtConnection.type === DbtProjectType.GITLAB) {
+            const installation =
+                await this.gitlabProvider.resolveInstallation(organizationUuid);
+            if (installation.provider !== PullRequestProvider.GITLAB) {
+                throw new WritebackGitNotConnectedError(
+                    PullRequestProvider.GITLAB,
+                    'GitLab App is not installed for this organization',
+                );
+            }
+            const connection = parseGitlabConnection(dbtConnection);
+            // parseGitlabConnection omits the branch; read it from the typed
+            // connection (GitLab dbt config always carries a branch).
+            return {
+                provider: 'gitlab',
+                owner: connection.owner,
+                repo: connection.repo,
+                branch: dbtConnection.branch,
+                token: installation.token,
+                hostDomain: connection.hostDomain,
+                subPath: connection.projectSubPath,
+            };
+        }
+
+        throw new WritebackGitNotConnectedError(
+            this.getGitProvider(dbtConnection.type).provider,
+            'Repository read access is currently only supported for GitHub and GitLab dbt connections',
+        );
     }
 
     /**

--- a/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/githubRepoSource.ts
@@ -7,6 +7,19 @@ import {
 } from '../../../../clients/github/Github';
 import Logger from '../../../../logging/logger';
 import { RepoSource } from './RepoFs';
+import {
+    isDeniedRepoPath,
+    type RepoFsTimingCallback,
+} from './repoSourceShared';
+
+// Re-exported for backward compatibility: these provider-agnostic helpers moved
+// to ./repoSourceShared so a non-GitHub source can reuse them, but existing
+// importers (AiAgentService, tests) still reach them through this module.
+export {
+    isDeniedRepoPath,
+    type RepoFsTimingEvent,
+    type RepoFsTimingCallback,
+} from './repoSourceShared';
 
 /** Message + sentinel code for a GitHub rate-limit hit. The `ERATELIMIT` code is
  *  mapped to an agent-recoverable ShellError in {@link ./bashShell} so a 403 from
@@ -27,45 +40,6 @@ export const rethrowAsRecoverable = (error: unknown): never => {
     }
     throw error;
 };
-
-/**
- * Latency signal for each backing GitHub call, so a caller (e.g. the agent
- * service) can record metrics without coupling this layer to Prometheus.
- */
-export type RepoFsTimingEvent =
-    | { kind: 'tree'; durationMs: number }
-    | {
-          kind: 'file';
-          durationMs: number;
-          outcome: 'found' | 'missing' | 'error';
-      }
-    | { kind: 'search'; durationMs: number };
-
-export type RepoFsTimingCallback = (event: RepoFsTimingEvent) => void;
-
-/**
- * Paths that must never be exposed through the read-only shell. Removing the
- * `subPath` confinement (so the whole repo is readable for an explicit
- * `exploreRepo` target) widens the blast radius to secrets that previously lived
- * outside the dbt subdirectory, so deny common credential/secret files at the
- * source layer — they're filtered from listings and read back as absent.
- */
-const DENIED_PATH_PATTERNS: RegExp[] = [
-    /(^|\/)\.env(\..*)?$/i, // .env, .env.local, .env.production, ...
-    /\.pem$/i,
-    /\.key$/i,
-    /\.p12$/i,
-    /\.pfx$/i,
-    /(^|\/)id_rsa(\.pub)?$/i,
-    /(^|\/)id_ed25519(\.pub)?$/i,
-    /(^|\/)\.npmrc$/i,
-    /(^|\/)\.pypirc$/i,
-    /(^|\/)credentials$/i,
-    /\.keyfile(\.json)?$/i,
-];
-
-export const isDeniedRepoPath = (path: string): boolean =>
-    DENIED_PATH_PATTERNS.some((re) => re.test(path));
 
 /**
  * A read-only {@link RepoSource} backed by the GitHub API (Git Trees + Contents)

--- a/packages/backend/src/ee/services/ai/repoFs/gitlabRepoSource.test.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/gitlabRepoSource.test.ts
@@ -1,0 +1,202 @@
+import { NotFoundError, UnexpectedGitError } from '@lightdash/common';
+import {
+    getFileContent,
+    getGitlabRepoTree,
+    isGitlabRateLimitError,
+} from '../../../../clients/gitlab/Gitlab';
+import { createGitlabRepoSource } from './gitlabRepoSource';
+import { type RepoFsTimingCallback } from './repoSourceShared';
+
+jest.mock('../../../../clients/gitlab/Gitlab');
+
+const mockGetFileContent = getFileContent as jest.MockedFunction<
+    typeof getFileContent
+>;
+const mockGetRepoTree = getGitlabRepoTree as jest.MockedFunction<
+    typeof getGitlabRepoTree
+>;
+const mockIsRateLimit = isGitlabRateLimitError as jest.MockedFunction<
+    typeof isGitlabRateLimitError
+>;
+
+const source = (onTiming?: RepoFsTimingCallback) =>
+    createGitlabRepoSource({
+        owner: 'acme',
+        repo: 'jaffle',
+        branch: 'main',
+        token: 'tok',
+        onTiming,
+    });
+
+describe('gitlabRepoSource.readFile error handling', () => {
+    beforeEach(() => {
+        mockGetFileContent.mockReset();
+        mockIsRateLimit.mockReset();
+    });
+
+    it('returns content for a found file', async () => {
+        mockGetFileContent.mockResolvedValue({
+            content: 'select 1 as id',
+            sha: 'abc',
+        });
+        await expect(source().readFile('models/x.sql')).resolves.toBe(
+            'select 1 as id',
+        );
+    });
+
+    it('returns null for a missing file (NotFoundError)', async () => {
+        mockGetFileContent.mockRejectedValue(
+            new NotFoundError('GitLab resource not found'),
+        );
+        await expect(
+            source().readFile('models/missing.sql'),
+        ).resolves.toBeNull();
+    });
+
+    it('returns null for a binary blob (contains a NUL byte)', async () => {
+        // GitLab's Files API returns binary files inline (unlike GitHub
+        // Contents), so the source screens them out as non-text → absent.
+        mockGetFileContent.mockResolvedValue({
+            content: 'PNG\0\0binary',
+            sha: 'abc',
+        });
+        await expect(source().readFile('assets/logo.png')).resolves.toBeNull();
+    });
+
+    it('converts a rate limit into a recoverable ERATELIMIT error (not a silent empty)', async () => {
+        mockGetFileContent.mockRejectedValue(
+            new UnexpectedGitError('429 Too Many Requests'),
+        );
+        mockIsRateLimit.mockReturnValue(true);
+        await expect(source().readFile('models/x.sql')).rejects.toMatchObject({
+            code: 'ERATELIMIT',
+            message: expect.stringMatching(/rate limit reached/i),
+        });
+    });
+
+    it('re-throws other unexpected errors (network / 5xx) unchanged', async () => {
+        mockGetFileContent.mockRejectedValue(
+            new UnexpectedGitError('socket hang up'),
+        );
+        mockIsRateLimit.mockReturnValue(false);
+        await expect(source().readFile('models/x.sql')).rejects.toThrow(
+            'socket hang up',
+        );
+    });
+});
+
+describe('gitlabRepoSource.listAllPaths', () => {
+    beforeEach(() => {
+        mockGetRepoTree.mockReset();
+        mockGetFileContent.mockReset();
+    });
+
+    it('lists every file path from the recursive tree', async () => {
+        mockGetRepoTree.mockResolvedValue({
+            files: [
+                { path: 'models/orders.sql', size: 0 },
+                { path: 'dbt_project.yml', size: 0 },
+            ],
+            truncated: false,
+        });
+        const { files, truncated } = await source().listAllPaths();
+        expect(files.map((f) => f.path)).toEqual([
+            'models/orders.sql',
+            'dbt_project.yml',
+        ]);
+        expect(truncated).toBe(false);
+        expect(mockGetRepoTree).toHaveBeenCalledWith(
+            expect.objectContaining({
+                owner: 'acme',
+                repo: 'jaffle',
+                branch: 'main',
+                token: 'tok',
+            }),
+        );
+    });
+
+    it('scopes and re-roots paths to the sub-path, dropping those outside it', async () => {
+        mockGetRepoTree.mockResolvedValue({
+            files: [
+                { path: 'transform/dbt/models/orders.sql', size: 0 },
+                { path: 'app/src/index.ts', size: 0 },
+            ],
+            truncated: true,
+        });
+        const scoped = createGitlabRepoSource({
+            owner: 'acme',
+            repo: 'jaffle',
+            branch: 'main',
+            token: 'tok',
+            subPath: 'transform/dbt',
+        });
+        const { files, truncated } = await scoped.listAllPaths();
+        expect(files.map((f) => f.path)).toEqual(['models/orders.sql']);
+        expect(truncated).toBe(true);
+    });
+});
+
+describe('gitlabRepoSource secrets denylist', () => {
+    beforeEach(() => {
+        mockGetFileContent.mockReset();
+        mockGetRepoTree.mockReset();
+    });
+
+    it.each([
+        '.env',
+        '.env.production',
+        'config/.env.local',
+        'certs/server.pem',
+        'deploy/id_rsa',
+        'service.keyfile.json',
+    ])('does not list or read the denied path %s', async (path) => {
+        mockGetRepoTree.mockResolvedValue({
+            files: [
+                { path, size: 0 },
+                { path: 'models/x.sql', size: 0 },
+            ],
+            truncated: false,
+        });
+        const repo = source();
+        const { files } = await repo.listAllPaths();
+        expect(files.map((f) => f.path)).toEqual(['models/x.sql']);
+
+        // Even with a truncated listing, an explicit read is refused.
+        await expect(repo.readFile(path)).resolves.toBeNull();
+        expect(mockGetFileContent).not.toHaveBeenCalled();
+    });
+});
+
+describe('gitlabRepoSource onTiming (metrics hook)', () => {
+    beforeEach(() => {
+        mockGetFileContent.mockReset();
+        mockGetRepoTree.mockReset();
+    });
+
+    it('reports outcome=found for a successful read', async () => {
+        const onTiming = jest.fn();
+        mockGetFileContent.mockResolvedValue({ content: 'x', sha: 'abc' });
+        await source(onTiming).readFile('models/x.sql');
+        expect(onTiming).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'file', outcome: 'found' }),
+        );
+    });
+
+    it('reports outcome=missing for a NotFoundError', async () => {
+        const onTiming = jest.fn();
+        mockGetFileContent.mockRejectedValue(new NotFoundError('nope'));
+        await source(onTiming).readFile('models/x.sql');
+        expect(onTiming).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'file', outcome: 'missing' }),
+        );
+    });
+
+    it('reports a tree timing event on listAllPaths', async () => {
+        const onTiming = jest.fn();
+        mockGetRepoTree.mockResolvedValue({ files: [], truncated: false });
+        await source(onTiming).listAllPaths();
+        expect(onTiming).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: 'tree' }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ai/repoFs/gitlabRepoSource.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/gitlabRepoSource.ts
@@ -1,0 +1,191 @@
+import { getErrorMessage, NotFoundError } from '@lightdash/common';
+import {
+    getFileContent,
+    getGitlabRepoTree,
+    isGitlabRateLimitError,
+} from '../../../../clients/gitlab/Gitlab';
+import Logger from '../../../../logging/logger';
+import { RepoSource } from './RepoFs';
+import {
+    isDeniedRepoPath,
+    type RepoFsTimingCallback,
+} from './repoSourceShared';
+
+/** Message + sentinel code for a GitLab rate-limit hit. Mirrors the GitHub
+ *  source: the `ERATELIMIT` code is mapped to an agent-recoverable ShellError in
+ *  {@link ./bashShell}, so a 429 from GitLab (a transient, external limit — easy
+ *  to hit when a command reads many files) degrades to a clear "back off / narrow
+ *  the search" message instead of crashing the agent run or paging Sentry. */
+const RATE_LIMIT_MESSAGE =
+    'GitLab API rate limit reached for this organization. ' +
+    'Narrow the search to fewer files, or try again in a few minutes.';
+
+/** Re-throw a GitLab error: a rate-limit becomes the recoverable ERATELIMIT
+ *  error; anything else propagates unchanged. */
+export const rethrowGitlabAsRecoverable = (error: unknown): never => {
+    if (isGitlabRateLimitError(error)) {
+        throw Object.assign(new Error(RATE_LIMIT_MESSAGE), {
+            code: 'ERATELIMIT',
+        });
+    }
+    throw error;
+};
+
+/**
+ * A read-only {@link RepoSource} backed by the GitLab REST API (Repository Trees
+ * + Files) using the org's GitLab app-install OAuth token — no clone, no sandbox.
+ * The GitHub-source twin ({@link ./githubRepoSource}); see it for the shared
+ * design. GitLab specifics:
+ *
+ * - `owner`/`repo` form the URL-encoded project path (`group/project`), and
+ *   `hostDomain` targets self-hosted instances (defaults to gitlab.com).
+ * - `listAllPaths` uses the recursive Trees API, which does NOT return blob
+ *   sizes, so sizes are reported as 0 (used only for `ls -l` display).
+ * - `readFile` returns null for missing/binary files; GitLab's Files API has no
+ *   inline-size cap, so very large text files are returned in full.
+ * - Code search is not implemented yet — the shell's `grep` falls back to
+ *   reading files, so it still works (just without server-side search).
+ *
+ * `subPath` scopes the filesystem to the dbt project subdirectory exactly as the
+ * GitHub source does. `onTiming` (optional) receives each call's duration.
+ */
+export const createGitlabRepoSource = ({
+    owner,
+    repo,
+    branch,
+    token,
+    hostDomain,
+    subPath = '.',
+    onTiming,
+}: {
+    owner: string;
+    repo: string;
+    branch: string;
+    token: string;
+    hostDomain?: string;
+    subPath?: string;
+    onTiming?: RepoFsTimingCallback;
+}): RepoSource => {
+    const root =
+        subPath === '.' || subPath === '' ? '' : subPath.replace(/\/+$/, '');
+    const prefix = root ? `${root}/` : '';
+    return {
+        label: `${owner}/${repo}@${branch}${root ? `/${root}` : ''}`,
+        listAllPaths: async () => {
+            const start = Date.now();
+            const { files, truncated } = await getGitlabRepoTree({
+                owner,
+                repo,
+                branch,
+                token,
+                hostDomain,
+            }).catch(rethrowGitlabAsRecoverable);
+            const durationMs = Date.now() - start;
+            Logger.info(
+                `[repoShell] gitlab tree fetched in ${durationMs}ms (${
+                    files.length
+                } files${truncated ? ', truncated' : ''})`,
+                {
+                    event: 'ai.repofs.gitlab.tree',
+                    repo: `${owner}/${repo}`,
+                    branch,
+                    fileCount: files.length,
+                    truncated,
+                    durationMs,
+                },
+            );
+            onTiming?.({ kind: 'tree', durationMs });
+            if (!root) {
+                return {
+                    files: files.filter((f) => !isDeniedRepoPath(f.path)),
+                    truncated,
+                };
+            }
+            const scoped = files
+                .filter((f) => f.path.startsWith(prefix))
+                .map((f) => ({
+                    path: f.path.slice(prefix.length),
+                    size: f.size,
+                }))
+                .filter((f) => !isDeniedRepoPath(f.path));
+            return { files: scoped, truncated };
+        },
+        readFile: async (path) => {
+            // Never read a denied secret file, even if a truncated tree means it
+            // wasn't filtered from the listing above.
+            if (isDeniedRepoPath(path)) return null;
+            const start = Date.now();
+            try {
+                const { content } = await getFileContent({
+                    fileName: `${prefix}${path}`,
+                    owner,
+                    repo,
+                    branch,
+                    token,
+                    hostDomain,
+                });
+                // A NUL byte means the blob is binary; the RepoSource contract
+                // represents non-text content as `null` rather than feeding
+                // mojibake to the agent. (GitLab, unlike GitHub Contents, returns
+                // even binary files inline, so we screen here.)
+                if (content.includes('\0')) {
+                    onTiming?.({
+                        kind: 'file',
+                        durationMs: Date.now() - start,
+                        outcome: 'missing',
+                    });
+                    return null;
+                }
+                const durationMs = Date.now() - start;
+                Logger.debug(
+                    `[repoShell] gitlab file fetched in ${durationMs}ms (${content.length}b): ${prefix}${path}`,
+                    {
+                        event: 'ai.repofs.gitlab.file',
+                        path: `${prefix}${path}`,
+                        bytes: content.length,
+                        durationMs,
+                    },
+                );
+                onTiming?.({ kind: 'file', durationMs, outcome: 'found' });
+                return content;
+            } catch (error) {
+                const durationMs = Date.now() - start;
+                // getFileContent throws NotFoundError for a genuine 404, which the
+                // RepoSource contract represents as `null` (absent).
+                if (error instanceof NotFoundError) {
+                    Logger.debug(
+                        `[repoShell] gitlab file miss in ${durationMs}ms: ${prefix}${path}`,
+                        {
+                            event: 'ai.repofs.gitlab.file_miss',
+                            path: `${prefix}${path}`,
+                            durationMs,
+                        },
+                    );
+                    onTiming?.({
+                        kind: 'file',
+                        durationMs,
+                        outcome: 'missing',
+                    });
+                    return null;
+                }
+                // Anything else (rate limit, network, 5xx) is NOT "file absent".
+                // Returning null would make grep/cat silently behave as if the
+                // file were empty — wrong results with no signal. Surface it.
+                Logger.warn(
+                    `[repoShell] gitlab file read failed in ${durationMs}ms: ${prefix}${path} — ${getErrorMessage(
+                        error,
+                    )}`,
+                    {
+                        event: 'ai.repofs.gitlab.file_error',
+                        path: `${prefix}${path}`,
+                        durationMs,
+                    },
+                );
+                onTiming?.({ kind: 'file', durationMs, outcome: 'error' });
+                // A rate-limit becomes a recoverable ERATELIMIT error (clear
+                // "back off" message, no Sentry); other faults propagate as-is.
+                return rethrowGitlabAsRecoverable(error);
+            }
+        },
+    };
+};

--- a/packages/backend/src/ee/services/ai/repoFs/repoSourceShared.ts
+++ b/packages/backend/src/ee/services/ai/repoFs/repoSourceShared.ts
@@ -1,0 +1,45 @@
+/**
+ * Provider-agnostic helpers shared by every {@link RepoSource} implementation
+ * (GitHub, GitLab, …): the secret-path denylist and the latency-timing event
+ * shape. Kept out of any one provider file so a new source can reuse them
+ * without importing a sibling provider.
+ */
+
+/**
+ * Paths that must never be exposed through the read-only shell. Removing the
+ * `subPath` confinement (so the whole repo is readable for an explicit
+ * `exploreRepo` target) widens the blast radius to secrets that previously lived
+ * outside the dbt subdirectory, so deny common credential/secret files at the
+ * source layer — they're filtered from listings and read back as absent.
+ */
+const DENIED_PATH_PATTERNS: RegExp[] = [
+    /(^|\/)\.env(\..*)?$/i, // .env, .env.local, .env.production, ...
+    /\.pem$/i,
+    /\.key$/i,
+    /\.p12$/i,
+    /\.pfx$/i,
+    /(^|\/)id_rsa(\.pub)?$/i,
+    /(^|\/)id_ed25519(\.pub)?$/i,
+    /(^|\/)\.npmrc$/i,
+    /(^|\/)\.pypirc$/i,
+    /(^|\/)credentials$/i,
+    /\.keyfile(\.json)?$/i,
+];
+
+export const isDeniedRepoPath = (path: string): boolean =>
+    DENIED_PATH_PATTERNS.some((re) => re.test(path));
+
+/**
+ * Latency signal for each backing repo-host call, so a caller (e.g. the agent
+ * service) can record metrics without coupling this layer to Prometheus.
+ */
+export type RepoFsTimingEvent =
+    | { kind: 'tree'; durationMs: number }
+    | {
+          kind: 'file';
+          durationMs: number;
+          outcome: 'found' | 'missing' | 'error';
+      }
+    | { kind: 'search'; durationMs: number };
+
+export type RepoFsTimingCallback = (event: RepoFsTimingEvent) => void;

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -103,6 +103,16 @@ export default class PrometheusMetrics {
     // so a runaway crawl that drains the installation's rate limit is visible.
     public repoFsGithubRequestCounter: prometheus.Counter<'kind'> | null = null;
 
+    // repoShell (read-only repo VFS) GitLab API latency — twin of the GitHub
+    // metrics above, for dbt repos connected over GitLab.
+    public repoFsGitlabTreeDurationHistogram: prometheus.Histogram | null =
+        null;
+
+    public repoFsGitlabFileDurationHistogram: prometheus.Histogram<'outcome'> | null =
+        null;
+
+    public repoFsGitlabRequestCounter: prometheus.Counter<'kind'> | null = null;
+
     // GitHub rate limit by resource (core | search | code_search | graphql),
     // read from x-ratelimit-* response headers on every call. The limit is
     // installation-wide (shared across writeback, PR ops, the repo shell, …), so
@@ -440,6 +450,30 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
+                this.repoFsGitlabTreeDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_repofs_gitlab_tree_duration_ms',
+                        help: 'repoShell GitLab Repository Trees fetch (repo file listing) duration in ms',
+                        buckets: githubRequestBuckets,
+                        ...rest,
+                    });
+
+                this.repoFsGitlabFileDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'ai_repofs_gitlab_file_duration_ms',
+                        help: 'repoShell GitLab Files fetch (per file) duration in ms',
+                        labelNames: ['outcome'],
+                        buckets: githubRequestBuckets,
+                        ...rest,
+                    });
+
+                this.repoFsGitlabRequestCounter = new prometheus.Counter({
+                    name: 'ai_repofs_gitlab_requests_total',
+                    help: 'repoShell GitLab API requests by kind (tree | file | search | list)',
+                    labelNames: ['kind'],
+                    ...rest,
+                });
+
                 this.githubRateLimitLimitGauge = new prometheus.Gauge({
                     name: 'github_ratelimit_limit',
                     help: 'GitHub App installation rate limit (max) by resource, from x-ratelimit-limit',
@@ -519,10 +553,12 @@ export default class PrometheusMetrics {
                 // entire first burst of observations is invisible to rate().
                 (['found', 'missing', 'error'] as const).forEach((outcome) => {
                     this.repoFsGithubFileDurationHistogram?.zero({ outcome });
+                    this.repoFsGitlabFileDurationHistogram?.zero({ outcome });
                 });
                 (['tree', 'file', 'search', 'list'] as const).forEach(
                     (kind) => {
                         this.repoFsGithubRequestCounter?.inc({ kind }, 0);
+                        this.repoFsGitlabRequestCounter?.inc({ kind }, 0);
                     },
                 );
                 (['success', 'error'] as const).forEach((status) => {
@@ -1193,6 +1229,26 @@ export default class PrometheusMetrics {
         kind: 'tree' | 'file' | 'search' | 'list',
     ) {
         this.repoFsGithubRequestCounter?.inc({ kind });
+    }
+
+    public observeRepoFsGitlabTreeDuration(durationMs: number) {
+        this.repoFsGitlabTreeDurationHistogram?.observe(durationMs);
+    }
+
+    public observeRepoFsGitlabFileDuration(
+        durationMs: number,
+        outcome: 'found' | 'missing' | 'error',
+    ) {
+        this.repoFsGitlabFileDurationHistogram?.observe(
+            { outcome },
+            durationMs,
+        );
+    }
+
+    public incrementRepoFsGitlabRequest(
+        kind: 'tree' | 'file' | 'search' | 'list',
+    ) {
+        this.repoFsGitlabRequestCounter?.inc({ kind });
     }
 
     public observeGithubRateLimit(rl: {

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -144,6 +144,10 @@ if test -f .env.development.local; then
             && mv .env.development.local.tmp .env.development.local
         ENV_PORTS_CHANGED=1
     }
+    # LD_INSTANCE_ID namespaces PM2 process names (ecosystem.config.js). If it's empty
+    # or wrong (e.g. the heredoc expanded it before the slot env was sourced), ecosystem
+    # defaults to "lightdash" and collides with another worktree's generic stack.
+    reconcile_env LD_INSTANCE_ID "${LD_INSTANCE_ID}"
     reconcile_env PGPORT "${LD_PG_PORT}"
     reconcile_env PORT "${PORT}"
     reconcile_env FE_PORT "${FE_PORT}"

--- a/scripts/dev-reconcile.sh
+++ b/scripts/dev-reconcile.sh
@@ -24,12 +24,17 @@ ENV_FILE=".env.development.local"
 [ -f "$ENV_FILE" ] || { echo "FAIL: reconcile -- $ENV_FILE missing (run the profile setup first)" >&2; exit 1; }
 
 # The secret the backend actually decrypts with — read from the running pm2 api process.
-RUNNING_SECRET="$(pm2 jlist 2>/dev/null | LD_INSTANCE_ID="$LD_INSTANCE_ID" python3 -c "
+# Match the api process by its instance-prefixed name first; if pnpm pm2:start named it
+# generically (e.g. `lightdash-api`), fall back to the api whose pm_cwd is in THIS worktree.
+RUNNING_SECRET="$(pm2 jlist 2>/dev/null | LD_INSTANCE_ID="$LD_INSTANCE_ID" REPO_ROOT="$REPO_ROOT" python3 -c "
 import sys, json, os
-inst = os.environ['LD_INSTANCE_ID']
+inst = os.environ['LD_INSTANCE_ID']; root = os.environ['REPO_ROOT']
 try: ps = json.load(sys.stdin)
 except Exception: ps = []
 api = [p for p in ps if p.get('name') == inst + '-api']
+if not api:
+    api = [p for p in ps if p.get('name','').endswith('-api')
+           and (p.get('pm2_env',{}).get('pm_cwd','') or '').startswith(root)]
 print(api[0]['pm2_env'].get('LIGHTDASH_SECRET', '') if api else '')
 " 2>/dev/null)"
 if [ -z "$RUNNING_SECRET" ]; then


### PR DESCRIPTION
## Summary

Adds **GitLab** support to the read-only repo VFS (`repoFs`) that backs the agent's `exploreRepo` tool. Previously the VFS could only read dbt source from **GitHub**-connected projects; for GitLab-connected projects the `/dbt` mount was unavailable. Writeback already abstracts over both providers — this brings the read path to parity.

## What changed

**GitLab repo source (read path)**
- `clients/gitlab/Gitlab.ts`: new `getGitlabRepoTree` (recursive, paginated GitLab Trees API with a truncation cap) and `isGitlabRateLimitError`.
- `ee/services/ai/repoFs/gitlabRepoSource.ts`: a `RepoSource` backed by GitLab Trees + Files — `subPath` scoping, the shared secret denylist, binary screening, and recoverable rate-limit handling. The GitHub-source twin.
- Provider-agnostic helpers (denylist, timing types) extracted to `repoFs/repoSourceShared.ts` and re-exported from `githubRepoSource.ts` for compatibility.

**Provider selection**
- `AiWritebackService.getRepoReadAccess` now returns a provider-tagged union (`github | gitlab`); the shared `view:SourceCode` gate is factored out into a helper.
- `AiAgentService` picks the matching source in `buildDbtRepoFs` and mounts `/dbt` for GitLab as well as GitHub.

**Prometheus metrics**
- New GitLab twins (`ai_repofs_gitlab_tree_duration_ms`, `ai_repofs_gitlab_file_duration_ms`, `ai_repofs_gitlab_requests_total`) with the timing callback routed by the repo's host, so GitLab activity is no longer mislabelled under the GitHub metrics.

**Dev tooling** (unrelated, small)
- `dev-fast-start.sh` now reconciles `LD_INSTANCE_ID` (an empty value caused a worktree to hijack another's PM2 stack); `dev-reconcile.sh` matches the running api by working directory when the instance-prefixed name isn't found.

## Notes / scope
- GitLab v1 covers the `/dbt` mount only (the GitHub-App multi-repo browse has no GitLab equivalent in the current model).
- Code search (`searchCode`) is deferred for GitLab — the shell's `grep` falls back to reading files.
- GitLab's tree API omits blob sizes, so sizes are reported as `0` (used only for `ls -l` display).

## Testing
- Unit tests: new `gitlabRepoSource.test.ts` + a GitLab case in `AiWritebackService.test.ts` (typecheck + lint clean).
- Live end-to-end against a real GitLab repo, driven through the **agent UI**: the agent ran `ls`, `find`, and `cat` against the `/dbt` mount and returned real file contents. Confirmed it used the GitLab path (not GitHub) via the structured logs (`[repoShell] gitlab tree/file fetched`) and the new counters (`ai_repofs_gitlab_requests_total` incremented while `ai_repofs_github_*` tree/file stayed at 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
