### PR TITLE
feat(ai): promote reviews from homepage

### DIFF
--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -11,13 +11,16 @@ import {
 import { useForm } from '@mantine/form';
 import {
     IconArrowUp,
+    IconArrowRight,
     IconCornerDownLeft,
+    IconGitPullRequest,
     IconSettings,
     IconSparkles,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Provider } from 'react-redux';
 import { Link, useNavigate } from 'react-router';
+import { CategoryBadge } from '../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../../components/common/PolymorphicGroupButton';
 import { CompactAgentSelector } from '../../../features/aiCopilot/components/AgentSelector';
@@ -26,6 +29,7 @@ import {
     AI_ROUTING_SEARCH_PARAM,
 } from '../../../features/aiCopilot/components/AgentSelector/AgentSelectorUtils';
 import { usePendingPrompt } from '../../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
+import { useAiAgentAdminReviewItems } from '../../../features/aiCopilot/hooks/useAiAgentAdmin';
 import { useAiAgentPermission } from '../../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useAiRouterConfig } from '../../../features/aiCopilot/hooks/useAiRouter';
@@ -41,9 +45,13 @@ import { SearchDropdown } from './SearchDropdown';
 
 type Props = {
     projectUuid: string;
+    showAiReviewsPromo?: boolean;
 };
 
-const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
+const AiSearchBoxInner: FC<Props> = ({
+    projectUuid,
+    showAiReviewsPromo = false,
+}) => {
     const navigate = useNavigate();
 
     const { data: agents, isLoading: isLoadingAgents } = useProjectAiAgents({
@@ -54,6 +62,8 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
     const isTrial =
         aiOrganizationSettingsQuery.isSuccess &&
         aiOrganizationSettingsQuery.data.isTrial;
+    const reviewsEnabled =
+        aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
     const {
         data: userAgentPreferences,
         isLoading: isLoadingUserAgentPreferences,
@@ -65,9 +75,37 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
         action: 'manage',
         projectUuid,
     });
+    const canViewReviews = useAiAgentPermission({
+        action: 'manage',
+    });
+    const showReviewsPromo =
+        showAiReviewsPromo && canViewReviews && reviewsEnabled;
+    const { data: reviewItems } = useAiAgentAdminReviewItems(
+        { statuses: ['open'] },
+        { enabled: showReviewsPromo },
+    );
+    const projectReviewItems =
+        reviewItems?.filter(
+            (item) =>
+                item.projectUuid === projectUuid ||
+                item.latestFinding?.projectUuid === projectUuid,
+        ) ?? [];
+    const prReadyCount = projectReviewItems.filter(
+        (item) => item.writebackEligibility.eligible,
+    ).length;
+    const linkedPrCount = projectReviewItems.filter(
+        (item) => !!item.linkedPrUrl,
+    ).length;
+    const reviewsPromoLabel =
+        prReadyCount > 0
+            ? 'Review findings, ship PRs, improve agents'
+            : 'Review AI findings to improve future answers';
 
     const noAgentsAvailable =
         !isLoadingAgents && (!agents || agents.length === 0);
+    const showAgentSetupPrompt =
+        canManageAgents && (isTrial || noAgentsAvailable);
+    const showFooter = canManageAgents || showReviewsPromo;
 
     const showAutoOption =
         (agents?.length ?? 0) > 1 && aiRouterConfigQuery.data?.enabled === true;
@@ -256,20 +294,13 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                     </Group>
                 </form>
             </Box>
-            {canManageAgents && (
+            {showFooter && (
                 <>
                     <Divider color="ldGray.2" />
                     <Box bg="ldGray.0" px="md" py="5px">
-                        <Group
-                            flex={1}
-                            justify={
-                                isTrial || noAgentsAvailable
-                                    ? 'space-between'
-                                    : 'flex-end'
-                            }
-                        >
-                            <Group gap={2}>
-                                {noAgentsAvailable ? (
+                        <Group flex={1} justify="space-between">
+                            <Group gap="xs">
+                                {showAgentSetupPrompt && noAgentsAvailable ? (
                                     <Button
                                         size="compact-xs"
                                         variant="subtle"
@@ -296,7 +327,7 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                             </Text>
                                         </Group>
                                     </Button>
-                                ) : isTrial ? (
+                                ) : showAgentSetupPrompt && isTrial ? (
                                     <Group gap="xs">
                                         <MantineIcon
                                             icon={IconSparkles}
@@ -309,27 +340,83 @@ const AiSearchBoxInner: FC<Props> = ({ projectUuid }) => {
                                         </Text>
                                     </Group>
                                 ) : null}
+
+                                {showReviewsPromo && (
+                                    <Button
+                                        size="compact-xs"
+                                        variant="transparent"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconGitPullRequest}
+                                                color="ldGray.7"
+                                                strokeWidth={1.7}
+                                            />
+                                        }
+                                        rightSection={
+                                            <MantineIcon
+                                                icon={IconArrowRight}
+                                                size={13}
+                                                color="ldGray.7"
+                                            />
+                                        }
+                                        component={Link}
+                                        to={`/generalSettings/ai/reviews?projects=${projectUuid}`}
+                                        className={styles.reviewsPromoButton}
+                                    >
+                                        <Group gap="xs" wrap="nowrap">
+                                            <Text span fz="xs" fw={700}>
+                                                {reviewsPromoLabel}
+                                            </Text>
+                                            <CategoryBadge
+                                                label={`${projectReviewItems.length} open`}
+                                                color="yellow.5"
+                                                className={
+                                                    styles.reviewsPromoBadge
+                                                }
+                                            />
+                                            <CategoryBadge
+                                                label={`${prReadyCount} PR-ready`}
+                                                color="green.5"
+                                                className={
+                                                    styles.reviewsPromoBadge
+                                                }
+                                            />
+                                            {linkedPrCount > 0 && (
+                                                <CategoryBadge
+                                                    label={`${linkedPrCount} linked`}
+                                                    color="blue.5"
+                                                    className={
+                                                        styles.reviewsPromoBadge
+                                                    }
+                                                />
+                                            )}
+                                        </Group>
+                                    </Button>
+                                )}
                             </Group>
 
-                            <Button
-                                size="compact-xs"
-                                variant="subtle"
-                                leftSection={
-                                    <MantineIcon
-                                        color="ldGray.7"
-                                        icon={IconSettings}
-                                        strokeWidth={1.5}
-                                    />
-                                }
-                                component={Link}
-                                to="/generalSettings/ai/agents"
-                                classNames={{
-                                    label: styles.adminSettingsButtonLabel,
-                                    section: styles.adminSettingsButtonSection,
-                                }}
-                            >
-                                Admin Settings
-                            </Button>
+                            {canManageAgents && (
+                                <Button
+                                    size="compact-xs"
+                                    variant="subtle"
+                                    leftSection={
+                                        <MantineIcon
+                                            color="ldGray.7"
+                                            icon={IconSettings}
+                                            strokeWidth={1.5}
+                                        />
+                                    }
+                                    component={Link}
+                                    to="/generalSettings/ai/agents"
+                                    classNames={{
+                                        label: styles.adminSettingsButtonLabel,
+                                        section:
+                                            styles.adminSettingsButtonSection,
+                                    }}
+                                >
+                                    Admin Settings
+                                </Button>
+                            )}
                         </Group>
                     </Box>
                 </>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -81,6 +81,24 @@
     overflow: hidden;
 }
 
+.reviewsPromoButton {
+    color: var(--mantine-color-ldGray-8);
+    padding-inline: 8px;
+    max-width: 100%;
+
+    &:hover {
+        background-color: var(--mantine-color-ldGray-1);
+        color: var(--mantine-color-ldDark-9);
+    }
+}
+
+.reviewsPromoBadge {
+    border-color: var(--mantine-color-ldGray-2);
+    background-color: var(--mantine-color-white);
+    color: var(--mantine-color-ldGray-7);
+    box-shadow: none;
+}
+
 .adminSettingsButtonLabel {
     color: var(--mantine-color-ldGray-7);
 }

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { ProjectType } from '@lightdash/common';
+import { DbtProjectType, ProjectType } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useParams } from 'react-router';
@@ -71,6 +71,10 @@ const Home: FC = () => {
         return <ForbiddenPanel />;
     }
 
+    const isGitHubProject =
+        project.data.type !== ProjectType.PREVIEW &&
+        project.data.dbtConnection.type === DbtProjectType.GITHUB;
+
     return (
         <Page withFixedContent withPaddedContent withFooter>
             <Stack gap="xl">
@@ -93,6 +97,7 @@ const Home: FC = () => {
                         {isAiAgentsEnabled && (
                             <AiSearchBox
                                 projectUuid={project.data.projectUuid}
+                                showAiReviewsPromo={isGitHubProject}
                             />
                         )}
                         <PinnedItemsProvider


### PR DESCRIPTION
## Summary

- Adds an AI Reviews promo CTA into the existing homepage AI search box footer.
- Shows the CTA only for non-preview GitHub projects when AI Reviews are enabled and the user can manage org-level AI agents.
- Links to the Reviews settings page filtered to the current project, with badges for open, PR-ready, and linked PR counts.

## Validation

- `pnpm -F frontend run formatter src/ee/components/Home/AiSearchBox/AiSearchBox.tsx src/ee/components/Home/AiSearchBox/aiSearchBox.module.css src/pages/Home.tsx`
- `pnpm -F frontend run linter src/ee/components/Home/AiSearchBox/AiSearchBox.tsx src/ee/components/Home/AiSearchBox/aiSearchBox.module.css src/pages/Home.tsx`
- `pnpm -F frontend typecheck`