### PR TITLE
fix: hide "View chart" action in embed mode

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -17,6 +17,7 @@ import {
 } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { lightdashApi } from '../api';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import useApp from '../providers/App/useApp';
 import { convertDateFilters } from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
@@ -365,6 +366,8 @@ export const useCreateMutation = ({
     const navigate = useNavigate();
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const queryClient = useQueryClient();
+    const { embedToken } = useEmbed();
+    const isEmbedded = embedToken !== undefined;
     const { showToastSuccess, showToastError, showToastApiError } =
         useToaster();
     return useMutation<SavedChart, ApiError, CreateSavedChart>(
@@ -384,7 +387,9 @@ export const useCreateMutation = ({
                     showToastSuccess({
                         title: `Success! Chart was saved.`,
                         action:
-                            redirectOnSuccess || !showViewChartAction
+                            isEmbedded ||
+                            redirectOnSuccess ||
+                            !showViewChartAction
                                 ? undefined
                                 : {
                                       children: 'View chart',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-540/ux-improvement-remove-view-chartbutton-on-embed-ai

### Description:
When saving a chart in an embedded context, the "View chart" action toast notification is now hidden. This prevents embedded users from being shown a navigation action that would not work correctly within the embed environment.