### PR TITLE
feat(ai): capture AI telemetry on workers + sample AI traces at 100%

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -16,8 +16,12 @@ import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import { STREAM_CONFIGS, type NatsWorkerStream } from './nats/natsConfig';
 import { NatsWorker } from './nats/NatsWorker';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
-import { IGNORE_ERRORS } from './sentry';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
+import {
+    getAiTracesSampleRate,
+    getSentryAiIntegrations,
+    IGNORE_ERRORS,
+} from './sentry/shared';
 import {
     OperationContext,
     ServiceProviderMap,
@@ -174,9 +178,10 @@ export default class NatsWorkerApp {
                 this.environment === 'development'
                     ? 'development'
                     : this.lightdashConfig.mode,
-            integrations: [],
+            integrations: getSentryAiIntegrations(this.lightdashConfig),
             ignoreErrors: IGNORE_ERRORS,
-            tracesSampleRate:
+            tracesSampler: (context) =>
+                getAiTracesSampleRate(context, this.lightdashConfig) ??
                 this.lightdashConfig.sentry.queryTracesSampleRate ??
                 this.lightdashConfig.sentry.tracesSampleRate,
         });

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -23,8 +23,12 @@ import {
     derivePoolIdFromEnv,
     SchedulerWorkerHealth,
 } from './scheduler/SchedulerWorkerHealth';
-import { IGNORE_ERRORS } from './sentry';
 import { createOrganizationNameResolver } from './sentry/organizationNameResolver';
