### PR TITLE
feat(ai-agents): add gradient Ask AI icon

### DIFF
--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -172,7 +172,7 @@ export const MobileNavBar: FC = () => {
                         exact
                         label="Ask AI"
                         to={`/projects/${activeProjectUuid}/ai-agents`}
-                        leftSection={<AiAgentIcon size={18} />}
+                        leftSection={<AiAgentIcon size={16} />}
                         onClick={toggleMenu}
                     />
                 )}

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -16,7 +16,6 @@ import {
     IconHome,
     IconLayoutDashboard,
     IconLogout,
-    IconRobot,
 } from '@tabler/icons-react';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import {
@@ -35,6 +34,7 @@ import ProjectSwitcher from './components/NavBar/ProjectSwitcher';
 import { ThemeSwitcher } from './components/NavBar/ThemeSwitcher';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
+import { AiAgentIcon } from './ee/features/aiCopilot/components/AiAgentIcon';
 import { useAiAgentButtonVisibility } from './ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
@@ -172,7 +172,7 @@ export const MobileNavBar: FC = () => {
                         exact
                         label="Ask AI"
                         to={`/projects/${activeProjectUuid}/ai-agents`}
-                        leftSection={<MantineIcon icon={IconRobot} />}
+                        leftSection={<AiAgentIcon size={18} />}
                         onClick={toggleMenu}
                     />
                 )}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -93,7 +93,7 @@ const getDashboardTileErrorMessage = (
     return error.error?.message;
 };
 
-import { AskAiAgentMenuItem } from '../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { AskAiAgentButton } from '../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
 import { DashboardTileComments } from '../../features/comments';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import { DateZoomInfoOnTile } from '../../features/dateZoom';
@@ -1452,17 +1452,25 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                         </>
                     }
                     titleLeftIcon={
-                        metricQuery?.metadata?.hasADateDimension &&
-                        savedChartUuid &&
-                        dateZoomGranularity &&
-                        chartsWithDateZoomApplied?.has(savedChartUuid) ? (
-                            <DateZoomInfoOnTile
-                                dateDimension={
-                                    metricQuery.metadata.hasADateDimension
-                                }
-                                dateZoomGranularity={dateZoomGranularity}
+                        <>
+                            <AskAiAgentButton
+                                projectUuid={projectUuid}
+                                chartUuid={savedChartUuid ?? undefined}
+                                dashboardUuid={dashboardUuid}
+                                clickedFrom="dashboard_chart_tile"
                             />
-                        ) : null
+                            {metricQuery?.metadata?.hasADateDimension &&
+                            savedChartUuid &&
+                            dateZoomGranularity &&
+                            chartsWithDateZoomApplied?.has(savedChartUuid) ? (
+                                <DateZoomInfoOnTile
+                                    dateDimension={
+                                        metricQuery.metadata.hasADateDimension
+                                    }
+                                    dateZoomGranularity={dateZoomGranularity}
+                                />
+                            ) : null}
+                        </>
                     }
                     title={title || chart.name || ''}
                     chartName={chart.name}
