### PR TITLE
fix(promote): stop hiding promote button from developers when upstream exists

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -320,24 +320,13 @@ const SavedChartsHeader: FC = () => {
             subject('SavedChart', { ...savedChart }),
         );
 
-    // Mirror the backend promote check: promoting also requires promote
-    // rights on the upstream (destination) project, so hide the action when
-    // an upstream exists but the user has no promote access there.
     const userCanPromoteChart =
         savedChart &&
         !savedChart?.dashboardUuid &&
         user.data?.ability?.can(
             'promote',
             subject('SavedChart', { ...savedChart }),
-        ) &&
-        (project?.upstreamProjectUuid === undefined ||
-            user.data?.ability?.can(
-                'promote',
-                subject('SavedChart', {
-                    organizationUuid: savedChart.organizationUuid,
-                    projectUuid: project.upstreamProjectUuid,
-                }),
-            ));
+        );
 
     const userCanManageExplore = user.data?.ability.can(
         'manage',

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -297,26 +297,14 @@ const DashboardHeader = memo(
             }),
         );
 
-        // Mirror the backend promote check: promoting also requires promote
-        // rights on the upstream (destination) project, so hide the action
-        // when an upstream exists but the user has no promote access there.
-        const userCanPromoteDashboard =
-            user.data?.ability?.can(
-                'promote',
-                subject('Dashboard', {
-                    organizationUuid,
-                    projectUuid,
-                    access: dashboard.access,
-                }),
-            ) &&
-            (project?.upstreamProjectUuid === undefined ||
-                user.data?.ability?.can(
-                    'promote',
-                    subject('Dashboard', {
-                        organizationUuid,
-                        projectUuid: project.upstreamProjectUuid,
-                    }),
-                ));
+        const userCanPromoteDashboard = user.data?.ability?.can(
+            'promote',
+            subject('Dashboard', {
+                organizationUuid,
+                projectUuid,
+                access: dashboard.access,
+            }),
+        );
 
         const canManageContentVerification =
             user.data?.ability?.can(


### PR DESCRIPTION
Closes: #24352

### Description:

The dashboard and chart headers gated the **Promote** button on a second ability check against the **upstream** (destination) project. That check passes a `subject` with no space `access` field, so the org-level promote rule for Developer/Editor — which requires `access: { $elemMatch: { role: EDITOR } }` — can never match. As a result the button is hidden whenever an upstream project exists (i.e. always, in previews). Admins were unaffected because their `manage` ability carries no `access` condition, which is why an admin could see the button on a dashboard where a developer could not.

The frontend cannot evaluate upstream promote access correctly: it has no access context for the destination space (it would need to resolve the destination space in the other project and fetch its membership). The backend already enforces the destination-space restriction at promote time, so this drops the upstream gate and shows the button based on the current-project promote check only.

The regression was introduced in #24153.