### PR TITLE
feat(ai): extend Sentry AI telemetry to all production LLM calls

### DIFF
--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -262,11 +262,18 @@ export class AiAgentDocumentService extends BaseService {
             enableReasoning: false,
             useFastModel: true,
         });
-        const summary = await generateDocumentSummary(modelOptions, {
-            name: body.name,
-            content: body.content,
-            projectExplores,
-        });
+        const summary = await generateDocumentSummary(
+            modelOptions,
+            {
+                name: body.name,
+                content: body.content,
+                projectExplores,
+            },
+            {
+                organizationId: organizationUuid,
+                ...(body.projectUuid ? { projectId: body.projectUuid } : {}),
+            },
+        );
 
         const storageKey = `org/${organizationUuid}/doc/${uuidv4()}.${
             mimeType === 'text/markdown' ? 'md' : 'txt'

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -990,6 +990,17 @@ export class AiAgentReviewClassifierService extends BaseService {
             ...model.callOptions,
             providerOptions: model.providerOptions,
             schema: aiAgentReviewClassifierJudgeOutputSchema,
+            experimental_telemetry: {
+                functionId: 'classifyReviewTurn',
+                isEnabled: true,
+                recordInputs: false,
+                recordOutputs: false,
+                metadata: {
+                    projectId: candidate.subject.projectUuid,
+                    threadId: candidate.subject.threadUuid,
+                    promptUuid: candidate.subject.assistantPromptUuid,
+                },
+            },
             messages: [
                 {
                     role: 'system',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3829,10 +3829,17 @@ export class AiAgentService extends BaseService {
         const serializedInput =
             Compaction.serializeConversation(messagesToCompact);
 
-        const summary = await generateCompactionSummary(compactionModel, {
-            previousSummary: latestCompaction?.summary,
-            conversation: serializedInput,
-        });
+        const summary = await generateCompactionSummary(
+            compactionModel,
+            {
+                previousSummary: latestCompaction?.summary,
+                conversation: serializedInput,
+            },
+            {
+                threadId: threadUuid,
+                promptUuid: prompt.promptUuid,
+            },
+        );
 
         const createdCompaction =
             await this.aiAgentModel.createThreadCompaction({
@@ -4314,6 +4321,11 @@ export class AiAgentService extends BaseService {
             const title = await generateTitleFromMessages(
                 modelOptions,
                 chatHistoryMessages,
+                {
+                    organizationId: user.organizationUuid!,
+                    agentId: agentUuid,
+                    threadId: threadUuid,
+                },
             );
 
             // Save the title to the database
@@ -9432,6 +9444,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         name: project.name,
                     })),
                     promptText,
+                    { organizationId: organizationUuid },
                 );
                 if (routedProjectUuid) {
                     return await resolveAgentForProject(routedProjectUuid);
@@ -9543,6 +9556,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             model,
             candidates: availableAgents,
             prompt: messageText,
+            metadata: {
+                organizationId: organizationUuid,
+                userId: userUuid,
+            },
         });
 
         const selectedAgent =

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.test.ts
@@ -165,6 +165,10 @@ describe('AiRouterService', () => {
             candidates,
             prompt: 'show revenue by month',
             instructions: 'Route finance questions to @[Finance](agent-2)',
+            metadata: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+            },
         });
         expect(result.candidates).toEqual(candidates);
         expect(result.suggestedAgent.uuid).toBe('agent-2');

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -170,6 +170,10 @@ export class AiRouterService extends BaseService {
             candidates,
             prompt,
             instructions: instruction?.instruction ?? null,
+            metadata: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+            },
         });
 
         const suggestedAgent =

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -467,15 +467,23 @@ export class AiService {
     ): Promise<GeneratedChartMetadata> {
         const modelOptions = await this.getAmbientAiModel(user);
 
-        const result = await generateChartMetadataFromContext(modelOptions, {
-            tableName: payload.tableName,
-            chartType: payload.chartType,
-            dimensions: payload.dimensions,
-            metrics: payload.metrics,
-            filters: payload.filters,
-            fieldsContext: payload.fieldsContext,
-            chartConfigJson: payload.chartConfigJson,
-        });
+        const result = await generateChartMetadataFromContext(
+            modelOptions,
+            {
+                tableName: payload.tableName,
+                chartType: payload.chartType,
+                dimensions: payload.dimensions,
+                metrics: payload.metrics,
+                filters: payload.filters,
+                fieldsContext: payload.fieldsContext,
+                chartConfigJson: payload.chartConfigJson,
+            },
+            {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                userId: user.userUuid,
+            },
+        );
 
         this.analytics.track<GenerateChartMetadataGenerated>({
             userId: user.userUuid,
@@ -506,14 +514,22 @@ export class AiService {
             throw new ForbiddenError('Warehouse type is not available');
         }
 
-        const result = await generateTableCalculationFromContext(modelOptions, {
-            prompt: payload.prompt,
-            tableName: payload.tableName,
-            warehouseType,
-            fieldsContext: payload.fieldsContext,
-            existingTableCalculations: payload.existingTableCalculations,
-            currentSql: payload.currentSql,
-        });
+        const result = await generateTableCalculationFromContext(
+            modelOptions,
+            {
+                prompt: payload.prompt,
+                tableName: payload.tableName,
+                warehouseType,
+                fieldsContext: payload.fieldsContext,
+                existingTableCalculations: payload.existingTableCalculations,
+                currentSql: payload.currentSql,
+            },
+            {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                userId: user.userUuid,
+            },
+        );
 
         this.analytics.track<GenerateTableCalculationGenerated>({
             userId: user.userUuid,
@@ -543,6 +559,12 @@ export class AiService {
         const result = await generateFormulaTableCalculationFromContext(
             modelOptions,
             payload,
+            {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                userId: user.userUuid,
+                mode: payload.mode,
+            },
         );
 
         if (payload.mode === 'convert-sql') {
@@ -582,11 +604,19 @@ export class AiService {
     ): Promise<GeneratedTooltip> {
         const modelOptions = await this.getAmbientAiModel(user);
 
-        const result = await generateTooltipFromContext(modelOptions, {
-            prompt: payload.prompt,
-            fieldsContext: payload.fieldsContext,
-            currentHtml: payload.currentHtml,
-        });
+        const result = await generateTooltipFromContext(
+            modelOptions,
+            {
+                prompt: payload.prompt,
+                fieldsContext: payload.fieldsContext,
+                currentHtml: payload.currentHtml,
+            },
+            {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                userId: user.userUuid,
+            },
+        );
 
         this.analytics.track<GenerateTooltipGenerated>({
             userId: user.userUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -3034,6 +3034,17 @@ export class AppGenerateService extends BaseService {
                 providerOptions: modelOptions.providerOptions,
                 schema: clarifySchema,
                 abortSignal: AbortSignal.timeout(CLARIFY_TIMEOUT_MS),
+                experimental_telemetry: {
+                    functionId: 'clarifyApp',
+                    isEnabled: true,
+                    recordInputs: false,
+                    recordOutputs: false,
+                    metadata: {
+                        organizationId: organizationUuid,
+                        projectId: projectUuid,
+                        userId: user.userUuid,
+                    },
+                },
                 messages: [
                     {
                         role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/agentSelector.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentSelector.ts
@@ -118,11 +118,13 @@ export async function selectAgent({
     candidates,
     prompt,
     instructions = null,
+    metadata = {},
 }: {
     model: LanguageModel;
     candidates: AiAgentWithContext[];
     prompt: string;
     instructions?: string | null;
+    metadata?: Record<string, string>;
 }): Promise<RouterDecision> {
     if (candidates.length === 0) {
         throw new Error('No agents available for selection');
@@ -148,6 +150,13 @@ export async function selectAgent({
     const result = await generateObject({
         model,
         schema: AgentSelectionSchema,
+        experimental_telemetry: {
+            functionId: 'selectAgent',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             { role: 'system', content: systemPrompt },
             {

--- a/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/chartMetadataGenerator.ts
@@ -59,6 +59,7 @@ function buildFieldLabelMap(fieldsContext: FieldInfo[]): string {
 export async function generateChartMetadata(
     modelOptions: GeneratorModelOptions,
     context: ChartMetadataContext,
+    metadata: Record<string, string> = {},
 ): Promise<GeneratedChartMetadata> {
     const fieldLabelMap = buildFieldLabelMap(context.fieldsContext);
 
@@ -67,6 +68,13 @@ export async function generateChartMetadata(
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: ChartMetadataSchema,
+        experimental_telemetry: {
+            functionId: 'generateChartMetadata',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/compactionGenerator.ts
@@ -10,11 +10,19 @@ export async function generateCompactionSummary(
         previousSummary?: string | null;
         conversation: string;
     },
+    metadata: Record<string, string> = {},
 ): Promise<string> {
     const result = await generateText({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
+        experimental_telemetry: {
+            functionId: 'generateCompactionSummary',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
@@ -65,12 +65,20 @@ export async function generateDocumentSummary(
         content: string;
         projectExplores: Explore[];
     },
+    metadata: Record<string, string> = {},
 ): Promise<AiAgentDocumentStructuredSummary> {
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: DocumentSummarySchema,
+        experimental_telemetry: {
+            functionId: 'generateDocumentSummary',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/formulaTableCalculationGenerator.ts
@@ -327,6 +327,7 @@ function buildUserContent(
 export async function generateFormulaTableCalculation(
     modelOptions: GeneratorModelOptions,
     context: FormulaTableCalculationContext,
+    metadata: Record<string, string> = {},
 ): Promise<GeneratedFormulaTableCalculation> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
     const systemPrompt = buildSystemPrompt();
@@ -344,6 +345,13 @@ export async function generateFormulaTableCalculation(
             ...modelOptions.callOptions,
             providerOptions: modelOptions.providerOptions,
             schema: FormulaTableCalculationSchema,
+            experimental_telemetry: {
+                functionId: 'generateFormulaTableCalculation',
+                isEnabled: true,
+                recordInputs: false,
+                recordOutputs: false,
+                metadata,
+            },
             messages: [
                 { role: 'system', content: systemPrompt },
                 { role: 'user', content: userContent },

--- a/packages/backend/src/ee/services/ai/agents/projectRouter.ts
+++ b/packages/backend/src/ee/services/ai/agents/projectRouter.ts
@@ -27,6 +27,7 @@ export async function routeProjectForSlack(
     model: LanguageModel,
     projects: { projectUuid: string; name: string }[],
     userQuery: string,
+    metadata: Record<string, string> = {},
 ): Promise<string | null> {
     if (projects.length === 0) {
         return null;
@@ -42,6 +43,13 @@ export async function routeProjectForSlack(
     const result = await generateObject({
         model,
         schema: ProjectRoutingSchema,
+        experimental_telemetry: {
+            functionId: 'routeProjectForSlack',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tableCalculationGenerator.ts
@@ -257,6 +257,7 @@ function buildFieldReferenceGuide(
 export async function generateTableCalculation(
     modelOptions: GeneratorModelOptions,
     context: TableCalculationContext,
+    metadata: Record<string, string> = {},
 ): Promise<GeneratedTableCalculation> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
@@ -265,6 +266,13 @@ export async function generateTableCalculation(
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: TableCalculationSchema,
+        experimental_telemetry: {
+            functionId: 'generateTableCalculation',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -19,12 +19,20 @@ export type GeneratedTitle = z.infer<typeof TitleSchema>;
 export async function generateThreadTitle(
     modelOptions: GeneratorModelOptions,
     messages: ModelMessage[],
+    metadata: Record<string, string> = {},
 ): Promise<string> {
     const result = await generateObject({
         model: modelOptions.model,
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: TitleSchema,
+        experimental_telemetry: {
+            functionId: 'generateThreadTitle',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',

--- a/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/tooltipGenerator.ts
@@ -32,6 +32,7 @@ function buildFieldReferenceGuide(
 export async function generateTooltip(
     modelOptions: GeneratorModelOptions,
     context: TooltipContext,
+    metadata: Record<string, string> = {},
 ): Promise<GeneratedTooltip> {
     const fieldReferenceGuide = buildFieldReferenceGuide(context.fieldsContext);
 
@@ -40,6 +41,13 @@ export async function generateTooltip(
         ...modelOptions.callOptions,
         providerOptions: modelOptions.providerOptions,
         schema: TooltipSchema,
+        experimental_telemetry: {
+            functionId: 'generateTooltip',
+            isEnabled: true,
+            recordInputs: false,
+            recordOutputs: false,
+            metadata,
+        },
         messages: [
             {
                 role: 'system',


### PR DESCRIPTION
## Summary

Extends the existing Sentry **`vercelAIIntegration`** coverage so that **every production Vercel AI SDK call** emits a named, correlated span in Sentry's AI Agents dashboard. Previously only the agent loop (`agentV2`, `discoverFields`) and three generators (`questionGenerator`, `embeddingGenerator`, `suggestionGenerator`) passed `experimental_telemetry`; the remaining production generators produced unnamed, uncorrelated spans (or none).

No new dependencies and no change to the observability stack — this reuses the integration already wired in `packages/backend/src/sentry.ts`. It does **not** adopt `@vercel/otel` / `@sentry/opentelemetry`; that path solves a problem we don't have (we never owned an OTel pipeline).

## What changed

Each call below now passes `experimental_telemetry` with a unique `functionId` and correlation `metadata`, matching the convention already used by the instrumented generators:

| `functionId` | Call site | Metadata |
|---|---|---|
| `generateThreadTitle` | `titleGenerator.ts` | org, agent, thread |
| `generateTooltip` | `tooltipGenerator.ts` | org, project, user |
| `generateChartMetadata` | `chartMetadataGenerator.ts` | org, project, user |
| `generateTableCalculation` | `tableCalculationGenerator.ts` | org, project, user |
| `generateFormulaTableCalculation` | `formulaTableCalculationGenerator.ts` | org, project, user, mode |
| `generateDocumentSummary` | `documentSummaryGenerator.ts` | org, project |
| `generateCompactionSummary` | `compactionGenerator.ts` | thread, prompt |
| `routeProjectForSlack` | `projectRouter.ts` | org |
| `selectAgent` | `agentSelector.ts` | org, project / org, user |
| `clarifyApp` | `AppGenerateService.ts` | org, project, user |
| `classifyReviewTurn` | `AiAgentReviewClassifierService.ts` | project, thread, prompt |

Generators gained an optional `metadata: Record<string, string> = {}` param; callers thread identifiers they already had in scope (mirroring the existing analytics `track()` calls).

## Behavior & regression analysis

- **Telemetry-only.** No control flow, prompts, schemas, or return values change. The only runtime effect is span attributes attached to LLM calls.
- **Gated by existing flags.** Spans are only captured when `LIGHTDASH_AI_COPILOT_ENABLED` + `LIGHTDASH_AI_COPILOT_TELEMETRY_ENABLED` are set (that's the condition under which `vercelAIIntegration` is registered at all). With telemetry off, this is a no-op.
- **No PII recorded.** Every added block sets `recordInputs: false` / `recordOutputs: false`, consistent with the other utility generators — titles, tooltips, and table calcs can echo data values, so their inputs/outputs are deliberately not recorded. Only opaque UUID identifiers go into `metadata`.
- **Unaffected:** the agent loop and the three already-instrumented generators (unchanged). Eval-harness judges (`llmAsAJudge`, `llmAsJudgeForTools`) are intentionally excluded — they don't run in the user request path.

## Verification

- `pnpm -F backend typecheck:fast` → exit 0, 0 errors
- `pnpm -F backend` eslint (with custom `--rulesdir`) → clean
- Pre-commit hooks (lint --fix + formatter) passed on all 15 files

## Tracking

Linear: _needs ticket — please add a `Closes:`/`Relates:` line_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
