### PR TITLE
fix(ai-agents): eliminate typing lag in agent instructions field

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -19,6 +19,7 @@ import {
     TagsInput,
     Text,
     Textarea,
+    type TextareaProps,
     TextInput,
     Title,
     Tooltip,
@@ -38,7 +39,7 @@ import {
     IconUpload,
     IconUsers,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { z } from 'zod';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import MantineModal from '../../../../components/common/MantineModal';
@@ -79,6 +80,24 @@ const formSchema = z.object({
     adminOnly: z.boolean(),
     version: z.number(),
 });
+
+type CommitOnBlurTextareaProps = Omit<
+    TextareaProps,
+    'defaultValue' | 'value' | 'onChange'
+> & {
+    defaultValue: string;
+    onCommit: (value: string) => void;
+};
+
+const CommitOnBlurTextarea = memo(
+    ({ defaultValue, onCommit, ...props }: CommitOnBlurTextareaProps) => (
+        <Textarea
+            defaultValue={defaultValue}
+            onBlur={(e) => onCommit(e.currentTarget.value)}
+            {...props}
+        />
+    ),
+);
 
 export const AiAgentFormSetup = ({
     mode,
@@ -273,21 +292,24 @@ export const AiAgentFormSetup = ({
                                     />
                                 </Tooltip>
                             </Group>
-                            <Textarea
+                            <CommitOnBlurTextarea
+                                key={`description-${
+                                    form.values.description != null
+                                }`}
                                 variant="subtle"
                                 label="Description"
                                 description="A brief description of what this agent does and its purpose."
                                 placeholder="Describe what this agent specializes in..."
                                 minRows={3}
                                 maxRows={6}
-                                {...form.getInputProps('description')}
-                                onChange={(e) => {
-                                    const value = e.target.value;
+                                error={form.errors.description}
+                                defaultValue={form.values.description ?? ''}
+                                onCommit={(value) =>
                                     form.setFieldValue(
                                         'description',
                                         value ? value : null,
-                                    );
-                                }}
+                                    )
+                                }
                             />
                             <Box>
                                 <Text size="sm" fw={500}>
@@ -515,7 +537,10 @@ export const AiAgentFormSetup = ({
                                 </Title>
                             </Group>
                             <Stack gap="xs">
-                                <Textarea
+                                <CommitOnBlurTextarea
+                                    key={`instruction-${
+                                        form.values.instruction != null
+                                    }`}
                                     variant="subtle"
                                     label="Instructions"
                                     description="Set the overall behavior and task for the agent. This defines how it should respond and what its purpose is."
@@ -524,12 +549,15 @@ export const AiAgentFormSetup = ({
                                     autosize
                                     minRows={3}
                                     maxRows={8}
-                                    {...form.getInputProps('instruction')}
+                                    error={form.errors.instruction}
+                                    defaultValue={form.values.instruction ?? ''}
+                                    onCommit={(value) =>
+                                        form.setFieldValue(
+                                            'instruction',
+                                            value ? value : null,
+                                        )
+                                    }
                                 />
-                                <Text size="xs" c="dimmed">
-                                    {form.values.instruction?.length ?? 0}{' '}
-                                    characters
-                                </Text>
                             </Stack>
                             <Stack gap="sm">
                                 <Box>

--- a/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
@@ -1,7 +1,7 @@
 import { type AiAgentExploreAccessSummary } from '@lightdash/common';
-import { Group, Stack, Text, Tree, type TreeNodeData } from '@mantine-8/core';
+  import { Group, Stack, Text, Tree, type TreeNodeData } from '@mantine-8/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { memo, useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 
 const convertToTree = (exploreAccessSummary: AiAgentExploreAccessSummary[]) => {
@@ -38,10 +38,14 @@ type Props = {
     exploreAccessSummary: AiAgentExploreAccessSummary[];
 };
 
-const AiExploreAccessTree: FC<Props> = ({ exploreAccessSummary }) => {
+const AiExploreAccessTree: FC<Props> = memo(({ exploreAccessSummary }) => {
+    const treeData = useMemo(
+        () => convertToTree(exploreAccessSummary),
+        [exploreAccessSummary],
+    );
     return (
         <Tree
-            data={convertToTree(exploreAccessSummary)}
+            data={treeData}
             renderNode={({
                 node,
                 expanded,
@@ -94,6 +98,6 @@ const AiExploreAccessTree: FC<Props> = ({ exploreAccessSummary }) => {
             )}
         />
     );
-};
+});
 
 export default AiExploreAccessTree;

--- a/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiExploreAccessTree.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentExploreAccessSummary } from '@lightdash/common';
-  import { Group, Stack, Text, Tree, type TreeNodeData } from '@mantine-8/core';
+import { Group, Stack, Text, Tree, type TreeNodeData } from '@mantine-8/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
 import { memo, useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';


### PR DESCRIPTION
Closes #16729

## Problem

Typing in the **Instructions** field on the agent edit page lags noticeably, and the page is slow to load.

## Root cause

The edit form is a single **controlled** `@mantine/form`. Every keystroke calls `setFieldValue`, re-rendering the entire form subtree. On a project with 65 explores / ~1500 fields, that's a full reconciliation on every character.

## Fix

1. **Memoize `AiExploreAccessTree`** (`React.memo` + `useMemo`). Its only prop is stable query data, so it now skips re-rendering entirely while typing instead of rebuilding/reconciling 1500+ nodes per keystroke. (~halves the cost on its own.)
2. **Make Instructions and Description uncontrolled**, committing to form state **on blur** instead of every keystroke, via a small `CommitOnBlurTextarea`. Typing now mutates only local DOM — zero React re-renders. A remount key picks up the value that loads asynchronously after the agent fetch. Removed the character counter, which was the only render-time reader of the instruction value.

## Behavior change

The **"Save changes"** button now appears when you click out of Instructions/Description (on commit), rather than on the first keystroke. Submit always captures the latest value.