@@ -1476,13 +1484,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                             userCanManageChart ||
                             userCanExportData) && (
                             <>
-                                <AskAiAgentMenuItem
-                                    projectUuid={projectUuid}
-                                    chartUuid={savedChartUuid ?? undefined}
-                                    dashboardUuid={dashboardUuid}
-                                    clickedFrom="dashboard_chart_tile"
-                                />
-
                                 <Tooltip
                                     disabled={!isEditMode}
                                     label="Finish editing dashboard to use these actions"

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -18,7 +18,7 @@ export const AiAgentsButton = () => {
             size="xs"
             variant="default"
             fz="sm"
-            leftSection={<AiAgentIcon size={16} />}
+            leftSection={<AiAgentIcon size={14} />}
             onClick={() => navigate(`/projects/${projectUuid}/ai-agents`)}
         >
             <Text span truncate="end" maw={150} size="sm">

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,9 +1,8 @@
 import { Button, Text } from '@mantine-8/core';
-import { IconMessageCircle } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
+import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useActiveProject } from '../../hooks/useActiveProject';
-import MantineIcon from '../common/MantineIcon';
 
 export const AiAgentsButton = () => {
     // Using `navigate` instead of the `Link` component to ensure round corners within a button group
@@ -19,9 +18,7 @@ export const AiAgentsButton = () => {
             size="xs"
             variant="default"
             fz="sm"
-            leftSection={
-                <MantineIcon icon={IconMessageCircle} color="ldGray.6" />
-            }
+            leftSection={<AiAgentIcon size={16} />}
             onClick={() => navigate(`/projects/${projectUuid}/ai-agents`)}
         >
             <Text span truncate="end" maw={150} size="sm">

--- a/packages/frontend/src/components/Settings/SettingsNavigation.tsx
+++ b/packages/frontend/src/components/Settings/SettingsNavigation.tsx
@@ -1,6 +1,7 @@
 import { Box, Highlight, Stack, Text, Title } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useLocation } from 'react-router';
+import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
 import {
     type SettingsNavigationItem,
     type SettingsNavigationSection,
@@ -21,7 +22,11 @@ const SettingsNavigation: FC<SettingsNavigationProps> = ({
     const isFiltering = searchQuery.trim().length > 0;
 
     const renderItem = (item: SettingsNavigationItem) => {
-        const leftSection = <MantineIcon icon={item.icon} />;
+        const leftSection = item.aiAgentIcon ? (
+            <AiAgentIcon muted size={14} />
+        ) : (
+            <MantineIcon icon={item.icon} />
+        );
         const label = isFiltering ? (
             <Highlight span inherit highlight={searchQuery}>
                 {item.label}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -48,7 +48,7 @@ import dayjs from 'dayjs';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
-import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { AskAiAgentButton } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -704,6 +704,18 @@ const DashboardHeader = memo(
                         )}
 
                         {!isFullscreen && (
+                            <AskAiAgentButton
+                                projectUuid={projectUuid}
+                                dashboardUuid={dashboard.uuid}
+                                clickedFrom="dashboard_header"
+                                variant="default"
+                                size="md"
+                                radius="md"
+                                iconSize={18}
+                            />
+                        )}
+
+                        {!isFullscreen && (
                             <Menu
                                 data-testid="dashboard-header-menu"
                                 position="bottom"
@@ -747,12 +759,6 @@ const DashboardHeader = memo(
                                 </Menu.Target>
 
                                 <Menu.Dropdown>
-                                    <AskAiAgentMenuItem
-                                        projectUuid={projectUuid}
-                                        dashboardUuid={dashboard.uuid}
-                                        clickedFrom="dashboard_header"
-                                        withDivider
-                                    />
                                     {!!userCanManageDashboard && (
                                         <>
                                             {preAggregatesEnabled &&

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -48,7 +48,7 @@ import dayjs from 'dayjs';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
-import { AskAiAgentButton } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
+import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -704,18 +704,6 @@ const DashboardHeader = memo(
                         )}
 
                         {!isFullscreen && (
-                            <AskAiAgentButton
-                                projectUuid={projectUuid}
-                                dashboardUuid={dashboard.uuid}
-                                clickedFrom="dashboard_header"
-                                variant="default"
-                                size="md"
-                                radius="md"
-                                iconSize={18}
-                            />
-                        )}
-
-                        {!isFullscreen && (
                             <Menu
                                 data-testid="dashboard-header-menu"
                                 position="bottom"
@@ -759,6 +747,12 @@ const DashboardHeader = memo(
                                 </Menu.Target>
 
                                 <Menu.Dropdown>
+                                    <AskAiAgentMenuItem
+                                        projectUuid={projectUuid}
+                                        dashboardUuid={dashboard.uuid}
+                                        clickedFrom="dashboard_header"
+                                        withDivider
+                                    />
                                     {!!userCanManageDashboard && (
                                         <>
                                             {preAggregatesEnabled &&

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -15,7 +15,6 @@ import {
     IconCornerDownLeft,
     IconGitPullRequest,
     IconSettings,
-    IconSparkles,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Provider } from 'react-redux';
@@ -23,6 +22,7 @@ import { Link, useNavigate } from 'react-router';
 import { CategoryBadge } from '../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../components/common/PolymorphicGroupButton';
+import { AiAgentIcon } from '../../../features/aiCopilot/components/AiAgentIcon';
 import { CompactAgentSelector } from '../../../features/aiCopilot/components/AgentSelector';
 import {
     AI_ROUTING_AUTO_VALUE,
@@ -236,14 +236,11 @@ const AiSearchBoxInner: FC<Props> = ({
                                         style={{ overflow: 'hidden' }}
                                         align="flex-start"
                                     >
-                                        <MantineIcon
+                                        <AiAgentIcon
                                             style={{
                                                 flexShrink: 0,
                                                 marginTop: 4,
                                             }}
-                                            icon={IconSparkles}
-                                            color="violet.4"
-                                            fill="violet.4"
                                             size={16}
                                         />
                                         <Text
@@ -304,13 +301,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                     <Button
                                         size="compact-xs"
                                         variant="subtle"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconSparkles}
-                                                color="violet.5"
-                                                fill="violet.5"
-                                            />
-                                        }
+                                        leftSection={<AiAgentIcon size={14} />}
                                         component={Link}
                                         to="/ai-agents"
                                     >
@@ -329,11 +320,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                     </Button>
                                 ) : showAgentSetupPrompt && isTrial ? (
                                     <Group gap="xs">
-                                        <MantineIcon
-                                            icon={IconSparkles}
-                                            color="violet.5"
-                                            fill="violet.5"
-                                        />
+                                        <AiAgentIcon size={14} />
                                         <Text size="xs" c="ldGray.8">
                                             You are trialing the AI Agents
                                             feature.

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -22,12 +22,12 @@ import { Link, useNavigate } from 'react-router';
 import { CategoryBadge } from '../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../components/common/PolymorphicGroupButton';
-import { AiAgentIcon } from '../../../features/aiCopilot/components/AiAgentIcon';
 import { CompactAgentSelector } from '../../../features/aiCopilot/components/AgentSelector';
 import {
     AI_ROUTING_AUTO_VALUE,
     AI_ROUTING_SEARCH_PARAM,
 } from '../../../features/aiCopilot/components/AgentSelector/AgentSelectorUtils';
+import { AiAgentIcon } from '../../../features/aiCopilot/components/AiAgentIcon';
 import { usePendingPrompt } from '../../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentAdminReviewItems } from '../../../features/aiCopilot/hooks/useAiAgentAdmin';
 import { useAiAgentPermission } from '../../../features/aiCopilot/hooks/useAiAgentPermission';
@@ -241,7 +241,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                                 flexShrink: 0,
                                                 marginTop: 4,
                                             }}
-                                            size={16}
+                                            size={14}
                                         />
                                         <Text
                                             size="sm"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
@@ -1,0 +1,136 @@
+.root {
+    --ai-agent-icon-size: 18px;
+    --ai-agent-icon-shadow: color-mix(in oklch, #5e4cff 34%, transparent);
+
+    position: relative;
+    display: inline-block;
+    width: var(--ai-agent-icon-size);
+    height: var(--ai-agent-icon-size);
+    flex-shrink: 0;
+    overflow: hidden;
+    border-radius: 50%;
+    isolation: isolate;
+    background:
+        radial-gradient(
+            circle at 30% 23%,
+            rgba(255, 255, 255, 0.98) 0 11%,
+            rgba(224, 210, 255, 0.88) 12% 24%,
+            transparent 36%
+        ),
+        radial-gradient(
+            circle at 72% 70%,
+            rgba(255, 255, 255, 0.72) 0 8%,
+            transparent 30%
+        ),
+        conic-gradient(
+            from 218deg at 52% 52%,
+            #9836ff 0deg,
+            #e0d2ff 72deg,
+            #ffffff 116deg,
+            #5e4cff 176deg,
+            #9836ff 230deg,
+            #e0d2ff 292deg,
+            #5e4cff 360deg
+        );
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.68),
+        inset 0 -5px 10px rgba(94, 76, 255, 0.22),
+        0 1px 2px rgba(94, 76, 255, 0.2),
+        0 0 0 1px var(--ai-agent-icon-shadow);
+    transform: translateZ(0);
+}
+
+.root::before,
+.root::after {
+    position: absolute;
+    inset: -34%;
+    content: '';
+    opacity: 0;
+    pointer-events: none;
+    transition:
+        opacity 180ms ease,
+        transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.root::before {
+    background:
+        radial-gradient(circle at 28% 44%, #ffffff 0 9%, transparent 24%),
+        radial-gradient(circle at 60% 30%, #9836ff 0 11%, transparent 30%),
+        radial-gradient(circle at 56% 68%, #e0d2ff 0 13%, transparent 32%),
+        radial-gradient(circle at 78% 60%, #5e4cff 0 10%, transparent 28%);
+    filter: blur(5px);
+    mix-blend-mode: screen;
+}
+
+.root::after {
+    background: conic-gradient(
+        from 90deg,
+        transparent,
+        rgba(255, 255, 255, 0.86),
+        rgba(224, 210, 255, 0.6),
+        transparent,
+        rgba(152, 54, 255, 0.72),
+        rgba(94, 76, 255, 0.7),
+        transparent
+    );
+    filter: blur(7px);
+    mix-blend-mode: soft-light;
+}
+
+.root:hover,
+:global(button:hover) .root,
+:global(a:hover) .root,
+:global(.mantine-Group-root:hover) .root,
+:global([role='menuitem']:hover) .root,
+:global([data-combobox-selected='true']) .root {
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.82),
+        inset 0 -5px 11px rgba(94, 76, 255, 0.28),
+        0 2px 7px rgba(152, 54, 255, 0.26),
+        0 0 0 1px color-mix(in oklch, #9836ff 42%, transparent);
+}
+
+.root:hover::before,
+.root:hover::after,
+:global(button:hover) .root::before,
+:global(button:hover) .root::after,
+:global(a:hover) .root::before,
+:global(a:hover) .root::after,
+:global(.mantine-Group-root:hover) .root::before,
+:global(.mantine-Group-root:hover) .root::after,
+:global([role='menuitem']:hover) .root::before,
+:global([role='menuitem']:hover) .root::after,
+:global([data-combobox-selected='true']) .root::before,
+:global([data-combobox-selected='true']) .root::after {
+    opacity: 1;
+    animation: ai-agent-icon-drift 1.6s cubic-bezier(0.22, 1, 0.36, 1) infinite
+        alternate;
+}
+
+.root:hover::after,
+:global(button:hover) .root::after,
+:global(a:hover) .root::after,
+:global(.mantine-Group-root:hover) .root::after,
+:global([role='menuitem']:hover) .root::after,
+:global([data-combobox-selected='true']) .root::after {
+    animation-duration: 2.1s;
+    animation-direction: alternate-reverse;
+}
+
+@keyframes ai-agent-icon-drift {
+    from {
+        transform: translate3d(-7%, -3%, 0) rotate(-10deg) scale(1);
+    }
+
+    to {
+        transform: translate3d(6%, 5%, 0) rotate(18deg) scale(1.08);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .root::before,
+    .root::after {
+        animation: none !important;
+        transition: opacity 120ms ease;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
@@ -12,9 +12,9 @@
     isolation: isolate;
     background:
         radial-gradient(
-            120% 120% at 26% 18%,
-            rgba(255, 255, 255, 0.9) 0%,
-            transparent 34%
+            120% 120% at 28% 24%,
+            rgba(255, 255, 255, 0.6) 0%,
+            transparent 40%
         ),
         radial-gradient(115% 130% at 82% 24%, #c9b6ff 0%, transparent 52%),
         radial-gradient(130% 120% at 84% 84%, #5e4cff 0%, transparent 56%),
@@ -56,16 +56,16 @@
     opacity: 0;
     pointer-events: none;
     transition:
-        opacity 200ms ease,
-        transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+        opacity 320ms ease,
+        transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .root::before {
     background:
-        radial-gradient(40% 55% at 30% 42%, #ffffff 0%, transparent 60%),
-        radial-gradient(45% 60% at 62% 28%, #9836ff 0%, transparent 62%),
-        radial-gradient(50% 60% at 54% 70%, #c9b6ff 0%, transparent 64%),
-        radial-gradient(42% 55% at 80% 62%, #5e4cff 0%, transparent 60%);
+        radial-gradient(46% 56% at 30% 28%, #ffffff 0%, transparent 60%),
+        radial-gradient(48% 60% at 66% 34%, #b18cff 0%, transparent 64%),
+        radial-gradient(46% 58% at 60% 70%, #9836ff 0%, transparent 64%),
+        radial-gradient(44% 56% at 24% 66%, #5e4cff 0%, transparent 62%);
     filter: blur(6px);
     mix-blend-mode: screen;
 }
@@ -113,8 +113,8 @@
 :global([data-combobox-selected='true']) .root::before,
 :global([data-combobox-selected='true']) .root::after {
     opacity: 1;
-    animation: ai-agent-icon-drift 2s cubic-bezier(0.45, 0, 0.55, 1) infinite
-        alternate;
+    animation: ai-agent-icon-drift 2.4s cubic-bezier(0.45, 0, 0.55, 1) 280ms
+        infinite alternate;
 }
 
 .root:hover::after,
@@ -143,11 +143,11 @@
 
 @keyframes ai-agent-icon-drift {
     from {
-        transform: translate3d(-6%, -2%, 0) rotate(-8deg) scale(1);
+        transform: translate3d(-2%, -1%, 0) rotate(-3deg) scale(1);
     }
 
     to {
-        transform: translate3d(5%, 4%, 0) rotate(14deg) scale(1.06);
+        transform: translate3d(5%, 4%, 0) rotate(12deg) scale(1.05);
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
@@ -1,6 +1,6 @@
 .root {
-    --ai-agent-icon-size: 18px;
-    --ai-agent-icon-shadow: color-mix(in oklch, #5e4cff 34%, transparent);
+    --ai-agent-icon-size: 16px;
+    --ai-agent-icon-shadow: color-mix(in oklch, #5e4cff 26%, transparent);
 
     position: relative;
     display: inline-block;
@@ -12,53 +12,61 @@
     isolation: isolate;
     background:
         radial-gradient(
-            circle at 30% 23%,
-            rgba(255, 255, 255, 0.98) 0 11%,
-            rgba(224, 210, 255, 0.88) 12% 24%,
-            transparent 36%
+            120% 120% at 26% 18%,
+            rgba(255, 255, 255, 0.9) 0%,
+            transparent 34%
         ),
-        radial-gradient(
-            circle at 72% 70%,
-            rgba(255, 255, 255, 0.72) 0 8%,
-            transparent 30%
-        ),
+        radial-gradient(115% 130% at 82% 24%, #c9b6ff 0%, transparent 52%),
+        radial-gradient(130% 120% at 84% 84%, #5e4cff 0%, transparent 56%),
+        radial-gradient(120% 130% at 16% 82%, #9836ff 0%, transparent 56%),
         conic-gradient(
-            from 218deg at 52% 52%,
-            #9836ff 0deg,
-            #e0d2ff 72deg,
-            #ffffff 116deg,
-            #5e4cff 176deg,
-            #9836ff 230deg,
-            #e0d2ff 292deg,
-            #5e4cff 360deg
+            from 210deg at 50% 50%,
+            #7a4cff,
+            #b18cff,
+            #5e4cff,
+            #9836ff,
+            #7a4cff
         );
+    background-size: 180% 180%;
+    background-position: 50% 50%;
     box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.68),
-        inset 0 -5px 10px rgba(94, 76, 255, 0.22),
-        0 1px 2px rgba(94, 76, 255, 0.2),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.5),
+        inset 0 -4px 9px rgba(94, 76, 255, 0.18),
+        0 1px 2px rgba(94, 76, 255, 0.16),
         0 0 0 1px var(--ai-agent-icon-shadow);
     transform: translateZ(0);
+    transition:
+        background-position 500ms ease,
+        box-shadow 220ms ease,
+        filter 240ms ease;
+}
+
+.muted {
+    filter: grayscale(1) brightness(0.98);
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.4),
+        0 0 0 1px rgba(0, 0, 0, 0.08);
 }
 
 .root::before,
 .root::after {
     position: absolute;
-    inset: -34%;
+    inset: -40%;
     content: '';
     opacity: 0;
     pointer-events: none;
     transition:
-        opacity 180ms ease,
-        transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+        opacity 200ms ease,
+        transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .root::before {
     background:
-        radial-gradient(circle at 28% 44%, #ffffff 0 9%, transparent 24%),
-        radial-gradient(circle at 60% 30%, #9836ff 0 11%, transparent 30%),
-        radial-gradient(circle at 56% 68%, #e0d2ff 0 13%, transparent 32%),
-        radial-gradient(circle at 78% 60%, #5e4cff 0 10%, transparent 28%);
-    filter: blur(5px);
+        radial-gradient(40% 55% at 30% 42%, #ffffff 0%, transparent 60%),
+        radial-gradient(45% 60% at 62% 28%, #9836ff 0%, transparent 62%),
+        radial-gradient(50% 60% at 54% 70%, #c9b6ff 0%, transparent 64%),
+        radial-gradient(42% 55% at 80% 62%, #5e4cff 0%, transparent 60%);
+    filter: blur(6px);
     mix-blend-mode: screen;
 }
 
@@ -66,14 +74,14 @@
     background: conic-gradient(
         from 90deg,
         transparent,
-        rgba(255, 255, 255, 0.86),
-        rgba(224, 210, 255, 0.6),
+        rgba(255, 255, 255, 0.7),
+        rgba(201, 182, 255, 0.5),
         transparent,
-        rgba(152, 54, 255, 0.72),
-        rgba(94, 76, 255, 0.7),
+        rgba(152, 54, 255, 0.62),
+        rgba(94, 76, 255, 0.6),
         transparent
     );
-    filter: blur(7px);
+    filter: blur(8px);
     mix-blend-mode: soft-light;
 }
 
@@ -83,11 +91,13 @@
 :global(.mantine-Group-root:hover) .root,
 :global([role='menuitem']:hover) .root,
 :global([data-combobox-selected='true']) .root {
+    filter: none;
     box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.82),
-        inset 0 -5px 11px rgba(94, 76, 255, 0.28),
-        0 2px 7px rgba(152, 54, 255, 0.26),
-        0 0 0 1px color-mix(in oklch, #9836ff 42%, transparent);
+        inset 0 0 0 1px rgba(255, 255, 255, 0.66),
+        inset 0 -4px 10px rgba(94, 76, 255, 0.24),
+        0 2px 6px rgba(152, 54, 255, 0.22),
+        0 0 0 1px color-mix(in oklch, #9836ff 36%, transparent);
+    animation: ai-agent-icon-morph 6s ease infinite;
 }
 
 .root:hover::before,
@@ -103,7 +113,7 @@
 :global([data-combobox-selected='true']) .root::before,
 :global([data-combobox-selected='true']) .root::after {
     opacity: 1;
-    animation: ai-agent-icon-drift 1.6s cubic-bezier(0.22, 1, 0.36, 1) infinite
+    animation: ai-agent-icon-drift 2s cubic-bezier(0.45, 0, 0.55, 1) infinite
         alternate;
 }
 
@@ -113,21 +123,36 @@
 :global(.mantine-Group-root:hover) .root::after,
 :global([role='menuitem']:hover) .root::after,
 :global([data-combobox-selected='true']) .root::after {
-    animation-duration: 2.1s;
+    animation-duration: 2.6s;
     animation-direction: alternate-reverse;
+}
+
+@keyframes ai-agent-icon-morph {
+    0% {
+        background-position: 43% 0%;
+    }
+
+    50% {
+        background-position: 58% 100%;
+    }
+
+    100% {
+        background-position: 43% 0%;
+    }
 }
 
 @keyframes ai-agent-icon-drift {
     from {
-        transform: translate3d(-7%, -3%, 0) rotate(-10deg) scale(1);
+        transform: translate3d(-6%, -2%, 0) rotate(-8deg) scale(1);
     }
 
     to {
-        transform: translate3d(6%, 5%, 0) rotate(18deg) scale(1.08);
+        transform: translate3d(5%, 4%, 0) rotate(14deg) scale(1.06);
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .root,
     .root::before,
     .root::after {
         animation: none !important;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
@@ -3,12 +3,14 @@ import styles from './AiAgentIcon.module.css';
 
 type Props = {
     size?: number | string;
+    muted?: boolean;
     className?: string;
     style?: CSSProperties;
 };
 
 export const AiAgentIcon: FC<Props> = ({
-    size = 18,
+    size = 16,
+    muted = false,
     className,
     style,
 }) => {
@@ -17,7 +19,9 @@ export const AiAgentIcon: FC<Props> = ({
     return (
         <span
             aria-hidden="true"
-            className={[styles.root, className].filter(Boolean).join(' ')}
+            className={[styles.root, muted && styles.muted, className]
+                .filter(Boolean)
+                .join(' ')}
             style={
                 {
                     '--ai-agent-icon-size': resolvedSize,

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
@@ -1,0 +1,29 @@
+import { type CSSProperties, type FC } from 'react';
+import styles from './AiAgentIcon.module.css';
+
+type Props = {
+    size?: number | string;
+    className?: string;
+    style?: CSSProperties;
+};
+
+export const AiAgentIcon: FC<Props> = ({
+    size = 18,
+    className,
+    style,
+}) => {
+    const resolvedSize = typeof size === 'number' ? `${size}px` : size;
+
+    return (
+        <span
+            aria-hidden="true"
+            className={[styles.root, className].filter(Boolean).join(' ')}
+            style={
+                {
+                    '--ai-agent-icon-size': resolvedSize,
+                    ...style,
+                } as CSSProperties
+            }
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/index.ts
@@ -1,0 +1,1 @@
+export { AiAgentIcon } from './AiAgentIcon';

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -22,7 +22,6 @@ import {
 import {
     IconFileText,
     IconFolderOpen,
-    IconSparkles,
     IconTrash,
     IconUpload,
 } from '@tabler/icons-react';
@@ -38,6 +37,7 @@ import {
     useDeleteAiAgentDocument,
 } from '../hooks/useAiAgentDocuments';
 import { AiAgentDocumentRelevanceCard } from './AiAgentDocumentRelevanceCard';
+import { AiAgentIcon } from './AiAgentIcon';
 import styles from './AiAgentKnowledgeFilesSection.module.css';
 
 const ACCEPT_ATTR =
@@ -470,11 +470,7 @@ export const AiAgentKnowledgeFilesSection = ({
                                     </Group>
 
                                     <Group gap={6}>
-                                        <MantineIcon
-                                            icon={IconSparkles}
-                                            size="sm"
-                                            color="gray"
-                                        />
+                                        <AiAgentIcon size={14} />
                                         <Text
                                             size="xs"
                                             c="dimmed"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -19,7 +19,6 @@ import {
     IconChevronDown,
     IconCirclePlus,
     IconInfoCircle,
-    IconSparkles,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -27,6 +26,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
 import { useInfiniteAiAgentThreads } from '../../hooks/useProjectAiAgents';
 import { AgentNamePill } from '../AgentNamePill';
+import { AiAgentIcon } from '../AiAgentIcon';
 import classes from './agentSidebar.module.css';
 import { SidebarButton } from './SidebarButton';
 
@@ -146,7 +146,7 @@ const ThreadList: FC<ThreadListProps> = ({
 
 const TrialAlert = () => (
     <Alert
-        icon={<MantineIcon icon={IconSparkles} />}
+        icon={<AiAgentIcon size={14} />}
         variant="outline"
         color="indigo.6"
         bg="indigo.0"

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton.tsx
@@ -1,4 +1,4 @@
-import { Menu } from '@mantine-8/core';
+import { ActionIcon, type ActionIconProps, Tooltip } from '@mantine-8/core';
 import { type FC } from 'react';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import { AiAgentIcon } from '../AiAgentIcon';
@@ -9,24 +9,26 @@ type Props = {
     chartUuid?: string;
     dashboardUuid?: string;
     clickedFrom: AiAgentAskClickedSource;
-    /**
-     * Render a `<Menu.Divider />` after the item. The divider is only rendered
-     * when the item itself is visible, so callers don't need to gate it.
-     */
-    withDivider?: boolean;
+    variant?: ActionIconProps['variant'];
+    size?: ActionIconProps['size'];
+    radius?: ActionIconProps['radius'];
+    iconSize?: number;
 };
 
 /**
- * Menu item that opens the AI agent launcher panel for a new conversation.
+ * Icon button that opens the AI agent launcher panel for a new conversation.
  * Renders nothing when AI agents are not enabled, the user lacks permission,
  * or no default agent can be resolved.
  */
-export const AskAiAgentMenuItem: FC<Props> = ({
+export const AskAiAgentButton: FC<Props> = ({
     projectUuid,
     chartUuid,
     dashboardUuid,
     clickedFrom,
-    withDivider = false,
+    variant = 'subtle',
+    size = 'sm',
+    radius,
+    iconSize = 16,
 }) => {
     const { canAsk, handleClick } = useAskAiAgentAction({
         projectUuid,
@@ -38,15 +40,16 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     if (!canAsk) return null;
 
     return (
-        <>
-            <Menu.Item
-                leftSection={<AiAgentIcon size={13} />}
+        <Tooltip label="Ask AI Agent" variant="xs" withinPortal>
+            <ActionIcon
+                variant={variant}
+                size={size}
+                radius={radius}
+                color="gray"
                 onClick={handleClick}
-                fw={550}
             >
-                Ask AI Agent
-            </Menu.Item>
-            {withDivider && <Menu.Divider />}
-        </>
+                <AiAgentIcon size={iconSize} />
+            </ActionIcon>
+        </Tooltip>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -1,7 +1,5 @@
 import { Menu } from '@mantine-8/core';
-import { IconMessageCircle } from '@tabler/icons-react';
 import { type FC } from 'react';
-import MantineIcon from '../../../../../components/common/MantineIcon';
 import useApp from '../../../../../providers/App/useApp';
 import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
 import useTracking from '../../../../../providers/Tracking/useTracking';
@@ -9,6 +7,7 @@ import { EventName } from '../../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { store as aiAgentStore } from '../../store';
 import { openPanel } from '../../store/aiAgentLauncherSlice';
+import { AiAgentIcon } from '../AiAgentIcon';
 import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
 
 type Props = {
@@ -66,7 +65,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     return (
         <>
             <Menu.Item
-                leftSection={<MantineIcon icon={IconMessageCircle} />}
+                leftSection={<AiAgentIcon size={16} />}
                 onClick={handleClick}
             >
                 Ask AI Agent

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem.tsx
@@ -65,7 +65,7 @@ export const AskAiAgentMenuItem: FC<Props> = ({
     return (
         <>
             <Menu.Item
-                leftSection={<AiAgentIcon size={16} />}
+                leftSection={<AiAgentIcon size={13} />}
                 onClick={handleClick}
             >
                 Ask AI Agent

--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -1,0 +1,59 @@
+import useApp from '../../../../../providers/App/useApp';
+import { type AiAgentAskClickedSource } from '../../../../../providers/Tracking/types';
+import useTracking from '../../../../../providers/Tracking/useTracking';
+import { EventName } from '../../../../../types/Events';
+import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
+import { store as aiAgentStore } from '../../store';
+import { openPanel } from '../../store/aiAgentLauncherSlice';
+import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
+
+type Args = {
+    projectUuid: string | undefined;
+    chartUuid?: string;
+    dashboardUuid?: string;
+    clickedFrom: AiAgentAskClickedSource;
+};
+
+/**
+ * Shared logic for the "Ask AI Agent" entry points: resolves whether the action
+ * should be shown and opens the launcher panel for a new conversation on click.
+ * `canAsk` is false when AI agents are disabled, the user lacks permission, or
+ * no default agent can be resolved.
+ */
+export const useAskAiAgentAction = ({
+    projectUuid,
+    chartUuid,
+    dashboardUuid,
+    clickedFrom,
+}: Args) => {
+    const isVisible = useAiAgentButtonVisibility();
+    const { agent } = useDefaultAiAgent(projectUuid);
+    const { user } = useApp();
+    const { track } = useTracking();
+
+    const canAsk = isVisible && !!agent;
+
+    const handleClick = () => {
+        if (!agent) return;
+        track({
+            name: EventName.AI_AGENT_ASK_CLICKED,
+            properties: {
+                userId: user?.data?.userUuid,
+                organizationId: user?.data?.organizationUuid,
+                projectId: projectUuid,
+                clickedFrom,
+            },
+        });
+        const pendingContext =
+            chartUuid || dashboardUuid ? { chartUuid, dashboardUuid } : null;
+        aiAgentStore.dispatch(
+            openPanel({
+                threadId: null,
+                agentUuid: agent.uuid,
+                pendingContext,
+            }),
+        );
+    };
+
+    return { canAsk, handleClick };
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -16,7 +16,6 @@ import {
     IconClipboardData,
     IconMessageChatbot,
     IconPlus,
-    IconRobot,
 } from '@tabler/icons-react';
 import { Link, Navigate, useParams, useSearchParams } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -24,6 +23,7 @@ import {
     AI_ROUTING_AUTO_VALUE,
     AI_ROUTING_SEARCH_PARAM,
 } from '../../features/aiCopilot/components/AgentSelector/AgentSelectorUtils';
+import { AiAgentIcon } from '../../features/aiCopilot/components/AiAgentIcon';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../features/aiCopilot/hooks/useAiOrganizationSettings';
@@ -169,9 +169,7 @@ const AgentsWelcome = () => {
             <Center mt="xl">
                 <Stack gap={32}>
                     <Stack align="center" gap="xxs">
-                        <Avatar size="lg" color="gray">
-                            <MantineIcon icon={IconRobot} size="xxl" />
-                        </Avatar>
+                        <AiAgentIcon size={48} />
                         <Title order={2}>Welcome to AI Agents</Title>
                         <Text c="dimmed" size="sm">
                             Your AI-powered BI assistants

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -12,6 +12,8 @@ export type SettingsNavigationItem = {
     label: string;
     to: string;
     icon: TablerIcon;
+    /** Render the gradient AI orb instead of `icon` in the sidebar. */
+    aiAgentIcon?: boolean;
     /** Hidden search aliases so e.g. "sso" finds "Single Sign-On". */
     keywords: string[];
     children: SettingsNavigationItem[];

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -426,6 +426,7 @@ export const useSettingsNavigation = (
                 label: 'Ask AI',
                 to: '/generalSettings/ai',
                 icon: IconBrain,
+                aiAgentIcon: true,
                 keywords: ['copilot', 'agents', 'ai'],
                 children: aiChildren,
             });


### PR DESCRIPTION
## Summary

- Adds a reusable gradient circle icon for Ask AI.
- Replaces existing brain/message/sparkle-style Ask AI icons in navbar, mobile nav, Ask AI menu item, and home AI search affordances.
- Adds hover wave/blend animation with reduced-motion support.

## Validation

- `git diff --cached --check` passed before commit.
- Full frontend formatter/typecheck not run because this worktree has no `node_modules`; `oxfmt` was unavailable.