### PR TITLE
feat(cli): support http(s) URLs for --combine-manifest

### DIFF
--- a/packages/cli/src/dbt/manifest.test.ts
+++ b/packages/cli/src/dbt/manifest.test.ts
@@ -1,5 +1,17 @@
 import { DbtManifest, DbtNode } from '@lightdash/common';
-import { combineManifests } from './manifest';
+import { promises as fs } from 'fs';
+import fetch from 'node-fetch';
+import { combineManifests, isHttpUrl, loadCombineManifest } from './manifest';
+
+jest.mock('node-fetch');
+jest.mock('fs', () => ({
+    promises: {
+        readFile: jest.fn(),
+    },
+}));
+
+const mockedFetch = fetch as unknown as jest.Mock;
+const mockedReadFile = fs.readFile as unknown as jest.Mock;
 
 const modelNode = (uniqueId: string, extra: Record<string, unknown> = {}) =>
     ({
@@ -142,5 +154,76 @@ describe('combineManifests', () => {
         expect(Object.keys(manifest.metrics)).toEqual(['metric.proj.p']);
         expect(Object.keys(manifest.docs)).toEqual(['doc.proj.p']);
         expect(manifest.metadata.adapter_type).toBe('postgres');
+    });
+});
+
+describe('isHttpUrl', () => {
+    test('returns true for http and https urls', () => {
+        expect(isHttpUrl('http://example.com/manifest.json')).toBe(true);
+        expect(isHttpUrl('https://bucket.s3.amazonaws.com/manifest.json')).toBe(
+            true,
+        );
+    });
+
+    test('returns false for local paths and bare strings', () => {
+        expect(isHttpUrl('./target/manifest.json')).toBe(false);
+        expect(isHttpUrl('/abs/path/manifest.json')).toBe(false);
+        expect(isHttpUrl('manifest.json')).toBe(false);
+        expect(isHttpUrl('s3://bucket/manifest.json')).toBe(false);
+    });
+});
+
+describe('loadCombineManifest', () => {
+    beforeEach(() => {
+        mockedFetch.mockReset();
+        mockedReadFile.mockReset();
+    });
+
+    test('fetches and parses a manifest from an http url', async () => {
+        const manifest = buildManifest({
+            'model.proj.a': modelNode('model.proj.a'),
+        });
+        mockedFetch.mockResolvedValue({
+            ok: true,
+            text: async () => JSON.stringify(manifest),
+        });
+
+        const result = await loadCombineManifest(
+            'https://example.com/manifest.json',
+        );
+
+        expect(mockedFetch).toHaveBeenCalledWith(
+            'https://example.com/manifest.json',
+        );
+        expect(Object.keys(result.nodes)).toEqual(['model.proj.a']);
+        expect(mockedReadFile).not.toHaveBeenCalled();
+    });
+
+    test('throws a wrapped error when the http response is not ok', async () => {
+        mockedFetch.mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            text: async () => '',
+        });
+
+        await expect(
+            loadCombineManifest('https://example.com/manifest.json'),
+        ).rejects.toThrow(
+            'Could not load manifest from https://example.com/manifest.json',
+        );
+    });
+
+    test('reads a manifest from a local path', async () => {
+        const manifest = buildManifest({
+            'model.proj.b': modelNode('model.proj.b'),
+        });
+        mockedReadFile.mockResolvedValue(JSON.stringify(manifest));
+
+        const result = await loadCombineManifest('./target/manifest.json');
+
+        expect(mockedReadFile).toHaveBeenCalled();
+        expect(Object.keys(result.nodes)).toEqual(['model.proj.b']);
+        expect(mockedFetch).not.toHaveBeenCalled();
     });
 });

