### PR TITLE
fix(explorer): correct timezone affordance for day-grain timestamp intervals

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -30,6 +30,7 @@ import {
     getEffectiveSeparator,
     getFormatterTimezone,
     isCalendarValueItem,
+    isItemTimezoneAffected,
     isMomentInput,
     isTimestampString,
     shouldShiftItemTimezone,
@@ -1061,6 +1062,71 @@ describe('Formatting', () => {
             } as TableCalculation;
             expect(isCalendarValueItem(dateTableCalc)).toBe(true);
             expect(isCalendarValueItem(timestampTableCalc)).toBe(false);
+        });
+    });
+
+    describe('isItemTimezoneAffected', () => {
+        const timestampBase: Dimension = {
+            ...dimension,
+            type: DimensionType.TIMESTAMP,
+        };
+        const timestampHour: Dimension = {
+            ...dimension,
+            type: DimensionType.TIMESTAMP,
+            timeInterval: TimeFrames.HOUR,
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const dateOverTimestampDay: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.DAY,
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const dateBase: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+        };
+        const dateOverDateDay: Dimension = {
+            ...dimension,
+            type: DimensionType.DATE,
+            timeInterval: TimeFrames.DAY,
+            timeIntervalBaseDimensionType: DimensionType.DATE,
+        };
+
+        test('any grain of a TIMESTAMP base is timezone-affected', () => {
+            expect(isItemTimezoneAffected(timestampBase)).toBe(true);
+            expect(isItemTimezoneAffected(timestampHour)).toBe(true);
+            // GLITCH-452: a day-or-coarser trunc of a TIMESTAMP base compiles to
+            // a real DATE but is still shifted server-side, so it IS affected.
+            expect(isItemTimezoneAffected(dateOverTimestampDay)).toBe(true);
+        });
+
+        test('DATE bases are not timezone-affected', () => {
+            expect(isItemTimezoneAffected(dateBase)).toBe(false);
+            expect(isItemTimezoneAffected(dateOverDateDay)).toBe(false);
+        });
+
+        test('skipTimezoneConversion opts out a TIMESTAMP base', () => {
+            const timestampBaseOptOut: Dimension = {
+                ...timestampBase,
+                skipTimezoneConversion: true,
+            };
+            const dateOverTimestampDayOptOut: Dimension = {
+                ...dateOverTimestampDay,
+                skipTimezoneConversion: true,
+            };
+            expect(isItemTimezoneAffected(timestampBaseOptOut)).toBe(false);
+            expect(isItemTimezoneAffected(dateOverTimestampDayOptOut)).toBe(
+                false,
+            );
+        });
+
+        test('non-dimensions classify by their resolved type', () => {
+            const maxMetric: Metric = { ...metric, type: MetricType.MAX };
+            expect(isItemTimezoneAffected(undefined)).toBe(false);
+            expect(isItemTimezoneAffected(dimension)).toBe(false); // STRING
+            expect(isItemTimezoneAffected(metric)).toBe(false); // COUNT
+            expect(isItemTimezoneAffected(maxMetric)).toBe(false);
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -227,17 +227,37 @@ export const toIsoWithProjectOffset = (
     return m.tz(timezone).toISOString(true);
 };
 
-// Only TIMESTAMP instants shift; calendar DATEs (incl. day-or-coarser truncs,
-// which now compile to a real DATE — GLITCH-452) and dims with
-// `skipTimezoneConversion` stay put. Keyed off getItemType so it classifies
-// non-field items (table calcs, custom dims) by their resolved type too. Used by
-// spreadsheet exports.
+// Use this when deciding whether to re-shift a fetched VALUE in the client
+// (chart rendering, spreadsheet exports). Only TIMESTAMP instants shift; calendar
+// DATEs (incl. day-or-coarser truncs, which now compile to a real DATE —
+// GLITCH-452) and `skipTimezoneConversion` dims stay put. Keyed off getItemType
+// (resolved type) so it also classifies non-field items (table calcs, custom dims).
+// NOT for "is this field timezone-sensitive" UI — use isItemTimezoneAffected.
 export const shouldShiftItemTimezone = (
     item: Item | AdditionalMetric | undefined,
 ): boolean => {
     if (!item) return false;
     if (isDimension(item) && item.skipTimezoneConversion) return false;
     return getItemType(item) === DimensionType.TIMESTAMP;
+};
+
+// Use this for "is this field timezone-sensitive" UI affordances (icons,
+// tooltips). Whether a field's value depends on the chart's timezone at all —
+// server-side or client-side. Differs from shouldShiftItemTimezone ("does the
+// client re-shift the value"): a day-or-coarser trunc of a TIMESTAMP base
+// compiles to a real DATE, so it isn't re-shifted client-side, yet the backend
+// shifts to project tz before truncating — so it IS timezone-affected. Keyed
+// off the base column type, mirroring MetricQueryBuilder.
+export const isItemTimezoneAffected = (
+    item: Item | AdditionalMetric | undefined,
+): boolean => {
+    if (!item) return false;
+    if (isDimension(item) && item.skipTimezoneConversion) return false;
+    const baseType =
+        isDimension(item) && item.timeIntervalBaseDimensionType
+            ? item.timeIntervalBaseDimensionType
+            : getItemType(item);
+    return baseType === DimensionType.TIMESTAMP;
 };
 
 // A calendar value is a bare wall-clock date (year/month/day, no instant) that

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -8,9 +8,9 @@ import {
     isDimension,
     isField,
     isFilterableField,
+    isItemTimezoneAffected,
     isTimeInterval,
     MetricType,
-    shouldShiftItemTimezone,
     timeFrameConfigs,
     type AdditionalMetric,
     type Dimension,
@@ -80,7 +80,7 @@ const NavItemIcon = ({
         const isTimestamp = item.type === DimensionType.TIMESTAMP;
         if (!isDate && !isTimestamp) return null;
         // TZ-sensitive dims keep the default glyph; only the tooltip flags them.
-        if (shouldShiftItemTimezone(item)) {
+        if (isItemTimezoneAffected(item)) {
             return {
                 pinIcon: null,
                 tooltip: isDate


### PR DESCRIPTION
Closes: GLITCH-519

### Description:
Day-or-coarser truncs (Day, Week, Month…) of a TIMESTAMP dimension compile to a real `DATE` (GLITCH-452) but are still shifted to project timezone server-side, yet the explorer sidebar wrongly showed them with the calendar-pin icon and "Calendar date, not affected by the chart's timezone" because the affordance keyed off `shouldShiftItemTimezone` (resolved type). This adds `isItemTimezoneAffected`, which keys off the field's base column type to answer "is this field timezone-sensitive?", and uses it for the affordance so these intervals now correctly read "shifts with the chart's timezone". `shouldShiftItemTimezone` is left unchanged (it answers a different question — whether the client should re-shift a fetched value); both functions' comments now state when to use each. Unit tests for `isItemTimezoneAffected` added in `formatting.test.ts`.
