### PR TITLE
feat: gsheets sync from data apps

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -9,6 +9,7 @@ import {
     MissingConfigError,
     OauthAuthenticationError,
     UnexpectedServerError,
+    UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import flash from 'connect-flash';
@@ -369,6 +370,14 @@ export default class App {
             );
         }
 
+        // Raise body-parser limit for the data-apps gsheet export route only.
+        // Must run BEFORE the global parser below — `express.json()` is a no-op
+        // when `req.body` is already populated, so whichever parser sees the
+        // request first wins.
+        expressApp.use(
+            '/api/v1/gdrive/upload-gsheet-from-rows',
+            express.json({ limit: UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES }),
+        );
         expressApp.use(
             express.json({ limit: this.lightdashConfig.maxPayloadSize }),
         );

--- a/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
@@ -3,6 +3,26 @@ import { GoogleDriveClient } from './GoogleDriveClient';
 
 describe('GoogleDriveClient', () => {
     describe('formatRow', () => {
+        test('should defuse spreadsheet formula injection', () => {
+            // Leading =, @, tab, and CR are unambiguous formula-injection
+            // vectors when a viewer edits and re-enters the cell. Prefix with
+            // a single quote to keep the cell literal.
+            expect(GoogleDriveClient.formatCell('=HYPERLINK("evil")')).toEqual(
+                `'=HYPERLINK("evil")`,
+            );
+            expect(GoogleDriveClient.formatCell('@SUM(A1:A10)')).toEqual(
+                "'@SUM(A1:A10)",
+            );
+            expect(GoogleDriveClient.formatCell('\t=A1')).toEqual("'\t=A1");
+            expect(GoogleDriveClient.formatCell('\r=A1')).toEqual("'\r=A1");
+            // Leading - / + are NOT sanitised — negative numeric strings like
+            // "-100" are extremely common and would otherwise be mangled.
+            expect(GoogleDriveClient.formatCell('-100')).toEqual('-100');
+            expect(GoogleDriveClient.formatCell('+0.5')).toEqual('+0.5');
+            // Embedded = / @ are safe; only leading characters matter.
+            expect(GoogleDriveClient.formatCell('a=b')).toEqual('a=b');
+        });
+
         test('should format values', async () => {
             expect(GoogleDriveClient.formatCell(1)).toEqual(1);
             expect(GoogleDriveClient.formatCell(1.99)).toEqual(1.99);

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -372,6 +372,16 @@ export class GoogleDriveClient {
                     formattedValue.substring(0, TRUNCATE_INDEX) +
                     TRUNCATION_SUFFIX;
             }
+            // Defuse spreadsheet formula injection. With valueInputOption: 'RAW'
+            // these are stored as text on write, but Sheets re-parses them as
+            // formulas the moment a viewer edits and re-enters the cell — a
+            // common CSV-injection vector. We prefix a single quote so the
+            // cell stays a literal string. Skip leading `-`/`+` because
+            // negative/signed numeric strings are extremely common and
+            // legitimate.
+            if (/^[=@\t\r]/.test(formattedValue)) {
+                formattedValue = `'${formattedValue}`;
+            }
         }
 
         return formattedValue;

--- a/packages/backend/src/controllers/googleDriveController.ts
+++ b/packages/backend/src/controllers/googleDriveController.ts
@@ -3,6 +3,7 @@ import {
     ApiGdriveAccessTokenResponse,
     ApiJobScheduledResponse,
     assertRegisteredAccount,
+    UploadGsheetFromRows,
     UploadMetricGsheet,
 } from '@lightdash/common';
 import {
@@ -68,6 +69,29 @@ export class GoogleDriveController extends BaseController {
             results: await req.services
                 .getGdriveService()
                 .scheduleUploadGsheet(req.account!, body),
+        };
+    }
+
+    /**
+     * Upload client-supplied rows to a new Google Sheet (data apps).
+     * @summary Upload rows to Google Sheet
+     * @param req express request
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/upload-gsheet-from-rows')
+    @OperationId('uploadGsheetFromRows')
+    async postFromRows(
+        @Body() body: UploadGsheetFromRows,
+        @Request() req: express.Request,
+    ): Promise<ApiJobScheduledResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await req.services
+                .getGdriveService()
+                .scheduleUploadGsheetFromRows(req.account, body),
         };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -12725,11 +12725,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12886,13 +12886,13 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13167,13 +13167,13 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -13480,18 +13480,13 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldId:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -13516,6 +13511,11 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -13781,6 +13781,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13847,77 +13918,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['updated'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -14012,11 +14012,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14077,11 +14077,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14142,11 +14142,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14236,13 +14236,13 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -14323,11 +14323,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14342,11 +14342,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14361,11 +14361,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14380,11 +14380,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -29313,7 +29313,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29323,7 +29323,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29333,7 +29333,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29346,7 +29346,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30001,7 +30001,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30011,7 +30011,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30021,7 +30021,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30034,7 +30034,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -33473,6 +33473,82 @@ const models: TsoaRoute.Models = {
                 showTableNames: { dataType: 'boolean', required: true },
                 metricQuery: { ref: 'MetricQueryResponse', required: true },
                 exploreId: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GsheetColumnType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['string'] },
+                { dataType: 'enum', enums: ['number'] },
+                { dataType: 'enum', enums: ['date'] },
+                { dataType: 'enum', enums: ['timestamp'] },
+                { dataType: 'enum', enums: ['boolean'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GsheetColumn: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                type: { ref: 'GsheetColumnType' },
+                label: { dataType: 'string' },
+                key: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.string-or-number-or-boolean-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'string' },
+                    { dataType: 'double' },
+                    { dataType: 'boolean' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GsheetRow: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Record_string.string-or-number-or-boolean-or-null_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UploadGsheetFromRows: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                rows: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GsheetRow' },
+                    required: true,
+                },
+                columns: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'GsheetColumn' },
+                    required: true,
+                },
+                title: { dataType: 'string', required: true },
                 projectUuid: { dataType: 'string', required: true },
             },
             validators: {},
@@ -67074,6 +67150,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'post',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsGoogleDriveController_postFromRows: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UploadGsheetFromRows',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/gdrive/upload-gsheet-from-rows',
+        ...fetchMiddlewares<RequestHandler>(GoogleDriveController),
+        ...fetchMiddlewares<RequestHandler>(
+            GoogleDriveController.prototype.postFromRows,
+        ),
+
+        async function GoogleDriveController_postFromRows(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsGoogleDriveController_postFromRows,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<GoogleDriveController>(
+                        GoogleDriveController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'postFromRows',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14316,6 +14316,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14346,10 +14359,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -14360,8 +14373,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
                                                                         "fieldType",
+                                                                        "tableName",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -14471,10 +14484,10 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
@@ -14485,8 +14498,8 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "tableName",
                                                                                     "fieldType",
+                                                                                    "tableName",
                                                                                     "label",
                                                                                     "name"
                                                                                 ],
@@ -14638,18 +14651,18 @@
                                                                                 "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
@@ -14659,10 +14672,10 @@
                                                                                 "fieldFilterType",
                                                                                 "fieldType",
                                                                                 "table",
-                                                                                "label",
                                                                                 "fieldId",
-                                                                                "name",
-                                                                                "description"
+                                                                                "label",
+                                                                                "description",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -14815,6 +14828,32 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14840,32 +14879,6 @@
                                                             "updated",
                                                             null
                                                         ],
-                                                        "nullable": true
-                                                    },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "label": {
-                                                                    "type": "string"
-                                                                },
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "label",
-                                                                "kind"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
                                                         "nullable": true
                                                     },
                                                     "prUrl": {
@@ -14939,8 +14952,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14983,10 +14996,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -14997,8 +15010,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "tableName",
                                                                         "fieldType",
+                                                                        "tableName",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -30058,22 +30071,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30633,22 +30646,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -34002,6 +34015,72 @@
                     "exploreId",
                     "projectUuid"
                 ],
+                "type": "object"
+            },
+            "GsheetColumnType": {
+                "type": "string",
+                "enum": ["string", "number", "date", "timestamp", "boolean"]
+            },
+            "GsheetColumn": {
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/GsheetColumnType"
+                    },
+                    "label": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    }
+                },
+                "required": ["key"],
+                "type": "object"
+            },
+            "Record_string.string-or-number-or-boolean-or-null_": {
+                "properties": {},
+                "additionalProperties": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number",
+                            "format": "double"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "nullable": true
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "GsheetRow": {
+                "$ref": "#/components/schemas/Record_string.string-or-number-or-boolean-or-null_"
+            },
+            "UploadGsheetFromRows": {
+                "properties": {
+                    "rows": {
+                        "items": {
+                            "$ref": "#/components/schemas/GsheetRow"
+                        },
+                        "type": "array"
+                    },
+                    "columns": {
+                        "items": {
+                            "$ref": "#/components/schemas/GsheetColumn"
+                        },
+                        "type": "array"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["rows", "columns", "title", "projectUuid"],
                 "type": "object"
             },
             "GithubUserCredential": {
@@ -39673,7 +39752,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3184.0",
+        "version": "0.3185.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -58257,6 +58336,48 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UploadMetricGsheet"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/gdrive/upload-gsheet-from-rows": {
+            "post": {
+                "operationId": "uploadGsheetFromRows",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiJobScheduledResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Upload client-supplied rows to a new Google Sheet (data apps).",
+                "summary": "Upload rows to Google Sheet",
+                "tags": ["Integrations"],
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UploadGsheetFromRows"
                             }
                         }
                     }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -46,6 +46,7 @@ import {
     SyncSlackChannelsPayload,
     TaskPayloadMap,
     TraceTaskBase,
+    UploadGsheetFromRowsPayload,
     UploadMetricGsheetPayload,
     ValidateProjectPayload,
     type DownloadAsyncQueryResultsPayload,
@@ -1154,6 +1155,35 @@ export class SchedulerClient {
                 exploreId: payload.exploreId,
                 metricQuery: payload.metricQuery,
                 organizationUuid: payload.organizationUuid,
+            },
+        });
+
+        return { jobId };
+    }
+
+    async uploadGsheetFromRowsJob(payload: UploadGsheetFromRowsPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY,
+            payload,
+            now,
+            JobPriority.HIGH,
+            3,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                createdByUserUuid: payload.userUuid,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+                title: payload.title,
+                rowCount: payload.rows.length,
             },
         });
 

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -1,14 +1,19 @@
 import {
+    DimensionType,
     FieldReferenceError,
+    FieldType,
     ForbiddenError,
     GoogleSheetsQuotaError,
     GoogleSheetsTransientError,
+    MetricType,
     NotEnoughResults,
     ThresholdOperator,
+    type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
 import type { ExecutionContextInfo } from '../logging/winston';
 import SchedulerTask, {
+    buildItemMapFromColumns,
     buildSchedulerLogContext,
     GSHEET_UPLOAD_MAX_ATTEMPTS,
     retryTransientGoogleSheetsWrite,
@@ -522,5 +527,171 @@ describe('retryTransientGoogleSheetsWrite', () => {
         await retryTransientGoogleSheetsWrite(write, onRetry);
 
         expect(onRetry.mock.calls).toEqual([[2], [3]]);
+    });
+});
+
+describe('buildItemMapFromColumns', () => {
+    it('maps a string column to a DIMENSION with STRING type', () => {
+        const result = buildItemMapFromColumns([
+            { key: 'name', label: 'Full Name', type: 'string' },
+        ]);
+        expect(result.name).toMatchObject({
+            name: 'name',
+            label: 'Full Name',
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.STRING,
+        });
+    });
+
+    it('maps a number column to a METRIC with NUMBER type', () => {
+        const result = buildItemMapFromColumns([
+            { key: 'revenue', type: 'number' },
+        ]);
+        expect(result.revenue).toMatchObject({
+            name: 'revenue',
+            label: 'revenue',
+            fieldType: FieldType.METRIC,
+            type: MetricType.NUMBER,
+        });
+    });
+
+    it('maps date, timestamp, and boolean column types correctly', () => {
+        const result = buildItemMapFromColumns([
+            { key: 'd', type: 'date' },
+            { key: 'ts', type: 'timestamp' },
+            { key: 'flag', type: 'boolean' },
+        ]);
+        expect(result.d).toMatchObject({
+            type: DimensionType.DATE,
+        });
+        expect(result.ts).toMatchObject({
+            type: DimensionType.TIMESTAMP,
+        });
+        expect(result.flag).toMatchObject({
+            type: DimensionType.BOOLEAN,
+        });
+    });
+
+    it('falls back to STRING type when column type is undefined', () => {
+        const result = buildItemMapFromColumns([{ key: 'misc' }]);
+        expect(result.misc).toMatchObject({
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.STRING,
+        });
+    });
+
+    it('uses key as label when label is absent', () => {
+        const result = buildItemMapFromColumns([{ key: 'col1' }]);
+        expect(result.col1).toMatchObject({ label: 'col1' });
+    });
+});
+
+describe('uploadGsheetFromQuery — rows branch', () => {
+    // SchedulerTask has 20+ constructor dependencies. We create minimal mocks
+    // for only the services touched by the rows branch.
+
+    const makeTask = (
+        overrides: Partial<ConstructorParameters<typeof SchedulerTask>[0]> = {},
+    ) => {
+        const stub = {} as ConstructorParameters<typeof SchedulerTask>[0];
+        const task = new SchedulerTask({
+            ...stub,
+            ...overrides,
+        });
+        return task;
+    };
+
+    it('calls createNewSheet with payload.title and appendToSheet with payload rows — never calls executeMetricQueryAndGetResults', async () => {
+        const mockCreateNewSheet = jest.fn().mockResolvedValue({
+            spreadsheetId: 'sheet-123',
+            spreadsheetUrl: 'https://sheets.example.com/sheet-123',
+        });
+        const mockAppendToSheet = jest.fn().mockResolvedValue(undefined);
+        const mockGetRefreshToken = jest
+            .fn()
+            .mockResolvedValue('refresh-token');
+        const mockGetAccountByUserUuid = jest.fn().mockResolvedValue({
+            user: { id: 'user-1' },
+        });
+        const mockLogSchedulerJob = jest.fn().mockResolvedValue(undefined);
+        const mockTrackAccount = jest.fn();
+        const mockTrack = jest.fn();
+        const mockExecuteMetricQueryAndGetResults = jest.fn();
+
+        const task = makeTask({
+            googleDriveClient: {
+                isEnabled: true,
+                createNewSheet: mockCreateNewSheet,
+                appendToSheet: mockAppendToSheet,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['googleDriveClient'],
+            userService: {
+                getRefreshToken: mockGetRefreshToken,
+                getAccountByUserUuid: mockGetAccountByUserUuid,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['userService'],
+            schedulerService: {
+                logSchedulerJob: mockLogSchedulerJob,
+                updateGsheetExportProgress: jest
+                    .fn()
+                    .mockResolvedValue(undefined),
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['schedulerService'],
+            analytics: {
+                trackAccount: mockTrackAccount,
+                track: mockTrack,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['analytics'],
+            asyncQueryService: {
+                executeMetricQueryAndGetResults:
+                    mockExecuteMetricQueryAndGetResults,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['asyncQueryService'],
+            lightdashConfig: {
+                query: {},
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['lightdashConfig'],
+        });
+
+        const payload = {
+            source: 'rows' as const,
+            userUuid: 'user-1',
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            title: 'My App Export',
+            columns: [
+                { key: 'name', label: 'Name', type: 'string' as const },
+                { key: 'amount', type: 'number' as const },
+            ],
+            rows: [
+                { name: 'Alice', amount: 100 },
+                { name: 'Bob', amount: 200 },
+            ],
+        };
+
+        // Access protected method via cast
+        await (
+            task as unknown as {
+                uploadGsheetFromQuery(
+                    jobId: string,
+                    scheduledTime: Date,
+                    payload: UploadGsheetPayload,
+                ): Promise<void>;
+            }
+        ).uploadGsheetFromQuery('job-1', new Date(), payload);
+
+        expect(mockCreateNewSheet).toHaveBeenCalledWith(
+            'refresh-token',
+            'My App Export',
+        );
+        expect(mockAppendToSheet).toHaveBeenCalledTimes(1);
+        expect(mockAppendToSheet.mock.calls[0][2]).toEqual(payload.rows);
+        expect(mockExecuteMetricQueryAndGetResults).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -12,12 +12,14 @@ import {
     DashboardFilters,
     DateZoom,
     derivePivotConfigurationFromPivotConfig,
+    DimensionType,
     DownloadFileType,
     EmailNotificationPayload,
     ExportContentPayload,
     ExportCsvDashboardPayload,
     FeatureFlags,
     FieldReferenceError,
+    FieldType,
     ForbiddenError,
     formatRows,
     friendlyName,
@@ -56,6 +58,7 @@ import {
     isVizTableConfig,
     LightdashPage,
     MAX_SAFE_INTEGER,
+    MetricType,
     MissingConfigError,
     NotEnoughResults,
     NotFoundError,
@@ -96,6 +99,8 @@ import {
     translateSlackError,
     UnexpectedGoogleSheetsError,
     UnexpectedServerError,
+    UploadGsheetFromRowsPayload,
+    UploadGsheetPayload,
     UploadMetricGsheetPayload,
     ValidateProjectPayload,
     VizColumn,
@@ -107,6 +112,7 @@ import {
     type EmailBatchNotificationPayload,
     type GoogleChatBatchNotificationPayload,
     type GoogleChatNotificationPayload,
+    type GsheetColumn,
     type ItemsMap,
     type MaterializePreAggregatePayload,
     type MetricQuery,
@@ -294,6 +300,45 @@ export async function retryTransientGoogleSheetsWrite(
         await onRetry(attempt + 1);
         await retryTransientGoogleSheetsWrite(write, onRetry, attempt + 1);
     }
+}
+
+function gsheetColumnTypeToFieldType(
+    columnType: GsheetColumn['type'],
+): MetricType | DimensionType {
+    switch (columnType) {
+        case 'number':
+            return MetricType.NUMBER;
+        case 'date':
+            return DimensionType.DATE;
+        case 'timestamp':
+            return DimensionType.TIMESTAMP;
+        case 'boolean':
+            return DimensionType.BOOLEAN;
+        default:
+            return DimensionType.STRING;
+    }
+}
+
+export function buildItemMapFromColumns(columns: GsheetColumn[]): ItemsMap {
+    // appendToSheet's formatter reads `type` (for date/timestamp parsing) and
+    // ignores most other Item fields, so a minimal synthetic shape is enough.
+    // Cast via unknown — the real Item union has many required fields, but
+    // appendToSheet's formatter only reads `type` and `fieldType`.
+    const map: ItemsMap = {};
+    for (const col of columns) {
+        map[col.key] = {
+            name: col.key,
+            label: col.label ?? col.key,
+            fieldType:
+                col.type === 'number' ? FieldType.METRIC : FieldType.DIMENSION,
+            type: gsheetColumnTypeToFieldType(col.type),
+            table: '',
+            tableLabel: '',
+            sql: '',
+            hidden: false,
+        } as unknown as ItemsMap[string];
+    }
+    return map;
 }
 
 export default class SchedulerTask {
@@ -2366,7 +2411,7 @@ export default class SchedulerTask {
     protected async uploadGsheetFromQuery(
         jobId: string,
         scheduledTime: Date,
-        payload: UploadMetricGsheetPayload,
+        payload: UploadGsheetPayload,
     ) {
         setSchedulerJobLogContext({ jobId });
         const baseLog: Pick<SchedulerLog, 'task' | 'jobId' | 'scheduledTime'> =
@@ -2389,9 +2434,10 @@ export default class SchedulerTask {
         try {
             if (!this.googleDriveClient.isEnabled) {
                 throw new Error(
-                    'Unable to upload Google Sheet from query, Google Drive is not enabled',
+                    'Unable to upload Google Sheet, Google Drive is not enabled',
                 );
             }
+
             await this.schedulerService.logSchedulerJob({
                 ...baseLog,
                 details: {
@@ -2411,99 +2457,29 @@ export default class SchedulerTask {
                 userId: payload.userUuid,
                 properties: analyticsProperties,
             });
-            // Build MetricQuery with exploreName (required by executeAsyncMetricQuery)
-            const metricQuery: MetricQuery = {
-                ...payload.metricQuery,
-                exploreName: payload.exploreId,
-            };
 
-            // Build PivotConfiguration if pivotConfig is present
-            let pivotConfiguration: PivotConfiguration | undefined;
-            if (payload.pivotConfig) {
-                const explore = await this.projectService.getExplore(
+            if (payload.source === 'rows') {
+                // Rows path has no query phase — go straight to upload.
+                failureStage = 'upload';
+                await this.uploadGsheetFromRowsInner(
+                    payload,
+                    baseLog,
+                    analyticsProperties,
                     account,
-                    payload.projectUuid,
-                    payload.exploreId,
+                    jobId,
                 );
-                const fields = getItemMap(
-                    explore,
-                    metricQuery.additionalMetrics,
-                    metricQuery.tableCalculations,
-                );
-                pivotConfiguration = derivePivotConfigurationFromPivotConfig(
-                    payload.pivotConfig,
-                    metricQuery,
-                    fields,
+            } else {
+                await this.uploadGsheetFromMetricQueryInner(
+                    payload,
+                    baseLog,
+                    analyticsProperties,
+                    account,
+                    jobId,
+                    () => {
+                        failureStage = 'upload';
+                    },
                 );
             }
-
-            const {
-                rows,
-                fields: itemMap,
-                pivotDetails,
-                displayTimezone,
-            } = await this.asyncQueryService.executeMetricQueryAndGetResults(
-                {
-                    account,
-                    projectUuid: payload.projectUuid,
-                    metricQuery,
-                    context: QueryExecutionContext.GSHEETS,
-                    pivotConfiguration,
-                },
-                SCHEDULER_POLLING_OPTIONS,
-            );
-
-            failureStage = 'upload';
-            await this.schedulerService.updateGsheetExportProgress(jobId, {
-                phase: 'upload',
-                attempt: 1,
-            });
-
-            const refreshToken = await this.userService.getRefreshToken(
-                payload.userUuid,
-            );
-            const { spreadsheetId, spreadsheetUrl } =
-                await this.googleDriveClient.createNewSheet(
-                    refreshToken,
-                    payload.exploreId,
-                );
-
-            if (!spreadsheetId) {
-                throw new Error('Unable to create new sheet');
-            }
-
-            await this.uploadResultsToGoogleSheet({
-                jobId,
-                refreshToken,
-                spreadsheetId,
-                rows,
-                itemMap,
-                pivotDetails,
-                displayTimezone,
-                payload,
-            });
-
-            const { csvCellsLimit } = await resolveOrganizationExportLimits(
-                this.organizationSettingsModel,
-                this.lightdashConfig.query,
-                payload.organizationUuid,
-            );
-            const truncated = this.csvService.couldBeTruncated(
-                rows,
-                csvCellsLimit,
-            );
-
-            await this.schedulerService.logSchedulerJob({
-                ...baseLog,
-                details: {
-                    fileUrl: spreadsheetUrl,
-                    createdByUserUuid: payload.userUuid,
-                    truncated,
-                    projectUuid: payload.projectUuid,
-                    organizationUuid: payload.organizationUuid,
-                },
-                status: SchedulerJobStatus.COMPLETED,
-            });
 
             this.analytics.trackAccount(account, {
                 event: 'download_results.completed',
@@ -2616,6 +2592,174 @@ export default class SchedulerTask {
                 ),
             onRetry,
         );
+    }
+
+    private async uploadGsheetFromMetricQueryInner(
+        payload: UploadMetricGsheetPayload,
+        baseLog: Pick<SchedulerLog, 'task' | 'jobId' | 'scheduledTime'>,
+        analyticsProperties: DownloadCsv['properties'],
+        account: AccountType,
+        jobId: string,
+        onQueryComplete: () => void,
+    ) {
+        const metricQuery: MetricQuery = {
+            ...payload.metricQuery,
+            exploreName: payload.exploreId,
+        };
+
+        let pivotConfiguration: PivotConfiguration | undefined;
+        if (payload.pivotConfig) {
+            const explore = await this.projectService.getExplore(
+                account,
+                payload.projectUuid,
+                payload.exploreId,
+            );
+            const fields = getItemMap(
+                explore,
+                metricQuery.additionalMetrics,
+                metricQuery.tableCalculations,
+            );
+            pivotConfiguration = derivePivotConfigurationFromPivotConfig(
+                payload.pivotConfig,
+                metricQuery,
+                fields,
+            );
+        }
+
+        const {
+            rows,
+            fields: itemMap,
+            pivotDetails,
+            displayTimezone,
+        } = await this.asyncQueryService.executeMetricQueryAndGetResults(
+            {
+                account,
+                projectUuid: payload.projectUuid,
+                metricQuery,
+                context: QueryExecutionContext.GSHEETS,
+                pivotConfiguration,
+            },
+            SCHEDULER_POLLING_OPTIONS,
+        );
+
+        onQueryComplete();
+        await this.schedulerService.updateGsheetExportProgress(jobId, {
+            phase: 'upload',
+            attempt: 1,
+        });
+
+        const refreshToken = await this.userService.getRefreshToken(
+            payload.userUuid,
+        );
+        const { spreadsheetId, spreadsheetUrl } =
+            await this.googleDriveClient.createNewSheet(
+                refreshToken,
+                payload.exploreId,
+            );
+
+        if (!spreadsheetId) {
+            throw new Error('Unable to create new sheet');
+        }
+
+        await this.uploadResultsToGoogleSheet({
+            jobId,
+            refreshToken,
+            spreadsheetId,
+            rows,
+            itemMap,
+            pivotDetails,
+            displayTimezone,
+            payload,
+        });
+
+        const { csvCellsLimit } = await resolveOrganizationExportLimits(
+            this.organizationSettingsModel,
+            this.lightdashConfig.query,
+            payload.organizationUuid,
+        );
+        const truncated = this.csvService.couldBeTruncated(rows, csvCellsLimit);
+
+        await this.schedulerService.logSchedulerJob({
+            ...baseLog,
+            details: {
+                fileUrl: spreadsheetUrl,
+                createdByUserUuid: payload.userUuid,
+                truncated,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+            },
+            status: SchedulerJobStatus.COMPLETED,
+        });
+    }
+
+    private async uploadGsheetFromRowsInner(
+        payload: UploadGsheetFromRowsPayload,
+        baseLog: Pick<SchedulerLog, 'task' | 'jobId' | 'scheduledTime'>,
+        analyticsProperties: DownloadCsv['properties'],
+        account: AccountType,
+        jobId: string,
+    ) {
+        // Rows path has no warehouse query step — we're already in the upload
+        // phase from the outer wrapper's perspective. Report progress + retry
+        // the Sheets write on transient errors, same as the metric-query path.
+        await this.schedulerService.updateGsheetExportProgress(jobId, {
+            phase: 'upload',
+            attempt: 1,
+        });
+
+        const refreshToken = await this.userService.getRefreshToken(
+            payload.userUuid,
+        );
+        const { spreadsheetId, spreadsheetUrl } =
+            await this.googleDriveClient.createNewSheet(
+                refreshToken,
+                payload.title,
+            );
+
+        if (!spreadsheetId) {
+            throw new Error('Unable to create new sheet');
+        }
+
+        const itemMap = buildItemMapFromColumns(payload.columns);
+        const columnOrder = payload.columns.map((c) => c.key);
+        const customLabels = Object.fromEntries(
+            payload.columns
+                .filter((c) => c.label)
+                .map((c) => [c.key, c.label as string]),
+        );
+
+        await retryTransientGoogleSheetsWrite(
+            () =>
+                this.googleDriveClient.appendToSheet(
+                    refreshToken,
+                    spreadsheetId,
+                    payload.rows,
+                    itemMap,
+                    false, // showTableNames — no table context for app-supplied rows
+                    undefined, // tabName
+                    columnOrder,
+                    customLabels,
+                    [], // hiddenFields
+                    undefined, // timezone
+                ),
+            (attempt) =>
+                this.schedulerService.updateGsheetExportProgress(jobId, {
+                    phase: 'upload',
+                    attempt,
+                }),
+        );
+
+        await this.schedulerService.logSchedulerJob({
+            ...baseLog,
+            details: {
+                fileUrl: spreadsheetUrl,
+                createdByUserUuid: payload.userUuid,
+                truncated: false,
+                projectUuid: payload.projectUuid,
+                organizationUuid: payload.organizationUuid,
+            },
+            status: SchedulerJobStatus.COMPLETED,
+        });
     }
 
     protected async sendEmailNotification(

--- a/packages/backend/src/services/GdriveService/GdriveService.test.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.test.ts
@@ -1,0 +1,145 @@
+import { detectSubjectType, subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    GoogleNotConnectedError,
+    NotFoundError,
+    ParameterError,
+} from '@lightdash/common';
+import { GdriveService } from './GdriveService';
+
+describe('GdriveService.scheduleUploadGsheetFromRows', () => {
+    const projectUuid = 'proj-1';
+    const organizationUuid = 'org-1';
+
+    const mkAccount = (userUuid: string) => ({
+        user: {
+            id: userUuid,
+            userUuid,
+            ability: { can: () => true, cannot: () => false },
+        },
+        organization: { organizationUuid },
+    });
+
+    const baseOptions = {
+        projectUuid,
+        title: 'My Export',
+        columns: [{ key: 'a', label: 'A', type: 'string' as const }],
+        rows: [{ a: 'hello' }],
+    };
+
+    function makeService(
+        overrides: Partial<{
+            ability: { can: jest.Mock; cannot: jest.Mock };
+            refreshTokenThrows: boolean;
+        }> = {},
+    ) {
+        const projectModel = {
+            getSummary: jest.fn().mockResolvedValue({
+                projectUuid,
+                organizationUuid,
+                name: 'Proj',
+            }),
+        };
+        const projectService = {
+            getProject: jest.fn().mockResolvedValue({ organizationUuid }),
+        };
+        const userModel = {
+            getRefreshToken: overrides.refreshTokenThrows
+                ? jest
+                      .fn()
+                      .mockRejectedValue(
+                          new NotFoundError('Cannot find refresh token'),
+                      )
+                : jest.fn().mockResolvedValue('rt'),
+        };
+        const schedulerClient = {
+            uploadGsheetFromRowsJob: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+        };
+
+        const service = new GdriveService({
+            lightdashConfig: {} as never,
+            projectService: projectService as never,
+            savedChartModel: {} as never,
+            dashboardModel: {} as never,
+            userModel: userModel as never,
+            schedulerClient: schedulerClient as never,
+            projectModel: projectModel as never,
+        });
+
+        const ability = overrides.ability ?? {
+            can: jest.fn(() => true),
+            cannot: jest.fn(() => false),
+        };
+        (
+            service as unknown as {
+                createAuditedAbility: () => unknown;
+            }
+        ).createAuditedAbility = () => ability;
+
+        return { service, schedulerClient, userModel, ability };
+    }
+
+    it('enqueues a rows job and returns the jobId', async () => {
+        const { service, schedulerClient } = makeService();
+        const result = await service.scheduleUploadGsheetFromRows(
+            mkAccount('u-1') as never,
+            baseOptions,
+        );
+        expect(result).toEqual({ jobId: 'job-1' });
+        expect(schedulerClient.uploadGsheetFromRowsJob).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: 'rows',
+                projectUuid,
+                userUuid: 'u-1',
+                organizationUuid,
+                title: 'My Export',
+                rows: baseOptions.rows,
+            }),
+        );
+    });
+
+    it('throws ForbiddenError when GoogleSheets ability is denied', async () => {
+        const ability = {
+            can: jest.fn(() => true),
+            cannot: jest.fn(
+                (
+                    _action: string,
+                    sub: Parameters<typeof detectSubjectType>[0],
+                ) => detectSubjectType(sub) === 'GoogleSheets',
+            ),
+        };
+        const { service } = makeService({ ability });
+        await expect(
+            service.scheduleUploadGsheetFromRows(
+                mkAccount('u-1') as never,
+                baseOptions,
+            ),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('throws GoogleNotConnectedError when refresh token is missing', async () => {
+        const { service } = makeService({ refreshTokenThrows: true });
+        await expect(
+            service.scheduleUploadGsheetFromRows(
+                mkAccount('u-1') as never,
+                baseOptions,
+            ),
+        ).rejects.toBeInstanceOf(GoogleNotConnectedError);
+    });
+
+    it('throws ParameterError when rows exceed the cap', async () => {
+        const { service } = makeService();
+        const bigOpts = {
+            ...baseOptions,
+            rows: Array.from({ length: 100_001 }, (_, i) => ({ a: `r${i}` })),
+        };
+        await expect(
+            service.scheduleUploadGsheetFromRows(
+                mkAccount('u-1') as never,
+                bigOpts,
+            ),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+});

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -3,7 +3,13 @@ import {
     Account,
     CustomSqlQueryForbiddenError,
     ForbiddenError,
+    GoogleNotConnectedError,
     isCustomSqlDimension,
+    NotFoundError,
+    ParameterError,
+    UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS,
+    UploadGsheetFromRows,
+    UploadGsheetFromRowsPayload,
     UploadMetricGsheet,
     UploadMetricGsheetPayload,
 } from '@lightdash/common';
@@ -107,10 +113,80 @@ export class GdriveService extends BaseService {
             ...gsheetOptions,
             userUuid: account.user.id,
             organizationUuid,
+            source: 'metricQuery',
         };
 
         const { jobId } =
             await this.schedulerClient.uploadGsheetFromQueryJob(payload);
+
+        return { jobId };
+    }
+
+    async scheduleUploadGsheetFromRows(
+        account: Account,
+        options: UploadGsheetFromRows,
+    ) {
+        const projectSummary = await this.projectModel.getSummary(
+            options.projectUuid,
+        );
+        const auditedAbility = this.createAuditedAbility(account);
+        const projectMetadata = {
+            projectUuid: projectSummary.projectUuid,
+            projectName: projectSummary.name,
+        };
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('ExportCsv', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('GoogleSheets', {
+                    organizationUuid: projectSummary.organizationUuid,
+                    projectUuid: projectSummary.projectUuid,
+                    metadata: projectMetadata,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (options.rows.length > UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS) {
+            throw new ParameterError(
+                `Export too large (max ${UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS} rows)`,
+            );
+        }
+
+        try {
+            await this.userModel.getRefreshToken(account.user.id);
+        } catch (e) {
+            if (e instanceof NotFoundError) {
+                throw new GoogleNotConnectedError(
+                    'Google account not connected',
+                );
+            }
+            throw e;
+        }
+
+        const payload: UploadGsheetFromRowsPayload = {
+            ...options,
+            userUuid: account.user.id,
+            organizationUuid: projectSummary.organizationUuid,
+            source: 'rows',
+        };
+
+        const { jobId } =
+            await this.schedulerClient.uploadGsheetFromRowsJob(payload);
 
         return { jobId };
     }

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -45,6 +45,17 @@ export class ForbiddenError extends LightdashError {
     }
 }
 
+export class GoogleNotConnectedError extends LightdashError {
+    constructor(message = 'Google account not connected') {
+        super({
+            message,
+            name: 'GoogleNotConnectedError',
+            statusCode: 412,
+            data: {},
+        });
+    }
+}
+
 export class DeactivatedAccountError extends LightdashError {
     constructor(
         message = 'Your account has been deactivated. Please contact your organization administrator.',

--- a/packages/common/src/types/gdrive.ts
+++ b/packages/common/src/types/gdrive.ts
@@ -10,6 +10,7 @@ export type ApiGdriveAccessTokenResponse = {
 export type CustomLabel = {
     [key: string]: string;
 };
+
 export type UploadMetricGsheet = {
     projectUuid: string;
     exploreId: string;
@@ -21,4 +22,44 @@ export type UploadMetricGsheet = {
     pivotConfig?: PivotConfig;
 };
 
-export type UploadMetricGsheetPayload = TraceTaskBase & UploadMetricGsheet;
+export type GsheetColumnType =
+    | 'string'
+    | 'number'
+    | 'date'
+    | 'timestamp'
+    | 'boolean';
+
+export type GsheetColumn = {
+    key: string;
+    label?: string;
+    type?: GsheetColumnType;
+};
+
+export type GsheetRow = Record<string, string | number | boolean | null>;
+
+export type UploadGsheetFromRows = {
+    projectUuid: string;
+    title: string;
+    columns: GsheetColumn[];
+    rows: GsheetRow[];
+};
+
+export type UploadMetricGsheetPayload = TraceTaskBase &
+    UploadMetricGsheet & {
+        source: 'metricQuery';
+    };
+
+export type UploadGsheetFromRowsPayload = TraceTaskBase &
+    UploadGsheetFromRows & {
+        source: 'rows';
+    };
+
+export type UploadGsheetPayload =
+    | UploadMetricGsheetPayload
+    | UploadGsheetFromRowsPayload;
+
+/** Max body size accepted by /gdrive/upload-gsheet-from-rows. */
+export const UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES = 25 * 1024 * 1024;
+
+/** Max row count accepted by /gdrive/upload-gsheet-from-rows. */
+export const UPLOAD_GSHEET_FROM_ROWS_MAX_ROWS = 100_000;

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -14,7 +14,7 @@ import {
     type SlackPromptJobPayload,
 } from '../ee';
 import { type SchedulerIndexCatalogJobPayload } from './catalog';
-import { type UploadMetricGsheetPayload } from './gdrive';
+import { type UploadGsheetPayload } from './gdrive';
 import { type RenameResourcesPayload } from './rename';
 import {
     type CompileProjectPayload,
@@ -133,7 +133,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.SEND_MSTEAMS_BATCH_NOTIFICATION]: MsTeamsBatchNotificationPayload;
     [SCHEDULER_TASKS.SEND_GOOGLE_CHAT_BATCH_NOTIFICATION]: GoogleChatBatchNotificationPayload;
     [SCHEDULER_TASKS.UPLOAD_GSHEETS]: GsheetsNotificationPayload;
-    [SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY]: UploadMetricGsheetPayload;
+    [SCHEDULER_TASKS.UPLOAD_GSHEET_FROM_QUERY]: UploadGsheetPayload;
     [SCHEDULER_TASKS.VALIDATE_PROJECT]: ValidateProjectPayload;
     [SCHEDULER_TASKS.COMPILE_PROJECT]: CompileProjectPayload;
     [SCHEDULER_TASKS.CREATE_PROJECT_WITH_COMPILE]: SchedulerCreateProjectWithCompilePayload;

--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -217,6 +217,7 @@ const DataAppTile: FC<Props> = (props) => {
                         identityKey={`${appUuid}:${latestReadyVersion}`}
                         dashboardFilters={dashboardFiltersForApp}
                         invalidateCache={invalidateCache}
+                        capabilities={{ gsheetExport: true }}
                     />
                 )}
             </Box>

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -65,6 +65,10 @@ type Props = {
     /** Fired on every iframe `onload` (including the initial about:blank).
      *  Used by `MinimalApp` to gate the screenshot readiness signal. */
     onIframeLoad?: () => void;
+    /** SDK capabilities the host opts into. Closed by default — hosts that
+     *  serve untrusted viewers (embed/JWT) must omit each capability flag.
+     *  `gsheetExport`: enables `exportToSheets()` from the iframe SDK. */
+    capabilities?: { gsheetExport?: boolean };
 };
 
 /**
@@ -103,6 +107,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
             dashboardFilters,
             invalidateCache,
             onIframeLoad,
+            capabilities,
         },
         ref,
     ) => {
@@ -126,6 +131,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 handleScreenshotAnnounce,
                 dashboardFilters,
                 invalidateCache,
+                capabilities,
             );
         const { captureScreenshot } = useIframeScreenshot(iframeRef);
 

--- a/packages/frontend/src/features/apps/hooks/handleGsheetExport.test.ts
+++ b/packages/frontend/src/features/apps/hooks/handleGsheetExport.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleGsheetExport } from './handleGsheetExport';
+
+describe('handleGsheetExport', () => {
+    const baseDeps = () => {
+        const getAccessToken = vi.fn();
+        const triggerLogin = vi.fn();
+        const lightdashApi = vi.fn();
+        const ability = { can: vi.fn(() => true) };
+        return {
+            getAccessToken,
+            triggerLogin,
+            lightdashApi,
+            ability,
+            health: {
+                auth: {
+                    google: {
+                        oauth2ClientId: 'x',
+                        googleDriveApiKey: 'y',
+                    },
+                },
+                siteUrl: 'https://lightdash.local',
+            },
+            projectUuid: 'proj-1',
+            organizationUuid: 'org-1',
+            pollIntervalMs: 1, // fast polling for tests
+        };
+    };
+
+    const req = {
+        title: 'My Export',
+        columns: [{ key: 'a' }],
+        rows: [{ a: 1 }],
+    };
+
+    it('rejects when capabilities.gsheetExport is not true', async () => {
+        const deps = baseDeps();
+        await expect(
+            handleGsheetExport(req, { ...deps, capability: false }),
+        ).rejects.toThrow(
+            'Google Sheets export is not available in this context',
+        );
+    });
+
+    it('rejects when GoogleSheets ability is denied', async () => {
+        const deps = baseDeps();
+        deps.ability.can = vi.fn(() => false);
+        await expect(
+            handleGsheetExport(req, { ...deps, capability: true }),
+        ).rejects.toThrow(/permission/i);
+    });
+
+    it('opens OAuth popup when access-token call fails, then retries and POSTs', async () => {
+        const deps = baseDeps();
+        deps.getAccessToken
+            .mockRejectedValueOnce(new Error('no token'))
+            .mockResolvedValueOnce('access-token');
+        deps.triggerLogin.mockResolvedValue(undefined);
+        deps.lightdashApi
+            .mockResolvedValueOnce({ jobId: 'job-1' })
+            .mockResolvedValueOnce({
+                status: 'completed',
+                url: 'https://sheets/abc',
+            });
+
+        const result = await handleGsheetExport(req, {
+            ...deps,
+            capability: true,
+        });
+        expect(deps.triggerLogin).toHaveBeenCalledWith(
+            'gdrive',
+            'https://lightdash.local',
+        );
+        expect(result).toEqual({ fileUrl: 'https://sheets/abc' });
+    });
+
+    it('rejects when the popup login fails', async () => {
+        const deps = baseDeps();
+        deps.getAccessToken.mockRejectedValueOnce(new Error('no token'));
+        deps.triggerLogin.mockRejectedValue(new Error('cancelled'));
+        await expect(
+            handleGsheetExport(req, { ...deps, capability: true }),
+        ).rejects.toThrow(/cancelled|Google authentication/);
+    });
+
+    it('rejects when the job errors', async () => {
+        const deps = baseDeps();
+        deps.getAccessToken.mockResolvedValue('access-token');
+        deps.lightdashApi
+            .mockResolvedValueOnce({ jobId: 'job-1' })
+            .mockResolvedValueOnce({
+                status: 'error',
+                error: 'Backend went boom',
+            });
+        await expect(
+            handleGsheetExport(req, { ...deps, capability: true }),
+        ).rejects.toThrow('Backend went boom');
+    });
+
+    it('rejects when completed status arrives without a url', async () => {
+        const deps = baseDeps();
+        deps.getAccessToken.mockResolvedValue('access-token');
+        deps.lightdashApi
+            .mockResolvedValueOnce({ jobId: 'job-1' })
+            .mockResolvedValueOnce({ status: 'completed' });
+        await expect(
+            handleGsheetExport(req, { ...deps, capability: true }),
+        ).rejects.toThrow(/no Google Sheets URL/);
+    });
+
+    it('rejects when the job stays pending past the poll deadline', async () => {
+        const deps = baseDeps();
+        deps.getAccessToken.mockResolvedValue('access-token');
+        deps.lightdashApi.mockImplementation(({ url }) => {
+            if (url === '/gdrive/upload-gsheet-from-rows') {
+                return Promise.resolve({ jobId: 'job-1' });
+            }
+            return Promise.resolve({ status: 'pending' });
+        });
+        await expect(
+            handleGsheetExport(req, {
+                ...deps,
+                capability: true,
+                pollIntervalMs: 1,
+                pollTimeoutMs: 10,
+            }),
+        ).rejects.toThrow(/timed out/);
+    });
+});

--- a/packages/frontend/src/features/apps/hooks/handleGsheetExport.ts
+++ b/packages/frontend/src/features/apps/hooks/handleGsheetExport.ts
@@ -1,0 +1,139 @@
+import { subject } from '@casl/ability';
+import {
+    type GsheetColumn as GsheetExportColumn,
+    type GsheetColumnType as GsheetExportColumnType,
+    type GsheetRow as GsheetExportRow,
+} from '@lightdash/common';
+
+export type { GsheetExportColumn, GsheetExportColumnType, GsheetExportRow };
+
+type HealthShape = {
+    auth: {
+        google: {
+            oauth2ClientId?: string;
+            googleDriveApiKey?: string;
+        };
+    };
+    siteUrl: string;
+};
+
+export type HandleGsheetExportRequest = {
+    title: string;
+    columns: GsheetExportColumn[];
+    rows: GsheetExportRow[];
+};
+
+// Minimal structural type — only the `can` method is needed here.
+// Using a structural interface keeps the dependency on the CASL Ability class
+// out of the type and makes the function easy to test with a plain mock.
+type CanCheck = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    can: (action: string, subject: any) => boolean;
+};
+
+export type HandleGsheetExportDeps = {
+    capability: boolean;
+    health: HealthShape;
+    ability: CanCheck;
+    projectUuid: string;
+    organizationUuid: string;
+    getAccessToken: () => Promise<unknown>;
+    triggerLogin: (path: 'gdrive', siteUrl: string) => Promise<void>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    lightdashApi: (args: {
+        url: string;
+        method: 'GET' | 'POST';
+        body?: string;
+    }) => Promise<any>;
+    pollIntervalMs?: number;
+    pollTimeoutMs?: number;
+};
+
+type JobStatusResponse = {
+    status: 'pending' | 'started' | 'completed' | 'error';
+    // The `/csv/{jobId}` endpoint returns the resulting file URL as `url`,
+    // not `fileUrl`. We map it back to `fileUrl` in our public return shape
+    // to keep the SDK promise contract stable.
+    url?: string;
+    error?: string;
+};
+
+export async function handleGsheetExport(
+    request: HandleGsheetExportRequest,
+    deps: HandleGsheetExportDeps,
+): Promise<{ fileUrl: string }> {
+    if (!deps.capability) {
+        throw new Error(
+            'Google Sheets export is not available in this context',
+        );
+    }
+    if (
+        !deps.health.auth.google.oauth2ClientId ||
+        !deps.health.auth.google.googleDriveApiKey
+    ) {
+        throw new Error(
+            'Google Sheets is not configured for this Lightdash instance',
+        );
+    }
+    if (
+        !deps.ability.can(
+            'manage',
+            subject('GoogleSheets', {
+                organizationUuid: deps.organizationUuid,
+                projectUuid: deps.projectUuid,
+            }),
+        )
+    ) {
+        throw new Error('Forbidden: missing GoogleSheets permission');
+    }
+
+    try {
+        await deps.getAccessToken();
+    } catch {
+        try {
+            await deps.triggerLogin('gdrive', deps.health.siteUrl);
+        } catch {
+            throw new Error('Google authentication was cancelled');
+        }
+        await deps.getAccessToken();
+    }
+
+    const { jobId } = (await deps.lightdashApi({
+        url: '/gdrive/upload-gsheet-from-rows',
+        method: 'POST',
+        body: JSON.stringify({
+            projectUuid: deps.projectUuid,
+            title: request.title,
+            columns: request.columns,
+            rows: request.rows,
+        }),
+    })) as { jobId: string };
+
+    const intervalMs = deps.pollIntervalMs ?? 2000;
+    // Match the iframe SDK's 120s timeout — once the SDK gives up, the parent
+    // has nothing to deliver to and shouldn't keep polling. Without a deadline
+    // a stuck job (worker dead, DB hiccup) would leak timers forever.
+    const timeoutMs = deps.pollTimeoutMs ?? 120_000;
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        // eslint-disable-next-line no-await-in-loop
+        const status = (await deps.lightdashApi({
+            url: `/csv/${jobId}`,
+            method: 'GET',
+        })) as JobStatusResponse;
+        if (status.status === 'completed') {
+            if (!status.url) {
+                throw new Error(
+                    'Export job completed but returned no Google Sheets URL',
+                );
+            }
+            return { fileUrl: status.url };
+        }
+        if (status.status === 'error') {
+            throw new Error(status.error ?? 'Export job failed');
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    throw new Error('Export job timed out');
+}

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -18,6 +18,17 @@ vi.mock('../../../ee/providers/Embed/useEmbed', () => ({
     }),
 }));
 
+vi.mock('../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: { data: undefined },
+        user: { data: undefined },
+    }),
+}));
+
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => undefined,
+}));
+
 const PROJECT_UUID = 'project-uuid';
 const POST_PATH = `/api/v2/projects/${PROJECT_UUID}/query/metric-query`;
 const UNDERLYING_DATA_PATH = `/api/v2/projects/${PROJECT_UUID}/query/underlying-data`;

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,6 +1,18 @@
 import { JWT_HEADER_NAME, type DashboardFilters } from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { lightdashApi } from '../../../api';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
+import {
+    getGdriveAccessToken,
+    triggerGdriveLogin,
+} from '../../../hooks/gdrive/useGdrive';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import useApp from '../../../providers/App/useApp';
+import {
+    handleGsheetExport,
+    type GsheetExportColumn,
+    type GsheetExportRow,
+} from './handleGsheetExport';
 
 // Same key the SDK persists `instanceUrl` under (sdk/index.tsx, api.ts).
 // Duplicated rather than imported to avoid threading a shared export through
@@ -161,6 +173,12 @@ export function useAppSdkBridge(
      * pressed. Set by `DashboardDataAppTile`; left undefined elsewhere.
      */
     invalidateCache?: boolean,
+    /**
+     * Feature capabilities the host page opts into. Currently gates the
+     * Google Sheets export flow — hosts that don't pass `gsheetExport: true`
+     * will receive an error response for those requests.
+     */
+    capabilities?: { gsheetExport?: boolean },
 ) {
     // Embed mode adapts the bridge's outgoing fetches in two ways:
     //   - Attaches the embed JWT header in lieu of session cookies
@@ -170,6 +188,8 @@ export function useAppSdkBridge(
     //     don't break on `client.auth.getUser()`. The SDK protocol is
     //     unchanged — the rewrite happens entirely on the parent side.
     const { embedToken, projectUuid: embedProjectUuid } = useEmbed();
+    const { health, user } = useApp();
+    const projectUuid = useProjectUuid();
 
     // Maps queryUuid → POST request id. The SDK transport assigns a fresh
     // request id to the POST (`/metric-query`) and again to each GET poll
@@ -213,6 +233,67 @@ export function useAppSdkBridge(
                 const label = typeof data.label === 'string' ? data.label : '';
                 if (label && onElementSelected) {
                     onElementSelected({ label });
+                }
+                return;
+            }
+
+            if (data?.type === 'lightdash:sdk:gsheet-export-request') {
+                const req = data as {
+                    id: string;
+                    title: string;
+                    columns: GsheetExportColumn[];
+                    rows: GsheetExportRow[];
+                };
+                const respondGsheet = (resp: {
+                    fileUrl?: string;
+                    error?: string;
+                }) =>
+                    iframeRef.current?.contentWindow?.postMessage(
+                        {
+                            type: 'lightdash:sdk:gsheet-export-response',
+                            id: req.id,
+                            ...resp,
+                        },
+                        '*',
+                    );
+                // Guard against iframe requests that arrive before health/user
+                // queries resolve — otherwise the non-null assertions below
+                // throw a TypeError that the app developer sees as a generic
+                // "Export failed" with no diagnostic.
+                if (!health.data || !user.data) {
+                    respondGsheet({
+                        error: 'Lightdash is still loading, try again shortly',
+                    });
+                    return;
+                }
+                try {
+                    const { fileUrl } = await handleGsheetExport(
+                        {
+                            title: req.title,
+                            columns: req.columns,
+                            rows: req.rows,
+                        },
+                        {
+                            capability: capabilities?.gsheetExport === true,
+                            health: health.data,
+                            ability: user.data.ability,
+                            projectUuid: projectUuid ?? '',
+                            organizationUuid: user.data.organizationUuid ?? '',
+                            getAccessToken: getGdriveAccessToken,
+                            triggerLogin: triggerGdriveLogin,
+                            lightdashApi: ({ url, method, body }) =>
+                                lightdashApi({
+                                    url,
+                                    method,
+                                    body: body ?? undefined,
+                                }),
+                        },
+                    );
+                    respondGsheet({ fileUrl });
+                } catch (e) {
+                    respondGsheet({
+                        error: e instanceof Error ? e.message : 'Export failed',
+                    });
                 }
                 return;
             }
@@ -489,6 +570,10 @@ export function useAppSdkBridge(
             invalidateCache,
             embedToken,
             embedProjectUuid,
+            capabilities,
+            health.data,
+            user.data,
+            projectUuid,
         ],
     );
 

--- a/packages/frontend/src/hooks/gdrive/useGdrive.ts
+++ b/packages/frontend/src/hooks/gdrive/useGdrive.ts
@@ -11,14 +11,14 @@ import { convertDateFilters } from '../../utils/dateFilter';
 import useHealth from '../health/useHealth';
 import useToaster from '../toaster/useToaster';
 
-const getGdriveAccessToken = async () =>
+export const getGdriveAccessToken = async () =>
     lightdashApi<ApiGdriveAccessTokenResponse['results']>({
         url: `/gdrive/get-access-token`,
         method: 'GET',
         body: undefined,
     });
 
-const triggerGdriveLogin = async (
+export const triggerGdriveLogin = async (
     loginPath: 'gdrive' | 'bigquery',
     siteUrl: string,
 ) => {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -248,6 +248,7 @@ const AppPreview = forwardRef<AppIframePreviewHandle, AppPreviewProps>(
                 onInspectorAvailabilityChange={onInspectorAvailabilityChange}
                 onScreenshotAvailabilityChange={onScreenshotAvailabilityChange}
                 onInspectorCancelled={onInspectorCancelled}
+                capabilities={{ gsheetExport: true }}
             />
         );
     },

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -258,6 +258,7 @@ export default function AppPreviewTest() {
                 identityKey={`${appUuid}:${version}`}
                 invalidateCache={invalidateCache}
                 onQueryEvent={handleQueryEvent}
+                capabilities={{ gsheetExport: true }}
             />
             {!queriesPanelHidden && (
                 <QueryInspector

--- a/packages/query-sdk/jest.config.cjs
+++ b/packages/query-sdk/jest.config.cjs
@@ -1,0 +1,18 @@
+/** @type {import('jest').Config} */
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    automock: false,
+    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+    maxWorkers: '50%',
+    globals: {
+        'ts-jest': {
+            tsconfig: {
+                module: 'commonjs',
+                moduleResolution: 'node',
+                esModuleInterop: true,
+                types: ['jest', 'node'],
+            },
+        },
+    },
+};

--- a/packages/query-sdk/package.json
+++ b/packages/query-sdk/package.json
@@ -29,6 +29,7 @@
         "lint": "eslint src/",
         "format": "oxfmt ./src --check",
         "fix-format": "oxfmt ./src",
+        "test": "jest --config jest.config.cjs",
         "release": "pnpm publish --no-git-checks --access public"
     },
     "peerDependencies": {

--- a/packages/query-sdk/src/exportToSheets.test.ts
+++ b/packages/query-sdk/src/exportToSheets.test.ts
@@ -1,0 +1,98 @@
+import { exportToSheets } from './exportToSheets';
+import type { SdkGsheetExportRequest } from './postMessageTransport';
+
+describe('exportToSheets', () => {
+    let listeners: Array<(e: MessageEvent) => void> = [];
+    let posted: unknown[] = [];
+    let mockParent: { postMessage: jest.Mock };
+    let mockWindow: {
+        addEventListener: jest.Mock;
+        removeEventListener: jest.Mock;
+        parent: { postMessage: jest.Mock };
+        crypto: { randomUUID: () => string };
+    };
+
+    beforeEach(() => {
+        listeners = [];
+        posted = [];
+
+        mockParent = {
+            postMessage: jest.fn((msg) => {
+                posted.push(msg);
+            }),
+        };
+
+        mockWindow = {
+            addEventListener: jest.fn((evt, cb) => {
+                if (evt === 'message') listeners.push(cb as never);
+            }),
+            removeEventListener: jest.fn((evt, cb) => {
+                if (evt === 'message') {
+                    listeners = listeners.filter((l) => l !== cb);
+                }
+            }),
+            parent: mockParent,
+            crypto: {
+                randomUUID: () =>
+                    `test-uuid-${Math.random().toString(36).slice(2)}`,
+            },
+        };
+
+        // Install mock window so exportToSheets sees it
+        (global as Record<string, unknown>).window = mockWindow;
+    });
+
+    afterEach(() => {
+        delete (global as Record<string, unknown>).window;
+        jest.restoreAllMocks();
+    });
+
+    const reply = (id: string, data: { fileUrl?: string; error?: string }) => {
+        for (const l of listeners) {
+            l(
+                new MessageEvent('message', {
+                    data: {
+                        type: 'lightdash:sdk:gsheet-export-response',
+                        id,
+                        ...data,
+                    },
+                }),
+            );
+        }
+    };
+
+    it('resolves with fileUrl when the parent responds successfully', async () => {
+        const p = exportToSheets({
+            title: 'T',
+            columns: [{ key: 'a' }],
+            rows: [{ a: 1 }],
+        });
+        const sent = posted[0] as SdkGsheetExportRequest;
+        expect(sent.type).toBe('lightdash:sdk:gsheet-export-request');
+        reply(sent.id, { fileUrl: 'https://sheets/abc' });
+        await expect(p).resolves.toEqual({ fileUrl: 'https://sheets/abc' });
+    });
+
+    it('rejects with the parent-supplied error message', async () => {
+        const p = exportToSheets({
+            title: 'T',
+            columns: [{ key: 'a' }],
+            rows: [{ a: 1 }],
+        });
+        const sent = posted[0] as SdkGsheetExportRequest;
+        reply(sent.id, { error: 'Google account not connected' });
+        await expect(p).rejects.toThrow('Google account not connected');
+    });
+
+    it('ignores responses with mismatched ids', async () => {
+        const p = exportToSheets({
+            title: 'T',
+            columns: [{ key: 'a' }],
+            rows: [{ a: 1 }],
+        });
+        const sent = posted[0] as SdkGsheetExportRequest;
+        reply('wrong-id', { fileUrl: 'nope' });
+        reply(sent.id, { fileUrl: 'right' });
+        await expect(p).resolves.toEqual({ fileUrl: 'right' });
+    });
+});

--- a/packages/query-sdk/src/exportToSheets.ts
+++ b/packages/query-sdk/src/exportToSheets.ts
@@ -1,0 +1,90 @@
+/**
+ * On-demand export to Google Sheets for data apps.
+ *
+ * The SDK posts a single message to the parent host. The parent owns the
+ * Google OAuth popup (sandboxed iframes can't), the backend POST, and the
+ * job polling. This function awaits one response.
+ */
+
+import type {
+    SdkGsheetExportColumn,
+    SdkGsheetExportRequest,
+    SdkGsheetExportResponse,
+    SdkGsheetExportRow,
+} from './postMessageTransport';
+
+const TIMEOUT_MS = 120_000;
+
+export type ExportToSheetsOptions = {
+    title: string;
+    columns: SdkGsheetExportColumn[];
+    rows: SdkGsheetExportRow[];
+};
+
+export type ExportToSheetsResult = {
+    fileUrl: string;
+};
+
+export async function exportToSheets(
+    options: ExportToSheetsOptions,
+): Promise<ExportToSheetsResult> {
+    if (typeof window === 'undefined') {
+        throw new Error(
+            'exportToSheets must run in a browser context (iframe)',
+        );
+    }
+    if (window.parent === window) {
+        throw new Error(
+            'exportToSheets must run inside a Lightdash data-app iframe',
+        );
+    }
+
+    const id =
+        typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const request: SdkGsheetExportRequest = {
+        type: 'lightdash:sdk:gsheet-export-request',
+        id,
+        title: options.title,
+        columns: options.columns,
+        rows: options.rows,
+    };
+
+    return new Promise<ExportToSheetsResult>((resolve, reject) => {
+        const handler = (event: MessageEvent) => {
+            const data = event.data as SdkGsheetExportResponse | undefined;
+            if (
+                !data ||
+                data.type !== 'lightdash:sdk:gsheet-export-response' ||
+                data.id !== id
+            ) {
+                return;
+            }
+            window.removeEventListener('message', handler);
+            clearTimeout(timer);
+            if (data.error) {
+                reject(new Error(data.error));
+                return;
+            }
+            if (!data.fileUrl) {
+                reject(new Error('Sheet export returned no file URL'));
+                return;
+            }
+            resolve({ fileUrl: data.fileUrl });
+        };
+
+        const timer = setTimeout(() => {
+            window.removeEventListener('message', handler);
+            reject(
+                new Error(
+                    `exportToSheets timed out after ${TIMEOUT_MS}ms`,
+                ),
+            );
+        }, TIMEOUT_MS);
+
+        window.addEventListener('message', handler);
+        window.parent.postMessage(request, '*');
+    });
+}

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -53,6 +53,11 @@ export type {
     SdkScreenshotAvailableMessage,
     SdkScreenshotRequest,
     SdkScreenshotResponse,
+    SdkGsheetExportRequest,
+    SdkGsheetExportResponse,
+    SdkGsheetExportColumn,
+    SdkGsheetExportColumnType,
+    SdkGsheetExportRow,
 } from './postMessageTransport';
 
 // Element inspector (click-to-edit) — protocol types for parent bridge.
@@ -60,3 +65,10 @@ export type {
     InspectAvailableMessage,
     InspectSelectedMessage,
 } from './inspector';
+
+// Google Sheets export (data apps)
+export { exportToSheets } from './exportToSheets';
+export type {
+    ExportToSheetsOptions,
+    ExportToSheetsResult,
+} from './exportToSheets';

--- a/packages/query-sdk/src/postMessageTransport.ts
+++ b/packages/query-sdk/src/postMessageTransport.ts
@@ -61,6 +61,48 @@ export type SdkScreenshotAvailableMessage = {
 };
 
 // ---------------------------------------------------------------------------
+// Google Sheets export protocol
+// ---------------------------------------------------------------------------
+
+export type SdkGsheetExportColumnType =
+    | 'string'
+    | 'number'
+    | 'date'
+    | 'timestamp'
+    | 'boolean';
+
+export type SdkGsheetExportColumn = {
+    key: string;
+    label?: string;
+    type?: SdkGsheetExportColumnType;
+};
+
+export type SdkGsheetExportRow = Record<string, string | number | boolean | null>;
+
+/**
+ * Iframe → parent. The parent host (useAppSdkBridge) runs the Google OAuth
+ * popup if needed, POSTs to /api/v1/gdrive/upload-gsheet-from-rows, polls
+ * the resulting job, and posts back an SdkGsheetExportResponse.
+ *
+ * Capability-gated on the parent side: hosts that don't opt in respond with
+ * an error message.
+ */
+export type SdkGsheetExportRequest = {
+    type: 'lightdash:sdk:gsheet-export-request';
+    id: string;
+    title: string;
+    columns: SdkGsheetExportColumn[];
+    rows: SdkGsheetExportRow[];
+};
+
+export type SdkGsheetExportResponse = {
+    type: 'lightdash:sdk:gsheet-export-response';
+    id: string;
+    fileUrl?: string;
+    error?: string;
+};
+
+// ---------------------------------------------------------------------------
 // postMessage FetchAdapter
 // ---------------------------------------------------------------------------
 

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -259,7 +259,7 @@ in the tool.
 
 ## SDK Reference
 
-The client and provider are already set up in `main.jsx`. Import `query` and `useLightdash` — that's it.
+The client and provider are already set up in `main.jsx`. Import `query` and `useLightdash` for queries; a few task-specific helpers (`exportToSheets`, `useLightdashClient`) are documented in their own sections below.
 
 ```tsx
 import { query, useLightdash } from '@lightdash/query-sdk';
@@ -558,6 +558,94 @@ Rules:
 - Disable export buttons while the query is loading or when `data.length === 0`.
 - Track export state (`exporting`, `isExporting`, etc.), disable export controls while awaiting `downloadResults()`, and show a spinner or "Exporting..." label until the promise settles.
 - Show a toast or inline note if the returned result has `truncated: true`.
+
+### Google Sheets export
+
+Use `exportToSheets()` when the user wants a one-click "Open in Google Sheets" button or otherwise needs the data to land in a new Google spreadsheet they own. It takes the in-memory rows the app already has and creates a new sheet against the viewer's connected Google account.
+
+`exportToSheets` is a top-level export from the SDK, not a `useLightdash` field — it isn't tied to a single query:
+
+```tsx
+import { exportToSheets } from '@lightdash/query-sdk';
+```
+
+When to use it vs `downloadResults`:
+
+- **`exportToSheets`** writes the rows you pass in to a *new Google Sheet*. The rows can be anything the app has produced — query results, joined/aggregated combinations of multiple queries, locally filtered subsets, computed columns. Use this when the data the user wants exported only exists in the React layer, or when the destination is Sheets specifically.
+- **`downloadResults`** re-runs the underlying Lightdash query server-side and produces a CSV/XLSX file. Use this when the user wants raw query results matching the warehouse, not a React-transformed view.
+
+If both fit (a straight `useLightdash(query)` table with no client transforms, and the user just wants "send to Sheets"), prefer `exportToSheets` for the Sheets case and `downloadResults` for CSV/XLSX.
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Loader2, ExternalLink } from 'lucide-react';
+import { exportToSheets } from '@lightdash/query-sdk';
+import { useState } from 'react';
+
+function ExportToSheetsButton() {
+    const { data, columns, loading } = useLightdash(revenueQuery);
+    const [exporting, setExporting] = useState(false);
+
+    const handleExport = async () => {
+        setExporting(true);
+        try {
+            const { fileUrl } = await exportToSheets({
+                title: 'Revenue by segment',
+                columns: columns.map((c) => ({
+                    key: c.name,
+                    label: c.label,
+                    type: c.type,
+                })),
+                rows: data,
+            });
+            window.open(fileUrl, '_blank');
+        } catch (err) {
+            // Show a toast in real app code. Common messages:
+            //  "Google Sheets export is not available in this context"
+            //     — running inside an embed; fall back to downloadResults.
+            //  "Google authentication was cancelled" — user closed OAuth popup.
+            //  "Export too large (max 100,000 rows / 25 MB)" — dataset too big.
+            console.error(err);
+        } finally {
+            setExporting(false);
+        }
+    };
+
+    const disabled = loading || exporting || data.length === 0;
+
+    return (
+        <Button variant="outline" size="sm" disabled={disabled} onClick={handleExport}>
+            {exporting ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+                <ExternalLink className="h-4 w-4 mr-1" />
+            )}
+            {exporting ? 'Exporting…' : 'Open in Google Sheets'}
+        </Button>
+    );
+}
+```
+
+Options:
+- `title`: spreadsheet name shown in Google Drive.
+- `columns`: ordered column definitions. `key` matches the row object key; optional `label` overrides the header text (defaults to `key`); optional `type` (`'string' | 'number' | 'date' | 'timestamp' | 'boolean'`) lets the backend format cells correctly.
+- `rows`: an array of plain objects keyed by the column `key`s. Values must be `string | number | boolean | null`.
+
+Returns `{ fileUrl }` — open it in a new tab to drop the user into the sheet.
+
+OAuth behavior:
+- If the viewer is signed into Lightdash but hasn't connected Google yet, the parent frame opens the standard Google OAuth popup automatically — `exportToSheets` awaits consent and then proceeds. Don't try to open the popup yourself; the iframe sandbox blocks it.
+
+Where it works:
+- First-party Lightdash sessions only (the app surfaces inside Lightdash's own UI and dashboard tiles).
+- **Not** available in JWT/public embed contexts. The promise rejects with `"Google Sheets export is not available in this context"`. Surface this as a clear toast and fall back to `downloadResults` if the same app may also render inside an embed.
+
+Rules:
+- Only call from explicit user actions such as a button or menu item.
+- Disable the button while exporting and when `data.length === 0`.
+- Track export state (`exporting`, `isExporting`, etc.) and show a spinner or "Exporting…" label until the promise settles.
+- After success, open the returned `fileUrl` in a new tab. Don't try to render Google Sheets inside the app iframe — embedded sheets need third-party cookies the sandbox blocks.
+- Hard limits: 100,000 rows and 25 MB serialized payload. If you can tell upfront the dataset will exceed either, disable the button with an explanatory tooltip.
 
 ### Client-side PDF downloads
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #23760 

### Description:

Adds `exportToSheets({ title, columns, rows })` to `@lightdash/query-sdk` so data apps can offer a one-click "Open in Google Sheets" button that creates a new spreadsheet from in-memory rows.

  Flow: SDK in the sandboxed iframe → postMessage to the parent host (`useAppSdkBridge`) → parent runs the existing Google OAuth popup if needed → POSTs to a new endpoint `POST /api/v1/gdrive/upload-gsheet-from-rows` → reuses the
  existing `UPLOAD_GSHEET_FROM_QUERY` Graphile task, now dispatched on `payload.source: 'metricQuery' | 'rows'`. Returns `{ fileUrl }` for the app to open or render.

  Scope: first-party Lightdash users with a connected Google account. JWT/embed viewers are gated off via a new `capabilities.gsheetExport` flag on `useAppSdkBridge` (closed by default). Anonymous/embed export will need its own auth
  design and is deferred.

  ## Notable

  - **Sheets formula-injection sanitisation in `GoogleDriveClient.formatCell`.** Leading `=`/`@`/`\t`/`\r` get a single-quote prefix so cells stay literal. Cells were written with`valueInputOption: 'RAW'` already, so injection was a
  re-entry/re-import threat rather than immediate execution — but apps now supply arbitrary client-side row content, which materially widens the surface. The fix also closes the same hole on the existing chart-export path. Leading
  `-`/`+` are deliberately not sanitised so signed numeric strings (`-100`, `+0.5`) aren't mangled.
  - **Capability gate is closed-by-default.** `useAppSdkBridge` gained a `capabilities` option; `AppGenerate`, `AppPreviewTest`, and `DashboardDataAppTile` opt in. `EmbedApp`, `EmbedDataAppTile`, `MinimalApp` deliberately do not, and
  the SDK rejects on those surfaces with `"Google Sheets export is not available in this context"`.
  - **Body-parser ordering.** The 25 MB per-route `express.json()` is mounted *before* the global parser — Express body-parser is a no-op once `req.body` is set, so ordering matters. A row-count cap of **100,000** and a payload cap of
  **25 MB** are enforced server-side.
  - **`uploadGsheetFromQuery` was split into an outer wrapper + two inner methods** (`...FromMetricQueryInner`, `...FromRowsInner`). The metric-query branch is a verbatim move; chart-export behaviour should be unchanged, but the pivot
  path is the highest-risk regression area to spot-check.
  - **`sandboxes/data-apps/template/skill.md`** documents the new method so the in-sandbox agent stops recommending CSV copy-paste workarounds. Resumed E2B sandboxes will keep thestale skill until rebuilt — coordinate the sandbox image
   rebuild with this merge.
