### PR TITLE
fix: hide "View saved chart" in embed mode

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -304,6 +304,15 @@ export const AiChartQuickOptions = ({
     if (!metricQuery) return null;
 
     const canVerify = !!artifactData && canManageAgent;
+    const hasSavedChartAction = !!message.savedQueryUuid && !isEmbed;
+    const hasSaveActions = !message.savedQueryUuid;
+    const hasExploreAction = !isEmbed;
+    const hasSqlActions = !!compiledSql;
+    const hasQuickActions =
+        hasSavedChartAction ||
+        hasSaveActions ||
+        hasExploreAction ||
+        hasSqlActions;
 
     return (
         <Fragment>
@@ -333,112 +342,122 @@ export const AiChartQuickOptions = ({
                     </ActionIcon>
                 </Tooltip>
             )}
-            <Menu withArrow position="bottom-end">
-                <Menu.Target>
-                    <ActionIcon size="sm" variant="subtle" color="ldGray.9">
-                        <MantineIcon icon={IconDots} size="lg" />
-                    </ActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                    <Menu.Label>Quick actions</Menu.Label>
-                    {message.savedQueryUuid ? (
-                        <Menu.Item
-                            component={Link}
-                            to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
-                            target="_blank"
-                            leftSection={
-                                <MantineIcon icon={IconTableShortcut} />
-                            }
-                        >
-                            View saved chart
-                        </Menu.Item>
-                    ) : (
-                        <>
-                            {quickSaveDashboard && (
+            {hasQuickActions && (
+                <Menu withArrow position="bottom-end">
+                    <Menu.Target>
+                        <ActionIcon size="sm" variant="subtle" color="ldGray.9">
+                            <MantineIcon icon={IconDots} size="lg" />
+                        </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Label>Quick actions</Menu.Label>
+                        {message.savedQueryUuid ? (
+                            !isEmbed && (
                                 <Menu.Item
-                                    onClick={() =>
-                                        void handleSaveToCurrentDashboard()
-                                    }
-                                    disabled={isDisabled || isSavingToDashboard}
+                                    component={Link}
+                                    to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
+                                    target="_blank"
                                     leftSection={
-                                        <MantineIcon
-                                            icon={IconLayoutDashboard}
-                                        />
+                                        <MantineIcon icon={IconTableShortcut} />
                                     }
                                 >
-                                    Save to current dashboard
+                                    View saved chart
                                 </Menu.Item>
-                            )}
+                            )
+                        ) : (
+                            <>
+                                {quickSaveDashboard && (
+                                    <Menu.Item
+                                        onClick={() =>
+                                            void handleSaveToCurrentDashboard()
+                                        }
+                                        disabled={
+                                            isDisabled || isSavingToDashboard
+                                        }
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconLayoutDashboard}
+                                            />
+                                        }
+                                    >
+                                        Save to current dashboard
+                                    </Menu.Item>
+                                )}
+                                <Menu.Item
+                                    onClick={() => open()}
+                                    leftSection={
+                                        <MantineIcon icon={IconDeviceFloppy} />
+                                    }
+                                >
+                                    {quickSaveDashboard ? 'Save to…' : 'Save'}
+                                </Menu.Item>
+                            </>
+                        )}
+
+                        {!isEmbed && (
                             <Menu.Item
-                                onClick={() => open()}
                                 leftSection={
-                                    <MantineIcon icon={IconDeviceFloppy} />
+                                    <MantineIcon icon={IconExternalLink} />
+                                }
+                                disabled={isDisabled}
+                                onClick={handleExploreFromHere}
+                            >
+                                Explore from here
+                            </Menu.Item>
+                        )}
+
+                        {!!compiledSql && (
+                            <HoverCard
+                                shadow="subtle"
+                                radius="md"
+                                position="left-start"
+                                withinPortal
+                                openDelay={120}
+                            >
+                                <HoverCard.Target>
+                                    <Menu.Item
+                                        leftSection={
+                                            <MantineIcon icon={IconEye} />
+                                        }
+                                        closeMenuOnClick={false}
+                                    >
+                                        View SQL
+                                    </Menu.Item>
+                                </HoverCard.Target>
+                                <HoverCard.Dropdown p={0} maw={500}>
+                                    <Prism
+                                        language="sql"
+                                        withLineNumbers
+                                        noCopy
+                                        styles={{
+                                            lineContent: {
+                                                fontSize: 10,
+                                            },
+                                        }}
+                                    >
+                                        {compiledSql}
+                                    </Prism>
+                                </HoverCard.Dropdown>
+                            </HoverCard>
+                        )}
+
+                        {!!compiledSql ? (
+                            <Menu.Item
+                                component={Link}
+                                to={{
+                                    pathname: `/projects/${projectUuid}/sql-runner`,
+                                }}
+                                state={{ sql: compiledSql }}
+                                leftSection={
+                                    <MantineIcon icon={IconTerminal2} />
                                 }
                             >
-                                {quickSaveDashboard ? 'Save to…' : 'Save'}
+                                Open in SQL Runner
                             </Menu.Item>
-                        </>
-                    )}
-
-                    {!isEmbed && (
-                        <Menu.Item
-                            leftSection={
-                                <MantineIcon icon={IconExternalLink} />
-                            }
-                            disabled={isDisabled}
-                            onClick={handleExploreFromHere}
-                        >
-                            Explore from here
-                        </Menu.Item>
-                    )}
-
-                    {!!compiledSql && (
-                        <HoverCard
-                            shadow="subtle"
-                            radius="md"
-                            position="left-start"
-                            withinPortal
-                            openDelay={120}
-                        >
-                            <HoverCard.Target>
-                                <Menu.Item
-                                    leftSection={<MantineIcon icon={IconEye} />}
-                                    closeMenuOnClick={false}
-                                >
-                                    View SQL
-                                </Menu.Item>
-                            </HoverCard.Target>
-                            <HoverCard.Dropdown p={0} maw={500}>
-                                <Prism
-                                    language="sql"
-                                    withLineNumbers
-                                    noCopy
-                                    styles={{
-                                        lineContent: {
-                                            fontSize: 10,
-                                        },
-                                    }}
-                                >
-                                    {compiledSql}
-                                </Prism>
-                            </HoverCard.Dropdown>
-                        </HoverCard>
-                    )}
-
-                    {!!compiledSql ? (
-                        <Menu.Item
-                            component={Link}
-                            to={{
-                                pathname: `/projects/${projectUuid}/sql-runner`,
-                            }}
-                            state={{ sql: compiledSql }}
-                            leftSection={<MantineIcon icon={IconTerminal2} />}
-                        >
-                            Open in SQL Runner
-                        </Menu.Item>
-                    ) : null}
-                </Menu.Dropdown>
-            </Menu>
+                        ) : null}
+                    </Menu.Dropdown>
+                </Menu>
+            )}
             <MantineModal
                 opened={opened}
                 onClose={close}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-537/after-saving-a-chart-on-ai-i-have-the-option-to-view-open-chart

<img width="1036" height="518" alt="CleanShot 2026-06-17 at 16 03 45@2x" src="https://github.com/user-attachments/assets/f5d60035-c022-4926-a1ec-4c6d999ca707" />

we also hide options menu if there are no options 

The PR looks big because wrapping the quick-actions menu in hasQuickActions && (...) indented the whole menu block. With whitespace ignored, the diff is much smaller: 22 insertions, 3 deletions.
So the scope is correct, but the rendered GitHub diff is noisier than ideal. The actual behavioral changes are just:
Don’t show View saved chart in embed mode.
Don’t show Explore from here in embed mode.
Hide the quick-actions menu when no actions remain.

### Description:
Hides the "View saved chart" menu item in the AI Copilot chart quick options when the app is running in embed mode. Previously, this link was always shown when a `savedQueryUuid` was present, which could expose navigation options that are not applicable or accessible in an embedded context.