### PR TITLE
fix(ai-writeback): surface GitHub write-permission failures as actionable guidance

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -2,6 +2,7 @@ import {
     AlreadyExistsError,
     ForbiddenError,
     getErrorMessage,
+    InsufficientGitPermissionsError,
     LightdashError,
     NotFoundError,
     ParameterError,
@@ -555,6 +556,25 @@ export const getRepoWorkflowFiles = async ({
     }
 };
 
+// A 403 permission denial on a Git write means the repo credentials lack write
+// access (terminal) → InsufficientGitPermissionsError; anything else stays an
+// UnexpectedGitError. REST errors carry `status`, GraphQL only the message.
+const toGitWriteError = (error: unknown): LightdashError => {
+    const message = getErrorMessage(error);
+    const status =
+        error instanceof Error && 'status' in error
+            ? (error as { status?: number }).status
+            : undefined;
+    const isPermissionDenied =
+        message.includes('Resource not accessible by integration') ||
+        (status === 403 &&
+            /permission|not accessible|forbidden|write access/i.test(message));
+    if (isPermissionDenied) {
+        return new InsufficientGitPermissionsError(message);
+    }
+    return new UnexpectedGitError(message);
+};
+
 export const createBranch = async ({
     owner,
     repo,
@@ -586,7 +606,7 @@ export const createBranch = async ({
         });
         return response;
     } catch (error) {
-        throw new UnexpectedGitError(getErrorMessage(error));
+        throw toGitWriteError(error);
     }
 };
 export const getBranchHeadSha = async ({
@@ -749,7 +769,7 @@ export const createSignedCommitOnBranch = async ({
         });
         return response.createCommitOnBranch.commit;
     } catch (e) {
-        throw new UnexpectedGitError(getErrorMessage(e));
+        throw toGitWriteError(e);
     }
 };
 
@@ -972,7 +992,7 @@ export const createPullRequest = async ({
 
         return response.data;
     } catch (e) {
-        throw new UnexpectedGitError(getErrorMessage(e));
+        throw toGitWriteError(e);
     }
 };
 
@@ -1007,7 +1027,7 @@ export const updatePullRequest = async ({
 
         return response.data;
     } catch (e) {
-        throw new UnexpectedGitError(getErrorMessage(e));
+        throw toGitWriteError(e);
     }
 };
 

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3652,6 +3652,7 @@ Parameters:
                         "gitlab_not_installed",
                         "unsupported_source_control",
                         "pull_request_not_open",
+                        "git_write_permission",
                         "unknown",
                       ],
                       "type": "string",

--- a/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
+++ b/packages/backend/src/ee/services/ai/tools/editDbtProject.ts
@@ -1,5 +1,6 @@
 import {
     editDbtProjectToolDefinition,
+    InsufficientGitPermissionsError,
     PullRequestProvider,
 } from '@lightdash/common';
 import { tool } from 'ai';
@@ -20,7 +21,19 @@ type WritebackErrorCode =
     | 'gitlab_not_installed'
     | 'unsupported_source_control'
     | 'pull_request_not_open'
+    | 'git_write_permission'
     | 'unknown';
+
+// Sent to the agent on a 403 branch-creation failure: explains the fix and
+// tells it not to retry.
+const GIT_WRITE_PERMISSION_AGENT_MESSAGE = [
+    'The change was prepared, but no pull request could be opened: this project’s Git connection does not have permission to create a branch (the host returned "Resource not accessible by integration").',
+    'This is a one-time setup fix, NOT a transient error — do NOT retry, it will keep failing until the connection is fixed.',
+    'Tell the user that an admin needs to either:',
+    '1. Reconnect the dbt project to GitHub via the GitHub App (Project Settings → dbt connection → GitHub) instead of a personal access token. This is the recommended fix; or',
+    '2. If they keep the personal access token, grant it write access to the repository (Contents: Read & write and Pull requests: Read & write).',
+    'Once that is done they can ask you to try again. In the meantime, offer to give them the exact YAML patch to paste in manually so they are not blocked.',
+].join('\n');
 
 // Map a thrown writeback error to the metadata code the chat card renders.
 // A not-connected error carries the expected git host, so the card can offer
@@ -38,6 +51,9 @@ const classifyWritebackError = (error: unknown): WritebackErrorCode => {
     }
     if (error instanceof WritebackThreadPrClosedError) {
         return 'pull_request_not_open';
+    }
+    if (error instanceof InsufficientGitPermissionsError) {
+        return 'git_write_permission';
     }
     return 'unknown';
 };
