### PR TITLE
fix(gsheets): stop re-running the query when an export fails, and surface a clear error

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1139,9 +1139,7 @@ export class SchedulerClient {
             payload,
             now,
             JobPriority.HIGH,
-            // Single attempt: a job-level retry would re-run the (often slow) warehouse
-            // query. The query step is terminal on failure; only the upload is retried,
-            // in-process, by the task itself.
+            // Single attempt: a retry would re-run the slow warehouse query.
             1,
         );
 

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1139,7 +1139,10 @@ export class SchedulerClient {
             payload,
             now,
             JobPriority.HIGH,
-            3,
+            // Single attempt: a job-level retry would re-run the (often slow) warehouse
+            // query. The query step is terminal on failure; only the upload is retried,
+            // in-process, by the task itself.
+            1,
         );
 
         await this.schedulerModel.logSchedulerJob({

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1,5 +1,8 @@
 import {
     FieldReferenceError,
+    ForbiddenError,
+    GoogleSheetsQuotaError,
+    GoogleSheetsTransientError,
     NotEnoughResults,
     ThresholdOperator,
 } from '@lightdash/common';
@@ -7,6 +10,8 @@ import ExecutionContext from 'node-execution-context';
 import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
     buildSchedulerLogContext,
+    GSHEET_UPLOAD_MAX_ATTEMPTS,
+    retryTransientGoogleSheetsWrite,
     setSchedulerJobLogContext,
 } from './SchedulerTask';
 import {
@@ -16,6 +21,12 @@ import {
     thresholdIncreasedByMock,
     thresholdLessThanMock,
 } from './SchedulerTask.mock';
+
+jest.mock('@lightdash/common', () => ({
+    ...jest.requireActual('@lightdash/common'),
+    // Skip real backoff delays so the retry loop runs instantly.
+    sleep: jest.fn().mockResolvedValue(undefined),
+}));
 
 describe('buildSchedulerLogContext', () => {
     it('returns null when no attribution fields are set', () => {
@@ -456,5 +467,47 @@ describe('evaluateThreshold', () => {
                 [{ m: 100 }],
             ),
         ).toThrow(FieldReferenceError);
+    });
+});
+
+describe('retryTransientGoogleSheetsWrite', () => {
+    it('writes once and resolves when the upload succeeds', async () => {
+        const write = jest.fn().mockResolvedValue(undefined);
+
+        await retryTransientGoogleSheetsWrite(write);
+
+        expect(write).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a transient Google error and succeeds without re-running the query', async () => {
+        const write = jest
+            .fn()
+            .mockRejectedValueOnce(new GoogleSheetsTransientError())
+            .mockResolvedValueOnce(undefined);
+
+        await retryTransientGoogleSheetsWrite(write);
+
+        // The query is not part of `write` — only the upload step retries.
+        expect(write).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after the max attempts when the transient error persists', async () => {
+        const write = jest.fn().mockRejectedValue(new GoogleSheetsQuotaError());
+
+        await expect(retryTransientGoogleSheetsWrite(write)).rejects.toThrow(
+            GoogleSheetsQuotaError,
+        );
+        expect(write).toHaveBeenCalledTimes(GSHEET_UPLOAD_MAX_ATTEMPTS);
+    });
+
+    it('does not retry a non-transient error', async () => {
+        const write = jest
+            .fn()
+            .mockRejectedValue(new ForbiddenError('no access'));
+
+        await expect(retryTransientGoogleSheetsWrite(write)).rejects.toThrow(
+            ForbiddenError,
+        );
+        expect(write).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -276,9 +276,6 @@ export function setSchedulerJobLogContext(
 export const GSHEET_UPLOAD_MAX_ATTEMPTS = 3;
 const GSHEET_UPLOAD_RETRY_BASE_MS = 2000;
 
-// Retries only the Google Sheets write step on transient Google errors. The query
-// results are passed in already-resolved, so a retry here never re-runs the warehouse
-// query — unlike a job-level retry, which would re-execute everything.
 export async function retryTransientGoogleSheetsWrite(
     write: () => Promise<void>,
     attempt = 1,
@@ -2385,6 +2382,8 @@ export default class SchedulerTask {
             fileType: SchedulerFormat.GSHEETS,
         };
 
+        let failureStage: 'query' | 'upload' = 'query';
+
         try {
             if (!this.googleDriveClient.isEnabled) {
                 throw new Error(
@@ -2451,6 +2450,8 @@ export default class SchedulerTask {
                 SCHEDULER_POLLING_OPTIONS,
             );
 
+            failureStage = 'upload';
+
             const refreshToken = await this.userService.getRefreshToken(
                 payload.userUuid,
             );
@@ -2502,12 +2503,18 @@ export default class SchedulerTask {
                 properties: analyticsProperties,
             });
         } catch (e) {
+            const userFacingError =
+                failureStage === 'query'
+                    ? "This export couldn't be completed because the query took too long or failed."
+                    : "We couldn't write the results to Google Sheets.";
+
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
                 status: SchedulerJobStatus.ERROR,
                 details: {
                     createdByUserUuid: payload.userUuid,
                     error: getErrorMessage(e),
+                    userFacingError,
                     projectUuid: payload.projectUuid,
                     organizationUuid: payload.organizationUuid,
                 },
@@ -2523,9 +2530,6 @@ export default class SchedulerTask {
         }
     }
 
-    // Writes already-resolved query results to the Google Sheet, retrying only the
-    // upload on transient Google errors. The query has already run by this point, so
-    // retries never re-execute it.
     private async uploadResultsToGoogleSheet({
         refreshToken,
         spreadsheetId,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -35,6 +35,8 @@ import {
     getRequestMethod,
     getSchedulerResourceTypeAndId,
     getSchedulerUuid,
+    GoogleSheetsQuotaError,
+    GoogleSheetsTransientError,
     GsheetsNotificationPayload,
     isChartScheduler,
     isChartValidationError,
@@ -83,6 +85,7 @@ import {
     setUuidParam,
     SlackInstallationNotFoundError,
     SlackNotificationPayload,
+    sleep,
     SqlRunnerPayload,
     SqlRunnerPivotQueryPayload,
     SyncSlackChannelsPayload,
@@ -104,12 +107,14 @@ import {
     type EmailBatchNotificationPayload,
     type GoogleChatBatchNotificationPayload,
     type GoogleChatNotificationPayload,
+    type ItemsMap,
     type MaterializePreAggregatePayload,
     type MetricQuery,
     type MsTeamsBatchNotificationPayload,
     type MsTeamsNotificationPayload,
     type PartialFailure,
     type PivotConfiguration,
+    type ReadyQueryResultsPage,
     type SchedulerIndexCatalogJobPayload,
     type SlackBatchNotificationPayload,
 } from '@lightdash/common';
@@ -266,6 +271,30 @@ export function setSchedulerJobLogContext(
     const scheduler = buildSchedulerLogContext(args);
     if (!scheduler) return;
     update({ scheduler });
+}
+
+export const GSHEET_UPLOAD_MAX_ATTEMPTS = 3;
+const GSHEET_UPLOAD_RETRY_BASE_MS = 2000;
+
+// Retries only the Google Sheets write step on transient Google errors. The query
+// results are passed in already-resolved, so a retry here never re-runs the warehouse
+// query — unlike a job-level retry, which would re-execute everything.
+export async function retryTransientGoogleSheetsWrite(
+    write: () => Promise<void>,
+    attempt = 1,
+): Promise<void> {
+    try {
+        await write();
+    } catch (e) {
+        const isTransient =
+            e instanceof GoogleSheetsTransientError ||
+            e instanceof GoogleSheetsQuotaError;
+        if (!isTransient || attempt >= GSHEET_UPLOAD_MAX_ATTEMPTS) {
+            throw e;
+        }
+        await sleep(GSHEET_UPLOAD_RETRY_BASE_MS * attempt);
+        await retryTransientGoogleSheetsWrite(write, attempt + 1);
+    }
 }
 
 export default class SchedulerTask {
@@ -2435,50 +2464,15 @@ export default class SchedulerTask {
                 throw new Error('Unable to create new sheet');
             }
 
-            if (payload.pivotConfig) {
-                if (!pivotDetails) {
-                    throw new UnexpectedServerError(
-                        'Cannot export pivoted results without SQL pivot details',
-                    );
-                }
-                // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
-                const formattedRows = formatRows(
-                    rows,
-                    itemMap,
-                    undefined,
-                    undefined,
-                    displayTimezone ?? undefined,
-                );
-
-                const pivotedResults = pivotResultsAsCsv({
-                    pivotConfig: payload.pivotConfig,
-                    rows: formattedRows,
-                    itemMap,
-                    customLabels: payload.customLabels,
-                    onlyRaw: true,
-                    pivotDetails,
-                    timezone: displayTimezone ?? undefined,
-                });
-
-                await this.googleDriveClient.appendCsvToSheet(
-                    refreshToken,
-                    spreadsheetId,
-                    pivotedResults,
-                );
-            } else {
-                await this.googleDriveClient.appendToSheet(
-                    refreshToken,
-                    spreadsheetId,
-                    rows,
-                    itemMap,
-                    payload.showTableNames,
-                    undefined, // tabName
-                    payload.columnOrder,
-                    payload.customLabels,
-                    payload.hiddenFields,
-                    displayTimezone ?? undefined,
-                );
-            }
+            await this.uploadResultsToGoogleSheet({
+                refreshToken,
+                spreadsheetId,
+                rows,
+                itemMap,
+                pivotDetails,
+                displayTimezone,
+                payload,
+            });
 
             const { csvCellsLimit } = await resolveOrganizationExportLimits(
                 this.organizationSettingsModel,
@@ -2527,6 +2521,77 @@ export default class SchedulerTask {
 
             throw e;
         }
+    }
+
+    // Writes already-resolved query results to the Google Sheet, retrying only the
+    // upload on transient Google errors. The query has already run by this point, so
+    // retries never re-execute it.
+    private async uploadResultsToGoogleSheet({
+        refreshToken,
+        spreadsheetId,
+        rows,
+        itemMap,
+        pivotDetails,
+        displayTimezone,
+        payload,
+    }: {
+        refreshToken: string;
+        spreadsheetId: string;
+        rows: Record<string, unknown>[];
+        itemMap: ItemsMap;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
+        payload: UploadMetricGsheetPayload;
+    }): Promise<void> {
+        if (payload.pivotConfig) {
+            if (!pivotDetails) {
+                throw new UnexpectedServerError(
+                    'Cannot export pivoted results without SQL pivot details',
+                );
+            }
+            // pivotResultsAsCsv expects a formatted ResultRow[] type, so we need to convert it first
+            const formattedRows = formatRows(
+                rows,
+                itemMap,
+                undefined,
+                undefined,
+                displayTimezone ?? undefined,
+            );
+
+            const pivotedResults = pivotResultsAsCsv({
+                pivotConfig: payload.pivotConfig,
+                rows: formattedRows,
+                itemMap,
+                customLabels: payload.customLabels,
+                onlyRaw: true,
+                pivotDetails,
+                timezone: displayTimezone ?? undefined,
+            });
+
+            await retryTransientGoogleSheetsWrite(() =>
+                this.googleDriveClient.appendCsvToSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    pivotedResults,
+                ),
+            );
+            return;
+        }
+
+        await retryTransientGoogleSheetsWrite(() =>
+            this.googleDriveClient.appendToSheet(
+                refreshToken,
+                spreadsheetId,
+                rows,
+                itemMap,
+                payload.showTableNames,
+                undefined, // tabName
+                payload.columnOrder,
+                payload.customLabels,
+                payload.hiddenFields,
+                displayTimezone ?? undefined,
+            ),
+        );
     }
 
     protected async sendEmailNotification(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1354,7 +1354,8 @@ export class SchedulerService extends BaseService {
         }
         if (job.status === 'error') {
             throw new NotFoundError(
-                job.details?.error ?? 'Unable to download CSV',
+                job.details?.userFacingError ??
+                    'This export could not be completed.',
             );
         }
         return job;


### PR DESCRIPTION
Closes: #24397

### Description

A Google Sheets export ran the warehouse query and the upload inside a single background job enqueued with `maxAttempts: 3`. Any failure re-ran the whole job — re-executing the (sometimes slow) warehouse query each time — so a slow query turned into a long sequence of repeated executions that usually still failed, while tripling warehouse load.

This PR:

- **Stops re-execution on failure** — the export job is now a single attempt (`maxAttempts: 1`). A slow/failed query is terminal rather than re-run.
- **Retries only the upload** — the Google Sheets write is retried in-process on transient Google errors, where the results are already in memory, so a retry never re-runs the query. The pivot-vs-flat upload is encapsulated in a private method so the main flow stays unaware of retries.
- **Clearer failure** — on failure the user is shown a short message ("the query took too long or failed" / "couldn't write the results to Google Sheets"). The raw error is preserved for engineers in the worker logs, Sentry, and `scheduler_log.details.error`.
