### PR TITLE
feat(embed): stable public CSS classnames for embedded dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/CLAUDE.md
+++ b/packages/frontend/src/ee/features/embed/CLAUDE.md
@@ -1,0 +1,43 @@
+<summary>
+Embedded dashboards expose a **public CSS class contract**: a fixed set of stable, human-readable classnames (e.g. `ld-dashboard-header`) that embedding customers target to override styles. CSS-module classes are hashed and change across builds, so they can't be targeted; these `ld-*` classes are the stable hooks. The vocabulary and the helper that applies it live in `styles/embedClassContract.ts`.
+</summary>
+
+<howToUse>
+When you add, rename, or restructure an element of an embedded dashboard that customers may want to style, give it a contract class.
+
+1. Add the classname to `EMBED_CLASS_CONTRACT` in `styles/embedClassContract.ts`. It must match `ld-[surface]-[element]` (the `satisfies` constraint enforces a known surface + element segment at compile time; add a new surface to `EmbedSurface` first if needed).
+2. Apply it with `embedContractClass(name, ...moduleClasses)`, which joins the public class with the hashed module class(es):
+
+```tsx
+import { embedContractClass } from '../../styles/embedClassContract';
+
+// Inline element (class lives on the embed-owned wrapper DOM node)
+<Box className={embedContractClass('ld-dashboard-header', styles.headerBar)}>
+```
+
+There are two placement mechanics, because some dropdowns render in a portal at `document.body`, outside the embed DOM tree:
+
+- **Inline elements** — put the class on the embed-owned wrapper. Customers reach inner triggers via descendant selectors (`.ld-dashboard-filters button {}`).
+- **Portalled dropdowns** (filter pills, date zoom, parameters) — a wrapper class can't reach them. Pass the class into the shared component's `dropdownClassName` prop, which applies it via Mantine `classNames={{ dropdown }}` so it lands on the portalled node.
+
+```tsx
+<DateZoom
+    isEditMode={false}
+    dropdownClassName={embedContractClass('ld-dashboard-date-zoom-dropdown')}
+/>
+```
+</howToUse>
+
+<importantToKnow>
+- **This is a public API.** Once a classname ships, renaming or removing it breaks customer stylesheets. Add freely; treat every existing name as frozen.
+- **Never apply a contract class unconditionally inside a shared component** (`features/dateZoom`, `features/dashboardFilters`, `features/parameters`). Those render in the main app too — the class would leak outside embeds. That's why the portalled dropdowns thread an optional `dropdownClassName` prop set only by the embed wrappers; a default/absent prop means no class in the main app.
+- **`[surface]` is the embedded surface the customer sees** (`dashboard`), not the React component name. Name by where it appears in the embed, not by which component renders it — the same shared component may render in several places.
+- If you change a shared component's dropdown structure, keep the `dropdownClassName` → `classNames={{ dropdown }}` wiring intact, or the contract silently breaks.
+</importantToKnow>
+
+<links>
+@/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts - The class vocabulary + `embedContractClass` helper
+@/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx - Inline contract class example
+@/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx - Inline + portalled (date zoom) example
+@/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx - Portalled dropdown via `dropdownClassName`
+</links>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -10,6 +10,7 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { DashboardFiltersBarSummary } from '../../../../../features/dashboardFilters/DashboardFiltersBarSummary';
 import { DateZoom } from '../../../../../features/dateZoom';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import { embedContractClass } from '../../styles/embedClassContract';
 import EmbedDashboardFilters from './EmbedDashboardFilters';
 import EmbedDashboardParameters from './EmbedDashboardParameters';
 