@@ -118,6 +134,17 @@ export const getEditDbtProject = ({ editDbtProject }: Dependencies) =>
                         metadata: {
                             status: 'error' as const,
                             errorCode: 'pull_request_not_open' as const,
+                        },
+                    };
+                }
+                // Terminal write-permission failure: relay the fix verbatim, no
+                // retry suffix, no Sentry noise.
+                if (error instanceof InsufficientGitPermissionsError) {
+                    return {
+                        result: GIT_WRITE_PERMISSION_AGENT_MESSAGE,
+                        metadata: {
+                            status: 'error' as const,
+                            errorCode: 'git_write_permission' as const,
                         },
                     };
                 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13983,6 +13983,12 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: [
+                                                                'git_write_permission',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: [null],
                                                         },
                                                         {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14904,6 +14904,7 @@
                                                             "gitlab_not_installed",
                                                             "unsupported_source_control",
                                                             "pull_request_not_open",
+                                                            "git_write_permission",
                                                             null
                                                         ],
                                                         "nullable": true

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -84,6 +84,7 @@ export const toolEditDbtProjectOutputSchema = z.object({
                     'gitlab_not_installed',
                     'unsupported_source_control',
                     'pull_request_not_open',
+                    'git_write_permission',
                     'unknown',
                 ])
                 .nullish(),

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -185,6 +185,28 @@ export class UnexpectedGitError extends LightdashError {
     }
 }
 
+/**
+ * Thrown when a Git write operation (create branch, commit, open/update PR) is
+ * rejected because the credentials backing the connection lack write access —
+ * e.g. GitHub returns 403 "Resource not accessible by integration". This is a
+ * terminal setup problem (a personal access token without write scope, or a
+ * GitHub App installation missing Contents/Pull-requests write), not a transient
+ * failure, so callers should surface a one-time fix rather than retry.
+ */
+export class InsufficientGitPermissionsError extends LightdashError {
+    constructor(
+        message = 'The Git connection does not have write access to this repository',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'InsufficientGitPermissionsError',
+            statusCode: 403,
+            data,
+        });
+    }
+}
+
 export class UnexpectedDatabaseError extends LightdashError {
     constructor(
         message = 'Unexpected error in Lightdash database.',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
@@ -13,7 +13,6 @@ import {
     ThemeIcon,
 } from '@mantine-8/core';
 import {
-    IconAlertTriangle,
     IconBrandGithub,
     IconBrandGitlab,
     IconCheck,
@@ -480,29 +479,12 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                 </Paper>
             );
         }
-        return (
-            <Paper withBorder p="sm" radius="md" bg="red.0">
-                <Group gap="xs" align="center" wrap="nowrap">
-                    <ThemeIcon
-                        variant="light"
-                        color="red"
-                        radius="md"
-                        size="md"
-                    >
-                        <MantineIcon icon={IconAlertTriangle} size={16} />
-                    </ThemeIcon>
-                    <Stack gap={0}>
-                        <Text size="sm" fw={500} c="red.7">
-                            Writeback failed
-                        </Text>
-                        <Text size="xs" c="red.6">
-                            The agent's run hit an error and no pull request was
-                            opened.
-                        </Text>
-                    </Stack>
-                </Group>
-            </Paper>
-        );
+        // Any other error (e.g. a write-permission 403, or an unclassified
+        // failure): the agent's own reply already explains what went wrong and,
+        // where relevant, how to fix it — so a separate red "Writeback failed"
+        // card would only duplicate that prose without adding an action. Render
+        // nothing and let the agent's message carry the explanation.
+        return null;
     }
 
     if (!metadata.prUrl) {


### PR DESCRIPTION
## What & why

When AI writeback (`editDbtProject`) fails because the project's Git connection lacks write access, GitHub rejects the branch-creation step (`POST /git/refs`) with **`Resource not accessible by integration`**. This is a one-time setup problem (a PAT or App installation without `Contents: write` + `Pull requests: write`), not a transient error.

Previously it surfaced as a generic `UnexpectedGitError` → `errorCode: 'unknown'`, so:
- the agent was told *"Try again if you believe the error can be resolved"* — but retrying **always** fails;
- the chat UI rendered a generic red **"Writeback failed"** card that just duplicated the agent's prose.

## Changes

- **`common`** — new `InsufficientGitPermissionsError` (403) + new shared tool errorCode `git_write_permission`.
- **`Github.ts`** — `toGitWriteError()` maps a 403 permission denial to the new error across all four write ops (create branch, signed commit, create/update PR); everything else stays `UnexpectedGitError`. Guards against false positives (404, secondary rate-limit 403).
- **`editDbtProject.ts`** — classifies the new error and returns one-time-fix guidance **verbatim** (no Sentry capture, no "try again"): reconnect via the GitHub App (recommended) or grant the PAT write scopes, plus an offer to paste the manual YAML patch. Mirrors the existing terminal `WritebackThreadPrClosedError` pattern.
- **Frontend** — removes the generic red "Writeback failed" card; the agent's own reply already explains the failure. Action-bearing cards (install app, edit connection, closed PR) are kept.
- Regenerated OpenAPI spec for the new enum value.

## Testing

Reproduced end-to-end through the chat UI by temporarily injecting the exact GitHub 403 at branch creation:
- tool result metadata: `{"status":"error","errorCode":"git_write_permission"}`
- the agent articulated the fix (both admin options + the manual YAML patch + *"ask me to try again"*)
- **no red error card** rendered — only the agent's prose

Backend typecheck, lint on all changed files, and `common` rebuild all pass.

Closes: PROD-8349

🤖 Generated with [Claude Code](https://claude.com/claude-code)