### PR TITLE
fix(excel): use inline strings for streaming export to avoid RangeError

### DIFF
--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -535,7 +535,9 @@ export class ExcelService {
         const workbook = new Excel.stream.xlsx.WorkbookWriter({
             filename: tempFilePath,
             useStyles: true,
-            useSharedStrings: true,
+            // Inline strings avoid buffering a shared-strings table that
+            // exceeds V8's max string length (~512MB) on large exports.
+            useSharedStrings: false,
         });
         const worksheet = workbook.addWorksheet('Sheet1');
 


### PR DESCRIPTION
## Summary

Large Excel exports (scheduled deliveries / direct downloads) crash at `workbook.commit()` with `RangeError: Invalid string length`.

With `useSharedStrings: true`, exceljs accumulates every unique cell value into a single in-memory shared-strings table and serializes it via `Array.join('')` on commit. For a large enough export the resulting string exceeds V8's maximum string length (~512 MB, `2^29 - 1` chars) and throws — failing the whole export.

This switches the streaming `WorkbookWriter` in `ExcelService.streamJsonlToExcelFile` to `useSharedStrings: false`, so strings are written inline per row. That removes the unbounded in-memory buffer and the end-of-stream giant-string serialization.

**Trade-off:** inline strings make the `.xlsx` slightly larger when values repeat a lot (the shared-strings de-dup is gone), but zip compression recovers most of it, and inline strings are the correct choice for the streaming export path — which exists precisely for large datasets.

## Reproduction

Verified locally by mirroring the `WorkbookWriter` setup and streaming ~5.5k rows of large unique string cells (~557 MB total):

- `useSharedStrings: true` → `RangeError: Invalid string length` (matches the reported crash at `workbook.commit()`)
- `useSharedStrings: false` → commits successfully

## Testing

- 42/42 existing `ExcelService` tests pass
- `backend typecheck:fast` clean

## Links

Fixes [LIGHTDASH-BACKEND-CZY](https://lightdash.sentry.io/issues/7559881183)