+import {
+    getAiTracesSampleRate,
+    getSentryAiIntegrations,
+    IGNORE_ERRORS,
+} from './sentry/shared';
 import {
     OperationContext,
     ServiceProviderMap,
@@ -213,8 +217,13 @@ export default class SchedulerApp {
                 this.environment === 'development'
                     ? 'development'
                     : this.lightdashConfig.mode,
-            integrations: [],
+            integrations: getSentryAiIntegrations(this.lightdashConfig),
             ignoreErrors: IGNORE_ERRORS,
+            // The scheduler runs Slack agent responses, writebacks, and
+            // embeddings — trace those AI spans, but leave other scheduled
+            // jobs untraced (default 0) to avoid a volume spike.
+            tracesSampler: (context) =>
+                getAiTracesSampleRate(context, this.lightdashConfig) ?? 0,
         });
     }
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -191,6 +191,7 @@ export const lightdashConfigMock: LightdashConfig = {
         environment: '',
         tracesSampleRate: 0,
         queryTracesSampleRate: null,
+        aiTracesSampleRate: 0,
         profilesSampleRate: 0,
         anr: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -186,6 +186,7 @@ test('Should use default sentry configuration if no environment vars', () => {
         environment: LightdashMode.DEFAULT,
         tracesSampleRate: 0.1,
         queryTracesSampleRate: null,
+        aiTracesSampleRate: 1.0,
         profilesSampleRate: 0.2,
         anr: {
             enabled: false,
@@ -209,6 +210,7 @@ test('Should parse sentry config from env', () => {
         environment: 'development',
         tracesSampleRate: 0.8,
         queryTracesSampleRate: null,
+        aiTracesSampleRate: 1.0,
         profilesSampleRate: 1.0,
         anr: {
             enabled: true,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1996,6 +1996,10 @@ export const parseConfig = (): LightdashConfig => {
                 getFloatFromEnvironmentVariable(
                     'SENTRY_QUERY_TRACES_SAMPLE_RATE',
                 ) ?? null, // defaults to null (use global tracesSampleRate), set to 1.0 to capture all query traces
+            aiTracesSampleRate:
+                getFloatFromEnvironmentVariable(
+                    'SENTRY_AI_TRACES_SAMPLE_RATE',
+                ) ?? 1.0, // AI agent traces are low-volume/high-value, so default to 100% when copilot telemetry is enabled
             profilesSampleRate:
                 getFloatFromEnvironmentVariable(
                     'SENTRY_PROFILES_SAMPLE_RATE',

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -1,27 +1,12 @@
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
 import { lightdashConfig } from './config/lightdashConfig';
+import {
+    getAiTracesSampleRate,
+    getSentryAiIntegrations,
+    IGNORE_ERRORS,
+} from './sentry/shared';
 import { VERSION } from './version';
-
-export const IGNORE_ERRORS = [
-    'WarehouseConnectionError',
-    'WarehouseQueryError',
-    'FieldReferenceError',
-    'NotEnoughResults',
-    'CompileError',
-    'NotFoundError',
-    'ForbiddenError',
-    'TokenError',
-    'AuthorizationError',
-    'SshTunnelError',
-    'ReadFileError',
-    'AiAgentValidatorError',
-    'UserInfoError', // Google oauth2 error when using invalid credentials
-    // Invalid user-supplied parameter (e.g. AI writeback requires a GitHub
-    // dbt connection but the project uses "none") — surfaced to the user,
-    // not a server bug.
-    'ParameterError',
-];
 
 const spotlightEnabled =
     process.env.NODE_ENV === 'development' && !!process.env.SENTRY_SPOTLIGHT;
@@ -57,15 +42,7 @@ Sentry.init({
                   }),
               ]
             : []),
-        ...(lightdashConfig.ai.copilot.enabled &&
-        lightdashConfig.ai.copilot.telemetryEnabled
-            ? [
-                  Sentry.vercelAIIntegration({
-                      recordInputs: true,
-                      recordOutputs: true,
-                  }),
-              ]
-            : []),
+        ...getSentryAiIntegrations(lightdashConfig),
     ],
     ignoreErrors: IGNORE_ERRORS,
     tracesSampler: (context) => {
@@ -83,6 +60,13 @@ Sentry.init({
             request?.headers?.['user-agent']?.includes('GoogleHC')
         ) {
             return 0.0;
+        }
+
+        // AI agent traces are low-volume/high-value — sample them at their
+        // own rate (100% by default) so the AI Agents dashboard is complete.
+        const aiSampleRate = getAiTracesSampleRate(context, lightdashConfig);
+        if (aiSampleRate !== null) {
+            return aiSampleRate;
         }
 
         if (context.parentSampled) {

--- a/packages/backend/src/sentry/shared.ts
+++ b/packages/backend/src/sentry/shared.ts
@@ -1,0 +1,101 @@
+import * as Sentry from '@sentry/node';
+import type { LightdashConfig } from '../config/parseConfig';
+
+// Derive the Sentry types from the installed @sentry/node runtime rather than
+// importing from @sentry/core directly — the backend pins a different
+// @sentry/core version, so a direct type import resolves to a mismatched copy.
+type SentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+type SamplingContext = Parameters<
+    NonNullable<SentryInitOptions['tracesSampler']>
+>[0];
+
+export const IGNORE_ERRORS = [
+    'WarehouseConnectionError',
+    'WarehouseQueryError',
+    'FieldReferenceError',
+    'NotEnoughResults',
+    'CompileError',
+    'NotFoundError',
+    'ForbiddenError',
+    'TokenError',
+    'AuthorizationError',
+    'SshTunnelError',
+    'ReadFileError',
+    'AiAgentValidatorError',
+    'UserInfoError', // Google oauth2 error when using invalid credentials
+    // Invalid user-supplied parameter (e.g. AI writeback requires a GitHub
+    // dbt connection but the project uses "none") — surfaced to the user,
+    // not a server bug.
+    'ParameterError',
+];
+
+/**
+ * The Vercel AI SDK integration captures `generateText`/`streamText`/
+ * `generateObject`/`embed` calls as spans for Sentry's AI Agents dashboard.
+ * Shared so the scheduler and NATS workers — where Slack agent responses,
+ * writebacks, and embeddings actually run — capture AI spans too, not just
+ * the synchronous API pod.
+ */
+export const getSentryAiIntegrations = (lightdashConfig: LightdashConfig) =>
+    lightdashConfig.ai.copilot.enabled &&
+    lightdashConfig.ai.copilot.telemetryEnabled
+        ? [
+              Sentry.vercelAIIntegration({
+                  recordInputs: true,
+                  recordOutputs: true,
+              }),
+          ]
+        : [];
+
+// AI SDK spans carry OpenTelemetry GenAI attributes; on the workers they
+// surface as their own root transactions (no HTTP parent), so we match on
+// these attribute prefixes to sample them.
+const AI_SPAN_ATTRIBUTE_PREFIXES = ['gen_ai.', 'ai.'];
+
+// Synchronous web agent endpoints on the API pod — here the AI call is a
+// child of the HTTP transaction, so we boost the request transaction itself.
+const AI_AGENT_ENDPOINT_RE =
+    /\/aiAgents\/[^/]+\/threads\/[^/]+\/(stream|messages)$/;
+
+/**
+ * Returns the AI traces sample rate when this trace is AI-related — a web
+ * agent request or an AI SDK span on a worker — otherwise null so the caller
+ * falls back to its own default. Returns null entirely when copilot telemetry
+ * is disabled, leaving non-AI sampling untouched.
+ */
+export const getAiTracesSampleRate = (
+    context: SamplingContext,
+    lightdashConfig: LightdashConfig,
+): number | null => {
+    if (
+        !lightdashConfig.ai.copilot.enabled ||
+        !lightdashConfig.ai.copilot.telemetryEnabled
+    ) {
+        return null;
+    }
+
+    const { aiTracesSampleRate } = lightdashConfig.sentry;
+
+    const url = context.normalizedRequest?.url;
+    if (url) {
+        try {
+            const { pathname } = new URL(url, 'http://localhost');
+            if (AI_AGENT_ENDPOINT_RE.test(pathname)) {
+                return aiTracesSampleRate;
+            }
+        } catch {
+            // Ignore URL parse errors, fall through
+        }
+    }
+
+    const attributes = context.attributes ?? {};
+    if (
+        Object.keys(attributes).some((key) =>
+            AI_SPAN_ATTRIBUTE_PREFIXES.some((prefix) => key.startsWith(prefix)),
+        )
+    ) {
+        return aiTracesSampleRate;
+    }
+
+    return null;
+};

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -394,6 +394,7 @@ export type SentryConfig = {
     environment: string;
     tracesSampleRate: number;
     queryTracesSampleRate: number | null;
+    aiTracesSampleRate: number;
     profilesSampleRate: number;
     anr: {
         enabled: boolean;


### PR DESCRIPTION
## Summary

The Sentry **`vercelAIIntegration`** was only registered on the API pod. But a large share of AI work runs on the **scheduler worker** — Slack agent responses (`replyToSlackPrompt`, the full agentV2 loop), AI writebacks, embeddings, batch review classification — and the worker's `Sentry.init` used `integrations: []` with no tracing. So all of that AI activity never reached Sentry's AI Agents dashboard, regardless of the per-call telemetry added in #24456.

This registers the AI integration on **both workers** and adds an **AI-aware `tracesSampler`** so AI traces sample at **100% by default** without inflating general HTTP/job tracing.

Stacked on #24456 (the per-call `experimental_telemetry` instrumentation).

## What changed

**New `packages/backend/src/sentry/shared.ts`** — pure, side-effect-free helpers shared by all three entry points:
- `IGNORE_ERRORS` (moved here from `sentry.ts`)
- `getSentryAiIntegrations(config)` — returns `vercelAIIntegration` when copilot telemetry is enabled, else `[]`
- `getAiTracesSampleRate(context, config)` — returns the AI rate when the trace is AI-related (web agent endpoint **or** a `gen_ai.*`/`ai.*` span on a worker), else `null`

**Wiring:**
- `sentry.ts` (API pod) — uses the shared helpers; AI sampling boost slots into the existing `tracesSampler` after the health-check short-circuit
- `SchedulerApp.ts` — registers the AI integration; `tracesSampler` returns the AI rate for AI spans, **`0` otherwise** (other scheduled jobs stay untraced — no volume spike)
- `NatsWorkerApp.ts` — registers the AI integration; AI rate for AI spans, falls back to its existing `queryTracesSampleRate ?? tracesSampleRate` default
- Both workers now import from `./sentry/shared` instead of the side-effecting `./sentry`, which also fixes an accidental double-`Sentry.init` (the API-pod init was running on workers at import time, then being overridden)

**Config:** new `SENTRY_AI_TRACES_SAMPLE_RATE` (default **`1.0`**) on `SentryConfig`. AI calls are low-volume/high-value, so 100% is the sensible default once copilot telemetry is on. Not exposed via the health endpoint (curated subset).

## Behavior & regression analysis

- **Gated by copilot telemetry flags.** `getAiTracesSampleRate` returns `null` (no change to any sampling) unless `AI_COPILOT_ENABLED` + `AI_COPILOT_TELEMETRY_ENABLED` are set. With telemetry off, this is a no-op everywhere.
- **Non-AI sampling unchanged.** API pod keeps its existing sampler logic (spotlight, health checks, `parentSampled`, query-trace boost, default rate). Scheduler default stays effectively off (`0`). NATS keeps its prior default. Only AI-related traces are added.
- **No new PII.** Sampling decision only; the span attributes/redaction are governed by the integration + the per-call `recordInputs/Outputs` settings from #24456.
- **Workers no longer double-init Sentry** — strictly a correctness improvement.

## Sampling levers (for reference)

- AI traces at 100%: default now (`SENTRY_AI_TRACES_SAMPLE_RATE=1.0`).
- Everything at 100%: `SENTRY_TRACES_SAMPLE_RATE=1.0` (blanket — larger volume/cost).

## Verification

- `pnpm -F backend typecheck:fast` → exit 0, 0 errors
- `pnpm -F backend test -- parseConfig` → 121/121 pass (updated sentry-config expectations)
- eslint (custom `--rulesdir`) → clean on all 8 files

## Tracking

Linear: _needs ticket — please add a `Closes:`/`Relates:` line_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