--- a/packages/cli/src/dbt/manifest.ts
+++ b/packages/cli/src/dbt/manifest.ts
@@ -5,6 +5,7 @@ import {
     getErrorMessage,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
+import fetch from 'node-fetch';
 import * as path from 'path';
 import globalState from '../globalState';
 
@@ -35,6 +36,41 @@ export const loadManifest = async ({
 }: LoadManifestArgs): Promise<DbtManifest> => {
     const filename = await getManifestPath(targetDir);
     return loadManifestFromFile(filename);
+};
+
+export const isHttpUrl = (value: string): boolean => {
+    try {
+        const { protocol } = new URL(value);
+        return protocol === 'http:' || protocol === 'https:';
+    } catch {
+        return false;
+    }
+};
+
+export const loadManifestFromUrl = async (
+    url: string,
+): Promise<DbtManifest> => {
+    globalState.debug(`> Loading dbt manifest from ${url}`);
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`${response.status} ${response.statusText}`);
+        }
+        const manifest = JSON.parse(await response.text()) as DbtManifest;
+        return manifest;
+    } catch (err: unknown) {
+        const msg = getErrorMessage(err);
+        throw new Error(`Could not load manifest from ${url}:\n  ${msg}`);
+    }
+};
+
+export const loadCombineManifest = async (
+    pathOrUrl: string,
+): Promise<DbtManifest> => {
+    if (isHttpUrl(pathOrUrl)) {
+        return loadManifestFromUrl(pathOrUrl);
+    }
+    return loadManifestFromFile(path.resolve(pathOrUrl));
 };
 
 export type CombineManifestsResult = {

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -26,8 +26,8 @@ import { LightdashAnalytics } from '../analytics/analytics';
 import { getDbtContext } from '../dbt/context';
 import {
     combineManifests,
+    loadCombineManifest,
     loadManifest,
-    loadManifestFromFile,
 } from '../dbt/manifest';
 import { validateDbtModel } from '../dbt/validation';
 import GlobalState from '../globalState';
@@ -233,9 +233,9 @@ export const compile = async (options: CompileHandlerOptions) => {
         let manifest = await loadManifest({ targetDir: context.targetDir });
         let effectiveCompiledModelIds = compiledModelIds;
         if (options.combineManifest) {
-            const externalManifestPath = path.resolve(options.combineManifest);
-            const externalManifest =
-                await loadManifestFromFile(externalManifestPath);
+            const externalManifest = await loadCombineManifest(
+                options.combineManifest,
+            );
             const { manifest: merged, addedModelIds } = combineManifests(
                 manifest,
                 externalManifest,
@@ -252,7 +252,7 @@ export const compile = async (options: CompileHandlerOptions) => {
             }
             console.info(
                 styles.info(
-                    `Combined external manifest from ${externalManifestPath}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
+                    `Combined external manifest from ${options.combineManifest}: added ${addedModelIds.length} model(s) not present in the preview manifest`,
                 ),
             );
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -531,8 +531,8 @@ program
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .option(
-        '--combine-manifest <path>',
-        'Path to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+        '--combine-manifest <path-or-url>',
+        'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
     )
     .option(
         '--table-configuration <prod|all>',
@@ -660,8 +660,8 @@ program
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .option(
-        '--combine-manifest <path>',
-        'Path to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
+        '--combine-manifest <path-or-url>',
+        'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the preview manifest are merged in so the preview shows the full project. The preview-generated manifest always wins on conflicts.',
     )
     .option(
         '--table-configuration <prod|all>',
@@ -873,8 +873,8 @@ program
     )
     .option('--ignore-errors', 'Allows deploy with errors on compile', false)
     .option(
-        '--combine-manifest <path>',
-        'Path to an additional dbt manifest.json. Models present in this file but missing from the deploy manifest are merged in so the deploy includes the full project. The deploy-generated manifest always wins on conflicts.',
+        '--combine-manifest <path-or-url>',
+        'Path or http(s) URL to an additional dbt manifest.json. Models present in this file but missing from the deploy manifest are merged in so the deploy includes the full project. The deploy-generated manifest always wins on conflicts.',
     )
     .option(
         '--start-of-week <number>',


### PR DESCRIPTION
Closes: PROD-8363
Closes: #24451

### Description:

The CLI `--combine-manifest` option (on `preview`, `start-preview`, and `deploy`) now accepts an `http`/`https` URL in addition to a local filesystem path, so a dbt `manifest.json` published to object storage (e.g. a presigned S3 URL) can be merged without downloading it first. URLs are fetched with the CLI's existing `node-fetch` dependency; anything else falls through to the existing local-path behaviour, and the `s3://` scheme is intentionally not supported (it would require bundling the AWS SDK into the globally-installed CLI). The change adds an `isHttpUrl`/`loadManifestFromUrl`/`loadCombineManifest` trio in `manifest.ts`, wires it into the compile handler, updates the three option descriptions, and adds unit tests covering URL fetch, non-ok responses, and local-path fallback.