### PR TITLE
feat(table): row grouping (merge repeated row values) on non-pivoted tables (PROD-8296)

### DIFF
--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -394,6 +394,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                 showColumnCalculation={showColumnCalculation}
                 showSubtotals={showSubtotals}
                 showSubtotalsExpanded={showSubtotalsExpanded}
+                showRowGrouping={showRowGrouping}
                 conditionalFormattings={conditionalFormattings}
                 minMaxMap={minMaxMap}
                 onColumnWidthChange={onColumnWidthChange}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.module.css
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.module.css
@@ -1,0 +1,6 @@
+.mergedDimCell {
+    vertical-align: top;
+    /* nudge the top-aligned value off the border so it lines up with the first
+       row's centered content (cells are 32px tall) */
+    padding-top: var(--mantine-spacing-xs);
+}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -5,6 +5,7 @@ import {
     type RawResultRow,
     type ResultRow,
 } from '@lightdash/common';
+import { clsx } from '@mantine/core';
 import {
     getHotkeyHandler,
     useClipboard,
@@ -26,6 +27,7 @@ import { JsonCellModal } from '../../JsonViewer/JsonCellViewer';
 import { type JsonCellValue } from '../../JsonViewer/utils';
 import { Td } from '../Table.styles';
 import { type CellContextMenuProps } from '../types';
+import bodyCellStyles from './BodyCell.module.css';
 import CellMenu from './CellMenu';
 import CellTooltip from './CellTooltip';
 
@@ -42,6 +44,8 @@ interface CommonBodyCellProps {
     isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
+    // Set on a row-grouping block-start cell that vertically merges >1 row.
+    rowSpan?: number;
 }
 
 const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
@@ -58,7 +62,9 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     style,
     tooltipContent,
     minimal = false,
+    rowSpan,
 }) => {
+    const isMerged = !!rowSpan && rowSpan > 1;
     const elementRef = useRef<HTMLTableCellElement>(null);
     const { showToastSuccess } = useToaster();
     const { copy } = useClipboard();
@@ -143,7 +149,11 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
         <>
             <Td
                 ref={elementRef}
-                className={className}
+                className={clsx(
+                    className,
+                    isMerged && bodyCellStyles.mergedDimCell,
+                )}
+                rowSpan={isMerged ? rowSpan : undefined}
                 style={style}
                 $rowIndex={index}
                 $isSelected={isMenuOpen}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -32,10 +32,15 @@ import {
 import { getConditionalRuleLabelFromItem } from '../../Filters/FilterInputs/utils';
 import MantineIcon from '../../MantineIcon';
 import {
+    getRowSpanMerges,
+    type RowSpanMerge,
+} from '../../PivotTable/getRowSpanMerges';
+import {
     FROZEN_COLUMN_BACKGROUND,
     ROW_HEIGHT_PX,
     SMALL_TEXT_LENGTH,
 } from '../constants';
+import { getGroupedDimensionColumnIds } from '../getGroupedDimensionColumnIds';
 import { Tr } from '../Table.styles';
 import { type TableContext } from '../types';
 import { useTableContext } from '../useTableContext';
@@ -69,6 +74,9 @@ interface TableRowProps {
     conditionalFormattings: TableContext['conditionalFormattings'];
     minMaxMap: TableContext['minMaxMap'];
     minimal?: boolean;
+    // Per-column rowSpan-merge info for row-grouping mode, keyed by column id;
+    // null when not in row-grouping mode.
+    rowSpanMergesByColumnId?: Map<string, RowSpanMerge[]> | null;
 }
 
 const TableRow: FC<TableRowProps> = ({
@@ -80,6 +88,7 @@ const TableRow: FC<TableRowProps> = ({
     conditionalFormattings,
     minMaxMap,
     minimal = false,
+    rowSpanMergesByColumnId,
 }) => {
     const { colorScheme } = useMantineColorScheme();
     const rowFields = useMemo(
@@ -130,6 +139,15 @@ const TableRow: FC<TableRowProps> = ({
     return (
         <Tr $index={index} ref={measureElement} data-index={virtualIndex}>
             {row.getVisibleCells().map((cell) => {
+                const rowSpanMerge = rowSpanMergesByColumnId?.get(
+                    cell.column.id,
+                )?.[index];
+                // Absorbed (non-block-start) merged cell: the block-start cell's
+                // rowSpan already covers this row, so render no <td> here.
+                if (rowSpanMerge && !rowSpanMerge.isBlockStart) {
+                    return null;
+                }
+
                 const meta = cell.column.columnDef.meta;
                 const field = meta?.item;
                 const cellValue = cell.getValue() as ResultRow[0] | undefined;
@@ -221,6 +239,7 @@ const TableRow: FC<TableRowProps> = ({
                 return (
                     <BodyCell
                         minimal={minimal}
+                        rowSpan={rowSpanMerge?.rowSpan}
                         key={cell.id}
                         style={meta?.style}
                         backgroundColor={backgroundColor}
@@ -314,9 +333,12 @@ const SCROLL_THRESHOLD = 100;
 const VirtualizedTableBody: FC<{
     tableContainerRef: React.RefObject<HTMLDivElement | null>;
     minimal?: boolean;
-}> = ({ tableContainerRef, minimal }) => {
+    showSubtotals?: boolean;
+    showRowGrouping?: boolean;
+}> = ({ tableContainerRef, minimal, showSubtotals, showRowGrouping }) => {
     const {
         table,
+        columns,
         cellContextMenu,
         conditionalFormattings,
         minMaxMap,
@@ -325,6 +347,30 @@ const VirtualizedTableBody: FC<{
         fetchMoreRows,
     } = useTableContext();
     const { rows } = table.getRowModel();
+
+    // Row-grouping (no subtotals): merge repeated dimension values with rowSpan,
+    // matching the pivot table. Renders a flat row model (no TanStack grouping),
+    // so rowSpans line up with the source rows.
+    const groupingOnlyMode = !!showRowGrouping && !showSubtotals;
+    const columnOrder = table.getState().columnOrder;
+    const rowSpanMergesByColumnId = useMemo(() => {
+        if (!groupingOnlyMode) return null;
+        const groupedColumnIds = getGroupedDimensionColumnIds(
+            columns,
+            columnOrder,
+        );
+        if (groupedColumnIds.length === 0) return null;
+        return getRowSpanMerges(
+            rows.length,
+            groupedColumnIds,
+            (rowIndex, columnId) =>
+                (
+                    rows[rowIndex]?.getValue(columnId) as
+                        | { value?: { raw?: unknown } }
+                        | undefined
+                )?.value?.raw,
+        );
+    }, [groupingOnlyMode, columns, columnOrder, rows]);
 
     const rowVirtualizer = useVirtualizer({
         getScrollElement: () => tableContainerRef.current,
@@ -400,6 +446,30 @@ const VirtualizedTableBody: FC<{
               (virtualRows[virtualRows.length - 1]?.end || 0)
             : 0;
 
+    // Row-grouping mode renders every row (no virtualization) so the merged
+    // dimension cells' rowSpans span their full block — virtualization would
+    // unmount the absorbed rows and break the span.
+    if (groupingOnlyMode) {
+        return (
+            <tbody>
+                {rows.map((row, index) => (
+                    <TableRow
+                        minimal={minimal}
+                        key={index}
+                        index={index}
+                        virtualIndex={index}
+                        measureElement={measureElement}
+                        row={row}
+                        cellContextMenu={cellContextMenu}
+                        conditionalFormattings={conditionalFormattings}
+                        minMaxMap={minMaxMap}
+                        rowSpanMergesByColumnId={rowSpanMergesByColumnId}
+                    />
+                ))}
+            </tbody>
+        );
+    }
+
     return (
         <tbody>
             {paddingTop > 0 && (
@@ -469,13 +539,22 @@ const VirtualizedTableBody: FC<{
 interface TableBodyProps {
     minimal?: boolean;
     tableContainerRef: React.RefObject<HTMLDivElement | null>;
+    showSubtotals?: boolean;
+    showRowGrouping?: boolean;
 }
 
-const TableBody: FC<TableBodyProps> = ({ minimal, tableContainerRef }) => {
+const TableBody: FC<TableBodyProps> = ({
+    minimal,
+    tableContainerRef,
+    showSubtotals,
+    showRowGrouping,
+}) => {
     return (
         <VirtualizedTableBody
             tableContainerRef={tableContainerRef}
             minimal={minimal}
+            showSubtotals={showSubtotals}
+            showRowGrouping={showRowGrouping}
         />
     );
 };

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableHeader.tsx
@@ -1,10 +1,11 @@
 import { Draggable } from '@hello-pangea/dnd';
-import { isCustomDimension, isDimension, isField } from '@lightdash/common';
+import { isField } from '@lightdash/common';
 import { Tooltip, useMantineTheme } from '@mantine/core';
 import { flexRender } from '@tanstack/react-table';
 import isEqual from 'lodash/isEqual';
 import React, { useEffect, type FC } from 'react';
 import { ROW_NUMBER_COLUMN_ID } from '../constants';
+import { getGroupedDimensionColumnIds } from '../getGroupedDimensionColumnIds';
 import {
     Th,
     ThActionsContainer,
@@ -35,25 +36,10 @@ const TableHeader: FC<TableHeaderProps> = ({
 
     useEffect(() => {
         if (showSubtotals) {
-            const groupedColumns = columns
-                .filter((col) => {
-                    const item = col.meta?.item;
-                    return (
-                        item && (isDimension(item) || isCustomDimension(item))
-                    );
-                })
-                .map((col) => col.id);
-
-            const sortedColumns = table
-                .getState()
-                .columnOrder.reduce<string[]>((acc, sortedId) => {
-                    return groupedColumns.includes(sortedId)
-                        ? [...acc, sortedId]
-                        : acc;
-                }, [])
-                // The last dimension column essentially groups rows for each unique value in that column.
-                // Grouping on it would result in many useless expandable groups containing just one item.
-                .slice(0, -1);
+            const sortedColumns = getGroupedDimensionColumnIds(
+                columns,
+                table.getState().columnOrder,
+            );
 
             if (!isEqual(sortedColumns, table.getState().grouping)) {
                 table.setGrouping(sortedColumns);

--- a/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/index.tsx
@@ -8,12 +8,14 @@ import TableHeader from './TableHeader';
 interface ScrollableTableProps {
     minimal?: boolean;
     showSubtotals?: boolean;
+    showRowGrouping?: boolean;
     isDashboard?: boolean;
 }
 
 const ScrollableTable: FC<ScrollableTableProps> = ({
     minimal = true,
     showSubtotals = true,
+    showRowGrouping = false,
     isDashboard = false,
 }) => {
     const { footer } = useTableContext();
@@ -29,6 +31,8 @@ const ScrollableTable: FC<ScrollableTableProps> = ({
                 <TableBody
                     tableContainerRef={tableContainerRef}
                     minimal={minimal}
+                    showSubtotals={showSubtotals}
+                    showRowGrouping={showRowGrouping}
                 />
                 <TableFooter />
             </Table>

--- a/packages/frontend/src/components/common/Table/getGroupedDimensionColumnIds.test.ts
+++ b/packages/frontend/src/components/common/Table/getGroupedDimensionColumnIds.test.ts
@@ -1,0 +1,86 @@
+import { DimensionType, FieldType, type Dimension } from '@lightdash/common';
+import { getGroupedDimensionColumnIds } from './getGroupedDimensionColumnIds';
+import { type TableColumn } from './types';
+
+const dimension = (name: string): Dimension =>
+    ({
+        fieldType: FieldType.DIMENSION,
+        type: DimensionType.STRING,
+        name,
+        label: name,
+        table: 't',
+        tableLabel: 't',
+        sql: '',
+        hidden: false,
+    }) as Dimension;
+
+const dimColumn = (id: string): TableColumn => ({
+    id,
+    meta: { item: dimension(id) },
+});
+
+const metricColumn = (id: string): TableColumn => ({
+    id,
+    // no dimension item -> treated as non-dimension (metric/calc)
+    meta: {},
+});
+
+describe('getGroupedDimensionColumnIds', () => {
+    it('returns dimension columns in display order minus the leaf', () => {
+        const columns = [
+            dimColumn('region'),
+            dimColumn('country'),
+            dimColumn('city'),
+            metricColumn('revenue'),
+        ];
+        const columnOrder = ['region', 'country', 'city', 'revenue'];
+
+        expect(getGroupedDimensionColumnIds(columns, columnOrder)).toEqual([
+            'region',
+            'country',
+        ]);
+    });
+
+    it('respects columnOrder, not the columns array order', () => {
+        const columns = [
+            dimColumn('city'),
+            dimColumn('region'),
+            dimColumn('country'),
+        ];
+        const columnOrder = ['region', 'country', 'city'];
+
+        // ordered by columnOrder (region, country, city) minus leaf (city)
+        expect(getGroupedDimensionColumnIds(columns, columnOrder)).toEqual([
+            'region',
+            'country',
+        ]);
+    });
+
+    it('ignores metric columns when picking the leaf', () => {
+        const columns = [
+            dimColumn('region'),
+            metricColumn('revenue'),
+            dimColumn('country'),
+        ];
+        // metric interleaved between dims; leaf is the last DIMENSION (country)
+        const columnOrder = ['region', 'revenue', 'country'];
+
+        expect(getGroupedDimensionColumnIds(columns, columnOrder)).toEqual([
+            'region',
+        ]);
+    });
+
+    it('returns empty for a single dimension (only the leaf, nothing to merge)', () => {
+        const columns = [dimColumn('region'), metricColumn('revenue')];
+        const columnOrder = ['region', 'revenue'];
+
+        expect(getGroupedDimensionColumnIds(columns, columnOrder)).toEqual([]);
+    });
+
+    it('returns empty when there are no dimensions', () => {
+        const columns = [metricColumn('revenue'), metricColumn('count')];
+        const columnOrder = ['revenue', 'count'];
+
+        expect(getGroupedDimensionColumnIds(columns, columnOrder)).toEqual([]);
+    });
+});

--- a/packages/frontend/src/components/common/Table/getGroupedDimensionColumnIds.ts
+++ b/packages/frontend/src/components/common/Table/getGroupedDimensionColumnIds.ts
@@ -1,0 +1,29 @@
+import { isCustomDimension, isDimension } from '@lightdash/common';
+import { type TableColumn, type TableHeader } from './types';
+
+/**
+ * Dimension column ids in display order, minus the leaf (last) dimension — the
+ * columns whose repeated values get grouped/merged. The leaf dimension stays
+ * per-row (grouping on it would produce one group per row).
+ *
+ * Shared between the subtotals grouping setup (TableHeader) and the rowSpan
+ * row-grouping body so the two stay in sync.
+ */
+export const getGroupedDimensionColumnIds = (
+    columns: Array<TableColumn | TableHeader>,
+    columnOrder: string[],
+): string[] => {
+    const dimensionColumnIds = new Set(
+        columns
+            .filter((col) => {
+                const item = col.meta?.item;
+                return !!item && (isDimension(item) || isCustomDimension(item));
+            })
+            .map((col) => col.id)
+            .filter((id): id is string => !!id),
+    );
+
+    return columnOrder
+        .filter((columnId) => dimensionColumnIds.has(columnId))
+        .slice(0, -1);
+};

--- a/packages/frontend/src/components/common/Table/index.tsx
+++ b/packages/frontend/src/components/common/Table/index.tsx
@@ -38,6 +38,7 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
     className,
     minimal = false,
     showSubtotals = true,
+    showRowGrouping = false,
     'data-testid': dataTestId,
     errorDetail,
     ...rest
@@ -65,6 +66,7 @@ const Table: FC<React.PropsWithChildren<Props>> = ({
                 <ScrollableTable
                     minimal={minimal}
                     showSubtotals={showSubtotals}
+                    showRowGrouping={showRowGrouping}
                     isDashboard={isDashboard}
                 />
 

--- a/packages/frontend/src/components/common/Table/types.ts
+++ b/packages/frontend/src/components/common/Table/types.ts
@@ -71,6 +71,7 @@ export type ProviderProps = {
     };
     showSubtotals?: boolean;
     showSubtotalsExpanded?: boolean;
+    showRowGrouping?: boolean;
     hideRowNumbers?: boolean;
     showColumnCalculation?: boolean;
     conditionalFormattings?: ConditionalFormattingConfig[];


### PR DESCRIPTION
Closes: #[24253](https://github.com/lightdash/lightdash/issues/24253) & PROD-8296<!-- reference the related issue e.g. #150 -->

### Description:

Adds a `showRowGrouping` mode to the scrollable table that visually merges repeated dimension values across consecutive rows using `rowSpan`, matching the behaviour of the pivot table. When row grouping is enabled without subtotals, block-start cells span their full group while absorbed cells are omitted from the DOM entirely.

To support this:

- A new `getGroupedDimensionColumnIds` utility extracts dimension column IDs in display order, excluding the leaf dimension (grouping on the leaf would produce one group per row). This logic is now shared between the subtotals grouping setup in `TableHeader` and the new row-grouping body, keeping the two in sync.
- `BodyCell` accepts an optional `rowSpan` prop and applies a `mergedDimCell` CSS class to top-align and nudge the value away from the cell border when spanning multiple rows.
- Because `rowSpan` requires all spanned rows to be present in the DOM simultaneously, row-grouping mode bypasses virtualization and renders all rows eagerly.
- `getRowSpanMerges` (from the pivot table) is reused to compute per-column merge metadata, keyed by column ID and row index.

Unit tests for `getGroupedDimensionColumnIds` cover ordering by `columnOrder`, interleaved metric columns, single-dimension edge cases, and the no-dimension case.