### PR TITLE
fix: screenshot size sync for data apps delivery

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1093,6 +1093,15 @@ export class UnfurlService extends BaseService {
                                 .internalLightdashHostIgnoreHttpsErrors,
                     });
 
+                    if (lightdashPage === LightdashPage.APP) {
+                        // Browserless connects over CDP, where the viewport
+                        // passed to newPage can be ignored. Apply it
+                        // explicitly before navigation so the app iframe's
+                        // 100vh/100% box starts at the intended screenshot
+                        // size.
+                        await page.setViewportSize(initialViewport);
+                    }
+
                     // Polyfill crypto.randomUUID (needed for Loom iframes)
                     await page.addInitScript(() => {
                         if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fix data app scheduled delivery screenshots by explicitly applying the app viewport after creating the Browserless/CDP page.

newPage({ viewport }) can be ignored over CDP, leaving app screenshots at the default 800x600. Calling setViewportSize before navigation restores the intended 1400x4000 viewport and prevents clipped captures.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->