### PR TITLE
feat: support Lightdash YAML semantic layer in git-backed projects (compile + AI writeback)

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -74,7 +74,7 @@ import { GitlabProvider } from './providers/GitlabProvider';
 import type { GitProvider } from './providers/GitProvider';
 import { buildGatherRepoContextScript } from './scripts';
 import { loadWarehouseSkills, warehouseTypeToSkillKey } from './skills';
-import { buildSystemPrompt } from './templates';
+import { buildSystemPrompt, type WritebackProjectFormat } from './templates';
 import type {
     AdoptedPullRequest,
     AiWritebackRunArgs,
@@ -866,14 +866,26 @@ export class AiWritebackService extends BaseService {
                 sandbox,
                 turn.gitConnection.projectSubPath,
             );
-            // Stage a credential-free profiles copy host-side so the agent
-            // doesn't burn turns discovering profiles.yml and hand-stripping
-            // Jinja (mkdir + cp + edit). Deterministic string work — no reason
-            // to spend LLM round-trips on it.
-            const profilesStaged = await this.prepareProfiles(
+            // Detect dbt vs Lightdash YAML from the cloned repo so the agent
+            // gets format-appropriate instructions. The sandbox compile and
+            // repo VFS are format-agnostic; only the prompt (and the dbt-only
+            // profiles staging) differ.
+            const projectFormat = await this.detectProjectFormat(
                 sandbox,
                 turn.gitConnection.projectSubPath,
             );
+            // Stage a credential-free profiles copy host-side so the agent
+            // doesn't burn turns discovering profiles.yml and hand-stripping
+            // Jinja (mkdir + cp + edit). Deterministic string work — no reason
+            // to spend LLM round-trips on it. Lightdash YAML projects have no
+            // profiles.yml, so this is dbt-only.
+            const profilesStaged =
+                projectFormat === 'dbt'
+                    ? await this.prepareProfiles(
+                          sandbox,
+                          turn.gitConnection.projectSubPath,
+                      )
+                    : false;
             const skillKey = warehouseTypeToSkillKey(turn.warehouseType);
             const systemPrompt = buildSystemPrompt(
                 turn.gitConnection.projectSubPath,
@@ -884,6 +896,7 @@ export class AiWritebackService extends BaseService {
                     warehouseType: turn.warehouseType,
                     hasWarehouseSkill: skillKey !== null,
                     profilesStaged,
+                    projectFormat,
                 },
             );
             const agent = await this.runAgentInSandbox({
@@ -1330,6 +1343,40 @@ export class AiWritebackService extends BaseService {
      * YAML) so the agent doesn't burn turns rediscovering them. Returns null
      * on any failure — the run continues without the context block.
      */
+    /**
+     * Detect whether the cloned repo is a dbt project or a Lightdash YAML
+     * (dbt-less) project. Lightdash YAML markers: a `lightdash.config.yml`, or a
+     * model file declaring `type: model` under `models/`/`lightdash/models/`.
+     * Defaults to `dbt` (the historical assumption) on any error.
+     */
+    private async detectProjectFormat(
+        sandbox: Sandbox,
+        projectSubPath: string,
+    ): Promise<WritebackProjectFormat> {
+        const dir = projectSubPath.replace(/^\/+|\/+$/g, '') || '.';
+        const cmd =
+            `( test -f "${dir}/lightdash.config.yml" || ` +
+            `grep -rlsE '^[[:space:]]*type:[[:space:]]*"?model"?' ` +
+            `"${dir}/models" "${dir}/lightdash/models" 2>/dev/null | head -1 | grep -q . ) ` +
+            `&& echo lightdash_yaml || echo dbt`;
+        try {
+            const result = await sandbox.commands.run(cmd, { cwd: CWD });
+            const format: WritebackProjectFormat =
+                result.stdout.trim() === 'lightdash_yaml'
+                    ? 'lightdash_yaml'
+                    : 'dbt';
+            this.logger.info(`AiWriteback: detected project format=${format}`);
+            return format;
+        } catch (error) {
+            this.logger.warn(
+                `AiWriteback: detectProjectFormat failed, defaulting to dbt: ${getErrorMessage(
+                    error,
+                )}`,
+            );
+            return 'dbt';
+        }
+    }
+
     private async gatherRepoContext(
         sandbox: Sandbox,
         projectSubPath: string,

--- a/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.test.ts
@@ -1,7 +1,7 @@
 import { WarehouseTypes } from '@lightdash/common';
 import { SHARED_SKILL_PATH, WAREHOUSE_SKILL_PATH } from './constants';
 import { warehouseTypeToSkillKey } from './skills';
-import { buildSystemPrompt } from './templates';
+import { buildSystemPrompt, type WritebackProjectFormat } from './templates';
 
 const DBT_PROJECT_DIR = 'analytics/dbt';
 const BASE_CONTEXT = {
@@ -13,12 +13,14 @@ const BASE_CONTEXT = {
 const buildFor = (
     warehouseType: WarehouseTypes | null,
     profilesStaged = false,
+    projectFormat: WritebackProjectFormat = 'dbt',
 ) =>
     buildSystemPrompt(DBT_PROJECT_DIR, {
         ...BASE_CONTEXT,
         warehouseType,
         hasWarehouseSkill: warehouseTypeToSkillKey(warehouseType) !== null,
         profilesStaged,
+        projectFormat,
     });
 
 describe('buildSystemPrompt — staged profiles', () => {
@@ -36,6 +38,25 @@ describe('buildSystemPrompt — staged profiles', () => {
         const notStaged = buildFor(WarehouseTypes.POSTGRES, false);
         expect(notStaged).toContain('Discover the profiles directory');
         expect(notStaged).toContain('Prepare a TEMPORARY profiles directory');
+    });
+});
+
+describe('buildSystemPrompt — Lightdash YAML projects', () => {
+    const yaml = buildFor(WarehouseTypes.POSTGRES, false, 'lightdash_yaml');
+
+    it('describes a Lightdash YAML project and not a dbt project', () => {
+        expect(yaml).toContain('**Lightdash YAML** project (no dbt)');
+        expect(yaml).toContain('top-level `metrics:` and `dimensions:`');
+        expect(yaml).not.toContain('The dbt project lives at');
+    });
+
+    it('skips the profiles.yml dance entirely', () => {
+        expect(yaml).not.toContain('Discover the profiles directory');
+        expect(yaml).not.toContain('Prepare a TEMPORARY profiles directory');
+        expect(yaml).not.toContain('--profiles-dir');
+        // still compiles (catalog skipped) and still emits the PR blocks
+        expect(yaml).toContain('--skip-warehouse-catalog');
+        expect(yaml).toMatch(/single-line PR title/);
     });
 });
 

--- a/packages/backend/src/ee/services/AiWritebackService/templates.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/templates.ts
@@ -71,6 +71,25 @@ const buildStagedProfilesSteps = (dbtProjectDir: string): string => `
 
 3. End your final reply with the two structured-output blocks below.`;
 
+export type WritebackProjectFormat = 'dbt' | 'lightdash_yaml';
+
+// Compile follow-up for a Lightdash YAML (dbt-less) project. There is no
+// dbt_project.yml and no profiles.yml — `lightdash compile` reads the
+// standalone YAML models directly, so the profiles dance is skipped entirely.
+const buildLightdashYamlCompileSteps = (projectDir: string): string => `
+1. From the repo root, run (use this exact wrapper command — it is the only
+   compile command available to you):
+     ${COMPILE_WRAPPER_PATH} --skip-warehouse-catalog \\
+       --project-dir ${projectDir}
+   Capture the exit code and the last meaningful line of output.
+
+2. In your final reply, include ONE line summarising the compile result —
+   for example: "lightdash compile: ok (exit 0)" or
+   "lightdash compile: failed (exit 1) — <short reason from stderr>". Do not
+   paste the full compile output.
+
+3. End your final reply with the two structured-output blocks below.`;
+
 export const buildSystemPrompt = (
     dbtProjectDir: string,
     context: {
@@ -80,6 +99,7 @@ export const buildSystemPrompt = (
         warehouseType: WarehouseTypes | null;
         hasWarehouseSkill: boolean;
         profilesStaged: boolean;
+        projectFormat: WritebackProjectFormat;
     },
 ): string =>
     `
@@ -94,8 +114,17 @@ You are an autonomous coding agent working inside a checkout of a git repository
   project, folder, or repository.
 - The repository is already cloned in your working directory. Edit the
   appropriate files to satisfy the user's request.
-- The dbt project lives at \`${dbtProjectDir}\` (relative to the repo root, which
-  is your working directory).
+${
+    context.projectFormat === 'lightdash_yaml'
+        ? `- This is a **Lightdash YAML** project (no dbt). The project lives at
+  \`${dbtProjectDir}\` (relative to the repo root). Models are defined as
+  standalone YAML files under \`models/\` or \`lightdash/models/\` — each has a
+  top-level \`type: model\`, a \`sql_from:\` pointing at a warehouse table, and
+  top-level \`metrics:\` and \`dimensions:\`. Edit those YAML files directly.
+  There is NO \`dbt_project.yml\`, NO dbt \`meta:\` tags, and NO \`profiles.yml\`.`
+        : `- The dbt project lives at \`${dbtProjectDir}\` (relative to the repo root, which
+  is your working directory).`
+}
 - Do NOT commit, push, or run any git commands — the host handles git.
 
 ${buildWarehouseSkillGuidance(context.warehouseType, context.hasWarehouseSkill)}
@@ -119,9 +148,12 @@ ${context.repoContext}
 }
 If you made any file changes, perform these follow-up steps before you finish:
 ${
-    context.profilesStaged
-        ? buildStagedProfilesSteps(dbtProjectDir)
-        : `
+    // eslint-disable-next-line no-nested-ternary
+    context.projectFormat === 'lightdash_yaml'
+        ? buildLightdashYamlCompileSteps(dbtProjectDir)
+        : context.profilesStaged
+          ? buildStagedProfilesSteps(dbtProjectDir)
+          : `
 1. The dbt project directory (containing \`dbt_project.yml\`) is
    \`${dbtProjectDir}\`. Use it as the \`--project-dir\`.
 

--- a/packages/backend/src/projectAdapters/gitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/gitProjectAdapter.ts
@@ -1,0 +1,112 @@
+/**
+ * Dispatcher for git-backed projects. Lazily clones the repo, detects whether
+ * it's a Lightdash YAML or dbt project, and delegates to the matching adapter:
+ *
+ *   - Lightdash YAML  -> LightdashYamlProjectAdapter (reuses this clone)
+ *   - dbt             -> the dbt adapter built by `createDbtAdapter` (unchanged)
+ *
+ * Detection is lazy (per the chosen design): the format isn't known until the
+ * repo is cloned. The dbt branch currently re-clones inside its own adapter —
+ * the throwaway detection clone here is a prototype wart; productionisation
+ * should share a single GitRepository clone across both branches.
+ */
+import {
+    DbtPackages,
+    Explore,
+    ExploreError,
+    type LightdashProjectConfig,
+    type ProjectContextEntry,
+} from '@lightdash/common';
+import { WarehouseClient } from '@lightdash/warehouses';
+import Logger from '../logging/logger';
+import { ProjectAdapter, type TrackingParams } from '../types';
+import { GitRepository } from './gitRepository';
+import { findLightdashModelFiles } from './lightdashYamlLoader';
+import { LightdashYamlProjectAdapter } from './lightdashYamlProjectAdapter';
+
+type GitProjectAdapterArgs = {
+    warehouseClient: WarehouseClient;
+    remoteRepositoryUrl: string;
+    branch: string;
+    projectDirectorySubPath: string;
+    createDbtAdapter: () => ProjectAdapter;
+};
+
+export class GitProjectAdapter implements ProjectAdapter {
+    private readonly args: GitProjectAdapterArgs;
+
+    private resolved: ProjectAdapter | undefined;
+
+    private yamlRepository: GitRepository | undefined;
+
+    constructor(args: GitProjectAdapterArgs) {
+        this.args = args;
+    }
+
+    private async resolveAdapter(): Promise<ProjectAdapter> {
+        if (this.resolved) {
+            return this.resolved;
+        }
+        const repository = new GitRepository(
+            this.args.remoteRepositoryUrl,
+            this.args.branch,
+            this.args.projectDirectorySubPath,
+        );
+        const projectDir = await repository.clone();
+        const lightdashModelFiles = await findLightdashModelFiles(projectDir);
+
+        if (lightdashModelFiles.length > 0) {
+            Logger.info(
+                `Detected Lightdash YAML project (${lightdashModelFiles.length} model file(s))`,
+            );
+            this.yamlRepository = repository;
+            this.resolved = new LightdashYamlProjectAdapter({
+                projectDir,
+                warehouseClient: this.args.warehouseClient,
+            });
+        } else {
+            Logger.info('Detected dbt project, delegating to dbt adapter');
+            await repository.destroy();
+            this.resolved = this.args.createDbtAdapter();
+        }
+        return this.resolved;
+    }
+
+    public async compileAllExplores(
+        trackingParams?: TrackingParams,
+        loadSources?: boolean,
+        allowPartialCompilation?: boolean,
+    ): Promise<(Explore | ExploreError)[]> {
+        const adapter = await this.resolveAdapter();
+        return adapter.compileAllExplores(
+            trackingParams,
+            loadSources,
+            allowPartialCompilation,
+        );
+    }
+
+    public async getDbtPackages(): Promise<DbtPackages | undefined> {
+        return (await this.resolveAdapter()).getDbtPackages();
+    }
+
+    public async test(): Promise<void> {
+        await (await this.resolveAdapter()).test();
+    }
+
+    public async getLightdashProjectConfig(
+        trackingParams?: TrackingParams,
+    ): Promise<LightdashProjectConfig> {
+        return (await this.resolveAdapter()).getLightdashProjectConfig(
+            trackingParams,
+        );
+    }
+
+    public async getProjectContext(): Promise<ProjectContextEntry[]> {
+        return (await this.resolveAdapter()).getProjectContext();
+    }
+
+    public async destroy(): Promise<void> {
+        await this.resolved?.destroy();
+        await this.yamlRepository?.destroy();
+    }
+}

--- a/packages/backend/src/projectAdapters/gitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/gitProjectAdapter.ts
@@ -52,24 +52,33 @@ export class GitProjectAdapter implements ProjectAdapter {
             this.args.branch,
             this.args.projectDirectorySubPath,
         );
-        const projectDir = await repository.clone();
-        const lightdashModelFiles = await findLightdashModelFiles(projectDir);
 
-        if (lightdashModelFiles.length > 0) {
-            Logger.info(
-                `Detected Lightdash YAML project (${lightdashModelFiles.length} model file(s))`,
-            );
-            this.yamlRepository = repository;
-            this.resolved = new LightdashYamlProjectAdapter({
-                projectDir,
-                warehouseClient: this.args.warehouseClient,
-            });
-        } else {
-            Logger.info('Detected dbt project, delegating to dbt adapter');
+        try {
+            const projectDir = await repository.clone();
+            const lightdashModelFiles =
+                await findLightdashModelFiles(projectDir);
+
+            if (lightdashModelFiles.length > 0) {
+                Logger.info(
+                    `Detected Lightdash YAML project (${lightdashModelFiles.length} model file(s))`,
+                );
+                this.yamlRepository = repository;
+                this.resolved = new LightdashYamlProjectAdapter({
+                    projectDir,
+                    warehouseClient: this.args.warehouseClient,
+                });
+            } else {
+                Logger.info('Detected dbt project, delegating to dbt adapter');
+                await repository.destroy();
+                this.resolved = this.args.createDbtAdapter();
+            }
+            return this.resolved;
+        } catch (error) {
+            // Don't leak the /tmp/git_* checkout if detection/adapter setup
+            // fails between clone and a successful handoff.
             await repository.destroy();
-            this.resolved = this.args.createDbtAdapter();
+            throw error;
         }
-        return this.resolved;
     }
 
     public async compileAllExplores(

--- a/packages/backend/src/projectAdapters/gitRepository.ts
+++ b/packages/backend/src/projectAdapters/gitRepository.ts
@@ -6,11 +6,20 @@
  * should be refactored onto this so dbt and YAML share a single clone (today
  * the dbt branch re-clones — see GitProjectAdapter).
  */
+import { getErrorMessage } from '@lightdash/common';
 import fs from 'fs';
 import * as fspromises from 'fs-extra';
 import * as path from 'path';
 import simpleGit, { type SimpleGit } from 'simple-git';
 import Logger from '../logging/logger';
+
+/**
+ * Redact `//user:token@host` credentials from any string before it can reach a
+ * log or error surface. Mirrors `stripTokensFromUrls` in dbtGitProjectAdapter —
+ * productionisation should unify the two into a shared git-error helper.
+ */
+const stripCredentials = (raw: string): string =>
+    raw.replace(/(https?:\/\/)[^@\s/]+@/gi, '$1*****@');
 
 export class GitRepository {
     private readonly localRepositoryDir: string;
@@ -34,14 +43,22 @@ export class GitRepository {
 
     async clone(): Promise<string> {
         const startTime = Date.now();
-        await this.git
-            .env('GIT_TERMINAL_PROMPT', '0')
-            .clone(this.remoteRepositoryUrl, this.localRepositoryDir, {
-                '--single-branch': null,
-                '--depth': 1,
-                '--branch': this.branch,
-                '--no-tags': null,
-            });
+        try {
+            await this.git
+                .env('GIT_TERMINAL_PROMPT', '0')
+                .clone(this.remoteRepositoryUrl, this.localRepositoryDir, {
+                    '--single-branch': null,
+                    '--depth': 1,
+                    '--branch': this.branch,
+                    '--no-tags': null,
+                });
+        } catch (e) {
+            // simple-git errors can include the clone command (and thus the
+            // tokenised remote URL); strip credentials before it propagates.
+            throw new Error(
+                `Git clone failed: ${stripCredentials(getErrorMessage(e))}`,
+            );
+        }
         Logger.info(`Git clone completed in ${Date.now() - startTime}ms`);
         return this.projectDir;
     }

--- a/packages/backend/src/projectAdapters/gitRepository.ts
+++ b/packages/backend/src/projectAdapters/gitRepository.ts
@@ -6,7 +6,7 @@
  * should be refactored onto this so dbt and YAML share a single clone (today
  * the dbt branch re-clones — see GitProjectAdapter).
  */
-import { getErrorMessage } from '@lightdash/common';
+import { getErrorMessage, UnexpectedGitError } from '@lightdash/common';
 import fs from 'fs';
 import * as fspromises from 'fs-extra';
 import * as path from 'path';
@@ -55,7 +55,7 @@ export class GitRepository {
         } catch (e) {
             // simple-git errors can include the clone command (and thus the
             // tokenised remote URL); strip credentials before it propagates.
-            throw new Error(
+            throw new UnexpectedGitError(
                 `Git clone failed: ${stripCredentials(getErrorMessage(e))}`,
             );
         }

--- a/packages/backend/src/projectAdapters/gitRepository.ts
+++ b/packages/backend/src/projectAdapters/gitRepository.ts
@@ -1,0 +1,59 @@
+/**
+ * Minimal git clone helper, decoupled from any compiler (dbt or Lightdash YAML).
+ *
+ * Extracted so a non-dbt adapter can materialise a repo without inheriting the
+ * dbt adapter chain. Productionisation: DbtGitProjectAdapter's own clone logic
+ * should be refactored onto this so dbt and YAML share a single clone (today
+ * the dbt branch re-clones — see GitProjectAdapter).
+ */
+import fs from 'fs';
+import * as fspromises from 'fs-extra';
+import * as path from 'path';
+import simpleGit, { type SimpleGit } from 'simple-git';
+import Logger from '../logging/logger';
+
+export class GitRepository {
+    private readonly localRepositoryDir: string;
+
+    private readonly projectDir: string;
+
+    private readonly git: SimpleGit;
+
+    constructor(
+        private readonly remoteRepositoryUrl: string,
+        private readonly branch: string,
+        projectDirectorySubPath: string,
+    ) {
+        this.localRepositoryDir = fs.mkdtempSync('/tmp/git_');
+        this.projectDir = path.join(
+            this.localRepositoryDir,
+            projectDirectorySubPath,
+        );
+        this.git = simpleGit();
+    }
+
+    async clone(): Promise<string> {
+        const startTime = Date.now();
+        await this.git
+            .env('GIT_TERMINAL_PROMPT', '0')
+            .clone(this.remoteRepositoryUrl, this.localRepositoryDir, {
+                '--single-branch': null,
+                '--depth': 1,
+                '--branch': this.branch,
+                '--no-tags': null,
+            });
+        Logger.info(`Git clone completed in ${Date.now() - startTime}ms`);
+        return this.projectDir;
+    }
+
+    getProjectDir(): string {
+        return this.projectDir;
+    }
+
+    async destroy(): Promise<void> {
+        await fspromises.rm(this.localRepositoryDir, {
+            recursive: true,
+            force: true,
+        });
+    }
+}

--- a/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
+++ b/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
@@ -1,0 +1,134 @@
+/**
+ * Loader for Lightdash YAML model files (dbt-less projects).
+ *
+ * Ported from the CLI (packages/cli/src/lightdash/loader.ts) so the backend can
+ * compile a git repo that defines its semantic layer in Lightdash YAML instead
+ * of dbt. Productionisation note: this should be lifted into @lightdash/common
+ * as the single source of truth shared by the CLI, the backend compile path,
+ * and the AI writeback agent.
+ */
+import { ParseError, type LightdashModel } from '@lightdash/common';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import * as path from 'path';
+import Logger from '../logging/logger';
+
+const VALID_MODEL_TYPES = ['model', 'model/v1beta', 'model/v1'];
+
+/**
+ * Load and validate a single Lightdash YAML model file.
+ */
+export async function loadLightdashModel(
+    filePath: string,
+): Promise<LightdashModel> {
+    try {
+        const fileContents = await fs.promises.readFile(filePath, 'utf8');
+        const parsed = yaml.load(fileContents) as LightdashModel;
+
+        if (!parsed.type || !parsed.name || !parsed.dimensions) {
+            throw new ParseError(
+                `Invalid Lightdash model in ${filePath}: must have type, name, and dimensions`,
+            );
+        }
+        if (!parsed.sql_from) {
+            throw new ParseError(
+                `Invalid Lightdash model in ${filePath}: must have sql_from`,
+            );
+        }
+        return parsed;
+    } catch (error) {
+        if (error instanceof ParseError) {
+            throw error;
+        }
+        throw new ParseError(
+            `Failed to load Lightdash model from ${filePath}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+}
+
+/**
+ * Whether a YAML file declares a Lightdash model (`type: model`). Checking the
+ * content avoids false positives from other YAML (e.g. content-as-code spaces).
+ */
+async function isLightdashModelFile(filePath: string): Promise<boolean> {
+    try {
+        const fileContents = await fs.promises.readFile(filePath, 'utf8');
+        const parsed = yaml.load(fileContents) as { type?: string } | null;
+        if (!parsed || typeof parsed !== 'object') {
+            return false;
+        }
+        return VALID_MODEL_TYPES.includes(parsed.type ?? '');
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Find all Lightdash YAML model files under `models/` or `lightdash/models/`.
+ */
+export async function findLightdashModelFiles(
+    projectDir: string,
+): Promise<string[]> {
+    const possibleDirs = [
+        path.join(projectDir, 'models'),
+        path.join(projectDir, 'lightdash', 'models'),
+    ];
+    const lightdashModelsDir = possibleDirs.find((dir) => fs.existsSync(dir));
+    if (!lightdashModelsDir) {
+        return [];
+    }
+
+    const yamlFiles: string[] = [];
+    async function walkDir(dir: string) {
+        const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+        for await (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                await walkDir(fullPath);
+            } else if (
+                entry.isFile() &&
+                (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml'))
+            ) {
+                yamlFiles.push(fullPath);
+            }
+        }
+    }
+    await walkDir(lightdashModelsDir);
+
+    const modelFiles: string[] = [];
+    for await (const filePath of yamlFiles) {
+        if (await isLightdashModelFile(filePath)) {
+            modelFiles.push(filePath);
+        }
+    }
+    return modelFiles;
+}
+
+/**
+ * Load all Lightdash YAML models from a project directory. Files that fail to
+ * parse are skipped with a warning rather than failing the whole compile.
+ */
+export async function loadLightdashModels(
+    projectDir: string,
+): Promise<LightdashModel[]> {
+    const modelFiles = await findLightdashModelFiles(projectDir);
+    Logger.debug(
+        `Found ${modelFiles.length} Lightdash YAML model files in ${projectDir}`,
+    );
+
+    const models: LightdashModel[] = [];
+    for await (const filePath of modelFiles) {
+        try {
+            models.push(await loadLightdashModel(filePath));
+        } catch (error) {
+            Logger.warn(
+                `Skipping ${filePath}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+    return models;
+}

--- a/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
+++ b/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
@@ -81,7 +81,15 @@ export async function findLightdashModelFiles(
         path.join(projectDir, 'models'),
         path.join(projectDir, 'lightdash', 'models'),
     ];
-    const lightdashModelsDir = possibleDirs.find((dir) => fs.existsSync(dir));
+    const dirExists = await Promise.all(
+        possibleDirs.map((dir) =>
+            fs.promises.access(dir).then(
+                () => true,
+                () => false,
+            ),
+        ),
+    );
+    const lightdashModelsDir = possibleDirs.find((_, i) => dirExists[i]);
     if (!lightdashModelsDir) {
         return [];
     }

--- a/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
+++ b/packages/backend/src/projectAdapters/lightdashYamlLoader.ts
@@ -23,7 +23,11 @@ export async function loadLightdashModel(
 ): Promise<LightdashModel> {
     try {
         const fileContents = await fs.promises.readFile(filePath, 'utf8');
-        const parsed = yaml.load(fileContents) as LightdashModel;
+        // JSON_SCHEMA: model files come from a cloned repo (untrusted); restrict
+        // to JSON-compatible types so no YAML-specific deserialization applies.
+        const parsed = yaml.load(fileContents, {
+            schema: yaml.JSON_SCHEMA,
+        }) as LightdashModel;
 
         if (!parsed.type || !parsed.name || !parsed.dimensions) {
             throw new ParseError(
@@ -55,7 +59,9 @@ export async function loadLightdashModel(
 async function isLightdashModelFile(filePath: string): Promise<boolean> {
     try {
         const fileContents = await fs.promises.readFile(filePath, 'utf8');
-        const parsed = yaml.load(fileContents) as { type?: string } | null;
+        const parsed = yaml.load(fileContents, {
+            schema: yaml.JSON_SCHEMA,
+        }) as { type?: string } | null;
         if (!parsed || typeof parsed !== 'object') {
             return false;
         }

--- a/packages/backend/src/projectAdapters/lightdashYamlProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/lightdashYamlProjectAdapter.ts
@@ -1,0 +1,131 @@
+/**
+ * Project adapter for Lightdash YAML (dbt-less) projects.
+ *
+ * Pairs a materialised project directory (local, or a cloned git repo) with the
+ * Lightdash YAML compiler. It implements ProjectAdapter directly and shares NO
+ * code with the dbt adapter chain — a Lightdash YAML project is not a dbt
+ * project. The heavy lifting (model→explore) reuses the same translator the dbt
+ * path uses, via convertLightdashModelsToDbtModels + convertExplores in common.
+ */
+import {
+    convertExplores,
+    convertLightdashModelsToDbtModels,
+    DbtPackages,
+    DEFAULT_SPOTLIGHT_CONFIG,
+    Explore,
+    ExploreError,
+    loadLightdashProjectConfig,
+    loadProjectContextFile,
+    NotFoundError,
+    type LightdashProjectConfig,
+    type ProjectContextEntry,
+} from '@lightdash/common';
+import { WarehouseClient } from '@lightdash/warehouses';
+import fs from 'fs/promises';
+import path from 'path';
+import { preAggregatePostProcessor } from '../ee/preAggregates/postProcessor';
+import Logger from '../logging/logger';
+import { ProjectAdapter, type TrackingParams } from '../types';
+import { loadLightdashModels } from './lightdashYamlLoader';
+
+const postProcessors = [preAggregatePostProcessor];
+
+export class LightdashYamlProjectAdapter implements ProjectAdapter {
+    private readonly projectDir: string;
+
+    private readonly warehouseClient: WarehouseClient;
+
+    constructor({
+        projectDir,
+        warehouseClient,
+    }: {
+        projectDir: string;
+        warehouseClient: WarehouseClient;
+    }) {
+        this.projectDir = projectDir;
+        this.warehouseClient = warehouseClient;
+    }
+
+    public async compileAllExplores(
+        trackingParams?: TrackingParams,
+        loadSources: boolean = false,
+        allowPartialCompilation: boolean = false,
+    ): Promise<(Explore | ExploreError)[]> {
+        Logger.info('Compiling Lightdash YAML models (dbt-less project)');
+        const lightdashModels = await loadLightdashModels(this.projectDir);
+        if (lightdashModels.length === 0) {
+            throw new NotFoundError('No Lightdash YAML models found');
+        }
+
+        // Types are declared in the YAML, so the warehouse catalog is not
+        // fetched (mirrors the CLI deploy path).
+        const dbtModels = convertLightdashModelsToDbtModels(lightdashModels);
+        const adapterType = this.warehouseClient.getAdapterType();
+        const lightdashProjectConfig = await this.getLightdashProjectConfig();
+        const disableTimestampConversion =
+            this.warehouseClient.credentials.type === 'snowflake' &&
+            this.warehouseClient.credentials.disableTimestampConversion ===
+                true;
+
+        const explores = await convertExplores(
+            dbtModels,
+            loadSources,
+            adapterType,
+            [],
+            this.warehouseClient,
+            lightdashProjectConfig,
+            {
+                disableTimestampConversion,
+                allowPartialCompilation,
+                postProcessors,
+            },
+        );
+        Logger.info(
+            `Finished compiling ${explores.length} Lightdash YAML explore(s)`,
+        );
+        return explores;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public async getDbtPackages(): Promise<DbtPackages | undefined> {
+        return undefined;
+    }
+
+    public async test(): Promise<void> {
+        await this.warehouseClient.test();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public async destroy(): Promise<void> {
+        Logger.debug('Destroy Lightdash YAML project adapter');
+    }
+
+    public async getLightdashProjectConfig(): Promise<LightdashProjectConfig> {
+        const configPath = path.join(this.projectDir, 'lightdash.config.yml');
+        try {
+            const fileContents = await fs.readFile(configPath, 'utf8');
+            return await loadLightdashProjectConfig(fileContents);
+        } catch (e) {
+            if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+                return { spotlight: DEFAULT_SPOTLIGHT_CONFIG };
+            }
+            throw e;
+        }
+    }
+
+    public async getProjectContext(): Promise<ProjectContextEntry[]> {
+        const contextPath = path.join(
+            this.projectDir,
+            'lightdash.project_context.yml',
+        );
+        try {
+            const fileContents = await fs.readFile(contextPath, 'utf8');
+            return loadProjectContextFile(fileContents);
+        } catch (e) {
+            if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+                return [];
+            }
+            throw e;
+        }
+    }
+}

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -19,6 +19,7 @@ import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import { DbtManifestProjectAdapter } from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
+import { GitProjectAdapter } from './gitProjectAdapter';
 
 export const projectAdapterFromConfig = async (
     config: DbtProjectConfig,
@@ -95,21 +96,33 @@ export const projectAdapterFromConfig = async (
                     `Missing repository for GitHub project`,
                 );
             }
-            return new DbtGithubProjectAdapter({
-                analytics,
+            const githubRemoteRepositoryUrl = `https://lightdash:${githubToken}@${
+                config.host_domain || 'github.com'
+            }/${config.repository}.git`;
+            return new GitProjectAdapter({
                 warehouseClient,
-                githubPersonalAccessToken: githubToken!,
-                githubRepository: config.repository,
-                githubBranch: config.branch,
+                remoteRepositoryUrl: githubRemoteRepositoryUrl,
+                branch: config.branch,
                 projectDirectorySubPath: config.project_sub_path,
-                hostDomain: config.host_domain,
-                warehouseCredentials,
-                targetName: config.target,
-                environment: config.environment,
-                cachedWarehouse,
-                dbtVersion,
+                // dbt branch is delegated to the existing adapter unchanged;
+                // the YAML branch is handled by GitProjectAdapter directly.
+                createDbtAdapter: () =>
+                    new DbtGithubProjectAdapter({
+                        analytics,
+                        warehouseClient,
+                        githubPersonalAccessToken: githubToken!,
+                        githubRepository: config.repository,
+                        githubBranch: config.branch,
+                        projectDirectorySubPath: config.project_sub_path,
+                        hostDomain: config.host_domain,
+                        warehouseCredentials,
+                        targetName: config.target,
+                        environment: config.environment,
+                        cachedWarehouse,
+                        dbtVersion,
 
-                selector: config.selector,
+                        selector: config.selector,
+                    }),
             });
         case DbtProjectType.GITLAB:
             return new DbtGitlabProjectAdapter({


### PR DESCRIPTION
## What

Makes a **git-connected project whose repo defines its semantic layer in Lightdash YAML** (dbt-less) a first-class citizen: it compiles in the backend **and** supports AI writeback — without touching the dbt adapters.

Today such a project fails: the backend git adapter always assumes dbt and dbt bails with `No dbt_project.yml found`, and the writeback agent's prompt is hardcoded around dbt (`dbt_project.yml`, `profiles.yml`).

## How

Two workstreams, one shared idea — *detect the project format once, then branch*:

**1. Backend compile** (`feat(backend): compile Lightdash YAML semantic layer from a git repo`)
- `gitRepository.ts` — clone helper decoupled from any compiler
- `lightdashYamlLoader.ts` — discover/parse `lightdash/models/*.yml` (ported from the CLI)
- `lightdashYamlProjectAdapter.ts` — a `ProjectAdapter` that compiles YAML models through the **shared `convertExplores` translator** (no dbt, no manifest, no warehouse-catalog fetch — types come from the YAML)
- `gitProjectAdapter.ts` — dispatcher: clone once, lazily detect dbt vs YAML, route YAML → the new adapter, else → the **unchanged** dbt adapter (delegated via a thunk)

**2. Writeback agent** (`feat(ai-writeback): make the writeback agent format-aware`)
- `AiWritebackService.detectProjectFormat()` sniffs the sandbox checkout for YAML markers
- `buildSystemPrompt` branches on `projectFormat`: the YAML branch tells the agent to edit top-level `metrics`/`dimensions`/`sql_from` and compile with no profiles dance; dbt-only profiles staging is gated to `dbt`

Because the YAML path reuses the **same translator → same field IDs**, every downstream consumer (queries, field-impact analysis, validation) is automatically format-agnostic. The dbt path is byte-for-byte unchanged (existing prompt snapshot tests pass).

## Verification (local EE)
- GitHub repo of Lightdash YAML → compiles 3 explores, queryable in the UI
- Default dbt project still compiles/queries (dbt path untouched)
- Real AI writeback run → opens a correct PR editing top-level `metrics:` (also auto-builds a preview project)
- Merge → refresh → recompile picks up the change through the new adapter
- `analyzeFieldImpact` correctly reports blast radius on the YAML project (Breaking, 1 chart)
- `pnpm -F backend typecheck` + writeback prompt unit tests pass

## Status / follow-ups
Proof-of-concept. Productionization TODOs (flagged in code):
- lift the loader + detection into `@lightdash/common` so the CLI, backend, and writeback agent share one detector
- share the single clone (the dbt branch currently re-clones after the detection clone)
- frontend connection wizard: detect/hide dbt-version + refresh affordances for YAML projects
- `analyzeFieldImpact` still only catches reference breakage, not silent value-drift (pre-existing, not YAML-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)