### PR TITLE
feat(backend): warn on sub-day table calcs over cast date dims (GLITCH-506)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5510,3 +5510,80 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
         expect(whereClause).toContain(wrapped);
     });
 });
+
+describe('compileQuery date-grain table calc warnings (GLITCH-506)', () => {
+    // created_at as a day-grain DATE cast of a TIMESTAMP base — the dimension
+    // GLITCH-452 collapses to a real DATE, dropping time-of-day.
+    const exploreWithCastDate: Explore = {
+        ...EXPLORE_WITH_DATE_DIMENSION,
+        tables: {
+            ...EXPLORE_WITH_DATE_DIMENSION.tables,
+            orders: {
+                ...EXPLORE_WITH_DATE_DIMENSION.tables.orders,
+                dimensions: {
+                    ...EXPLORE_WITH_DATE_DIMENSION.tables.orders.dimensions,
+                    created_at: {
+                        ...EXPLORE_WITH_DATE_DIMENSION.tables.orders.dimensions
+                            .created_at,
+                        timeInterval: TimeFrames.DAY,
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                    },
+                },
+            },
+        },
+    };
+
+    const metricQueryWithSubDayTableCalc: CompiledMetricQuery = {
+        ...METRIC_QUERY_WITH_DATE_FILTER,
+        sorts: [],
+        filters: {},
+        tableCalculations: [
+            {
+                name: 'hour_of_day',
+                displayName: 'Hour of day',
+                sql: 'EXTRACT(HOUR FROM ${orders.created_at})',
+            },
+        ],
+        compiledTableCalculations: [
+            {
+                name: 'hour_of_day',
+                displayName: 'Hour of day',
+                sql: 'EXTRACT(HOUR FROM ${orders.created_at})',
+                compiledSql: 'EXTRACT(HOUR FROM "orders_created_at")',
+                dependsOn: ['orders_created_at'],
+            },
+        ],
+    };
+
+    it('surfaces the warning through compileQuery().warnings when the flag is on', () => {
+        const { warnings } = buildQuery({
+            explore: exploreWithCastDate,
+            compiledMetricQuery: metricQueryWithSubDayTableCalc,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            useTimezoneAwareDateTrunc: true,
+        });
+
+        const dateGrainWarning = warnings.find((w) =>
+            /raw timestamp/i.test(w.message),
+        );
+        expect(dateGrainWarning).toBeDefined();
+        expect(dateGrainWarning?.fields).toContain('orders_created_at');
+    });
+
+    it('emits no such warning when the flag is off', () => {
+        const { warnings } = buildQuery({
+            explore: exploreWithCastDate,
+            compiledMetricQuery: metricQueryWithSubDayTableCalc,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            useTimezoneAwareDateTrunc: false,
+        });
+
+        expect(warnings.some((w) => /raw timestamp/i.test(w.message))).toBe(
+            false,
+        );
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -80,6 +80,7 @@ import {
 } from './parameters';
 import {
     assertValidDimensionRequiredAttribute,
+    findDateGrainTableCalcWarnings,
     findMetricInflationWarnings,
     findTablesWithMetricInflation,
     getCustomBinDimensionSql,
@@ -4348,6 +4349,20 @@ export class MetricQueryBuilder {
             }
         }
         warnings.push(...experimentalMetricsCteSQL.warnings);
+
+        try {
+            warnings.push(
+                ...findDateGrainTableCalcWarnings({
+                    tableCalculations: compiledMetricQuery.tableCalculations,
+                    dimensions: this.exploreDimensions,
+                    useTimezoneAwareDateTrunc:
+                        this.args.useTimezoneAwareDateTrunc ?? false,
+                }),
+            );
+        } catch (e) {
+            // Log error but don't block code execution
+            Logger.error('Error during date-grain table calc detection', e);
+        }
 
         // Deduplicated distinct CTE: build separate CTEs for distinct metrics (sum_distinct, average_distinct), joined on dimensions
         const ddMetricIds = this.getSelectedAndReferencedMetricIds().filter(

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -2,13 +2,16 @@ import {
     BinType,
     CompiledExploreJoin,
     CustomDimensionType,
+    DimensionType,
     Explore,
     ForbiddenError,
     isCustomBinDimension,
     JoinRelationship,
     MetricType,
     SupportedDbtAdapter,
+    TimeFrames,
     WeekDay,
+    type TableCalculation,
 } from '@lightdash/common';
 import {
     bigqueryClientMock,
@@ -28,6 +31,7 @@ import {
 import {
     applyLimitToSqlQuery,
     assertValidDimensionRequiredAttribute,
+    findDateGrainTableCalcWarnings,
     findMetricInflationWarnings,
     getCustomBinDimensionSql,
     getCustomSqlDimensionSql,
@@ -1445,5 +1449,115 @@ describe('getJoinedTables', () => {
         const result = getJoinedTables(explore, ['orders', 'users']);
 
         expect(result).toContain('intermediary_table');
+    });
+});
+
+describe('findDateGrainTableCalcWarnings (GLITCH-506)', () => {
+    // A day-or-coarser DATE_TRUNC of a TIMESTAMP base column: this is the
+    // dimension the GLITCH-452 cast collapses to a real DATE (loses time-of-day).
+    const dimensions = {
+        orders_order_date_day: {
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.DAY,
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+            label: 'Order date day',
+        },
+        // A plain string dimension — never a cast target.
+        orders_status: {
+            type: DimensionType.STRING,
+            label: 'Status',
+        },
+    };
+
+    const sqlCalc = (name: string, sql: string): TableCalculation => ({
+        name,
+        displayName: name,
+        sql,
+    });
+
+    it('warns when a sql calc applies sub-day ops to a cast date dimension', () => {
+        const warnings = findDateGrainTableCalcWarnings({
+            tableCalculations: [
+                sqlCalc(
+                    'hours_in',
+                    'EXTRACT(HOUR FROM ${orders.order_date_day})',
+                ),
+            ],
+            dimensions,
+            useTimezoneAwareDateTrunc: true,
+        });
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].fields).toContain('orders_order_date_day');
+        expect(warnings[0].message).toMatch(/raw timestamp/i);
+    });
+
+    it('warns for + interval hours and ::timestamp casts', () => {
+        expect(
+            findDateGrainTableCalcWarnings({
+                tableCalculations: [
+                    sqlCalc(
+                        'shift',
+                        "${orders.order_date_day} + interval '6 hours'",
+                    ),
+                ],
+                dimensions,
+                useTimezoneAwareDateTrunc: true,
+            }),
+        ).toHaveLength(1);
+        expect(
+            findDateGrainTableCalcWarnings({
+                tableCalculations: [
+                    sqlCalc('recast', '${orders.order_date_day}::timestamp'),
+                ],
+                dimensions,
+                useTimezoneAwareDateTrunc: true,
+            }),
+        ).toHaveLength(1);
+    });
+
+    it('does NOT warn for day-or-coarser date math (no spam)', () => {
+        expect(
+            findDateGrainTableCalcWarnings({
+                tableCalculations: [
+                    sqlCalc(
+                        'next_week',
+                        "${orders.order_date_day} + interval '7 days'",
+                    ),
+                    sqlCalc(
+                        'is_nye',
+                        "CASE WHEN ${orders.order_date_day} = '2024-01-01' THEN 1 END",
+                    ),
+                ],
+                dimensions,
+                useTimezoneAwareDateTrunc: true,
+            }),
+        ).toEqual([]);
+    });
+
+    it('does NOT warn when the timezone-aware flag is off', () => {
+        expect(
+            findDateGrainTableCalcWarnings({
+                tableCalculations: [
+                    sqlCalc(
+                        'hours_in',
+                        'EXTRACT(HOUR FROM ${orders.order_date_day})',
+                    ),
+                ],
+                dimensions,
+                useTimezoneAwareDateTrunc: false,
+            }),
+        ).toEqual([]);
+    });
+
+    it('does NOT warn for sub-day ops on a non-cast dimension', () => {
+        expect(
+            findDateGrainTableCalcWarnings({
+                tableCalculations: [
+                    sqlCalc('hours_in', 'EXTRACT(HOUR FROM ${orders.status})'),
+                ],
+                dimensions,
+                useTimezoneAwareDateTrunc: true,
+            }),
+        ).toEqual([]);
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -7,10 +7,12 @@ import {
     CompiledExploreJoin,
     CompiledMetric,
     CompiledTable,
+    convertFieldRefToFieldId,
     CustomBinDimension,
     CustomDimension,
     DbtModelJoinType,
     Dimension,
+    DimensionType,
     Explore,
     FieldId,
     FieldReferenceError,
@@ -27,11 +29,14 @@ import {
     getUserAttributeRegex,
     IntrinsicUserAttributes,
     isCompiledCustomSqlDimension,
+    isSqlTableCalculation,
     JoinRelationship,
+    lightdashVariablePattern,
     MetricType,
     parseAllReferences,
     QueryWarning,
     SupportedDbtAdapter,
+    TableCalculation,
     UserAttributeValueMap,
     WeekDay,
     type WarehouseSqlBuilder,
@@ -1062,6 +1067,106 @@ type FindMetricInflationWarningsProps = {
     baseTable: Explore['baseTable']; // query table
     joinedTables: Set<string>; // query joined tables
     metrics: Pick<CompiledMetric, 'name' | 'table' | 'type' | 'label'>[]; // metrics in query
+};
+
+/**
+ * Time-of-day operations that silently no-op once a day-or-coarser date
+ * dimension is cast to a real DATE (GLITCH-452). The reference is stripped
+ * before matching, so this only catches ops the user wrote, not field names.
+ * Kept tight on purpose: day-or-coarser math (intervals in days/weeks/months,
+ * comparisons, datediff) is unaffected and must not warn.
+ */
+const SUB_DAY_TABLE_CALC_PATTERN =
+    /\b(?:hours?|minutes?|seconds?|milliseconds?|microseconds?|epoch)\b|::\s*(?:timestamp|datetime)|\b(?:timestamp|datetime)_trunc\b|\bas\s+(?:timestamp|datetime)\b/i;
+
+/**
+ * Warns when a SQL table calculation applies a sub-day / time-of-day operation
+ * to a day-or-coarser date dimension that has been cast to a real DATE under
+ * timezone support. The cast drops the time component, so these ops produce
+ * wrong results — the user should reference the raw timestamp dimension.
+ */
+export const findDateGrainTableCalcWarnings = ({
+    tableCalculations,
+    dimensions,
+    useTimezoneAwareDateTrunc,
+}: {
+    tableCalculations: TableCalculation[];
+    dimensions: Record<
+        string,
+        Pick<
+            CompiledDimension,
+            'type' | 'timeIntervalBaseDimensionType' | 'label'
+        >
+    >;
+    useTimezoneAwareDateTrunc: boolean;
+}): QueryWarning[] => {
+    if (!useTimezoneAwareDateTrunc) {
+        return [];
+    }
+
+    const warnings: QueryWarning[] = [];
+
+    tableCalculations.forEach((calc) => {
+        if (!isSqlTableCalculation(calc)) {
+            return;
+        }
+
+        const refs = (calc.sql.match(lightdashVariablePattern) ?? []).map(
+            (match) => match.slice(2, -1), // strip ${ and }
+        );
+
+        const castDateFieldIds = [
+            ...new Set(
+                refs
+                    .map((ref) => {
+                        // A ref is either an already-resolved field id or a
+                        // "table.field" reference that needs converting.
+                        if (dimensions[ref]) {
+                            return ref;
+                        }
+                        try {
+                            return convertFieldRefToFieldId(ref);
+                        } catch {
+                            return null;
+                        }
+                    })
+                    .filter((fieldId): fieldId is string => {
+                        const dim = fieldId ? dimensions[fieldId] : undefined;
+                        // type DATE + TIMESTAMP base = a day-or-coarser trunc
+                        // that GLITCH-452 collapses to a real DATE.
+                        return (
+                            !!dim &&
+                            dim.type === DimensionType.DATE &&
+                            dim.timeIntervalBaseDimensionType ===
+                                DimensionType.TIMESTAMP
+                        );
+                    }),
+            ),
+        ];
+
+        if (castDateFieldIds.length === 0) {
+            return;
+        }
+
+        // Match time-of-day ops on the user-written SQL only (refs stripped).
+        const userSql = calc.sql.replace(lightdashVariablePattern, ' ');
+        if (!SUB_DAY_TABLE_CALC_PATTERN.test(userSql)) {
+            return;
+        }
+
+        const labels = castDateFieldIds
+            .map((fieldId) => dimensions[fieldId]?.label ?? fieldId)
+            .join(', ');
+
+        warnings.push({
+            message: `Table calculation "${
+                calc.displayName || calc.name
+            }" applies a time-of-day operation to date field(s) ${labels}, which are truncated to whole dates when timezone support is enabled. The time component is dropped, so the result may be incorrect — reference the raw timestamp dimension instead.`,
+            fields: castDateFieldIds,
+        });
+    });
+
+    return warnings;
 };
 
 /**


### PR DESCRIPTION
## Problem

When timezone support is enabled, day-or-coarser date dimensions are cast to a real `DATE` at compile time (GLITCH-452), which drops the time-of-day component. A SQL **table calculation** that then applies a sub-day / time-of-day operation to such a dimension goes wrong in one of two ways:

- **Hard error** — e.g. `EXTRACT(HOUR FROM ${order_date_day})` → the warehouse rejects it (`unit "hour" not supported for type date`).
- **Silent corruption** — e.g. `${order_date_day} + interval '6 hours'` → executes fine but every row becomes a constant `…T06:00:00` because 6h is added to *midnight* of the cast date. No error to tip the user off.

## Fix

Add a query warning, surfaced in the Explorer warnings popover, telling the user to reference the raw timestamp dimension instead.

- `findDateGrainTableCalcWarnings` — **tight heuristic** (the `${…}` references are stripped before matching, so field names can't false-trigger). Fires only when a `sql` table calc applies a sub-day token (`hour/minute/second/ms`, `::timestamp`, `*_trunc`, `as timestamp`) to a dimension that is `type DATE` with a `TIMESTAMP` base. Silent on day-or-coarser math (`interval '7 days'`), comparisons, datediff, and plain references. Gated on the timezone flag.
- Wired into the **live** `compileQuery()` warnings path — not the orphaned `getWarnings` — with an integration test through `compileQuery().warnings` so dead wiring can't regress.

## Testing

- Unit tests for the heuristic (fire / no-spam / flag-off / non-cast dim).
- Integration test through `compileQuery().warnings` (verified it goes red without the wiring).
- Reproduced in-browser against the `timezone_test` explore (flag on): hard-error case, silent-corruption case (warning + results coexist), and confirmed no false positives on day-level / plain-reference calcs via the live API.

Closes: GLITCH-506