@@ -82,6 +83,7 @@ const EmbedDashboardFilterBar: FC<Props> = ({
 
     return (
         <Group
+            className={embedContractClass('ld-dashboard-filters')}
             justify="space-between"
             align="flex-start"
             wrap="nowrap"
@@ -101,8 +103,15 @@ const EmbedDashboardFilterBar: FC<Props> = ({
 
             <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
                 {dashboard.canDateZoom && (
-                    <Box>
-                        <DateZoom isEditMode={false} />
+                    <Box
+                        className={embedContractClass('ld-dashboard-date-zoom')}
+                    >
+                        <DateZoom
+                            isEditMode={false}
+                            dropdownClassName={embedContractClass(
+                                'ld-dashboard-date-zoom-dropdown',
+                            )}
+                        />
                     </Box>
                 )}
                 {isCollapsible && (

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -79,6 +79,7 @@ const EmbedDashboardFilters: FC = () => {
                     onPopoverClose={handlePopoverClose}
                     openPopoverId={openPopoverId}
                     activeTabUuid={activeTab?.uuid}
+                    triggerClassName={embedContractClass('ld-dashboard-filter')}
                     dropdownClassName={embedContractClass(
                         'ld-dashboard-filter-dropdown',
                     )}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilters.tsx
@@ -5,6 +5,7 @@ import FiltersProvider from '../../../../../components/common/Filters/FiltersPro
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import ActiveFilters from '../../../../../features/dashboardFilters/ActiveFilters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
+import { embedContractClass } from '../../styles/embedClassContract';
 
 const EmbedDashboardFilters: FC = () => {
     const [openPopoverId, setPopoverId] = useState<string>();
@@ -78,6 +79,9 @@ const EmbedDashboardFilters: FC = () => {
                     onPopoverClose={handlePopoverClose}
                     openPopoverId={openPopoverId}
                     activeTabUuid={activeTab?.uuid}
+                    dropdownClassName={embedContractClass(
+                        'ld-dashboard-filter-dropdown',
+                    )}
                 />
             </Flex>
         </FiltersProvider>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardHeader.tsx
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { Box } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
+import { embedContractClass } from '../../styles/embedClassContract';
 import EmbedDashboardExportPdf from './EmbedDashboardExportPdf';
 import EmbedDashboardFilterBar from './EmbedDashboardFilterBar';
 import styles from './EmbedDashboardHeader.module.css';
@@ -44,7 +45,10 @@ const EmbedDashboardHeader: FC<Props> = ({ dashboard, projectUuid, tabs }) => {
 
     return (
         <Box
-            className={styles.headerBar}
+            className={embedContractClass(
+                'ld-dashboard-header',
+                styles.headerBar,
+            )}
             data-sticky={isSticky}
             data-has-tabs={Boolean(tabs)}
         >

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -45,6 +45,7 @@ const EmbedDashboardParameters: FC = () => {
                 parameters={referencedParameters}
                 isLoading={!areAllChartsLoaded}
                 missingRequiredParameters={missingRequiredParameters}
+                triggerClassName={embedContractClass('ld-dashboard-parameter')}
                 dropdownClassName={embedContractClass(
                     'ld-dashboard-parameter-dropdown',
                 )}

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -3,6 +3,7 @@ import { useMemo, type FC } from 'react';
 import { Parameters } from '../../../../../features/parameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../../../providers/Dashboard/useDashboardTileStatusContext';
+import { embedContractClass } from '../../styles/embedClassContract';
 
 const EmbedDashboardParameters: FC = () => {
     const parameterValues = useDashboardContext((c) => c.parameterValues);
@@ -30,7 +31,12 @@ const EmbedDashboardParameters: FC = () => {
     }, [parameterDefinitions, parameterReferences]);
 
     return (
-        <Group gap="xs" wrap="wrap" style={{ flexShrink: 0 }}>
+        <Group
+            className={embedContractClass('ld-dashboard-parameters')}
+            gap="xs"
+            wrap="wrap"
+            style={{ flexShrink: 0 }}
+        >
             <Parameters
                 isEditMode={false}
                 parameterValues={parameterValues}
@@ -39,6 +45,9 @@ const EmbedDashboardParameters: FC = () => {
                 parameters={referencedParameters}
                 isLoading={!areAllChartsLoaded}
                 missingRequiredParameters={missingRequiredParameters}
+                dropdownClassName={embedContractClass(
+                    'ld-dashboard-parameter-dropdown',
+                )}
             />
         </Group>
     );

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
@@ -4,9 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { EMBED_CLASS_CONTRACT, embedContractClass } from './embedClassContract';
 
-// Raw source of the embed wrappers that apply the contract classes. Every
-// `embedContractClass(...)` call site lives in this directory, so scanning it
-// tells us which classes are actually wired onto an element.
+// Every `embedContractClass(...)` call site lives in the embed wrappers.
 const componentsDir = join(
     dirname(fileURLToPath(import.meta.url)),
     '../EmbedDashboard/components',
@@ -17,9 +15,7 @@ const componentSource = readdirSync(componentsDir)
     .join('\n');
 
 describe('embed class contract', () => {
-    // The public class vocabulary is FROZEN: renaming or removing an entry
-    // breaks embedding customers' stylesheets. Change this list only with a
-    // deliberate deprecation — never to make a failing test pass.
+    // Frozen public vocabulary: renaming/removing a class breaks customer CSS.
     it('exposes exactly the published classnames', () => {
         expect([...EMBED_CLASS_CONTRACT]).toEqual([
             'ld-dashboard-header',
@@ -34,9 +30,7 @@ describe('embed class contract', () => {
         ]);
     });
 
-    // A registered class that is never applied is a hook customers are told
-    // exists but that never renders. Guard against adding to the registry
-    // without wiring it onto a component.
+    // Every registered class must actually be applied to an element.
     it.each([...EMBED_CLASS_CONTRACT])(
         'applies "%s" in an embed component',
         (className) => {

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { EMBED_CLASS_CONTRACT, embedContractClass } from './embedClassContract';
+
+// Raw source of the embed wrappers that apply the contract classes. Every
+// `embedContractClass(...)` call site lives in this directory, so scanning it
+// tells us which classes are actually wired onto an element.
+const componentsDir = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '../EmbedDashboard/components',
+);
+const componentSource = readdirSync(componentsDir)
+    .filter((file) => file.endsWith('.tsx'))
+    .map((file) => readFileSync(join(componentsDir, file), 'utf-8'))
+    .join('\n');
+
+describe('embed class contract', () => {
+    // The public class vocabulary is FROZEN: renaming or removing an entry
+    // breaks embedding customers' stylesheets. Change this list only with a
+    // deliberate deprecation — never to make a failing test pass.
+    it('exposes exactly the published classnames', () => {
+        expect([...EMBED_CLASS_CONTRACT]).toEqual([
+            'ld-dashboard-header',
+            'ld-dashboard-filters',
+            'ld-dashboard-filter',
+            'ld-dashboard-date-zoom',
+            'ld-dashboard-parameters',
+            'ld-dashboard-parameter',
+            'ld-dashboard-filter-dropdown',
+            'ld-dashboard-date-zoom-dropdown',
+            'ld-dashboard-parameter-dropdown',
+        ]);
+    });
+
+    // A registered class that is never applied is a hook customers are told
+    // exists but that never renders. Guard against adding to the registry
+    // without wiring it onto a component.
+    it.each([...EMBED_CLASS_CONTRACT])(
+        'applies "%s" in an embed component',
+        (className) => {
+            expect(componentSource).toContain(`'${className}'`);
+        },
+    );
+
+    describe('embedContractClass', () => {
+        it('joins the public class with module classes', () => {
+            expect(
+                embedContractClass('ld-dashboard-header', 'mod_abc123'),
+            ).toBe('ld-dashboard-header mod_abc123');
+        });
+
+        it('drops falsy module classes', () => {
+            expect(
+                embedContractClass(
+                    'ld-dashboard-filters',
+                    false,
+                    undefined,
+                    null,
+                ),
+            ).toBe('ld-dashboard-filters');
+        });
+    });
+});

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
@@ -1,0 +1,45 @@
+/**
+ * Embedded surfaces that expose a public class contract. Every contract class
+ * is scoped to one of these. Add a surface here before using it in a classname.
+ */
+type EmbedSurface = 'dashboard';
+
+/**
+ * Public CSS class contract for embedded dashboards.
+ *
+ * Each entry is a STABLE classname that embedding customers target to override
+ * styles. This is a public API: once a name ships, renaming or removing it
+ * breaks customer stylesheets. Add new names freely; treat every existing one
+ * as frozen.
+ *
+ * Convention: ld-[surface]-[element], where [surface] is the embedded surface the
+ * customer sees (dashboard), NOT the React component. Apply only on embed-owned
+ * wrappers, or — for portalled dropdowns — via the rendering component's
+ * `classNames={{ dropdown }}`. Never apply inside a shared component
+ * unconditionally, or the class leaks outside embeds.
+ */
+const EMBED_CLASS_CONTRACT = [
+    'ld-dashboard-header',
+    'ld-dashboard-filters',
+    'ld-dashboard-date-zoom',
+    'ld-dashboard-parameters',
+    'ld-dashboard-filter-dropdown', // portalled
+    'ld-dashboard-date-zoom-dropdown', // portalled
+    'ld-dashboard-parameter-dropdown', // portalled
+] as const satisfies readonly `ld-${EmbedSurface}-${string}`[];
+
+export type EmbedContractClassName = (typeof EMBED_CLASS_CONTRACT)[number];
+
+type ClassValue = string | false | null | undefined;
+
+/**
+ * Joins a stable public classname with the internal (hashed) CSS-module classes
+ * that own the styling. The public class is frozen across builds; the module
+ * classes are free to change.
+ *
+ *   className={embedContractClass('ld-dashboard-header', styles.headerBar)}
+ */
+export const embedContractClass = (
+    name: EmbedContractClassName,
+    ...moduleClasses: ClassValue[]
+): string => [name, ...moduleClasses].filter(Boolean).join(' ');

--- a/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
+++ b/packages/frontend/src/ee/features/embed/styles/embedClassContract.ts
@@ -18,11 +18,13 @@ type EmbedSurface = 'dashboard';
  * `classNames={{ dropdown }}`. Never apply inside a shared component
  * unconditionally, or the class leaks outside embeds.
  */
-const EMBED_CLASS_CONTRACT = [
+export const EMBED_CLASS_CONTRACT = [
     'ld-dashboard-header',
     'ld-dashboard-filters',
+    'ld-dashboard-filter', // each filter pill
     'ld-dashboard-date-zoom',
     'ld-dashboard-parameters',
+    'ld-dashboard-parameter', // each parameter pill
     'ld-dashboard-filter-dropdown', // portalled
     'ld-dashboard-date-zoom-dropdown', // portalled
     'ld-dashboard-parameter-dropdown', // portalled

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -51,6 +51,7 @@ type Props = {
     isTemporary?: boolean;
     field: DashboardFilterableField | undefined;
     filterRule: DashboardFilterRule;
+    dropdownClassName?: string;
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
@@ -65,6 +66,7 @@ const Filter: FC<Props> = ({
     isTemporary,
     field,
     filterRule,
+    dropdownClassName,
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
@@ -278,6 +280,7 @@ const Filter: FC<Props> = ({
                 offset={1}
                 arrowOffset={14}
                 withinPortal
+                classNames={{ dropdown: dropdownClassName }}
             >
                 <Popover.Target>
                     <Indicator

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -51,9 +51,7 @@ type Props = {
     isTemporary?: boolean;
     field: DashboardFilterableField | undefined;
     filterRule: DashboardFilterRule;
-    /** Public embed styling-contract class for the filter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     triggerClassName?: string;
-    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -327,10 +327,9 @@ const Filter: FC<Props> = ({
                                 }
                                 classNames={{
                                     label: classes.label,
+                                    root: triggerClassName,
                                 }}
-                                className={`${triggerClassName ?? ''} ${
-                                    classes.button
-                                } ${
+                                className={`${classes.button} ${
                                     hasUnsetRequiredFilter
                                         ? classes.unsetRequiredFilter
                                         : ''

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -51,6 +51,9 @@ type Props = {
     isTemporary?: boolean;
     field: DashboardFilterableField | undefined;
     filterRule: DashboardFilterRule;
+    /** Public embed styling-contract class for the filter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
+    triggerClassName?: string;
+    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
@@ -66,6 +69,7 @@ const Filter: FC<Props> = ({
     isTemporary,
     field,
     filterRule,
+    triggerClassName,
     dropdownClassName,
     openPopoverId,
     onPopoverOpen,
@@ -324,7 +328,9 @@ const Filter: FC<Props> = ({
                                 classNames={{
                                     label: classes.label,
                                 }}
-                                className={`${classes.button} ${
+                                className={`${triggerClassName ?? ''} ${
+                                    classes.button
+                                } ${
                                     hasUnsetRequiredFilter
                                         ? classes.unsetRequiredFilter
                                         : ''

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
@@ -28,6 +28,9 @@ interface ActiveFiltersProps {
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
+    /** Public embed styling-contract class for each filter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
+    triggerClassName?: string;
+    /** Public embed styling-contract class for the portalled filter dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 }
 
@@ -94,6 +97,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
+    triggerClassName,
     dropdownClassName,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
@@ -290,6 +294,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                         )}
                                         field={field}
                                         filterRule={item}
+                                        triggerClassName={triggerClassName}
                                         dropdownClassName={dropdownClassName}
                                         openPopoverId={openPopoverId}
                                         onPopoverOpen={onPopoverOpen}
@@ -350,6 +355,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                     {...getOrphanedState(item, appliesToTabs)}
                                     field={metricField}
                                     filterRule={item}
+                                    triggerClassName={triggerClassName}
                                     dropdownClassName={dropdownClassName}
                                     openPopoverId={openPopoverId}
                                     onPopoverOpen={onPopoverOpen}
@@ -398,6 +404,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         {...getOrphanedState(item, appliesToTabs)}
                         field={metricField}
                         filterRule={item}
+                        triggerClassName={triggerClassName}
                         dropdownClassName={dropdownClassName}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
@@ -448,6 +455,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         isEditMode={isEditMode}
                         field={field}
                         filterRule={item}
+                        triggerClassName={triggerClassName}
                         dropdownClassName={dropdownClassName}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
@@ -28,9 +28,7 @@ interface ActiveFiltersProps {
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
-    /** Public embed styling-contract class for each filter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     triggerClassName?: string;
-    /** Public embed styling-contract class for the portalled filter dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 }
 

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/index.tsx
@@ -28,6 +28,7 @@ interface ActiveFiltersProps {
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
+    dropdownClassName?: string;
 }
 
 const DraggableItem: FC<{
@@ -93,6 +94,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
+    dropdownClassName,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
@@ -288,6 +290,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                         )}
                                         field={field}
                                         filterRule={item}
+                                        dropdownClassName={dropdownClassName}
                                         openPopoverId={openPopoverId}
                                         onPopoverOpen={onPopoverOpen}
                                         onPopoverClose={onPopoverClose}
@@ -347,6 +350,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                                     {...getOrphanedState(item, appliesToTabs)}
                                     field={metricField}
                                     filterRule={item}
+                                    dropdownClassName={dropdownClassName}
                                     openPopoverId={openPopoverId}
                                     onPopoverOpen={onPopoverOpen}
                                     onPopoverClose={onPopoverClose}
@@ -394,6 +398,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         {...getOrphanedState(item, appliesToTabs)}
                         field={metricField}
                         filterRule={item}
+                        dropdownClassName={dropdownClassName}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
                         onPopoverClose={onPopoverClose}
@@ -443,6 +448,7 @@ const ActiveFilters: FC<ActiveFiltersProps> = ({
                         isEditMode={isEditMode}
                         field={field}
                         filterRule={item}
+                        dropdownClassName={dropdownClassName}
                         openPopoverId={openPopoverId}
                         onPopoverOpen={onPopoverOpen}
                         onPopoverClose={onPopoverClose}

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -114,7 +114,6 @@ const ViewModeGranularityItem: FC<ViewModeGranularityItemProps> = ({
 
 type Props = {
     isEditMode: boolean;
-    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -114,9 +114,10 @@ const ViewModeGranularityItem: FC<ViewModeGranularityItemProps> = ({
 
 type Props = {
     isEditMode: boolean;
+    dropdownClassName?: string;
 };
 
-export const DateZoom: FC<Props> = ({ isEditMode }) => {
+export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
     const [showOpenIcon, setShowOpenIcon] = useState(false);
 
     const dateZoomGranularity = useDashboardContext(
@@ -257,6 +258,7 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                 closeOnClickOutside
                 offset={-1}
                 position="bottom-end"
+                classNames={{ dropdown: dropdownClassName }}
                 onOpen={() => setShowOpenIcon(true)}
                 onClose={() => setShowOpenIcon(false)}
             >

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -114,6 +114,7 @@ const ViewModeGranularityItem: FC<ViewModeGranularityItemProps> = ({
 
 type Props = {
     isEditMode: boolean;
+    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -144,12 +144,13 @@ const Parameter: FC<Props> = ({
                         }
                         classNames={{
                             label: styles.label,
+                            root: triggerClassName,
                         }}
-                        className={`${triggerClassName ?? ''} ${
+                        className={
                             hasUnsetRequiredParameter
                                 ? styles.unsetRequired
                                 : ''
-                        }`}
+                        }
                         leftSection={
                             isDraggable && (
                                 <MantineIcon

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -34,9 +34,7 @@ type Props = {
     isRequired?: boolean;
     isEditMode?: boolean;
     isDraggable?: boolean;
-    /** Public embed styling-contract class for the parameter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     triggerClassName?: string;
-    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -34,6 +34,7 @@ type Props = {
     isRequired?: boolean;
     isEditMode?: boolean;
     isDraggable?: boolean;
+    dropdownClassName?: string;
 };
 
 const Parameter: FC<Props> = ({
@@ -48,6 +49,7 @@ const Parameter: FC<Props> = ({
     projectUuid,
     isRequired = false,
     isDraggable = false,
+    dropdownClassName,
 }) => {
     const popoverId = useId();
     const isPopoverOpen = openPopoverId === popoverId;
@@ -119,6 +121,7 @@ const Parameter: FC<Props> = ({
             offset={1}
             arrowOffset={14}
             withinPortal
+            classNames={{ dropdown: dropdownClassName }}
         >
             <Popover.Target>
                 <Tooltip

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -34,6 +34,9 @@ type Props = {
     isRequired?: boolean;
     isEditMode?: boolean;
     isDraggable?: boolean;
+    /** Public embed styling-contract class for the parameter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
+    triggerClassName?: string;
+    /** Public embed styling-contract class for the portalled dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 
@@ -49,6 +52,7 @@ const Parameter: FC<Props> = ({
     projectUuid,
     isRequired = false,
     isDraggable = false,
+    triggerClassName,
     dropdownClassName,
 }) => {
     const popoverId = useId();
@@ -141,11 +145,11 @@ const Parameter: FC<Props> = ({
                         classNames={{
                             label: styles.label,
                         }}
-                        className={
+                        className={`${triggerClassName ?? ''} ${
                             hasUnsetRequiredParameter
                                 ? styles.unsetRequired
                                 : ''
-                        }
+                        }`}
                         leftSection={
                             isDraggable && (
                                 <MantineIcon

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -30,6 +30,9 @@ type Props = {
     onParameterReorder?: (order: string[]) => void;
     /** Separator element to render with the first parameter (so they wrap together) */
     separator?: ReactNode;
+    /** Public embed styling-contract class for each parameter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
+    triggerClassName?: string;
+    /** Public embed styling-contract class for the portalled parameter dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 
@@ -43,6 +46,7 @@ export const Parameters: FC<Props> = ({
     separator,
     parameterOrder = [],
     onParameterReorder,
+    triggerClassName,
     dropdownClassName,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -133,6 +137,7 @@ export const Parameters: FC<Props> = ({
                                 parameter={parameter}
                                 value={parameterValues[paramKey] ?? null}
                                 parameterValues={parameterValues}
+                                triggerClassName={triggerClassName}
                                 dropdownClassName={dropdownClassName}
                                 openPopoverId={openPopoverId}
                                 onPopoverOpen={handlePopoverOpen}

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -30,9 +30,7 @@ type Props = {
     onParameterReorder?: (order: string[]) => void;
     /** Separator element to render with the first parameter (so they wrap together) */
     separator?: ReactNode;
-    /** Public embed styling-contract class for each parameter pill. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     triggerClassName?: string;
-    /** Public embed styling-contract class for the portalled parameter dropdown. Set only by the embed path; see ee/features/embed/CLAUDE.md. */
     dropdownClassName?: string;
 };
 

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -30,6 +30,7 @@ type Props = {
     onParameterReorder?: (order: string[]) => void;
     /** Separator element to render with the first parameter (so they wrap together) */
     separator?: ReactNode;
+    dropdownClassName?: string;
 };
 
 export const Parameters: FC<Props> = ({
@@ -42,6 +43,7 @@ export const Parameters: FC<Props> = ({
     separator,
     parameterOrder = [],
     onParameterReorder,
+    dropdownClassName,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [openPopoverId, setOpenPopoverId] = useState<string | undefined>();
@@ -131,6 +133,7 @@ export const Parameters: FC<Props> = ({
                                 parameter={parameter}
                                 value={parameterValues[paramKey] ?? null}
                                 parameterValues={parameterValues}
+                                dropdownClassName={dropdownClassName}
                                 openPopoverId={openPopoverId}
                                 onPopoverOpen={handlePopoverOpen}
                                 onPopoverClose={handlePopoverClose}


### PR DESCRIPTION
## Summary

Customers embedding Lightdash dashboards style them to blend into their own application. Until now the only styling hooks were CSS-module classnames, which are hashed and change between builds — so any CSS override a customer wrote was brittle and silently broke whenever internal layout shifted.

This adds a small, intentional set of stable, human-readable classnames — an `ld-[surface]-[element]` contract — on the key embedded dashboard elements: the header, filter bar, date zoom, parameters, and their dropdowns. They are a supported, frozen public API: customers can rely on them to stay stable across releases.

The hooks sit alongside the existing module classes, so styling internals are untouched — the contract only adds reliable targeting points. Elements that render in a portal receive their hook through the component that renders them, so it stays reachable from outside the dashboard container.

The vocabulary is defined and type-enforced in one place, and an inline helper keeps the public class and the internal classes decoupled.

Customer-facing documentation: lightdash/mintlify-docs#869

Closes: PROD-3593
Closes: #20617