### PR TITLE
feat: roadmap data contract, status mapping and redaction rules

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -284,6 +284,7 @@ export * from './types/queryHistory';
 export * from './types/rename';
 export * from './types/resourceViewItem';
 export * from './types/results';
+export * from './types/roadmap';
 export * from './types/roles';
 export * from './types/savedCharts';
 export * from './types/scheduler';

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -316,6 +316,13 @@ export enum FeatureFlags {
      * default; enable per-org.
      */
     EmailWhitelabel = 'email-whitelabel',
+
+    /**
+     * Gate the customer-facing read-only Roadmap page and its instance-side
+     * backend proxy to the central roadmap service. Off by default while the
+     * feature is built out across the roadmap service and app.
+     */
+    Roadmap = 'roadmap',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/roadmap.test.ts
+++ b/packages/common/src/types/roadmap.test.ts
@@ -4,6 +4,7 @@ import {
     findForbiddenRoadmapFields,
     mapLinearStateToRoadmapStatus,
     redactRoadmapItem,
+    redactRoadmapItems,
     RoadmapItemStatus,
     type RoadmapItem,
 } from './roadmap';
@@ -161,5 +162,69 @@ describe('redactRoadmapItem', () => {
         expect(() => redactRoadmapItem(raw as Record<string, unknown>)).toThrow(
             ParameterError,
         );
+    });
+});
+
+describe('redactRoadmapItems', () => {
+    it('redacts every item when all are clean', () => {
+        const result = redactRoadmapItems([
+            {
+                title: 'Dark mode',
+                description: 'body',
+                status: RoadmapItemStatus.SHIPPED,
+                id: 'leak',
+            },
+            {
+                title: 'Filters',
+                description: null,
+                status: RoadmapItemStatus.PLANNED,
+            },
+        ]);
+        expect(result.items).toEqual<RoadmapItem[]>([
+            {
+                title: 'Dark mode',
+                description: 'body',
+                status: RoadmapItemStatus.SHIPPED,
+            },
+            {
+                title: 'Filters',
+                description: null,
+                status: RoadmapItemStatus.PLANNED,
+            },
+        ]);
+        expect(result.rejected).toEqual([]);
+    });
+
+    it('excludes a forbidden item rather than failing the whole list', () => {
+        const result = redactRoadmapItems([
+            {
+                title: 'Dark mode',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+            },
+            {
+                title: 'Leaky',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+                arr: 50000,
+            },
+        ]);
+        expect(result.items).toEqual<RoadmapItem[]>([
+            {
+                title: 'Dark mode',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+            },
+        ]);
+        expect(result.rejected).toHaveLength(1);
+    });
+
+    it('excludes malformed items and never throws', () => {
+        const result = redactRoadmapItems([
+            { description: null, status: RoadmapItemStatus.BACKLOG },
+            { title: 't', description: null, status: 'Whenever' },
+        ]);
+        expect(result.items).toEqual([]);
+        expect(result.rejected).toHaveLength(2);
     });
 });

