### PR TITLE
feat(ai): make @-mentioned files and repositories typed context, not ambiguous text

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -283,13 +283,23 @@ export type AiAgentToolResultTable = Knex.CompositeTableType<
 
 export const AiPromptContextTableName = 'ai_prompt_context';
 
-export type AiPromptContextEntityType = 'chart' | 'dashboard' | 'thread';
+export type AiPromptContextEntityType =
+    | 'chart'
+    | 'dashboard'
+    | 'thread'
+    | 'file'
+    | 'repository';
 
 export type DbAiPromptContext = {
     ai_prompt_context_uuid: string;
     ai_prompt_uuid: string;
     entity_type: AiPromptContextEntityType;
-    entity_uuid: string;
+    // UUID-keyed entities (chart/dashboard/thread) store their uuid here;
+    // string-keyed entities (file/repository) leave it null and use entity_ref.
+    entity_uuid: string | null;
+    // Natural-key reference for entities without a uuid: a file path or a
+    // repository `owner/repo`. Null for uuid-keyed entities.
+    entity_ref: string | null;
     pinned_version_uuid: string | null;
     display_name: string | null;
     runtime_overrides: AiChartRuntimeOverrides | null;
@@ -298,11 +308,15 @@ export type DbAiPromptContext = {
 
 export type AiPromptContextTable = Knex.CompositeTableType<
     DbAiPromptContext,
-    Pick<DbAiPromptContext, 'ai_prompt_uuid' | 'entity_type' | 'entity_uuid'> &
+    Pick<DbAiPromptContext, 'ai_prompt_uuid' | 'entity_type'> &
         Partial<
             Pick<
                 DbAiPromptContext,
-                'pinned_version_uuid' | 'display_name' | 'runtime_overrides'
+                | 'entity_uuid'
+                | 'entity_ref'
+                | 'pinned_version_uuid'
+                | 'display_name'
+                | 'runtime_overrides'
             >
         >,
     never

--- a/packages/backend/src/ee/database/migrations/20260617120000_add_ai_prompt_context_entity_ref.ts
+++ b/packages/backend/src/ee/database/migrations/20260617120000_add_ai_prompt_context_entity_ref.ts
@@ -1,0 +1,61 @@
+import { Knex } from 'knex';
+
+const AI_PROMPT_CONTEXT_TABLE_NAME = 'ai_prompt_context';
+const OLD_UNIQUE = 'ai_prompt_context_prompt_entity_unique';
+const NEW_UNIQUE = 'ai_prompt_context_prompt_entity_ref_unique';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(AI_PROMPT_CONTEXT_TABLE_NAME)) {
+        if (
+            !(await knex.schema.hasColumn(
+                AI_PROMPT_CONTEXT_TABLE_NAME,
+                'entity_ref',
+            ))
+        ) {
+            await knex.schema.alterTable(
+                AI_PROMPT_CONTEXT_TABLE_NAME,
+                (table) => {
+                    table
+                        .text('entity_ref')
+                        .nullable()
+                        .comment(
+                            'Natural-key reference for entities without a uuid (file path, repository owner/repo).',
+                        );
+                    table.uuid('entity_uuid').nullable().alter();
+                },
+            );
+        }
+
+        // The original unique constraint keys on entity_uuid, which is null for
+        // file/repository rows. Replace it with a functional unique index that
+        // dedupes on the natural key for every entity type.
+        await knex.schema.alterTable(AI_PROMPT_CONTEXT_TABLE_NAME, (table) => {
+            table.dropUnique(
+                ['ai_prompt_uuid', 'entity_type', 'entity_uuid'],
+                OLD_UNIQUE,
+            );
+        });
+        await knex.raw(
+            `CREATE UNIQUE INDEX ?? ON ?? (ai_prompt_uuid, entity_type, COALESCE(entity_uuid::text, entity_ref))`,
+            [NEW_UNIQUE, AI_PROMPT_CONTEXT_TABLE_NAME],
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(AI_PROMPT_CONTEXT_TABLE_NAME)) {
+        await knex.raw(`DROP INDEX IF EXISTS ??`, [NEW_UNIQUE]);
+        // Rows without a uuid (file/repository) cannot satisfy the restored
+        // NOT NULL constraint, so drop them before reverting.
+        await knex(AI_PROMPT_CONTEXT_TABLE_NAME)
+            .whereNull('entity_uuid')
+            .delete();
+        await knex.schema.alterTable(AI_PROMPT_CONTEXT_TABLE_NAME, (table) => {
+            table.uuid('entity_uuid').notNullable().alter();
+            table.dropColumn('entity_ref');
+            table.unique(['ai_prompt_uuid', 'entity_type', 'entity_uuid'], {
+                indexName: OLD_UNIQUE,
+            });
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4910,9 +4910,21 @@ export class AiAgentModel {
         >,
         dashboardSlugByUuid: Map<string, string>,
     ): AiPromptContextItem {
+        // chart/dashboard/thread are uuid-keyed: entity_uuid is a non-null
+        // invariant (only file/repository leave it null, using entity_ref).
+        // A null here means a corrupt row — fail loud rather than emit a broken
+        // reference with an empty uuid.
+        const requireEntityUuid = (): string => {
+            if (row.entity_uuid === null) {
+                throw new Error(
+                    `ai_prompt_context row ${row.ai_prompt_context_uuid} of type '${row.entity_type}' is missing entity_uuid`,
+                );
+            }
+            return row.entity_uuid;
+        };
         switch (row.entity_type) {
             case 'chart': {
-                const entityUuid = row.entity_uuid ?? '';
+                const entityUuid = requireEntityUuid();
                 const chartData = chartDataByUuid.get(entityUuid);
                 return {
                     type: 'chart',
@@ -4925,7 +4937,7 @@ export class AiAgentModel {
                 };
             }
             case 'dashboard': {
-                const entityUuid = row.entity_uuid ?? '';
+                const entityUuid = requireEntityUuid();
                 return {
                     type: 'dashboard',
                     dashboardUuid: entityUuid,
@@ -4937,7 +4949,7 @@ export class AiAgentModel {
             case 'thread':
                 return {
                     type: 'thread',
-                    threadUuid: row.entity_uuid ?? '',
+                    threadUuid: requireEntityUuid(),
                     promptUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
                 };

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4801,6 +4801,25 @@ export class AiAgentModel {
                             thread?.title ?? thread?.first_prompt ?? null,
                     };
                 }
+                // File / repository references are self-contained — the path /
+                // `owner/repo` is the natural key, stored in entity_ref (no
+                // uuid, nothing to resolve).
+                case 'file':
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type: 'file' as AiPromptContextEntityType,
+                        entity_uuid: null,
+                        entity_ref: ctx.path,
+                        display_name: ctx.path,
+                    };
+                case 'repository':
+                    return {
+                        ai_prompt_uuid: promptUuid,
+                        entity_type: 'repository' as AiPromptContextEntityType,
+                        entity_uuid: null,
+                        entity_ref: ctx.fullName,
+                        display_name: ctx.fullName,
+                    };
                 default:
                     return assertUnreachable(
                         ctx,
@@ -4825,7 +4844,8 @@ export class AiAgentModel {
 
         const chartUuids = rows
             .filter((r) => r.entity_type === 'chart')
-            .map((r) => r.entity_uuid);
+            .map((r) => r.entity_uuid)
+            .filter((u): u is string => u !== null);
         const chartDataByUuid = new Map(
             (
                 await this.database(SavedChartsTableName)
@@ -4853,7 +4873,8 @@ export class AiAgentModel {
         );
         const dashboardUuids = rows
             .filter((r) => r.entity_type === 'dashboard')
-            .map((r) => r.entity_uuid);
+            .map((r) => r.entity_uuid)
+            .filter((u): u is string => u !== null);
         const dashboardSlugByUuid = new Map(
             (
                 await this.database(DashboardsTableName)
@@ -4891,10 +4912,11 @@ export class AiAgentModel {
     ): AiPromptContextItem {
         switch (row.entity_type) {
             case 'chart': {
-                const chartData = chartDataByUuid.get(row.entity_uuid);
+                const entityUuid = row.entity_uuid ?? '';
+                const chartData = chartDataByUuid.get(entityUuid);
                 return {
                     type: 'chart',
-                    chartUuid: row.entity_uuid,
+                    chartUuid: entityUuid,
                     chartSlug: chartData?.slug ?? null,
                     pinnedVersionUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
@@ -4902,22 +4924,29 @@ export class AiAgentModel {
                     chartKind: chartData?.chartKind ?? null,
                 };
             }
-            case 'dashboard':
+            case 'dashboard': {
+                const entityUuid = row.entity_uuid ?? '';
                 return {
                     type: 'dashboard',
-                    dashboardUuid: row.entity_uuid,
-                    dashboardSlug:
-                        dashboardSlugByUuid.get(row.entity_uuid) ?? null,
+                    dashboardUuid: entityUuid,
+                    dashboardSlug: dashboardSlugByUuid.get(entityUuid) ?? null,
                     pinnedVersionUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
                 };
+            }
             case 'thread':
                 return {
                     type: 'thread',
-                    threadUuid: row.entity_uuid,
+                    threadUuid: row.entity_uuid ?? '',
                     promptUuid: row.pinned_version_uuid,
                     displayName: row.display_name,
                 };
+            // File / repository references store their natural key in
+            // entity_ref; there is nothing to join back to.
+            case 'file':
+                return { type: 'file', path: row.entity_ref ?? '' };
+            case 'repository':
+                return { type: 'repository', fullName: row.entity_ref ?? '' };
             default:
                 return assertUnreachable(
                     row.entity_type,

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2562,10 +2562,15 @@ export class AiAgentModel {
             )
             .where(`${AiPromptTableName}.ai_thread_uuid`, threadUuid)
             .where(`${AiPromptContextTableName}.entity_type`, 'thread')
-            .distinct<{ entity_uuid: string }[]>(
+            .distinct<{ entity_uuid: string | null }[]>(
                 `${AiPromptContextTableName}.entity_uuid`,
             );
-        return rows.map((row) => row.entity_uuid);
+        // entity_uuid is nullable at the column level (file/repository rows use
+        // entity_ref); thread rows always carry it, but honor the type rather
+        // than asserting non-null.
+        return rows
+            .map((row) => row.entity_uuid)
+            .filter((u): u is string => u !== null);
     }
 
     async findThreadOwnership({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -652,10 +652,9 @@ export class AiAgentService extends BaseService {
             context?.filter((item) => item.type === 'chart').length ?? 0;
         const pinnedDashboardCount =
             context?.filter((item) => item.type === 'dashboard').length ?? 0;
-        const pinnedThreadCount =
-            context?.filter((item) => item.type === 'thread').length ?? 0;
-        const pinnedContextCount =
-            pinnedChartCount + pinnedDashboardCount + pinnedThreadCount;
+        // Count every attached item (chart/dashboard/thread/file/repository) so
+        // the total stays accurate as new context types are added.
+        const pinnedContextCount = context?.length ?? 0;
 
         return {
             hasPinnedContext: pinnedContextCount > 0,
@@ -685,6 +684,12 @@ export class AiAgentService extends BaseService {
                     break;
                 case 'thread':
                     key = `thread:${item.threadUuid}`;
+                    break;
+                case 'file':
+                    key = `file:${item.path}`;
+                    break;
+                case 'repository':
+                    key = `repository:${item.fullName}`;
                     break;
                 default:
                     return assertUnreachable(
@@ -738,6 +743,32 @@ export class AiAgentService extends BaseService {
                         );
                     }
                     await this.validateThreadContextAccess(user, item);
+                    return;
+                }
+
+                if (item.type === 'file' || item.type === 'repository') {
+                    // Embedded AI never exposes source code.
+                    if (allowedSpaces) {
+                        throw new ForbiddenError(
+                            'Source files are not available in embedded AI',
+                        );
+                    }
+                    // The agent's exploreRepo tool is the real access boundary;
+                    // gate attaching a source reference on the same
+                    // view:SourceCode ability the file/repo listing uses.
+                    if (
+                        this.createAuditedAbility(user).cannot(
+                            'view',
+                            subject('SourceCode', {
+                                organizationUuid: agent.organizationUuid,
+                                projectUuid: agent.projectUuid,
+                            }),
+                        )
+                    ) {
+                        throw new ForbiddenError(
+                            'You do not have permission to view this project source code',
+                        );
+                    }
                     return;
                 }
 
@@ -5438,9 +5469,9 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         if (context.length === 0) return null;
 
         const lines = context.map((item) => {
-            const name = item.displayName ?? '(name unavailable)';
             switch (item.type) {
                 case 'chart': {
+                    const name = item.displayName ?? '(name unavailable)';
                     const slugText = item.chartSlug ?? '(slug unavailable)';
                     const headline = `- Chart "${name}" (chartSlug: ${slugText})`;
                     const overrides = item.runtimeOverrides;
@@ -5464,14 +5495,25 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     if (overrideLines.length === 0) return headline;
                     return `${headline}\n  Runtime overrides applied when the chart was pinned:\n${overrideLines.join('\n')}`;
                 }
-                case 'dashboard':
+                case 'dashboard': {
+                    const name = item.displayName ?? '(name unavailable)';
                     return `- Dashboard "${name}" (dashboardSlug: ${item.dashboardSlug ?? '(slug unavailable)'})`;
-                case 'thread':
+                }
+                case 'thread': {
+                    const name = item.displayName ?? '(name unavailable)';
                     return `- Conversation "${name}" (threadUuid: ${item.threadUuid}${
                         item.promptUuid
                             ? `, the referenced turn is promptUuid: ${item.promptUuid}`
                             : ''
                     }) — a previous conversation attached as reference. Read it with the readPinnedThread tool. It may predate recent project changes, so verify any claims it contains against the current project instead of trusting them.`;
+                }
+                // Name the exact repo-filesystem mount path so the agent reads
+                // the right file/repo with exploreRepo and never mistakes a file
+                // path for an `owner/repo` repository.
+                case 'file':
+                    return `- File \`/dbt/${item.path}\` — a source file in this project's dbt repository. Read it with the exploreRepo tool.`;
+                case 'repository':
+                    return `- Repository \`${item.fullName}\` (mounted at \`/${item.fullName}\`) — explore it with the exploreRepo tool.`;
                 default:
                     return assertUnreachable(
                         item,

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -99,6 +99,31 @@ describe('AI context compaction helpers', () => {
         expect(serialized).toContain('[truncated 500 chars]');
     });
 
+    it('serializes a same-named file and repository as distinct, unambiguous lines', () => {
+        const serialized = Compaction.serializeConversation([
+            {
+                role: 'user',
+                uuid: 'prompt-1',
+                threadUuid: 'thread-1',
+                message: 'Look at hello/world',
+                createdAt: new Date().toISOString(),
+                user: { uuid: 'user-1', name: 'Test User' },
+                context: [
+                    { type: 'file', path: 'hello/world' },
+                    { type: 'repository', fullName: 'hello/world' },
+                ],
+                hidden: false,
+            },
+        ]);
+
+        // The bare text 'hello/world' is ambiguous, but the pinned context
+        // names each one's repo-filesystem mount path so they can't be confused.
+        expect(serialized).toContain('file /dbt/hello/world');
+        expect(serialized).toContain(
+            'repository hello/world (mounted at /hello/world',
+        );
+    });
+
     it('filters raw prompt rows after the latest compaction boundary', () => {
         const filtered = Compaction.filterThreadMessagesAfterCompaction(
             [

--- a/packages/backend/src/ee/services/ai/compaction.ts
+++ b/packages/backend/src/ee/services/ai/compaction.ts
@@ -193,6 +193,13 @@ export class Compaction {
                 return `dashboard ${item.displayName ?? item.dashboardUuid} (${item.dashboardUuid})`;
             case 'thread':
                 return `conversation ${item.displayName ?? item.threadUuid} (${item.threadUuid})`;
+            // Spell out the repo-filesystem mount path so the agent reads the
+            // exact file/repo with exploreRepo and never confuses a file path
+            // with an `owner/repo` repository.
+            case 'file':
+                return `file /dbt/${item.path} (a source file in the dbt project; read it with exploreRepo)`;
+            case 'repository':
+                return `repository ${item.fullName} (mounted at /${item.fullName}; explore it with exploreRepo)`;
             default:
                 return assertUnreachable(
                     item,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10764,8 +10764,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -11390,8 +11390,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -12396,6 +12396,28 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        path: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['file'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fullName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['repository'],
+                            required: true,
+                        },
+                    },
+                },
             ],
             validators: {},
         },
@@ -12727,11 +12749,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -12933,7 +12955,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12941,11 +12963,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -12960,7 +12978,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -12968,7 +12986,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -13273,13 +13295,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13306,13 +13328,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [
-                                                                'not_found',
-                                                            ],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: [
+                                                                'not_found',
+                                                            ],
                                                         },
                                                     ],
                                                     required: true,
@@ -13364,130 +13386,6 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
-                                                                fields: {
-                                                                    dataType:
-                                                                        'array',
-                                                                    array: {
-                                                                        dataType:
-                                                                            'nestedObjectLiteral',
-                                                                        nestedProperties:
-                                                                            {
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                isFromJoinedTable:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'boolean',
-                                                                                        required: true,
-                                                                                    },
-                                                                                caseSensitiveFilters:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'false',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldFilterType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldValueType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
-                                                                            },
-                                                                    },
-                                                                    required: true,
-                                                                },
                                                                 explore: {
                                                                     dataType:
                                                                         'nestedObjectLiteral',
@@ -13522,6 +13420,130 @@ const models: TsoaRoute.Models = {
                                                                         },
                                                                     required: true,
                                                                 },
+                                                                fields: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'false',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -13550,17 +13572,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -13685,14 +13707,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -13702,23 +13716,12 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
+                                                uuid: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13783,77 +13786,25 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                steps: {
+                                                status: {
                                                     dataType: 'union',
                                                     subSchemas: [
                                                         {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
+                                                            enums: ['success'],
                                                         },
                                                     ],
+                                                    required: true,
                                                 },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13931,6 +13882,77 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -13957,9 +13979,7 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [
-                                                                'git_write_permission',
-                                                            ],
+                                                            enums: ['unknown'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -13976,17 +13996,19 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'pull_request_not_open',
                                                             ],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['unknown'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
+                                                                'git_write_permission',
                                                             ],
                                                         },
                                                         {
@@ -14042,10 +14064,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 slug: {
                                                     dataType: 'string',
                                                     required: true,
@@ -14053,6 +14071,10 @@ const models: TsoaRoute.Models = {
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                name: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -14079,11 +14101,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14118,14 +14140,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -14144,11 +14166,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14165,6 +14187,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14254,13 +14295,6 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
-                                                                                ],
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
                                                                                     'metric',
                                                                                 ],
                                                                             },
@@ -14268,20 +14302,8 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    null,
+                                                                                    'dimension',
                                                                                 ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -14344,11 +14366,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14363,11 +14385,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14382,11 +14404,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14905,6 +14927,28 @@ const models: TsoaRoute.Models = {
                         type: {
                             dataType: 'enum',
                             enums: ['thread'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        path: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['file'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fullName: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['repository'],
                             required: true,
                         },
                     },
@@ -29315,7 +29359,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29325,7 +29369,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29335,7 +29379,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29348,7 +29392,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30003,7 +30047,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30013,7 +30057,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30023,7 +30067,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30036,7 +30080,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12391,7 +12391,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -13004,7 +13004,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -13979,6 +13979,34 @@
                             "type"
                         ],
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "path": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["file"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["path", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "fullName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["repository"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["fullName", "type"],
+                        "type": "object"
                     }
                 ]
             },
@@ -14322,6 +14350,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -14378,16 +14419,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -14535,19 +14576,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "name",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14557,8 +14598,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "not_found",
-                                                            "success"
+                                                            "success",
+                                                            "not_found"
                                                         ]
                                                     }
                                                 },
@@ -14588,66 +14629,6 @@
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "false",
-                                                                                        "not_applicable",
-                                                                                        "true"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "description",
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldFilterType",
-                                                                                "fieldValueType",
-                                                                                "fieldType",
-                                                                                "table",
-                                                                                "label",
-                                                                                "name",
-                                                                                "fieldId"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "joinedTables": {
@@ -14674,6 +14655,66 @@
                                                                         ],
                                                                         "type": "object"
                                                                     },
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric",
+                                                                                        "dimension"
+                                                                                    ]
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldValueType",
+                                                                                "fieldFilterType",
+                                                                                "description",
+                                                                                "fieldType",
+                                                                                "table",
+                                                                                "fieldId",
+                                                                                "label",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -14684,8 +14725,8 @@
                                                                 },
                                                                 "required": [
                                                                     "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -14698,10 +14739,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -14709,8 +14750,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -14793,12 +14834,6 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14806,47 +14841,27 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "uuid": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "uuid",
-                                                    "name",
                                                     "slug",
-                                                    "status"
+                                                    "status",
+                                                    "uuid",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "label": {
-                                                                    "type": "string"
-                                                                },
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "compile",
-                                                                        "edit",
-                                                                        "read",
-                                                                        "search",
-                                                                        "stage"
-                                                                    ]
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "label",
-                                                                "kind"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14874,6 +14889,32 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -14892,12 +14933,12 @@
                                                     "errorCode": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "git_write_permission",
+                                                            "unknown",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "pull_request_not_open",
-                                                            "unknown",
                                                             "unsupported_source_control",
+                                                            "pull_request_not_open",
+                                                            "git_write_permission",
                                                             null
                                                         ],
                                                         "nullable": true
@@ -14916,9 +14957,6 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
-                                                        "type": "string"
-                                                    },
                                                     "slug": {
                                                         "type": "string"
                                                     },
@@ -14926,13 +14964,16 @@
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "name",
                                                     "slug",
-                                                    "status"
+                                                    "status",
+                                                    "name"
                                                 ],
                                                 "type": "object"
                                             },
@@ -14945,8 +14986,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14959,8 +15000,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
                                                             "timeout"
                                                         ]
                                                     }
@@ -14972,6 +15013,10 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
@@ -15011,21 +15056,17 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "dimension",
                                                                     "metric",
+                                                                    "dimension",
                                                                     null
                                                                 ],
-                                                                "nullable": true
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
                                                                 "nullable": true
                                                             }
                                                         },
                                                         "required": [
+                                                            "searchQuery",
                                                             "fields",
-                                                            "type",
-                                                            "searchQuery"
+                                                            "type"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -15517,6 +15558,34 @@
                             }
                         },
                         "required": ["threadUuid", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "path": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["file"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["path", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "fullName": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["repository"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["fullName", "type"],
                         "type": "object"
                     }
                 ]
@@ -30064,22 +30133,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30639,22 +30708,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39745,7 +39814,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3187.2",
+        "version": "0.3189.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -107,6 +107,19 @@ export type AiPromptContextItemInput =
           threadUuid: string;
           // The turn the reference points at (e.g. a flagged prompt).
           promptUuid?: string | null;
+      }
+    | {
+          // A dbt source file the user @-mentioned. `path` is relative to the
+          // dbt sub-folder (as the project-files endpoint returns it); the
+          // agent's repo filesystem mounts that folder at `/dbt`.
+          type: 'file';
+          path: string;
+      }
+    | {
+          // A GitHub repository the user @-mentioned, as `owner/repo`. The
+          // agent's repo filesystem mounts it at `/owner/repo`.
+          type: 'repository';
+          fullName: string;
       };
 
 export type AiPromptContextInput = AiPromptContextItemInput[];
@@ -133,6 +146,17 @@ export type AiPromptContextItem =
           threadUuid: string;
           promptUuid: string | null;
           displayName: string | null;
+      }
+    | {
+          // Resolved file reference — a passthrough of the input (the path is
+          // self-contained, there is nothing to look up server-side).
+          type: 'file';
+          path: string;
+      }
+    | {
+          // Resolved repository reference — a passthrough of the input.
+          type: 'repository';
+          fullName: string;
       };
 
 export type AiPromptContext = AiPromptContextItem[];

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -150,6 +150,11 @@ export const AgentChatInput = ({
     projectUuidRef.current = projectUuid;
     const contentMentionPriorityItemsRef = useRef(contentMentionPriorityItems);
     contentMentionPriorityItemsRef.current = contentMentionPriorityItems;
+    // Tracks whether the @-mention dropdown is open, sourced from the suggestion
+    // render lifecycle. Enter must select from the dropdown (or be a no-op while
+    // it loads), never submit, so we guard on this in addition to the plugin's
+    // `active` flag — which can read stale in the keydown vs async-items race.
+    const contentMentionPopupOpenRef = useRef(false);
 
     // Hide the chip strip while the user is scrolled away from the input.
     // Reappears as they scroll back toward the bottom of the thread — chips
@@ -262,6 +267,9 @@ export const AgentChatInput = ({
             createContentMentionExtension({
                 getProjectUuid: () => projectUuidRef.current,
                 getPriorityItems: () => contentMentionPriorityItemsRef.current,
+                onPopupOpenChange: (open) => {
+                    contentMentionPopupOpenRef.current = open;
+                },
             }),
         ],
         editable: !disabled,
@@ -280,7 +288,10 @@ export const AgentChatInput = ({
                     !event.isComposing
                 ) {
                     const ed = editorRef.current;
-                    if (isContentMentionSuggestionActive(ed)) {
+                    if (
+                        isContentMentionSuggestionActive(ed) ||
+                        contentMentionPopupOpenRef.current
+                    ) {
                         return false;
                     }
                     if (loadingRef.current || disabledRef.current) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -103,14 +103,24 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
             >
                 {hasInlineReferences && projectUuid ? (
                     <div className={`${styles.markdown} ${styles.messageText}`}>
-                        {segments.map((segment, idx) =>
-                            segment.type === 'text' ? (
-                                <MDEditor.Markdown
-                                    key={`text-${idx}`}
-                                    source={segment.text}
-                                    className={`${styles.markdown} ${styles.inlineMarkdown}`}
-                                />
-                            ) : (
+                        {segments.map((segment, idx) => {
+                            if (segment.type === 'text') {
+                                return (
+                                    <MDEditor.Markdown
+                                        key={`text-${idx}`}
+                                        source={segment.text}
+                                        className={`${styles.markdown} ${styles.inlineMarkdown}`}
+                                    />
+                                );
+                            }
+                            // File/repository (and thread) references have no
+                            // in-app destination — only show the arrow and link
+                            // affordance when there is somewhere to navigate to.
+                            const href = getPromptContextItemHref(
+                                segment.item,
+                                projectUuid,
+                            );
+                            return (
                                 <ContentReferenceLink
                                     key={`${segment.key}-${idx}`}
                                     chartKind={
@@ -120,19 +130,15 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                                             : undefined
                                     }
                                     kind={segment.item.type}
-                                    rel="noreferrer"
-                                    target="_blank"
-                                    to={
-                                        getPromptContextItemHref(
-                                            segment.item,
-                                            projectUuid,
-                                        ) ?? undefined
-                                    }
+                                    rel={href ? 'noreferrer' : undefined}
+                                    target={href ? '_blank' : undefined}
+                                    to={href ?? undefined}
+                                    showArrow={href !== null}
                                 >
                                     {segment.label}
                                 </ContentReferenceLink>
-                            ),
-                        )}
+                            );
+                        })}
                     </div>
                 ) : (
                     <MDEditor.Markdown

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -1,5 +1,13 @@
 import { type AiAgentMessageUser, type AiAgentUser } from '@lightdash/common';
-import { Anchor, Card, Group, Stack, Text, Tooltip } from '@mantine-8/core';
+import {
+    Anchor,
+    Box,
+    Card,
+    Group,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import MDEditor from '@uiw/react-md-editor';
 import { format, parseISO } from 'date-fns';
 import { type FC } from 'react';
@@ -102,7 +110,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 className={styles.messageCard}
             >
                 {hasInlineReferences && projectUuid ? (
-                    <div className={`${styles.markdown} ${styles.messageText}`}>
+                    <Box className={`${styles.markdown} ${styles.messageText}`}>
                         {segments.map((segment, idx) => {
                             if (segment.type === 'text') {
                                 return (
@@ -139,7 +147,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                                 </ContentReferenceLink>
                             );
                         })}
-                    </div>
+                    </Box>
                 ) : (
                     <MDEditor.Markdown
                         source={message.message}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
@@ -31,6 +31,20 @@
     );
 }
 
+/* Non-interactive reference chip (e.g. file/repository) — same chrome, but no
+   pointer or hover since there is nowhere to navigate. */
+.static {
+    cursor: default;
+}
+
+.static:hover {
+    background-color: transparent !important;
+    border-color: light-dark(
+        var(--mantine-color-ldGray-2),
+        var(--mantine-color-ldGray-3)
+    );
+}
+
 .contentLink[data-artifact-active='true'] {
     background-color: light-dark(
         color-mix(

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -1,8 +1,10 @@
 import { ChartKind } from '@lightdash/common';
-import { Anchor, Text, type AnchorProps } from '@mantine-8/core';
+import { Anchor, Box, Text, type AnchorProps } from '@mantine-8/core';
 import {
     IconArrowRight,
+    IconBrandGithub,
     IconChartBar,
+    IconFile,
     IconLayoutDashboard,
     IconMessages,
     type Icon,
@@ -13,7 +15,13 @@ import MantineIcon from '../../../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../../../components/common/ResourceIcon/utils';
 import styles from './ContentLink.module.css';
 
-type ContentReferenceKind = 'artifact' | 'chart' | 'dashboard' | 'thread';
+type ContentReferenceKind =
+    | 'artifact'
+    | 'chart'
+    | 'dashboard'
+    | 'thread'
+    | 'file'
+    | 'repository';
 
 type Props = {
     chartKind?: ChartKind;
@@ -55,6 +63,18 @@ const getIconMeta = ({
                 color: 'violet.7',
                 fill: 'violet.4',
                 icon: IconMessages,
+            };
+        case 'file':
+            return {
+                color: 'ldGray.7',
+                fill: 'ldGray.4',
+                icon: IconFile,
+            };
+        case 'repository':
+            return {
+                color: 'ldGray.7',
+                fill: 'ldGray.4',
+                icon: IconBrandGithub,
             };
         case 'chart':
         default:
@@ -111,17 +131,30 @@ export const ContentReferenceLink = ({
         classNames: { root: styles.contentLink },
     };
 
-    return to ? (
+    // With no destination, render a plain span — no link semantics, no pointer,
+    // no hover — so the chip reads as a static reference, not a clickable link.
+    if (!to) {
+        return (
+            <Box
+                component="span"
+                fz="xs"
+                fw={500}
+                c="ldGray.8"
+                className={`${styles.contentLink} ${styles.static}`}
+                data-content-link="true"
+            >
+                {content}
+            </Box>
+        );
+    }
+
+    return (
         <Anchor
             {...anchorProps}
             component={Link}
             data-content-link="true"
             to={to}
         >
-            {content}
-        </Anchor>
-    ) : (
-        <Anchor {...anchorProps} data-content-link="true">
             {content}
         </Anchor>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.test.ts
@@ -59,6 +59,37 @@ describe('contentMentions', () => {
         ]);
     });
 
+    it('dedupes file and repository context by their natural key, first wins', () => {
+        expect(
+            mergeAiPromptContextInput(
+                [
+                    { type: 'file', path: 'models/orders.sql' },
+                    { type: 'repository', fullName: 'acme/dbt' },
+                ],
+                [
+                    { type: 'file', path: 'models/orders.sql' },
+                    { type: 'repository', fullName: 'acme/other' },
+                ],
+            ),
+        ).toEqual([
+            { type: 'file', path: 'models/orders.sql' },
+            { type: 'repository', fullName: 'acme/dbt' },
+            { type: 'repository', fullName: 'acme/other' },
+        ]);
+    });
+
+    it('keeps a file and a repository with the same name as distinct items', () => {
+        expect(
+            mergeAiPromptContextInput([
+                { type: 'file', path: 'hello/world' },
+                { type: 'repository', fullName: 'hello/world' },
+            ]),
+        ).toEqual([
+            { type: 'file', path: 'hello/world' },
+            { type: 'repository', fullName: 'hello/world' },
+        ]);
+    });
+
     it('merges mention suggestions deduping charts by uuid, first wins', () => {
         const threadChart: ContentMentionSuggestionItem = {
             id: 'thread:chart:chart-1',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -261,6 +261,10 @@ const getContextKey = (item: AiPromptContextInput[number]) => {
             return `dashboard:${item.dashboardUuid}`;
         case 'thread':
             return `thread:${item.threadUuid}`;
+        case 'file':
+            return `file:${item.path}`;
+        case 'repository':
+            return `repository:${item.fullName}`;
         default:
             return assertUnreachable(
                 item,
@@ -826,7 +830,10 @@ export const extractContentMentionContext = (
         if (node.type.name !== CONTENT_MENTION_NAME) return;
 
         const attrs = node.attrs as {
-            contentType?: ContentType;
+            contentType?:
+                | ContentType
+                | typeof FILE_MENTION_CONTENT_TYPE
+                | typeof REPOSITORY_MENTION_CONTENT_TYPE;
             uuid?: string;
             slug?: string | null;
             label?: string | null;
@@ -881,6 +888,30 @@ export const extractContentMentionContext = (
                 dashboardSlug: attrs.slug ?? null,
                 displayName: attrs.label ?? null,
                 pinnedVersionUuid: null,
+            });
+            return;
+        }
+
+        // File / repository mentions carry their reference in `label` (the path
+        // / `owner/repo`) — emit a structured context item so the agent knows
+        // it's a file or a repo, never having to disambiguate from the text.
+        if (
+            attrs.contentType === FILE_MENTION_CONTENT_TYPE &&
+            typeof attrs.label === 'string'
+        ) {
+            context.push({ type: 'file', path: attrs.label });
+            optimisticContext.push({ type: 'file', path: attrs.label });
+            return;
+        }
+
+        if (
+            attrs.contentType === REPOSITORY_MENTION_CONTENT_TYPE &&
+            typeof attrs.label === 'string'
+        ) {
+            context.push({ type: 'repository', fullName: attrs.label });
+            optimisticContext.push({
+                type: 'repository',
+                fullName: attrs.label,
             });
         }
     });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -601,9 +601,11 @@ const renderContentMentionItem = (
 const generateContentMentionSuggestion = ({
     getProjectUuid,
     getPriorityItems,
+    onPopupOpenChange,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    onPopupOpenChange?: (open: boolean) => void;
 }): MentionOptions['suggestion'] => ({
     char: '@',
     allowSpaces: true,
@@ -681,6 +683,7 @@ const generateContentMentionSuggestion = ({
 
         return {
             onStart: (props) => {
+                onPopupOpenChange?.(true);
                 component = new ReactRenderer(SuggestionList, {
                     props: {
                         ...props,
@@ -723,12 +726,14 @@ const generateContentMentionSuggestion = ({
             },
             onKeyDown: (props) => {
                 if (props.event.key === 'Escape') {
+                    onPopupOpenChange?.(false);
                     popup?.hide();
                     return true;
                 }
                 return component?.ref?.onKeyDown(props) ?? false;
             },
             onExit: () => {
+                onPopupOpenChange?.(false);
                 popup?.destroy();
                 component?.destroy();
                 popup = undefined;
@@ -741,9 +746,11 @@ const generateContentMentionSuggestion = ({
 export const createContentMentionExtension = ({
     getProjectUuid,
     getPriorityItems,
+    onPopupOpenChange,
 }: {
     getProjectUuid: () => string | undefined;
     getPriorityItems: () => ContentMentionSuggestionItem[];
+    onPopupOpenChange?: (open: boolean) => void;
 }) =>
     Mention.extend({
         name: CONTENT_MENTION_NAME,
@@ -790,6 +797,7 @@ export const createContentMentionExtension = ({
         suggestion: generateContentMentionSuggestion({
             getProjectUuid,
             getPriorityItems,
+            onPopupOpenChange,
         }),
         renderText: ({ node }) =>
             typeof node.attrs.label === 'string' ? node.attrs.label : '',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -61,4 +61,27 @@ describe('contentReferenceUtils', () => {
             'chart:chart-2',
         ]);
     });
+
+    it('renders a reference chip for every occurrence of a repeated tag', () => {
+        const result = buildContentReferenceSegments(
+            'test charliedowler/Slugger charliedowler/Slugger charliedowler/Slugger',
+            [{ type: 'repository', fullName: 'charliedowler/Slugger' }],
+        );
+
+        const references = result.segments.filter(
+            (segment) => segment.type === 'reference',
+        );
+        expect(references).toHaveLength(3);
+        expect(
+            references.every(
+                (segment) =>
+                    segment.type === 'reference' &&
+                    segment.label === 'charliedowler/Slugger',
+            ),
+        ).toBe(true);
+        // The key is still recorded once for pinned-card accounting.
+        expect([...result.matchedKeys]).toEqual([
+            'repository:charliedowler/Slugger',
+        ]);
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -108,4 +108,54 @@ describe('contentReferenceUtils', () => {
             'repository:hello/world',
         ]);
     });
+
+    it('does not match a label inside a larger word', () => {
+        const result = buildContentReferenceSegments(
+            'please reorders the list',
+            [{ type: 'file', path: 'orders' }],
+        );
+
+        // `orders` lives inside `reorders` — it is not a real reference, so no
+        // chip should be rendered and the key should not be recorded.
+        const references = result.segments.filter(
+            (segment) => segment.type === 'reference',
+        );
+        expect(references).toHaveLength(0);
+        expect([...result.matchedKeys]).toEqual([]);
+    });
+
+    it('still matches a path-like label next to sentence punctuation', () => {
+        const result = buildContentReferenceSegments(
+            'see (acme/dbt) and models/orders.sql, then stop',
+            [
+                { type: 'repository', fullName: 'acme/dbt' },
+                { type: 'file', path: 'models/orders.sql' },
+            ],
+        );
+
+        // Brackets and a trailing comma are token boundaries, not word
+        // characters, so the references are still recognised.
+        const references = result.segments.filter(
+            (segment) => segment.type === 'reference',
+        );
+        expect(references.map((s) => s.type === 'reference' && s.key)).toEqual([
+            'repository:acme/dbt',
+            'file:models/orders.sql',
+        ]);
+    });
+
+    it('matches a standalone whole-word label (the irreducible text-match case)', () => {
+        const result = buildContentReferenceSegments(
+            'the orders table tracks orders by day',
+            [{ type: 'file', path: 'orders' }],
+        );
+
+        // Documents a known limitation: a coincidental standalone word equal to
+        // a label still matches, because the stored message carries no mention
+        // offsets. Mitigated in practice by labels being path-like.
+        const references = result.segments.filter(
+            (segment) => segment.type === 'reference',
+        );
+        expect(references).toHaveLength(2);
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.test.ts
@@ -84,4 +84,28 @@ describe('contentReferenceUtils', () => {
             'repository:charliedowler/Slugger',
         ]);
     });
+
+    it('matches a same-named file and repository to separate occurrences', () => {
+        const result = buildContentReferenceSegments(
+            'compare file hello/world with repo hello/world',
+            [
+                { type: 'file', path: 'hello/world' },
+                { type: 'repository', fullName: 'hello/world' },
+            ],
+        );
+
+        const references = result.segments.filter(
+            (segment) => segment.type === 'reference',
+        );
+        // Two occurrences, two distinct references — the first goes to the file,
+        // the second to the repository (not the file twice).
+        expect(references.map((s) => s.type === 'reference' && s.key)).toEqual([
+            'file:hello/world',
+            'repository:hello/world',
+        ]);
+        expect([...result.matchedKeys]).toEqual([
+            'file:hello/world',
+            'repository:hello/world',
+        ]);
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -20,20 +20,27 @@ export const getPromptContextItemKey = (item: AiPromptContextItem) => {
             return `dashboard:${item.dashboardUuid}`;
         case 'thread':
             return `thread:${item.threadUuid}`;
+        case 'file':
+            return `file:${item.path}`;
+        case 'repository':
+            return `repository:${item.fullName}`;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
 };
 
 const getPromptContextItemLabel = (item: AiPromptContextItem) => {
-    if (item.displayName) return item.displayName;
     switch (item.type) {
         case 'chart':
-            return item.chartSlug ?? 'Chart';
+            return item.displayName ?? item.chartSlug ?? 'Chart';
         case 'dashboard':
-            return item.dashboardSlug ?? 'Dashboard';
+            return item.displayName ?? item.dashboardSlug ?? 'Dashboard';
         case 'thread':
-            return 'Conversation';
+            return item.displayName ?? 'Conversation';
+        case 'file':
+            return item.path;
+        case 'repository':
+            return item.fullName;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }
@@ -51,6 +58,11 @@ export const getPromptContextItemHref = (
         // A pinned thread can live in another project, so there is no
         // reliable in-project URL to offer.
         case 'thread':
+            return null;
+        // File / repository references point at source the agent reads, not at
+        // an in-app route, so there is no link to offer.
+        case 'file':
+        case 'repository':
             return null;
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
@@ -75,8 +87,11 @@ export const buildContentReferenceSegments = (
     let cursor = 0;
 
     while (cursor < message.length) {
+        // Match every occurrence of a reference, not just the first — the same
+        // file/repo/chart can be tagged multiple times in one message. We still
+        // record each key in matchedKeys (a Set) so the caller knows which
+        // pinned items were referenced inline.
         const nextMatch = candidates
-            .filter(({ key }) => !matchedKeys.has(key))
             .map((candidate) => ({
                 ...candidate,
                 start: message.indexOf(candidate.label, cursor),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -99,6 +99,13 @@ export const buildContentReferenceSegments = (
             .filter(({ start }) => start >= 0)
             .sort((a, b) => {
                 if (a.start !== b.start) return a.start - b.start;
+                // When two references share a label and position (e.g. a file
+                // and a repository both named "owner/name"), prefer the one not
+                // yet matched so each distinct reference claims an occurrence,
+                // rather than the first reference claiming them all.
+                const aMatched = matchedKeys.has(a.key) ? 1 : 0;
+                const bMatched = matchedKeys.has(b.key) ? 1 : 0;
+                if (aMatched !== bMatched) return aMatched - bMatched;
                 if (a.label.length !== b.label.length) {
                     return b.label.length - a.label.length;
                 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentReferenceUtils.ts
@@ -69,6 +69,36 @@ export const getPromptContextItemHref = (
     }
 };
 
+// A label matches only when it sits on token boundaries — the characters on
+// either side must not be word characters. This stops a path/slug label from
+// matching inside a larger word (e.g. `orders` inside `reorders`). It does NOT
+// try to tell a real inline mention from a coincidental standalone word equal to
+// the label: the stored message is plain text with no mention offsets, so that
+// residual ambiguity is unavoidable here, mitigated by labels being path-like.
+const WORD_CHARACTER = /[\p{L}\p{N}_]/u;
+
+const isTokenBoundary = (character: string | undefined): boolean =>
+    character === undefined || !WORD_CHARACTER.test(character);
+
+const indexOfBoundedLabel = (
+    message: string,
+    label: string,
+    fromIndex: number,
+): number => {
+    let from = fromIndex;
+    while (from <= message.length) {
+        const start = message.indexOf(label, from);
+        if (start < 0) return -1;
+        const before = start > 0 ? message[start - 1] : undefined;
+        const after = message[start + label.length];
+        if (isTokenBoundary(before) && isTokenBoundary(after)) {
+            return start;
+        }
+        from = start + 1;
+    }
+    return -1;
+};
+
 export const buildContentReferenceSegments = (
     message: string,
     context: AiPromptContextItem[],
@@ -94,7 +124,7 @@ export const buildContentReferenceSegments = (
         const nextMatch = candidates
             .map((candidate) => ({
                 ...candidate,
-                start: message.indexOf(candidate.label, cursor),
+                start: indexOfBoundedLabel(message, candidate.label, cursor),
             }))
             .filter(({ start }) => start >= 0)
             .sort((a, b) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -8,7 +8,7 @@ type Props = {
 };
 
 type ItemMeta = {
-    kind: 'chart' | 'dashboard' | 'thread';
+    kind: 'chart' | 'dashboard' | 'thread' | 'file' | 'repository';
     label: string;
     href: string | null;
 };
@@ -38,6 +38,10 @@ const getItemMeta = (
                 label: item.displayName ?? 'Conversation',
                 href: null,
             };
+        case 'file':
+            return { kind: 'file', label: item.path, href: null };
+        case 'repository':
+            return { kind: 'repository', label: item.fullName, href: null };
         default:
             return assertUnreachable(item, 'Unknown AiPromptContextItem type');
     }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -630,6 +630,10 @@ const toOptimisticContextItem = (
                 promptUuid: item.promptUuid ?? null,
                 displayName: null,
             };
+        case 'file':
+            return { type: 'file', path: item.path };
+        case 'repository':
+            return { type: 'repository', fullName: item.fullName };
         default:
             return assertUnreachable(
                 item,


### PR DESCRIPTION
## Problem

When you tag a file or a repository in the AI agent chat, the reference was serialized to the agent as **plain text** — the bare file path or `owner/repo`. So a file named `hello/world` and a repository `hello/world` reached the agent as the *same* token, with no signal of which was meant. Unlike chart/dashboard mentions (which carry a structured, typed reference), file/repo mentions carried nothing but their label.

## What this does

Carries file and repository `@`-mentions as **structured `AiPromptContext` items**, end to end, the same way charts and dashboards already work:

- **common** — adds `file` (`{ path }`) and `repository` (`{ fullName }`) variants to `AiPromptContextItem` and its input type.
- **frontend** — emits the structured context on send; renders each reference as a distinct, icon-typed chip (file vs GitHub); keeps non-navigable references **non-interactive** (no arrow, no pointer, not a link) since there's nowhere to go; and renders a chip for **every** occurrence of a repeated tag, not just the first — matching on **token boundaries** so a path/slug label only chips when it stands as its own token (e.g. `orders` no longer lights up inside `reorders`).
- **backend** — validates the references (gated on `view:SourceCode`, rejected in embedded AI), persists them, resolves them on read, and serializes them into the agent prompt with the exact repo-filesystem mount path — `/dbt/<path>` for files, `/<owner>/<repo>` for repositories — so the agent always knows which is which.
- **migration** — `ai_prompt_context.entity_uuid` becomes nullable and a new `entity_ref` text column holds the natural key for string-keyed entities (file path, `owner/repo`), with a `COALESCE(entity_uuid::text, entity_ref)` unique index so duplicates still dedupe.

## Testing

- Unit tests: structured context dedupe keeps a same-named file and repo distinct; repeated tags each render a chip; the agent-prompt serialization emits the disambiguated mount paths.
- Verified live end to end via the API + UI: a message tagging a file and a repo both named `hello/world` persists as two distinct rows (`entity_ref` set, `entity_uuid` null), resolves back to two typed items, and the agent prompt receives `/dbt/hello/world` vs `hello/world (mounted at /hello/world)`. The chat bubble renders two distinct, non-clickable file/GitHub chips.
- Inline chip matching is token-boundary aware: a label only chips on whole-token matches, so a path/slug never highlights inside a larger word. Verified in the rendered chat bubble — `compare orders to reorders` (with `orders` attached) renders a single chip on the standalone `orders` while `reorders` stays plain text, and `please reorders the list` renders none. A genuinely repeated mention still chips each occurrence. (A standalone prose word identical to a label is the one residual match, since the stored message carries no mention offsets.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
