### PR TITLE
fix: handle scim group patch errors

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -1,6 +1,10 @@
 import {
+    GroupWithMembers,
     LightdashUser,
+    NotFoundError,
     OrganizationMemberRole,
+    ParameterError,
+    ScimError,
     ScimSchemaType,
     ScimUserRole,
 } from '@lightdash/common';
@@ -678,6 +682,101 @@ describe('ScimService', () => {
                     }),
                 }),
             );
+        });
+    });
+
+    describe('updateGroup', () => {
+        const mockGroup: GroupWithMembers = {
+            uuid: 'group-uuid',
+            name: 'Data Platform',
+            createdAt: new Date('2024-01-01'),
+            createdByUserUuid: null,
+            updatedAt: new Date('2024-01-01'),
+            updatedByUserUuid: null,
+            organizationUuid: mockUser.organizationUuid,
+            members: [],
+            memberUuids: [],
+        };
+
+        const patchOp: ScimPatch = {
+            schemas: [ScimSchemaType.PATCH],
+            Operations: [
+                {
+                    op: 'Replace',
+                    path: 'displayName',
+                    value: 'Data Platform - BI - Explorer',
+                },
+            ],
+        };
+
+        const createServiceWithGroupError = (error: Error) =>
+            new ScimService({
+                ...ScimServiceArgumentsMock,
+                groupsModel: {
+                    getGroupWithMembers: jest.fn().mockResolvedValue(mockGroup),
+                    updateGroup: jest.fn().mockRejectedValue(error),
+                } as never,
+            });
+
+        test('should return 400 invalidValue when group update rejects invalid members', async () => {
+            const groupService = createServiceWithGroupError(
+                new ParameterError('Some provided user UUIDs are invalid'),
+            );
+
+            await expect(
+                groupService.updateGroup(
+                    mockScimAccount,
+                    mockUser.organizationUuid,
+                    mockGroup.uuid,
+                    patchOp,
+                ),
+            ).rejects.toMatchObject({
+                detail: 'Some provided user UUIDs are invalid',
+                status: '400',
+                scimType: 'invalidValue',
+            });
+        });
+
+        test('should return 404 noTarget when model cannot find the group', async () => {
+            const groupService = createServiceWithGroupError(
+                new NotFoundError('No group found'),
+            );
+
+            await expect(
+                groupService.updateGroup(
+                    mockScimAccount,
+                    mockUser.organizationUuid,
+                    mockGroup.uuid,
+                    patchOp,
+                ),
+            ).rejects.toMatchObject({
+                detail: `Group with UUID ${mockGroup.uuid} not found`,
+                status: '404',
+                scimType: 'noTarget',
+            });
+        });
+
+        test('should preserve SCIM errors', async () => {
+            const groupService = createServiceWithGroupError(
+                new ScimError({
+                    detail: 'displayName is required',
+                    status: 400,
+                    scimType: 'invalidValue',
+                }),
+            );
+
+            await expect(
+                groupService.updateGroup(
+                    mockScimAccount,
+                    mockUser.organizationUuid,
+                    mockGroup.uuid,
+                    patchOp,
+                ),
+            ).rejects.toMatchObject({
+                detail: 'displayName is required',
+                status: '400',
+                scimType: 'invalidValue',
+            });
         });
     });
 

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1697,40 +1697,42 @@ export class ScimService extends BaseService {
             return this.convertLightdashGroupToScimGroup(updatedGroup);
         } catch (error) {
             if (error instanceof ScimError) {
-                switch (error.constructor) {
-                    case ParameterError:
-                    case InvalidScimPatchRequest:
-                        throw new ScimError({
-                            detail: error.message,
-                            status: 400,
-                            scimType: 'invalidValue',
-                        });
-                    case NotFoundError:
-                        throw new ScimError({
-                            detail: `Group with UUID ${groupUuid} not found`,
-                            status: 404,
-                            scimType: 'noTarget',
-                        });
-                    case ScimError:
-                        throw error; // pass through scim errors
-                    default:
-                        this.logger.error(
-                            `Failed to patch SCIM group: ${getErrorMessage(
-                                error,
-                            )}`,
-                        );
-                        const scimError = new ScimError({
-                            detail: 'Failed to patch SCIM group',
-                            status: ScimService.getErrorStatus(error) ?? 500,
-                        });
-                        Sentry.captureException(scimError);
-                        throw scimError;
-                }
+                throw error;
             }
-            throw new ScimError({
-                detail: 'Failed to patch SCIM group: unknown error',
+            if (
+                error instanceof ParameterError ||
+                error instanceof InvalidScimPatchRequest
+            ) {
+                throw new ScimError({
+                    detail: error.message,
+                    status: 400,
+                    scimType: 'invalidValue',
+                });
+            }
+            if (error instanceof NotFoundError) {
+                throw new ScimError({
+                    detail: `Group with UUID ${groupUuid} not found`,
+                    status: 404,
+                    scimType: 'noTarget',
+                });
+            }
+            if (error instanceof AlreadyExistsError) {
+                throw new ScimError({
+                    detail: error.message,
+                    status: 409,
+                    scimType: 'uniqueness',
+                });
+            }
+
+            this.logger.error(
+                `Failed to patch SCIM group: ${getErrorMessage(error)}`,
+            );
+            const scimError = new ScimError({
+                detail: 'Failed to patch SCIM group',
                 status: ScimService.getErrorStatus(error) ?? 500,
             });
+            Sentry.captureException(scimError);
+            throw scimError;
         }
     }
 


### PR DESCRIPTION
### Description

Mitigates SCIM group PATCH failures by translating expected model errors into SCIM 4xx responses instead of a generic retryable 500.

This does not make invalid or out-of-order group membership updates succeed. It stops known validation failures from spiraling as unknown server errors in IdP provisioning retries.

### Testing

- `pnpm -F backend test -- ScimService.test.ts --runInBand`
- `pnpm -F backend typecheck:fast`

Relates: #24404

Closes: https://github.com/lightdash/lightdash/issues/24458