### PR TITLE
feat(timezone): merge DST fall-back hour on BigQuery behind flag

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -96,7 +96,7 @@ describe('TimeFrames', () => {
             );
         });
 
-        test('BigQuery 3-arg TIMESTAMP_TRUNC wraps inner expr in TIMESTAMP() so DATETIME inputs coerce', () => {
+        test('BigQuery wrapped path shifts to a naive DATETIME, truncates, and re-attaches the zone (merge)', () => {
             expect(
                 getSqlForTruncatedDate(
                     SupportedDbtAdapter.BIGQUERY,
@@ -107,7 +107,7 @@ describe('TimeFrames', () => {
                     'America/New_York',
                 ),
             ).toEqual(
-                "TIMESTAMP_TRUNC(TIMESTAMP(${TABLE}.created), DAY, 'America/New_York')",
+                "TIMESTAMP(DATETIME_TRUNC(DATETIME(TIMESTAMP(${TABLE}.created), 'America/New_York'), DAY), 'America/New_York')",
             );
         });
 
@@ -660,6 +660,22 @@ describe('TimeFrames', () => {
             );
         });
 
+        test('BigQuery toProjectTz shifts a TIMESTAMP-coerced instant into a naive project-TZ DATETIME (merge)', () => {
+            const { toProjectTz } =
+                dateTruncTimezoneConversions[SupportedDbtAdapter.BIGQUERY];
+            expect(toProjectTz('col', 'America/New_York')).toEqual(
+                `DATETIME(TIMESTAMP(col), 'America/New_York')`,
+            );
+        });
+
+        test('BigQuery toUTC re-attaches the project zone to recover a real instant (merge)', () => {
+            const { toUTC } =
+                dateTruncTimezoneConversions[SupportedDbtAdapter.BIGQUERY];
+            expect(toUTC('truncated', 'America/New_York')).toEqual(
+                `TIMESTAMP(truncated, 'America/New_York')`,
+            );
+        });
+
         test('Snowflake toProjectTz defaults sourceTimezone to UTC', () => {
             const { toProjectTz } =
                 dateTruncTimezoneConversions[SupportedDbtAdapter.SNOWFLAKE];
@@ -778,11 +794,12 @@ describe('TimeFrames', () => {
             ).toEqual(`CAST(DATE_TRUNC('DAY', ${col}) AS DATE)`);
         });
 
-        // GLITCH-452: BigQuery's TIMESTAMP_TRUNC returns the tz-midnight UTC
-        // instant, so the day grain must DATE(expr, tz) — CAST(... AS DATE) reads
-        // the UTC date and lands a day early in positive offsets (verified
-        // against BigQuery: Asia/Tokyo bucketed 15:00Z to the previous day).
-        test('BigQuery day grain casts via DATE(expr, tz), not CAST AS DATE', () => {
+        // GLITCH-509: BigQuery now shifts to a naive DATETIME before truncating,
+        // so the day-grain trunc is already a tz-midnight wall-clock value and the
+        // generic CAST(... AS DATE) reads the right calendar date (no positive-
+        // offset off-by-one). Verified on BigQuery: Asia/Tokyo 15:00Z buckets to
+        // the same calendar day.
+        test('BigQuery day grain casts the naive DATETIME trunc to DATE (merge)', () => {
             expect(
                 getSqlForTruncatedDate(
                     SupportedDbtAdapter.BIGQUERY,
@@ -795,7 +812,7 @@ describe('TimeFrames', () => {
                     true, // castDayOrCoarserToDate
                 ),
             ).toEqual(
-                `DATE(TIMESTAMP_TRUNC(TIMESTAMP(${col}), DAY, '${tz}'), '${tz}')`,
+                `CAST(DATETIME_TRUNC(DATETIME(TIMESTAMP(${col}), '${tz}'), DAY) AS DATE)`,
             );
         });
 

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -84,10 +84,9 @@ type WarehouseConfig = {
 /** Per-warehouse SQL for the DATE_TRUNC timezone round-trip. `toProjectTz`
  *  shifts into project-local wall-clock before truncation; `toUTC` converts
  *  the truncated value back into a proper UTC instant. `castAsDate` casts a
- *  truncated wall-clock value to a real DATE (GLITCH-452) — default
- *  `CAST(x AS DATE)`, but BigQuery needs `DATE(x, tz)` because its
- *  `TIMESTAMP_TRUNC` returns a UTC instant (a plain cast would read its UTC
- *  date — off by one on positive offsets). `sourceTimezone` is the timezone the
+ *  truncated wall-clock value to a real DATE (GLITCH-452) — every adapter's
+ *  wrapped path truncates a naive project-local wall-clock, so `CAST(x AS DATE)`
+ *  reads the right date. `sourceTimezone` is the timezone the
  *  column is in — only Snowflake uses it explicitly (in `CONVERT_TIMEZONE`);
  *  other adapters ignore it. */
 type DateTruncTimezoneConversion = {
@@ -100,12 +99,15 @@ export const dateTruncTimezoneConversions: Record<
     SupportedDbtAdapter,
     DateTruncTimezoneConversion
 > = {
-    // BigQuery: TIMESTAMP_TRUNC accepts timezone natively and preserves the
-    // UTC instant — round-trip is a no-op.
+    // BigQuery: shift the UTC instant into a naive project-TZ DATETIME so the
+    // DST fall-back fold collapses under DATETIME_TRUNC (merge), then re-attach
+    // the zone to recover a real instant. Coerce via TIMESTAMP() first because a
+    // declared-TIMESTAMP dim can emit DATETIME at runtime; DATETIME(timestamp,
+    // tz) requires a TIMESTAMP left side.
     [SupportedDbtAdapter.BIGQUERY]: {
-        toProjectTz: (sql) => sql,
-        toUTC: (sql) => sql,
-        castAsDate: (sql, tz) => `DATE(${sql}, '${tz}')`,
+        toProjectTz: (sql, tz) => `DATETIME(TIMESTAMP(${sql}), '${tz}')`,
+        toUTC: (sql, tz) => `TIMESTAMP(${sql}, '${tz}')`,
+        castAsDate: (sql) => `CAST(${sql} AS DATE)`,
     },
     [SupportedDbtAdapter.SNOWFLAKE]: {
         toProjectTz: (sql, tz, sourceTimezone = 'UTC') =>
@@ -252,10 +254,10 @@ const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
 };
 
 const bigqueryConfig: WarehouseConfig = {
-    // BigQuery: TIMESTAMP_TRUNC(ts, part, tz) truncates in the given zone and
-    // returns a TIMESTAMP (real UTC instant). We intentionally do NOT wrap
-    // with DATETIME(..., tz) — that would strip the zone back to a naive
-    // wall-clock and mis-label it as UTC downstream.
+    // BigQuery: on the timezone-wrapped path `toProjectTz` has already shifted
+    // the value into a naive project-TZ DATETIME, so truncate with
+    // DATETIME_TRUNC (the fold merges) and let `toUTC` re-attach the zone. The
+    // bare path (no timezone) keeps TIMESTAMP_TRUNC, truncating the UTC instant.
     getSqlForTruncatedDate: (
         timeFrame,
         originalSql,
@@ -269,9 +271,7 @@ const bigqueryConfig: WarehouseConfig = {
                 : timeFrame;
         if (type === DimensionType.TIMESTAMP) {
             if (timezone) {
-                // 3-arg overload requires TIMESTAMP; coerce in case the
-                // declared TIMESTAMP dim emits DATETIME at runtime.
-                return `TIMESTAMP_TRUNC(TIMESTAMP(${originalSql}), ${datePart}, '${timezone}')`;
+                return `DATETIME_TRUNC(${originalSql}, ${datePart})`;
             }
             return `TIMESTAMP_TRUNC(${originalSql}, ${datePart})`;
         }
@@ -768,8 +768,10 @@ export const getSqlForTruncatedDate = (
         wrap.timezone,
     );
     // Day-or-coarser grains return a real DATE (drop the toUTC round-trip).
-    // The per-adapter cast lives on the Record — most use CAST(... AS DATE);
-    // BigQuery needs DATE(expr, tz). See `castAsDate` in dateTruncTimezoneConversions.
+    // Every adapter's wrapped path now truncates to a naive wall-clock value
+    // (BigQuery shifts to DATETIME in toProjectTz), so the per-adapter castAsDate
+    // — CAST(... AS DATE) everywhere — reads the right calendar date in the
+    // project tz. See `castAsDate` in dateTruncTimezoneConversions.
     if (!castToDate) {
         return toUTC(truncated, wrap.timezone);
     }


### PR DESCRIPTION
## What

Same DST fall-back merge fix for BigQuery, stacked on the ClickHouse PR. Folds BigQuery into the generic naive truncation mechanism so the fall-back hour merges into one `count = 2` bucket.

## Why

BigQuery used 3-arg `TIMESTAMP_TRUNC(ts, part, tz)`, which truncates in the instant domain and split the fall-back into two `01:00` bars. This brings it in line with every other adapter.

## How

Three coordinated changes in `timeFrames.ts`:
1. `dateTruncTimezoneConversions[BIGQUERY]` shifts the UTC instant into a naive project-TZ `DATETIME` (`toProjectTz`) and re-attaches the zone (`toUTC`), instead of being no-ops.
2. `bigqueryConfig` truncates the wrapped path with `DATETIME_TRUNC` (the bare path keeps `TIMESTAMP_TRUNC`).
3. The BigQuery-specific `DATE(expr, tz)` day-grain branch is removed. The truncated value is now a naive `DATETIME` at tz-midnight, so the generic `CAST(... AS DATE)` reads the right calendar date.

Gated behind `EnableTimezoneSupport` via the same wrapped-path mechanism. Flag off is byte-identical.

## Verification

- Unit tests updated to the naive-domain shape (`DATETIME` / `DATETIME_TRUNC` / `TIMESTAMP`, and `CAST(... AS DATE)` for day grain).
- Live query check on BigQuery: one `01:00` bucket count 2; DAY grain returns correct calendar dates with no positive-offset off-by-one.
- Manual UI check across all six warehouses (Postgres, ClickHouse, BigQuery, Snowflake, Trino, Databricks): merged `01:00` bar with count 2 everywhere; drill and view-underlying-data return exactly the two folded events.

Relates: GLITCH-509