--- a/packages/common/src/types/roadmap.test.ts
+++ b/packages/common/src/types/roadmap.test.ts
@@ -10,35 +10,47 @@ import {
 
 describe('mapLinearStateToRoadmapStatus', () => {
     it.each([
-        ['Triage', RoadmapItemStatus.BACKLOG],
-        ['Backlog', RoadmapItemStatus.BACKLOG],
-        ['Todo', RoadmapItemStatus.PLANNED],
-        ['Planned', RoadmapItemStatus.PLANNED],
-        ['In Progress', RoadmapItemStatus.BUILDING],
-        ['Done', RoadmapItemStatus.SHIPPED],
-        ['Canceled', RoadmapItemStatus.NOT_PLANNED],
-    ])('maps state name "%s" to %s', (name, expected) => {
+        ['triage', RoadmapItemStatus.BACKLOG],
+        ['backlog', RoadmapItemStatus.BACKLOG],
+        ['unstarted', RoadmapItemStatus.PLANNED],
+        ['started', RoadmapItemStatus.BUILDING],
+        ['completed', RoadmapItemStatus.SHIPPED],
+        ['canceled', RoadmapItemStatus.NOT_PLANNED],
+    ])('maps canonical state type "%s" to %s', (type, expected) => {
         expect(
-            mapLinearStateToRoadmapStatus({ name, type: 'ignored' }),
+            mapLinearStateToRoadmapStatus({ name: 'ignored', type }),
         ).toBe(expected);
     });
 
-    it('matches state names case-insensitively', () => {
+    it('prefers the canonical type over a renamed state name', () => {
+        // a started state renamed to "Done" must still map to Building
+        expect(
+            mapLinearStateToRoadmapStatus({ name: 'Done', type: 'started' }),
+        ).toBe(RoadmapItemStatus.BUILDING);
+    });
+
+    it('falls back to the state name when the type is missing', () => {
+        expect(
+            mapLinearStateToRoadmapStatus({ name: 'In Progress', type: '' }),
+        ).toBe(RoadmapItemStatus.BUILDING);
+    });
+
+    it('falls back to the state name when the type is unrecognised', () => {
+        expect(
+            mapLinearStateToRoadmapStatus({
+                name: 'Canceled',
+                type: 'custom',
+            }),
+        ).toBe(RoadmapItemStatus.NOT_PLANNED);
+    });
+
+    it('matches the name fallback case-insensitively', () => {
         expect(
             mapLinearStateToRoadmapStatus({ name: 'IN PROGRESS', type: '' }),
         ).toBe(RoadmapItemStatus.BUILDING);
     });
 
-    it('falls back to canonical state type when the name is renamed', () => {
-        expect(
-            mapLinearStateToRoadmapStatus({
-                name: 'In dev review',
-                type: 'started',
-            }),
-        ).toBe(RoadmapItemStatus.BUILDING);
-    });
-
-    it('returns null when neither name nor type is recognised', () => {
+    it('returns null when neither type nor name is recognised', () => {
         expect(
             mapLinearStateToRoadmapStatus({ name: 'Wishlist', type: 'custom' }),
         ).toBeNull();
@@ -49,13 +61,11 @@ describe('buildRoadmapItem', () => {
     it('builds a curated item with the mapped status', () => {
         expect(
             buildRoadmapItem({
-                id: 'abc',
                 title: 'Dark mode',
                 description: 'Please add dark mode',
                 state: { name: 'In Progress', type: 'started' },
             }),
         ).toEqual<RoadmapItem>({
-            id: 'abc',
             title: 'Dark mode',
             description: 'Please add dark mode',
             status: RoadmapItemStatus.BUILDING,
@@ -65,7 +75,6 @@ describe('buildRoadmapItem', () => {
     it('throws when the Linear state cannot be mapped', () => {
         expect(() =>
             buildRoadmapItem({
-                id: 'abc',
                 title: 'Dark mode',
                 description: null,
                 state: { name: 'Wishlist', type: 'custom' },
@@ -88,7 +97,6 @@ describe('findForbiddenRoadmapFields', () => {
     it('returns an empty array for a clean item', () => {
         expect(
             findForbiddenRoadmapFields({
-                id: '1',
                 title: 'x',
                 description: null,
                 status: RoadmapItemStatus.BACKLOG,
@@ -108,13 +116,11 @@ describe('redactRoadmapItem', () => {
             sortOrder: 3,
         });
         expect(result).toEqual<RoadmapItem>({
-            id: '1',
             title: 'Dark mode',
             description: 'body',
             status: RoadmapItemStatus.SHIPPED,
         });
         expect(Object.keys(result)).toEqual([
-            'id',
             'title',
             'description',
             'status',
@@ -124,7 +130,6 @@ describe('redactRoadmapItem', () => {
     it('rejects payloads containing a forbidden field', () => {
         expect(() =>
             redactRoadmapItem({
-                id: '1',
                 title: 'Dark mode',
                 description: null,
                 status: RoadmapItemStatus.BACKLOG,
@@ -136,7 +141,6 @@ describe('redactRoadmapItem', () => {
     it('allows a null description', () => {
         expect(
             redactRoadmapItem({
-                id: '1',
                 title: 'Dark mode',
                 description: null,
                 status: RoadmapItemStatus.BACKLOG,
@@ -145,13 +149,12 @@ describe('redactRoadmapItem', () => {
     });
 
     it.each([
-        ['missing id', { title: 't', description: null, status: RoadmapItemStatus.BACKLOG }],
-        ['missing title', { id: '1', description: null, status: RoadmapItemStatus.BACKLOG }],
+        ['missing title', { description: null, status: RoadmapItemStatus.BACKLOG }],
         [
             'invalid description',
-            { id: '1', title: 't', description: 5, status: RoadmapItemStatus.BACKLOG },
+            { title: 't', description: 5, status: RoadmapItemStatus.BACKLOG },
         ],
-        ['invalid status', { id: '1', title: 't', description: null, status: 'Whenever' }],
+        ['invalid status', { title: 't', description: null, status: 'Whenever' }],
     ])('rejects %s', (_label, raw) => {
         expect(() =>
             redactRoadmapItem(raw as Record<string, unknown>),

--- a/packages/common/src/types/roadmap.test.ts
+++ b/packages/common/src/types/roadmap.test.ts
@@ -17,9 +17,9 @@ describe('mapLinearStateToRoadmapStatus', () => {
         ['completed', RoadmapItemStatus.SHIPPED],
         ['canceled', RoadmapItemStatus.NOT_PLANNED],
     ])('maps canonical state type "%s" to %s', (type, expected) => {
-        expect(
-            mapLinearStateToRoadmapStatus({ name: 'ignored', type }),
-        ).toBe(expected);
+        expect(mapLinearStateToRoadmapStatus({ name: 'ignored', type })).toBe(
+            expected,
+        );
     });
 
     it('prefers the canonical type over a renamed state name', () => {
@@ -120,11 +120,7 @@ describe('redactRoadmapItem', () => {
             description: 'body',
             status: RoadmapItemStatus.SHIPPED,
         });
-        expect(Object.keys(result)).toEqual([
-            'title',
-            'description',
-            'status',
-        ]);
+        expect(Object.keys(result)).toEqual(['title', 'description', 'status']);
     });
 
     it('rejects payloads containing a forbidden field', () => {
@@ -149,15 +145,21 @@ describe('redactRoadmapItem', () => {
     });
 
     it.each([
-        ['missing title', { description: null, status: RoadmapItemStatus.BACKLOG }],
+        [
+            'missing title',
+            { description: null, status: RoadmapItemStatus.BACKLOG },
+        ],
         [
             'invalid description',
             { title: 't', description: 5, status: RoadmapItemStatus.BACKLOG },
         ],
-        ['invalid status', { title: 't', description: null, status: 'Whenever' }],
+        [
+            'invalid status',
+            { title: 't', description: null, status: 'Whenever' },
+        ],
     ])('rejects %s', (_label, raw) => {
-        expect(() =>
-            redactRoadmapItem(raw as Record<string, unknown>),
-        ).toThrow(ParameterError);
+        expect(() => redactRoadmapItem(raw as Record<string, unknown>)).toThrow(
+            ParameterError,
+        );
     });
 });

--- a/packages/common/src/types/roadmap.test.ts
+++ b/packages/common/src/types/roadmap.test.ts
@@ -219,6 +219,20 @@ describe('redactRoadmapItems', () => {
         expect(result.rejected).toHaveLength(1);
     });
 
+    it('captures the offending item title on a rejection for internal triage', () => {
+        const result = redactRoadmapItems([
+            {
+                title: 'Leaky',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+                arr: 50000,
+            },
+        ]);
+        expect(result.rejected).toEqual([
+            { title: 'Leaky', reason: expect.stringContaining('arr') },
+        ]);
+    });
+
     it('excludes malformed items and never throws', () => {
         const result = redactRoadmapItems([
             { description: null, status: RoadmapItemStatus.BACKLOG },
@@ -226,5 +240,14 @@ describe('redactRoadmapItems', () => {
         ]);
         expect(result.items).toEqual([]);
         expect(result.rejected).toHaveLength(2);
+    });
+
+    it('leaves the rejection title undefined when the raw title is unusable', () => {
+        const result = redactRoadmapItems([
+            { title: 42, description: null, status: RoadmapItemStatus.BACKLOG },
+        ]);
+        expect(result.rejected).toEqual([
+            { title: undefined, reason: expect.any(String) },
+        ]);
     });
 });

--- a/packages/common/src/types/roadmap.test.ts
+++ b/packages/common/src/types/roadmap.test.ts
@@ -1,0 +1,160 @@
+import { ParameterError } from './errors';
+import {
+    buildRoadmapItem,
+    findForbiddenRoadmapFields,
+    mapLinearStateToRoadmapStatus,
+    redactRoadmapItem,
+    RoadmapItemStatus,
+    type RoadmapItem,
+} from './roadmap';
+
+describe('mapLinearStateToRoadmapStatus', () => {
+    it.each([
+        ['Triage', RoadmapItemStatus.BACKLOG],
+        ['Backlog', RoadmapItemStatus.BACKLOG],
+        ['Todo', RoadmapItemStatus.PLANNED],
+        ['Planned', RoadmapItemStatus.PLANNED],
+        ['In Progress', RoadmapItemStatus.BUILDING],
+        ['Done', RoadmapItemStatus.SHIPPED],
+        ['Canceled', RoadmapItemStatus.NOT_PLANNED],
+    ])('maps state name "%s" to %s', (name, expected) => {
+        expect(
+            mapLinearStateToRoadmapStatus({ name, type: 'ignored' }),
+        ).toBe(expected);
+    });
+
+    it('matches state names case-insensitively', () => {
+        expect(
+            mapLinearStateToRoadmapStatus({ name: 'IN PROGRESS', type: '' }),
+        ).toBe(RoadmapItemStatus.BUILDING);
+    });
+
+    it('falls back to canonical state type when the name is renamed', () => {
+        expect(
+            mapLinearStateToRoadmapStatus({
+                name: 'In dev review',
+                type: 'started',
+            }),
+        ).toBe(RoadmapItemStatus.BUILDING);
+    });
+
+    it('returns null when neither name nor type is recognised', () => {
+        expect(
+            mapLinearStateToRoadmapStatus({ name: 'Wishlist', type: 'custom' }),
+        ).toBeNull();
+    });
+});
+
+describe('buildRoadmapItem', () => {
+    it('builds a curated item with the mapped status', () => {
+        expect(
+            buildRoadmapItem({
+                id: 'abc',
+                title: 'Dark mode',
+                description: 'Please add dark mode',
+                state: { name: 'In Progress', type: 'started' },
+            }),
+        ).toEqual<RoadmapItem>({
+            id: 'abc',
+            title: 'Dark mode',
+            description: 'Please add dark mode',
+            status: RoadmapItemStatus.BUILDING,
+        });
+    });
+
+    it('throws when the Linear state cannot be mapped', () => {
+        expect(() =>
+            buildRoadmapItem({
+                id: 'abc',
+                title: 'Dark mode',
+                description: null,
+                state: { name: 'Wishlist', type: 'custom' },
+            }),
+        ).toThrow(ParameterError);
+    });
+});
+
+describe('findForbiddenRoadmapFields', () => {
+    it('detects known internal fields', () => {
+        expect(
+            findForbiddenRoadmapFields({
+                title: 'x',
+                arr: 50000,
+                comments: [],
+            }),
+        ).toEqual(expect.arrayContaining(['arr', 'comments']));
+    });
+
+    it('returns an empty array for a clean item', () => {
+        expect(
+            findForbiddenRoadmapFields({
+                id: '1',
+                title: 'x',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+            }),
+        ).toEqual([]);
+    });
+});
+
+describe('redactRoadmapItem', () => {
+    it('strips fields outside the allowlist', () => {
+        const result = redactRoadmapItem({
+            id: '1',
+            title: 'Dark mode',
+            description: 'body',
+            status: RoadmapItemStatus.SHIPPED,
+            url: 'https://internal',
+            sortOrder: 3,
+        });
+        expect(result).toEqual<RoadmapItem>({
+            id: '1',
+            title: 'Dark mode',
+            description: 'body',
+            status: RoadmapItemStatus.SHIPPED,
+        });
+        expect(Object.keys(result)).toEqual([
+            'id',
+            'title',
+            'description',
+            'status',
+        ]);
+    });
+
+    it('rejects payloads containing a forbidden field', () => {
+        expect(() =>
+            redactRoadmapItem({
+                id: '1',
+                title: 'Dark mode',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+                arr: 50000,
+            }),
+        ).toThrow(ParameterError);
+    });
+
+    it('allows a null description', () => {
+        expect(
+            redactRoadmapItem({
+                id: '1',
+                title: 'Dark mode',
+                description: null,
+                status: RoadmapItemStatus.BACKLOG,
+            }).description,
+        ).toBeNull();
+    });
+
+    it.each([
+        ['missing id', { title: 't', description: null, status: RoadmapItemStatus.BACKLOG }],
+        ['missing title', { id: '1', description: null, status: RoadmapItemStatus.BACKLOG }],
+        [
+            'invalid description',
+            { id: '1', title: 't', description: 5, status: RoadmapItemStatus.BACKLOG },
+        ],
+        ['invalid status', { id: '1', title: 't', description: null, status: 'Whenever' }],
+    ])('rejects %s', (_label, raw) => {
+        expect(() =>
+            redactRoadmapItem(raw as Record<string, unknown>),
+        ).toThrow(ParameterError);
+    });
+});

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -208,7 +208,10 @@ export const findForbiddenRoadmapFields = (
  *  - strips every field not in {@link ROADMAP_ITEM_ALLOWED_FIELDS};
  *  - validates the remaining fields' types.
  *
- * Throws {@link ParameterError} on any validation failure.
+ * Throws {@link ParameterError} on any validation failure. The throw is an
+ * internal alarm for the sync/proxy layer, not a customer-facing response —
+ * to serve a list, use {@link redactRoadmapItems}, which excludes a failing
+ * item rather than letting its (potentially revealing) error reach a customer.
  */
 export const redactRoadmapItem = (
     raw: Record<string, unknown>,
@@ -238,6 +241,46 @@ export const redactRoadmapItem = (
 
     // Reconstruct from the allowlist only — no other key can leak through.
     return { title, description, status };
+};
+
+/**
+ * An item dropped by {@link redactRoadmapItems}. The `reason` is for internal
+ * logging/alerting only — it can echo the offending field name and must never
+ * be sent to a customer.
+ */
+export type RoadmapRedactionRejection = {
+    reason: string;
+};
+
+export type RoadmapRedactionResult = {
+    items: RoadmapItem[];
+    rejected: RoadmapRedactionRejection[];
+};
+
+/**
+ * Collection-level redaction — the safe entry point for serving a list.
+ *
+ * Runs {@link redactRoadmapItem} over each raw item and *excludes* any that
+ * fail rather than throwing, so a single forbidden/malformed item can never
+ * fail the whole response or leak its raw error to a customer. Failures are
+ * collected in `rejected` so the sync/proxy layer can log/alert on them
+ * internally (their presence means upstream curation is broken).
+ */
+export const redactRoadmapItems = (
+    raw: ReadonlyArray<Record<string, unknown>>,
+): RoadmapRedactionResult => {
+    const items: RoadmapItem[] = [];
+    const rejected: RoadmapRedactionRejection[] = [];
+    raw.forEach((item) => {
+        try {
+            items.push(redactRoadmapItem(item));
+        } catch (error) {
+            rejected.push({
+                reason: error instanceof Error ? error.message : String(error),
+            });
+        }
+    });
+    return { items, rejected };
 };
 
 export type ApiRoadmapResponse = {

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -1,0 +1,264 @@
+import { ParameterError } from './errors';
+
+/**
+ * Shared v1 contract for the customer-facing Roadmap feature.
+ *
+ * A single trusted Roadmap service mirrors Linear feature requests, curates
+ * them per org, and serves a read-only view to enterprise customers. The
+ * types and constants here are the contract between that service and the
+ * Lightdash app, and they encode the curation boundary: only `title`,
+ * `description` and a customer-friendly `status` are ever exposed. Internal
+ * data (comments, ARR/priority weighting, other accounts' identities) must
+ * never cross this boundary.
+ */
+
+/**
+ * Customer-facing roadmap stage. These are the only statuses a customer ever
+ * sees; the raw Linear workflow state is mapped onto one of these.
+ */
+export enum RoadmapItemStatus {
+    BACKLOG = 'Backlog',
+    PLANNED = 'Planned',
+    BUILDING = 'Building',
+    SHIPPED = 'Shipped',
+    NOT_PLANNED = 'Not planned',
+}
+
+export const ROADMAP_ITEM_STATUSES = Object.values(RoadmapItemStatus);
+
+export const isRoadmapItemStatus = (
+    value: unknown,
+): value is RoadmapItemStatus =>
+    typeof value === 'string' &&
+    ROADMAP_ITEM_STATUSES.includes(value as RoadmapItemStatus);
+
+/**
+ * A single curated roadmap item, exactly as exposed to customers.
+ *
+ * `id` is an opaque, stable identifier used for list keys and detail lookup;
+ * it carries no internal data. `description` is nullable because a Linear
+ * issue may have an empty body.
+ */
+export type RoadmapItem = {
+    id: string;
+    title: string;
+    description: string | null;
+    status: RoadmapItemStatus;
+};
+
+/**
+ * The complete set of keys allowed on a curated {@link RoadmapItem}. The
+ * redaction step builds items from exactly these keys and rejects anything
+ * else — this is the allowlist that defines the public surface.
+ */
+export const ROADMAP_ITEM_ALLOWED_FIELDS = [
+    'id',
+    'title',
+    'description',
+    'status',
+] as const satisfies ReadonlyArray<keyof RoadmapItem>;
+
+/**
+ * The public content fields, i.e. the subset already synced to the public
+ * GitHub issue. Kept separate from {@link ROADMAP_ITEM_ALLOWED_FIELDS} (which
+ * additionally includes the opaque `id`) so callers can reason about "content"
+ * vs "metadata" explicitly.
+ */
+export const ROADMAP_PUBLIC_CONTENT_FIELDS = [
+    'title',
+    'description',
+    'status',
+] as const;
+
+/**
+ * Known internal/sensitive field names that must never appear on a curated
+ * item. This is a defensive denylist used to fail loudly: the allowlist above
+ * already strips unknown fields, but if any of these are seen we reject the
+ * payload outright rather than silently dropping it, because their presence
+ * means upstream curation is broken.
+ */
+export const ROADMAP_FORBIDDEN_FIELDS = [
+    'comments',
+    'comment',
+    'discussion',
+    'arr',
+    'priority',
+    'priorityLabel',
+    'priorityValue',
+    'weight',
+    'weighting',
+    'estimate',
+    'customer',
+    'customers',
+    'assignee',
+    'assigneeId',
+    'subscribers',
+    'internalNotes',
+] as const;
+
+/**
+ * Canonical Linear workflow state types. Unlike state names (which teams can
+ * rename freely) these six values are fixed by Linear, so they make a robust
+ * fallback when a state name isn't recognised.
+ */
+export enum LinearWorkflowStateType {
+    TRIAGE = 'triage',
+    BACKLOG = 'backlog',
+    UNSTARTED = 'unstarted',
+    STARTED = 'started',
+    COMPLETED = 'completed',
+    CANCELED = 'canceled',
+}
+
+/**
+ * A Linear workflow state as read from the Linear API. `name` is the
+ * human-readable, team-customisable label; `type` is the canonical category.
+ */
+export type LinearWorkflowState = {
+    name: string;
+    type: string;
+};
+
+/**
+ * Primary mapping: Linear state name (lower-cased) -> customer-facing status,
+ * exactly as defined in the project design.
+ */
+export const LINEAR_STATE_NAME_TO_ROADMAP_STATUS: Record<
+    string,
+    RoadmapItemStatus
+> = {
+    triage: RoadmapItemStatus.BACKLOG,
+    backlog: RoadmapItemStatus.BACKLOG,
+    todo: RoadmapItemStatus.PLANNED,
+    planned: RoadmapItemStatus.PLANNED,
+    'in progress': RoadmapItemStatus.BUILDING,
+    done: RoadmapItemStatus.SHIPPED,
+    canceled: RoadmapItemStatus.NOT_PLANNED,
+    cancelled: RoadmapItemStatus.NOT_PLANNED,
+};
+
+/**
+ * Fallback mapping by canonical Linear state type, used when a renamed state
+ * name isn't in {@link LINEAR_STATE_NAME_TO_ROADMAP_STATUS}.
+ */
+export const LINEAR_STATE_TYPE_TO_ROADMAP_STATUS: Record<
+    LinearWorkflowStateType,
+    RoadmapItemStatus
+> = {
+    [LinearWorkflowStateType.TRIAGE]: RoadmapItemStatus.BACKLOG,
+    [LinearWorkflowStateType.BACKLOG]: RoadmapItemStatus.BACKLOG,
+    [LinearWorkflowStateType.UNSTARTED]: RoadmapItemStatus.PLANNED,
+    [LinearWorkflowStateType.STARTED]: RoadmapItemStatus.BUILDING,
+    [LinearWorkflowStateType.COMPLETED]: RoadmapItemStatus.SHIPPED,
+    [LinearWorkflowStateType.CANCELED]: RoadmapItemStatus.NOT_PLANNED,
+};
+
+/**
+ * Map a Linear workflow state to a customer-facing status. Matches on state
+ * name first, then falls back to the canonical state type. Returns `null` when
+ * neither is recognised so the caller can decide whether to exclude the item
+ * rather than mislabelling it.
+ */
+export const mapLinearStateToRoadmapStatus = (
+    state: LinearWorkflowState,
+): RoadmapItemStatus | null => {
+    const byName =
+        LINEAR_STATE_NAME_TO_ROADMAP_STATUS[state.name.trim().toLowerCase()];
+    if (byName) {
+        return byName;
+    }
+    const byType =
+        LINEAR_STATE_TYPE_TO_ROADMAP_STATUS[
+            state.type.trim().toLowerCase() as LinearWorkflowStateType
+        ];
+    return byType ?? null;
+};
+
+/**
+ * Build a curated {@link RoadmapItem} from a Linear issue's public parts.
+ *
+ * This is the curation step run while syncing the mirror: it maps the status
+ * and keeps only the allowed fields. Throws {@link ParameterError} if the
+ * status can't be mapped, so an item with an unexpected state is never served
+ * with a wrong status.
+ */
+export const buildRoadmapItem = (input: {
+    id: string;
+    title: string;
+    description: string | null;
+    state: LinearWorkflowState;
+}): RoadmapItem => {
+    const status = mapLinearStateToRoadmapStatus(input.state);
+    if (status === null) {
+        throw new ParameterError(
+            `Cannot map Linear state "${input.state.name}" (type "${input.state.type}") to a roadmap status`,
+        );
+    }
+    return {
+        id: input.id,
+        title: input.title,
+        description: input.description,
+        status,
+    };
+};
+
+/**
+ * Return the known internal/sensitive field names present on an arbitrary
+ * object (see {@link ROADMAP_FORBIDDEN_FIELDS}). Empty array means none were
+ * found. Use this as a redaction-checkpoint alarm before serving.
+ */
+export const findForbiddenRoadmapFields = (
+    raw: Record<string, unknown>,
+): string[] =>
+    ROADMAP_FORBIDDEN_FIELDS.filter((field) =>
+        Object.prototype.hasOwnProperty.call(raw, field),
+    );
+
+/**
+ * Defensively redact an arbitrary object down to a safe {@link RoadmapItem}.
+ *
+ * This is the final checkpoint before a curated item is served. It:
+ *  - rejects the payload if any known internal/sensitive field is present
+ *    (fail loud rather than silently strip — see {@link ROADMAP_FORBIDDEN_FIELDS});
+ *  - strips every field not in {@link ROADMAP_ITEM_ALLOWED_FIELDS};
+ *  - validates the remaining fields' types.
+ *
+ * Throws {@link ParameterError} on any validation failure.
+ */
+export const redactRoadmapItem = (
+    raw: Record<string, unknown>,
+): RoadmapItem => {
+    const forbidden = findForbiddenRoadmapFields(raw);
+    if (forbidden.length > 0) {
+        throw new ParameterError(
+            `Roadmap item contains forbidden fields: ${forbidden.join(', ')}`,
+        );
+    }
+
+    const { id, title, description, status } = raw;
+
+    if (typeof id !== 'string' || id.length === 0) {
+        throw new ParameterError('Roadmap item is missing a valid "id"');
+    }
+    if (typeof title !== 'string') {
+        throw new ParameterError('Roadmap item is missing a valid "title"');
+    }
+    if (description !== null && typeof description !== 'string') {
+        throw new ParameterError(
+            'Roadmap item "description" must be a string or null',
+        );
+    }
+    if (!isRoadmapItemStatus(status)) {
+        throw new ParameterError(
+            `Roadmap item has an invalid "status": ${String(status)}`,
+        );
+    }
+
+    // Reconstruct from the allowlist only — no other key can leak through.
+    return { id, title, description, status };
+};
+
+export type ApiRoadmapResponse = {
+    status: 'ok';
+    results: RoadmapItem[];
+};

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -61,6 +61,12 @@ export const ROADMAP_ITEM_ALLOWED_FIELDS = [
  * already strips unknown fields, but if any of these are seen we reject the
  * payload outright rather than silently dropping it, because their presence
  * means upstream curation is broken.
+ *
+ * This list is intentionally NOT exhaustive and is not the security boundary —
+ * the allowlist reconstruction in {@link redactRoadmapItem} is what actually
+ * guarantees nothing but `title`/`description`/`status` is served. This denylist
+ * only exists to turn a known curation regression into a loud failure; adding a
+ * new sensitive field here is a defence-in-depth nicety, not a requirement.
  */
 export const ROADMAP_FORBIDDEN_FIELDS = [
     'comments',
@@ -244,11 +250,16 @@ export const redactRoadmapItem = (
 };
 
 /**
- * An item dropped by {@link redactRoadmapItems}. The `reason` is for internal
- * logging/alerting only — it can echo the offending field name and must never
- * be sent to a customer.
+ * An item dropped by {@link redactRoadmapItems}.
+ *
+ * Both fields are for internal logging/alerting only — `reason` can echo the
+ * offending field name and must never be sent to a customer. `title` is a
+ * best-effort identifier (the raw item's `title` if it's a string, otherwise
+ * `undefined`) so an operator can tell *which* item failed curation; `title`
+ * is already a public field, so surfacing it internally leaks nothing.
  */
 export type RoadmapRedactionRejection = {
+    title: string | undefined;
     reason: string;
 };
 
@@ -276,6 +287,7 @@ export const redactRoadmapItems = (
             items.push(redactRoadmapItem(item));
         } catch (error) {
             rejected.push({
+                title: typeof item.title === 'string' ? item.title : undefined,
                 reason: error instanceof Error ? error.message : String(error),
             });
         }

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -33,14 +33,12 @@ export const isRoadmapItemStatus = (
     ROADMAP_ITEM_STATUSES.includes(value as RoadmapItemStatus);
 
 /**
- * A single curated roadmap item, exactly as exposed to customers.
- *
- * `id` is an opaque, stable identifier used for list keys and detail lookup;
- * it carries no internal data. `description` is nullable because a Linear
+ * A single curated roadmap item, exactly as exposed to customers. These are
+ * the only fields allowed across the curation boundary — the subset already
+ * synced to the public GitHub issue. `description` is nullable because a Linear
  * issue may have an empty body.
  */
 export type RoadmapItem = {
-    id: string;
     title: string;
     description: string | null;
     status: RoadmapItemStatus;
@@ -52,23 +50,10 @@ export type RoadmapItem = {
  * else — this is the allowlist that defines the public surface.
  */
 export const ROADMAP_ITEM_ALLOWED_FIELDS = [
-    'id',
     'title',
     'description',
     'status',
 ] as const satisfies ReadonlyArray<keyof RoadmapItem>;
-
-/**
- * The public content fields, i.e. the subset already synced to the public
- * GitHub issue. Kept separate from {@link ROADMAP_ITEM_ALLOWED_FIELDS} (which
- * additionally includes the opaque `id`) so callers can reason about "content"
- * vs "metadata" explicitly.
- */
-export const ROADMAP_PUBLIC_CONTENT_FIELDS = [
-    'title',
-    'description',
-    'status',
-] as const;
 
 /**
  * Known internal/sensitive field names that must never appear on a curated
@@ -154,24 +139,26 @@ export const LINEAR_STATE_TYPE_TO_ROADMAP_STATUS: Record<
 };
 
 /**
- * Map a Linear workflow state to a customer-facing status. Matches on state
- * name first, then falls back to the canonical state type. Returns `null` when
- * neither is recognised so the caller can decide whether to exclude the item
- * rather than mislabelling it.
+ * Map a Linear workflow state to a customer-facing status. Matches on the
+ * canonical state type first, since that's fixed by Linear, and only falls
+ * back to the (team-customisable) state name when the type is missing or
+ * unrecognised — this avoids mislabelling a renamed state (e.g. a `started`
+ * state renamed to "Done"). Returns `null` when neither is recognised so the
+ * caller can exclude the item rather than mislabelling it.
  */
 export const mapLinearStateToRoadmapStatus = (
     state: LinearWorkflowState,
 ): RoadmapItemStatus | null => {
-    const byName =
-        LINEAR_STATE_NAME_TO_ROADMAP_STATUS[state.name.trim().toLowerCase()];
-    if (byName) {
-        return byName;
-    }
     const byType =
         LINEAR_STATE_TYPE_TO_ROADMAP_STATUS[
             state.type.trim().toLowerCase() as LinearWorkflowStateType
         ];
-    return byType ?? null;
+    if (byType) {
+        return byType;
+    }
+    const byName =
+        LINEAR_STATE_NAME_TO_ROADMAP_STATUS[state.name.trim().toLowerCase()];
+    return byName ?? null;
 };
 
 /**
@@ -183,7 +170,6 @@ export const mapLinearStateToRoadmapStatus = (
  * with a wrong status.
  */
 export const buildRoadmapItem = (input: {
-    id: string;
     title: string;
     description: string | null;
     state: LinearWorkflowState;
@@ -195,7 +181,6 @@ export const buildRoadmapItem = (input: {
         );
     }
     return {
-        id: input.id,
         title: input.title,
         description: input.description,
         status,
@@ -235,11 +220,8 @@ export const redactRoadmapItem = (
         );
     }
 
-    const { id, title, description, status } = raw;
+    const { title, description, status } = raw;
 
-    if (typeof id !== 'string' || id.length === 0) {
-        throw new ParameterError('Roadmap item is missing a valid "id"');
-    }
     if (typeof title !== 'string') {
         throw new ParameterError('Roadmap item is missing a valid "title"');
     }
@@ -255,7 +237,7 @@ export const redactRoadmapItem = (
     }
 
     // Reconstruct from the allowlist only — no other key can leak through.
-    return { id, title, description, status };
+    return { title, description, status };
 };
 
 export type ApiRoadmapResponse = {


### PR DESCRIPTION
Defines the shared v1 contract for the customer-facing Roadmap feature in `@lightdash/common`, so the central roadmap service and the app work against one source of truth. This is the foundational ticket the rest of the project (service sync, instance proxy, page) builds on — no service or UI is wired up here.

All in `packages/common/src/types/roadmap.ts`:

- **`RoadmapItem`** — the curated shape exposed to customers: `title`, `description`, `status`. Exactly the spec's allowed fields, nothing else.
- **`RoadmapItemStatus`** — customer-facing stages (Backlog / Planned / Building / Shipped / Not planned).
- **Status mapping** — `mapLinearStateToRoadmapStatus` maps on the canonical Linear state *type* first (the six types are fixed by Linear), falling back to the state name only when the type is missing or unrecognised. This avoids mislabelling a renamed state (e.g. a `started` state renamed to "Done"). Returns `null` for unmappable states so the caller can exclude rather than mislabel.
- **Redaction** — `redactRoadmapItem` is the checkpoint before serving: it rejects payloads carrying any known-internal field (ARR, comments, priority weighting, other customers — `ROADMAP_FORBIDDEN_FIELDS`) and otherwise reconstructs the item from an allowlist so unknown fields can't leak through. `buildRoadmapItem` does the curation during sync.
- **`Roadmap` feature flag** for downstream gating, and an `ApiRoadmapResponse` type.

Includes focused unit tests for the mapping and redaction boundary; broader coverage (feature-flag paths, integration) is tracked separately in CS-20.