### PR TITLE
feat(backend): shared SSRF-safe fetch utility (secureFetch) + geoJSON refactor

### DIFF
--- a/packages/backend/src/controllers/geoJsonProxyController.test.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.test.ts
@@ -1,0 +1,117 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    secureFetch,
+    SecureFetchError,
+} from '../utils/secureFetch/secureFetch';
+import { GeoJsonProxyController } from './geoJsonProxyController';
+
+jest.mock('../utils/secureFetch/secureFetch', () => {
+    const actual = jest.requireActual('../utils/secureFetch/secureFetch');
+    return {
+        __esModule: true,
+        SecureFetchError: actual.SecureFetchError,
+        secureFetch: jest.fn(),
+    };
+});
+
+const mockedSecureFetch = secureFetch as jest.Mock;
+
+const makeController = (): GeoJsonProxyController => {
+    // GeoJsonProxyController does not use the ServiceRepository; pass a minimal stub.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const controller = new GeoJsonProxyController({} as any);
+    // setStatus is provided by TSOA's Controller base at runtime; stub it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (controller as any).setStatus = jest.fn();
+    return controller;
+};
+
+describe('GeoJsonProxyController parity', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('rejects non-.json/.geojson/.topojson extensions before fetching', async () => {
+        const controller = makeController();
+        await expect(
+            controller.get('https://example.com/data.txt'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockedSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-https URLs before fetching', async () => {
+        const controller = makeController();
+        await expect(
+            controller.get('http://example.com/data.json'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockedSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('translates a blocked_ip SecureFetchError into a ParameterError', async () => {
+        mockedSecureFetch.mockRejectedValue(
+            new SecureFetchError('blocked_ip', 'blocked'),
+        );
+        const controller = makeController();
+        await expect(
+            controller.get('https://internal.example.com/data.json'),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('translates a redirect SecureFetchError into a ParameterError', async () => {
+        mockedSecureFetch.mockRejectedValue(
+            new SecureFetchError('redirect', 'redirect'),
+        );
+        const controller = makeController();
+        await expect(
+            controller.get('https://example.com/data.json'),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('returns parsed GeoJSON object on the happy path', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: '{"type":"FeatureCollection","features":[]}',
+            truncated: false,
+        });
+        const controller = makeController();
+        const result = await controller.get('https://example.com/data.geojson');
+        expect(result).toEqual({
+            type: 'FeatureCollection',
+            features: [],
+        });
+        expect(mockedSecureFetch).toHaveBeenCalledWith(
+            'https://example.com/data.geojson',
+            expect.objectContaining({
+                method: 'GET',
+                allowedContentTypes: expect.arrayContaining([
+                    'application/json',
+                ]),
+            }),
+        );
+    });
+
+    it('rejects a JSON array body (not a GeoJSON object)', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: '[1,2,3]',
+            truncated: false,
+        });
+        const controller = makeController();
+        await expect(
+            controller.get('https://example.com/data.json'),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('rejects invalid JSON bodies', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: 'not json',
+            truncated: false,
+        });
+        const controller = makeController();
+        await expect(
+            controller.get('https://example.com/data.json'),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+});

--- a/packages/backend/src/controllers/geoJsonProxyController.test.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.test.ts
@@ -82,9 +82,8 @@ describe('GeoJsonProxyController parity', () => {
             'https://example.com/data.geojson',
             expect.objectContaining({
                 method: 'GET',
-                allowedContentTypes: expect.arrayContaining([
-                    'application/json',
-                ]),
+                // Empty list = no content-type restriction (parity with original).
+                allowedContentTypes: [],
             }),
         );
     });
@@ -113,5 +112,44 @@ describe('GeoJsonProxyController parity', () => {
         await expect(
             controller.get('https://example.com/data.json'),
         ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('accepts GeoJSON served with application/octet-stream content-type (parity)', async () => {
+        // Real-world GeoJSON sources often serve with generic binary or missing
+        // content-types. The original controller accepted any type; parity requires
+        // allowedContentTypes: [] so secureFetch never rejects on content-type.
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/octet-stream',
+            bodyText: '{"type":"FeatureCollection","features":[]}',
+            truncated: false,
+        });
+        const controller = makeController();
+        const result = await controller.get('https://example.com/data.geojson');
+        expect(result).toEqual({ type: 'FeatureCollection', features: [] });
+    });
+
+    it('accepts GeoJSON served with a missing content-type (parity)', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: '',
+            bodyText: '{"type":"FeatureCollection","features":[]}',
+            truncated: false,
+        });
+        const controller = makeController();
+        const result = await controller.get('https://example.com/data.geojson');
+        expect(result).toEqual({ type: 'FeatureCollection', features: [] });
+    });
+
+    it('accepts GeoJSON served with application/vnd.geo+json content-type (parity)', async () => {
+        mockedSecureFetch.mockResolvedValue({
+            status: 200,
+            contentType: 'application/vnd.geo+json',
+            bodyText: '{"type":"FeatureCollection","features":[]}',
+            truncated: false,
+        });
+        const controller = makeController();
+        const result = await controller.get('https://example.com/data.geojson');
+        expect(result).toEqual({ type: 'FeatureCollection', features: [] });
     });
 });

--- a/packages/backend/src/controllers/geoJsonProxyController.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.ts
@@ -9,90 +9,61 @@ import {
     SuccessResponse,
     Tags,
 } from '@tsoa/runtime';
-import dns from 'dns/promises';
-import https from 'https';
-import { LookupFunction } from 'net';
-import fetch, {
-    FetchError,
-    type Response as NodeFetchResponse,
-} from 'node-fetch';
+import {
+    secureFetch,
+    SecureFetchError,
+} from '../utils/secureFetch/secureFetch';
 import { allowApiKeyAuthentication, isAuthenticated } from './authentication';
 import { BaseController } from './baseController';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const TIMEOUT_MS = 30000; // 30 seconds
 
-const isPrivateIPv4 = (ip: string): boolean => {
-    const parts = ip.split('.').map(Number);
-    if (
-        parts.length !== 4 ||
-        parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
-    ) {
-        return true; // unparseable — fail closed
+// Translate the generic secureFetch failure reasons into the ParameterError
+// messages this endpoint returned before it was refactored onto secureFetch.
+const toParameterError = (error: SecureFetchError): ParameterError => {
+    switch (error.reason) {
+        case 'invalid_url':
+            return new ParameterError('Invalid URL format');
+        case 'non_https':
+            return new ParameterError('Only HTTPS protocol is allowed');
+        case 'blocked_ip':
+            return new ParameterError(
+                'Access to private/internal addresses is not allowed',
+            );
+        case 'redirect':
+            return new ParameterError(
+                'Redirects are not supported for security reasons',
+            );
+        case 'timeout':
+            return new ParameterError('Failed to fetch GeoJSON: timed out');
+        case 'too_large':
+            return new ParameterError(
+                `File too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
+            );
+        case 'disallowed_content_type':
+            return new ParameterError('Failed to fetch GeoJSON: invalid type');
+        case 'request_failed':
+        default:
+            return new ParameterError(
+                `Failed to fetch GeoJSON: ${error.message}`,
+            );
     }
-    const [a, b] = parts;
-    if (a === 0) return true; // 0.0.0.0/8
-    if (a === 10) return true; // 10.0.0.0/8 RFC 1918
-    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-    if (a === 127) return true; // 127.0.0.0/8 loopback
-    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (AWS/GCP IMDS)
-    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 RFC 1918
-    if (a === 192 && b === 168) return true; // 192.168.0.0/16 RFC 1918
-    if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
-    return false;
 };
 
-const isPrivateIPv6 = (ip: string): boolean => {
-    const lower = ip.toLowerCase();
-    if (lower === '::1' || lower === '::') return true;
-    if (/^f[cd]/.test(lower)) return true; // fc00::/7 unique local
-    if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
-    if (/^ff/.test(lower)) return true; // ff00::/8 multicast
-
-    const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-    if (mappedHex) {
-        const hi = parseInt(mappedHex[1], 16);
-        const lo = parseInt(mappedHex[2], 16);
-        return isPrivateIPv4(
-            `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${
-                lo % 256
-            }`,
-        );
-    }
-    const mappedDotted = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (mappedDotted) return isPrivateIPv4(mappedDotted[1]);
-
-    const compat = lower.match(/^::(\d+\.\d+\.\d+\.\d+)$/);
-    if (compat) return isPrivateIPv4(compat[1]);
-
-    return false;
-};
-
-const isPrivateAddress = (address: string, family: number): boolean => {
-    if (family === 4) return isPrivateIPv4(address);
-    if (family === 6) return isPrivateIPv6(address);
-    return true; // unknown family — fail closed
-};
-
-const PRIVATE_HOST_ERROR =
-    'Access to private/internal addresses is not allowed';
-
-const validateUrlSyntax = (url: string): URL => {
+const validateGeoJsonUrlSyntax = (url: string): void => {
     if (!url) {
         throw new ParameterError('URL parameter is required');
     }
-
     let parsedUrl: URL;
     try {
         parsedUrl = new URL(url);
-    } catch (error) {
+    } catch {
         throw new ParameterError('Invalid URL format');
     }
-
     if (parsedUrl.protocol !== 'https:') {
         throw new ParameterError('Only HTTPS protocol is allowed');
     }
-
     const pathname = parsedUrl.pathname.toLowerCase();
     if (
         !pathname.endsWith('.json') &&
@@ -102,84 +73,6 @@ const validateUrlSyntax = (url: string): URL => {
         throw new ParameterError(
             'Only .json, .geojson, or .topojson files are allowed',
         );
-    }
-
-    return parsedUrl;
-};
-
-const resolveAndValidateHost = async (
-    hostname: string,
-): Promise<{ address: string; family: 4 | 6 }> => {
-    // URL.hostname returns IPv6 literals wrapped in brackets ("[::1]") — strip them.
-    const cleanHost = hostname.replace(/^\[/, '').replace(/\]$/, '');
-
-    let addresses: Array<{ address: string; family: number }>;
-    try {
-        addresses = await dns.lookup(cleanHost, {
-            all: true,
-            verbatim: true,
-        });
-    } catch (error) {
-        throw new ParameterError('Unable to resolve hostname');
-    }
-
-    if (addresses.length === 0) {
-        throw new ParameterError('Unable to resolve hostname');
-    }
-
-    for (const { address, family } of addresses) {
-        if (isPrivateAddress(address, family)) {
-            throw new ParameterError(PRIVATE_HOST_ERROR);
-        }
-    }
-
-    const { address, family } = addresses[0];
-    return { address, family: family === 6 ? 6 : 4 };
-};
-
-// Returns an HTTPS agent whose DNS lookup is pinned to a single
-// pre-validated IP. This defeats DNS rebinding between the time we
-// validated the resolved IPs and the time `fetch` opens the socket —
-// the kernel never resolves the hostname a second time.
-const createPinnedHttpsAgent = (
-    address: string,
-    family: 4 | 6,
-): https.Agent => {
-    const lookup: LookupFunction = (_hostname, options, callback) => {
-        if (options && (options as { all?: boolean }).all) {
-            (
-                callback as (
-                    err: NodeJS.ErrnoException | null,
-                    addrs: Array<{ address: string; family: number }>,
-                ) => void
-            )(null, [{ address, family }]);
-            return;
-        }
-        callback(null, address, family);
-    };
-    return new https.Agent({ lookup } as https.AgentOptions);
-};
-
-const readResponseWithSizeLimit = async (
-    response: NodeFetchResponse,
-): Promise<string> => {
-    const contentLength = response.headers.get('content-length');
-    if (contentLength && parseInt(contentLength, 10) > MAX_FILE_SIZE) {
-        throw new ParameterError(
-            `File too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
-        );
-    }
-    try {
-        return await response.text();
-    } catch (error) {
-        // node-fetch's `size` option throws FetchError with type 'max-size'
-        // when the streamed body exceeds the limit.
-        if (error instanceof FetchError && error.type === 'max-size') {
-            throw new ParameterError(
-                `File too large (max ${MAX_FILE_SIZE / 1024 / 1024}MB)`,
-            );
-        }
-        throw error;
     }
 };
 
@@ -197,50 +90,35 @@ export class GeoJsonProxyController extends BaseController {
     @Get()
     @OperationId('getGeoJson')
     async get(@Query() url: string): Promise<Record<string, unknown>> {
-        const parsedUrl = validateUrlSyntax(url);
-        const { address, family } = await resolveAndValidateHost(
-            parsedUrl.hostname,
-        );
-        const agent = createPinnedHttpsAgent(address, family);
+        // Extension allowlist is geoJson-specific and stays here, not in the util.
+        validateGeoJsonUrlSyntax(url);
 
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-        let response: NodeFetchResponse;
+        let bodyText: string;
         try {
-            response = await fetch(url, {
-                agent,
-                redirect: 'manual',
-                signal: controller.signal as never,
-                size: MAX_FILE_SIZE,
+            const result = await secureFetch(url, {
+                method: 'GET',
+                timeoutMs: TIMEOUT_MS,
+                maxResponseBytes: MAX_FILE_SIZE,
+                allowedContentTypes: [
+                    'application/json',
+                    'application/geo+json',
+                    'text/plain',
+                ],
             });
-        } finally {
-            clearTimeout(timer);
+            bodyText = result.bodyText;
+        } catch (error) {
+            if (error instanceof SecureFetchError) {
+                throw toParameterError(error);
+            }
+            throw error;
         }
-
-        // Validation only covered the initial URL. Any redirect target is
-        // unvalidated, so the response chain ends here.
-        if (response.status >= 300 && response.status < 400) {
-            throw new ParameterError(
-                'Redirects are not supported for security reasons',
-            );
-        }
-
-        if (!response.ok) {
-            throw new ParameterError(
-                `Failed to fetch GeoJSON: ${response.status}`,
-            );
-        }
-
-        const text = await readResponseWithSizeLimit(response);
 
         let data: unknown;
         try {
-            data = JSON.parse(text);
-        } catch (error) {
+            data = JSON.parse(bodyText);
+        } catch {
             throw new ParameterError('Invalid JSON format');
         }
-
         if (typeof data !== 'object' || data === null || Array.isArray(data)) {
             throw new ParameterError('Invalid GeoJSON: expected an object');
         }

--- a/packages/backend/src/controllers/geoJsonProxyController.ts
+++ b/packages/backend/src/controllers/geoJsonProxyController.ts
@@ -99,11 +99,9 @@ export class GeoJsonProxyController extends BaseController {
                 method: 'GET',
                 timeoutMs: TIMEOUT_MS,
                 maxResponseBytes: MAX_FILE_SIZE,
-                allowedContentTypes: [
-                    'application/json',
-                    'application/geo+json',
-                    'text/plain',
-                ],
+                // Empty list = no content-type restriction: parity with the
+                // original controller, which accepted any content-type.
+                allowedContentTypes: [],
             });
             bodyText = result.bodyText;
         } catch (error) {

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -75,6 +75,10 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
             { address: '169.254.169.254', family: 4 },
         ],
         ['IPv4 224/4 multicast', { address: '224.0.0.1', family: 4 }],
+        [
+            'IPv4 192.0.2.1 reserved (TEST-NET)',
+            { address: '192.0.2.1', family: 4 },
+        ],
         ['IPv6 ::1 loopback', { address: '::1', family: 6 }],
         ['IPv6 fc00::/7 unique-local', { address: 'fc00::1', family: 6 }],
         ['IPv6 fe80::/10 link-local', { address: 'fe80::1', family: 6 }],
@@ -82,6 +86,14 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
         [
             'IPv6 mapped private ::ffff:169.254.169.254',
             { address: '::ffff:169.254.169.254', family: 6 },
+        ],
+        [
+            'IPv6 6to4 2002:7f00:1:: (tunnels to 127.0.0.1)',
+            { address: '2002:7f00:1::', family: 6 },
+        ],
+        [
+            'IPv6 NAT64 64:ff9b::7f00:1 (maps to 127.0.0.1)',
+            { address: '64:ff9b::7f00:1', family: 6 },
         ],
     ];
 
@@ -116,8 +128,13 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
         );
     });
 
-    it('fails closed on unknown address family', async () => {
-        mockedLookup.mockResolvedValue([{ address: '1.2.3.4', family: 0 }]);
+    it('fails closed on an unparseable address string from DNS', async () => {
+        // The family field from dns.lookup is no longer used for classification;
+        // only the address string matters. An address that ipaddr.js cannot parse
+        // triggers the fail-closed catch branch and is treated as blocked.
+        mockedLookup.mockResolvedValue([
+            { address: 'not-an-ip-at-all', family: 4 },
+        ]);
         await expectReason(
             secureFetch('https://evil.example.com/x.json', BASE_OPTIONS),
             'blocked_ip',
@@ -387,5 +404,42 @@ describe('secureFetch size and content-type', () => {
         });
         expect(result.contentType).toBe('application/json');
         expect(result.bodyText).toBe('{"ok":true}');
+    });
+
+    it('skips content-type check when allowedContentTypes is empty', async () => {
+        // Empty allowlist = explicit opt-out of the content-type check. Any
+        // content-type (or none at all) must be accepted and the body returned.
+        mockedFetch.mockResolvedValue(
+            new Response('raw body', {
+                status: 200,
+                headers: { 'content-type': 'text/html' },
+            }),
+        );
+        const result = await secureFetch('https://example.com/file', {
+            ...BASE_OPTIONS,
+            allowedContentTypes: [],
+        });
+        expect(result.bodyText).toBe('raw body');
+        expect(result.contentType).toBe('text/html');
+    });
+
+    it('accepts a response with no content-type header when allowedContentTypes is empty', async () => {
+        // Simulate a server that sends no content-type header by using a plain
+        // object mock (node-fetch's Response always sets a default content-type).
+        const noContentTypeResponse = {
+            status: 200,
+            ok: true,
+            headers: {
+                get: (name: string) => (name === 'content-type' ? null : null),
+            },
+            text: jest.fn().mockResolvedValue('{}'),
+        };
+        mockedFetch.mockResolvedValue(noContentTypeResponse);
+        const result = await secureFetch('https://example.com/file', {
+            ...BASE_OPTIONS,
+            allowedContentTypes: [],
+        });
+        expect(result.bodyText).toBe('{}');
+        expect(result.contentType).toBe('');
     });
 });

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -61,3 +61,82 @@ describe('secureFetch URL validation', () => {
         expect(mockedFetch).not.toHaveBeenCalled();
     });
 });
+
+describe('secureFetch blocks private/internal resolved IPs', () => {
+    const blocked: Array<[string, { address: string; family: number }]> = [
+        ['IPv4 loopback 127.0.0.1', { address: '127.0.0.1', family: 4 }],
+        ['IPv4 0.0.0.0/8', { address: '0.0.0.0', family: 4 }],
+        ['IPv4 10/8 RFC1918', { address: '10.1.2.3', family: 4 }],
+        ['IPv4 172.16/12 RFC1918', { address: '172.16.5.5', family: 4 }],
+        ['IPv4 192.168/16 RFC1918', { address: '192.168.1.1', family: 4 }],
+        ['IPv4 100.64/10 CGNAT', { address: '100.64.0.1', family: 4 }],
+        [
+            'IPv4 169.254 link-local/metadata',
+            { address: '169.254.169.254', family: 4 },
+        ],
+        ['IPv4 224/4 multicast', { address: '224.0.0.1', family: 4 }],
+        ['IPv6 ::1 loopback', { address: '::1', family: 6 }],
+        ['IPv6 fc00::/7 unique-local', { address: 'fc00::1', family: 6 }],
+        ['IPv6 fe80::/10 link-local', { address: 'fe80::1', family: 6 }],
+        ['IPv6 ff00::/8 multicast', { address: 'ff02::1', family: 6 }],
+        [
+            'IPv6 mapped private ::ffff:169.254.169.254',
+            { address: '::ffff:169.254.169.254', family: 6 },
+        ],
+    ];
+
+    it.each(blocked)(
+        'blocks %s with reason blocked_ip',
+        async (_label, resolved) => {
+            mockedLookup.mockResolvedValue([resolved]);
+            await expectReason(
+                secureFetch('https://evil.example.com/x.json', BASE_OPTIONS),
+                'blocked_ip',
+            );
+            expect(mockedFetch).not.toHaveBeenCalled();
+        },
+    );
+
+    it('blocks when ANY resolved address is private (mixed set)', async () => {
+        mockedLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+            { address: '10.0.0.5', family: 4 },
+        ]);
+        await expectReason(
+            secureFetch('https://evil.example.com/x.json', BASE_OPTIONS),
+            'blocked_ip',
+        );
+    });
+
+    it('fails closed on unparseable IPv4 from DNS', async () => {
+        mockedLookup.mockResolvedValue([{ address: '999.1.1.1', family: 4 }]);
+        await expectReason(
+            secureFetch('https://evil.example.com/x.json', BASE_OPTIONS),
+            'blocked_ip',
+        );
+    });
+
+    it('fails closed on unknown address family', async () => {
+        mockedLookup.mockResolvedValue([{ address: '1.2.3.4', family: 0 }]);
+        await expectReason(
+            secureFetch('https://evil.example.com/x.json', BASE_OPTIONS),
+            'blocked_ip',
+        );
+    });
+
+    it('rejects with blocked_ip when DNS resolution fails', async () => {
+        mockedLookup.mockRejectedValue(new Error('ENOTFOUND'));
+        await expectReason(
+            secureFetch('https://nope.example.com/x.json', BASE_OPTIONS),
+            'blocked_ip',
+        );
+    });
+
+    it('rejects with blocked_ip when DNS returns no addresses', async () => {
+        mockedLookup.mockResolvedValue([]);
+        await expectReason(
+            secureFetch('https://empty.example.com/x.json', BASE_OPTIONS),
+            'blocked_ip',
+        );
+    });
+});

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -1,5 +1,5 @@
 import dns from 'dns/promises';
-import fetch, { Response } from 'node-fetch';
+import fetch, { FetchError, Response } from 'node-fetch';
 import { secureFetch, SecureFetchError } from './secureFetch';
 
 jest.mock('dns/promises', () => ({
@@ -209,5 +209,86 @@ describe('secureFetch GET behavior', () => {
         expect(calledOpts.method).toBe('GET');
         expect(calledOpts.size).toBe(BASE_OPTIONS.maxResponseBytes);
         expect(calledOpts.agent).toBeDefined();
+    });
+});
+
+describe('secureFetch timeout', () => {
+    it('maps an aborted request to reason timeout', async () => {
+        const abortError = new FetchError(
+            'The user aborted a request.',
+            'aborted',
+        );
+        mockedFetch.mockRejectedValue(abortError);
+        await expectReason(
+            secureFetch('https://example.com/x.json', {
+                ...BASE_OPTIONS,
+                timeoutMs: 1,
+            }),
+            'timeout',
+        );
+    });
+
+    it('aborts the request after the configured timeout', async () => {
+        jest.useFakeTimers();
+        let capturedSignal: AbortSignal | undefined;
+        // Use a real promise so dns.lookup mock settles without fake timers.
+        let resolveFetch!: (value?: unknown) => void;
+        mockedFetch.mockImplementation((_url, opts) => {
+            capturedSignal = opts.signal as AbortSignal;
+            return new Promise((resolve) => {
+                resolveFetch = resolve;
+            });
+        });
+
+        const pending = secureFetch('https://example.com/x.json', {
+            ...BASE_OPTIONS,
+            timeoutMs: 500,
+        });
+        // Flush microtasks: dns.lookup mock (real Promise) + then-chains.
+        // We need several ticks because the async function has multiple awaits.
+        for (let i = 0; i < 10; i += 1) {
+            // eslint-disable-next-line no-await-in-loop
+            await Promise.resolve();
+        }
+
+        expect(capturedSignal?.aborted).toBe(false);
+        jest.advanceTimersByTime(500);
+        expect(capturedSignal?.aborted).toBe(true);
+
+        // Let the pending promise settle.
+        resolveFetch();
+        await pending.catch(() => undefined);
+        jest.useRealTimers();
+    });
+
+    it('hard-caps the timeout at 30000ms', async () => {
+        jest.useFakeTimers();
+        let capturedSignal: AbortSignal | undefined;
+        let resolveFetch!: (value?: unknown) => void;
+        mockedFetch.mockImplementation((_url, opts) => {
+            capturedSignal = opts.signal as AbortSignal;
+            return new Promise((resolve) => {
+                resolveFetch = resolve;
+            });
+        });
+
+        const pending = secureFetch('https://example.com/x.json', {
+            ...BASE_OPTIONS,
+            timeoutMs: 999999, // way over the cap
+        });
+        for (let i = 0; i < 10; i += 1) {
+            // eslint-disable-next-line no-await-in-loop
+            await Promise.resolve();
+        }
+
+        expect(capturedSignal?.aborted).toBe(false);
+        jest.advanceTimersByTime(29999);
+        expect(capturedSignal?.aborted).toBe(false);
+        jest.advanceTimersByTime(1);
+        expect(capturedSignal?.aborted).toBe(true);
+
+        resolveFetch();
+        await pending.catch(() => undefined);
+        jest.useRealTimers();
     });
 });

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -292,3 +292,65 @@ describe('secureFetch timeout', () => {
         jest.useRealTimers();
     });
 });
+
+describe('secureFetch size and content-type', () => {
+    it('rejects when content-length exceeds maxResponseBytes', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('{}', {
+                headers: { 'content-length': String(50 * 1024 * 1024) },
+            }),
+        );
+        await expectReason(
+            secureFetch('https://example.com/x.json', {
+                ...BASE_OPTIONS,
+                maxResponseBytes: 1024,
+            }),
+            'too_large',
+        );
+    });
+
+    it('rejects when the streamed body exceeds maxResponseBytes (node-fetch max-size)', async () => {
+        const fakeResponse = {
+            status: 200,
+            ok: true,
+            headers: { get: () => 'application/json' },
+            text: jest
+                .fn()
+                .mockRejectedValue(
+                    new FetchError('content size over limit', 'max-size'),
+                ),
+        };
+        mockedFetch.mockResolvedValue(fakeResponse);
+        await expectReason(
+            secureFetch('https://example.com/x.json', BASE_OPTIONS),
+            'too_large',
+        );
+    });
+
+    it('rejects a disallowed content-type', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('<html></html>', { contentType: 'text/html' }),
+        );
+        await expectReason(
+            secureFetch('https://example.com/x.json', {
+                ...BASE_OPTIONS,
+                allowedContentTypes: ['application/json'],
+            }),
+            'disallowed_content_type',
+        );
+    });
+
+    it('accepts an allowed content-type ignoring charset suffix', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('{"ok":true}', {
+                contentType: 'application/json; charset=utf-8',
+            }),
+        );
+        const result = await secureFetch('https://example.com/x.json', {
+            ...BASE_OPTIONS,
+            allowedContentTypes: ['application/json'],
+        });
+        expect(result.contentType).toBe('application/json');
+        expect(result.bodyText).toBe('{"ok":true}');
+    });
+});

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -1,5 +1,5 @@
 import dns from 'dns/promises';
-import fetch from 'node-fetch';
+import fetch, { Response } from 'node-fetch';
 import { secureFetch, SecureFetchError } from './secureFetch';
 
 jest.mock('dns/promises', () => ({
@@ -138,5 +138,76 @@ describe('secureFetch blocks private/internal resolved IPs', () => {
             secureFetch('https://empty.example.com/x.json', BASE_OPTIONS),
             'blocked_ip',
         );
+    });
+});
+
+const jsonResponse = (
+    body: string,
+    init: {
+        status?: number;
+        contentType?: string;
+        headers?: Record<string, string>;
+    } = {},
+): InstanceType<typeof Response> =>
+    new Response(body, {
+        status: init.status ?? 200,
+        headers: {
+            'content-type': init.contentType ?? 'application/json',
+            ...(init.headers ?? {}),
+        },
+    });
+
+describe('secureFetch GET behavior', () => {
+    it('rejects a 3xx redirect with reason redirect', async () => {
+        mockedFetch.mockResolvedValue(
+            new Response('', {
+                status: 302,
+                headers: { location: 'https://elsewhere.example.com/x.json' },
+            }),
+        );
+        await expectReason(
+            secureFetch('https://example.com/x.json', BASE_OPTIONS),
+            'redirect',
+        );
+    });
+
+    it('rejects a non-ok status (>=400) with reason request_failed', async () => {
+        mockedFetch.mockResolvedValue(jsonResponse('nope', { status: 503 }));
+        await expectReason(
+            secureFetch('https://example.com/x.json', BASE_OPTIONS),
+            'request_failed',
+        );
+    });
+
+    it('returns a SecureFetchResult on a happy-path GET', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('{"hello":"world"}', { status: 200 }),
+        );
+        const result = await secureFetch(
+            'https://example.com/x.json',
+            BASE_OPTIONS,
+        );
+        expect(result).toEqual({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: '{"hello":"world"}',
+            truncated: false,
+        });
+    });
+
+    it('pins the agent to the validated IP and disables redirects', async () => {
+        mockedLookup.mockResolvedValue([
+            { address: '93.184.216.34', family: 4 },
+        ]);
+        mockedFetch.mockResolvedValue(jsonResponse('{}'));
+        await secureFetch('https://example.com/x.json', BASE_OPTIONS);
+
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        const [calledUrl, calledOpts] = mockedFetch.mock.calls[0];
+        expect(calledUrl).toBe('https://example.com/x.json');
+        expect(calledOpts.redirect).toBe('manual');
+        expect(calledOpts.method).toBe('GET');
+        expect(calledOpts.size).toBe(BASE_OPTIONS.maxResponseBytes);
+        expect(calledOpts.agent).toBeDefined();
     });
 });

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -212,6 +212,41 @@ describe('secureFetch GET behavior', () => {
     });
 });
 
+describe('secureFetch POST behavior', () => {
+    it('returns a SecureFetchResult on a happy-path POST', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('{"accepted":true}', { status: 200 }),
+        );
+        const result = await secureFetch('https://example.com/x.json', {
+            ...BASE_OPTIONS,
+            method: 'POST',
+            body: '{"amount":500}',
+        });
+        expect(result).toEqual({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: '{"accepted":true}',
+            truncated: false,
+        });
+    });
+
+    it('passes method and body through to fetch on a POST', async () => {
+        mockedFetch.mockResolvedValue(
+            jsonResponse('{"accepted":true}', { status: 200 }),
+        );
+        await secureFetch('https://example.com/x.json', {
+            ...BASE_OPTIONS,
+            method: 'POST',
+            body: '{"amount":500}',
+        });
+
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        const [, calledOpts] = mockedFetch.mock.calls[0];
+        expect(calledOpts.method).toBe('POST');
+        expect(calledOpts.body).toBe('{"amount":500}');
+    });
+});
+
 describe('secureFetch timeout', () => {
     it('maps an aborted request to reason timeout', async () => {
         const abortError = new FetchError(

--- a/packages/backend/src/utils/secureFetch/secureFetch.test.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.test.ts
@@ -1,0 +1,63 @@
+import dns from 'dns/promises';
+import fetch from 'node-fetch';
+import { secureFetch, SecureFetchError } from './secureFetch';
+
+jest.mock('dns/promises', () => ({
+    __esModule: true,
+    default: { lookup: jest.fn() },
+}));
+jest.mock('node-fetch', () => {
+    const actual = jest.requireActual('node-fetch');
+    const mockFetch = jest.fn();
+    return {
+        __esModule: true,
+        default: mockFetch,
+        FetchError: actual.FetchError,
+        Response: actual.Response,
+    };
+});
+
+const mockedLookup = dns.lookup as unknown as jest.Mock;
+const mockedFetch = fetch as unknown as jest.Mock;
+
+const BASE_OPTIONS = {
+    method: 'GET' as const,
+    timeoutMs: 5000,
+    maxResponseBytes: 1024 * 1024,
+    allowedContentTypes: ['application/json'],
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+});
+
+const expectReason = async (
+    promise: Promise<unknown>,
+    reason: string,
+): Promise<void> => {
+    await expect(promise).rejects.toBeInstanceOf(SecureFetchError);
+    await expect(promise).rejects.toMatchObject({ reason });
+};
+
+describe('secureFetch URL validation', () => {
+    it('rejects an unparseable URL with reason invalid_url', async () => {
+        await expectReason(
+            secureFetch('not-a-url', BASE_OPTIONS),
+            'invalid_url',
+        );
+        expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty URL with reason invalid_url', async () => {
+        await expectReason(secureFetch('', BASE_OPTIONS), 'invalid_url');
+    });
+
+    it('rejects http (non-https) with reason non_https', async () => {
+        await expectReason(
+            secureFetch('http://example.com/data.json', BASE_OPTIONS),
+            'non_https',
+        );
+        expect(mockedFetch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -1,4 +1,7 @@
 import dns from 'dns/promises';
+import https from 'https';
+import { LookupFunction } from 'net';
+import fetch, { FetchError } from 'node-fetch';
 
 export type SecureFetchReason =
     | 'non_https'
@@ -135,6 +138,28 @@ const resolveAndValidateHost = async (
     return { address, family: family === 6 ? 6 : 4 };
 };
 
+// HTTPS agent whose DNS lookup is pinned to a single pre-validated IP. This
+// defeats DNS rebinding between validation and socket open: the kernel never
+// resolves the hostname a second time.
+const createPinnedHttpsAgent = (
+    address: string,
+    family: 4 | 6,
+): https.Agent => {
+    const lookup: LookupFunction = (_hostname, lookupOptions, callback) => {
+        if (lookupOptions && (lookupOptions as { all?: boolean }).all) {
+            (
+                callback as (
+                    err: NodeJS.ErrnoException | null,
+                    addrs: Array<{ address: string; family: number }>,
+                ) => void
+            )(null, [{ address, family }]);
+            return;
+        }
+        callback(null, address, family);
+    };
+    return new https.Agent({ lookup } as https.AgentOptions);
+};
+
 export async function secureFetch(
     rawUrl: string,
     options: SecureFetchOptions,
@@ -143,8 +168,53 @@ export async function secureFetch(
     const { address, family } = await resolveAndValidateHost(
         parsedUrl.hostname,
     );
-    throw new SecureFetchError(
-        'request_failed',
-        `not implemented (resolved ${address}/${family})`,
-    );
+    const agent = createPinnedHttpsAgent(address, family);
+
+    let response: import('node-fetch').Response;
+    try {
+        response = await fetch(rawUrl, {
+            method: options.method,
+            body: options.body,
+            headers: options.headers,
+            agent,
+            redirect: 'manual',
+            size: options.maxResponseBytes,
+        });
+    } catch (error) {
+        if (error instanceof FetchError) {
+            throw new SecureFetchError(
+                'request_failed',
+                `Request failed: ${error.message}`,
+            );
+        }
+        throw new SecureFetchError('request_failed', 'Request failed');
+    }
+
+    // Validation only covered the initial URL; any redirect target is
+    // unvalidated, so the chain ends here.
+    if (response.status >= 300 && response.status < 400) {
+        throw new SecureFetchError(
+            'redirect',
+            'Redirects are not allowed for security reasons',
+        );
+    }
+    if (!response.ok) {
+        throw new SecureFetchError(
+            'request_failed',
+            `Request failed with status ${response.status}`,
+        );
+    }
+
+    const contentType = (response.headers.get('content-type') ?? '')
+        .split(';')[0]
+        .trim()
+        .toLowerCase();
+    const bodyText = await response.text();
+
+    return {
+        status: response.status,
+        contentType,
+        bodyText,
+        truncated: false,
+    };
 }

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -1,3 +1,5 @@
+import dns from 'dns/promises';
+
 export type SecureFetchReason =
     | 'non_https'
     | 'blocked_ip'
@@ -54,13 +56,95 @@ const parseHttpsUrl = (rawUrl: string): URL => {
     return parsedUrl;
 };
 
+const isPrivateIPv4 = (ip: string): boolean => {
+    const parts = ip.split('.').map(Number);
+    if (
+        parts.length !== 4 ||
+        parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
+    ) {
+        return true; // unparseable — fail closed
+    }
+    const [a, b] = parts;
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 10) return true; // 10.0.0.0/8 RFC 1918
+    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+    if (a === 127) return true; // 127.0.0.0/8 loopback
+    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (IMDS)
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 RFC 1918
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16 RFC 1918
+    if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+    return false;
+};
+
+const isPrivateIPv6 = (ip: string): boolean => {
+    const lower = ip.toLowerCase();
+    if (lower === '::1' || lower === '::') return true;
+    if (/^f[cd]/.test(lower)) return true; // fc00::/7 unique local
+    if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
+    if (/^ff/.test(lower)) return true; // ff00::/8 multicast
+
+    const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedHex) {
+        const hi = parseInt(mappedHex[1], 16);
+        const lo = parseInt(mappedHex[2], 16);
+        return isPrivateIPv4(
+            `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${
+                lo % 256
+            }`,
+        );
+    }
+    const mappedDotted = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mappedDotted) return isPrivateIPv4(mappedDotted[1]);
+
+    const compat = lower.match(/^::(\d+\.\d+\.\d+\.\d+)$/);
+    if (compat) return isPrivateIPv4(compat[1]);
+
+    return false;
+};
+
+const isPrivateAddress = (address: string, family: number): boolean => {
+    if (family === 4) return isPrivateIPv4(address);
+    if (family === 6) return isPrivateIPv6(address);
+    return true; // unknown family — fail closed
+};
+
+const resolveAndValidateHost = async (
+    hostname: string,
+): Promise<{ address: string; family: 4 | 6 }> => {
+    // URL.hostname wraps IPv6 literals in brackets ("[::1]") — strip them.
+    const cleanHost = hostname.replace(/^\[/, '').replace(/\]$/, '');
+
+    let addresses: Array<{ address: string; family: number }>;
+    try {
+        addresses = await dns.lookup(cleanHost, { all: true, verbatim: true });
+    } catch {
+        throw new SecureFetchError('blocked_ip', 'Unable to resolve hostname');
+    }
+    if (addresses.length === 0) {
+        throw new SecureFetchError('blocked_ip', 'Unable to resolve hostname');
+    }
+    for (const { address, family } of addresses) {
+        if (isPrivateAddress(address, family)) {
+            throw new SecureFetchError(
+                'blocked_ip',
+                'Access to private/internal addresses is not allowed',
+            );
+        }
+    }
+    const { address, family } = addresses[0];
+    return { address, family: family === 6 ? 6 : 4 };
+};
+
 export async function secureFetch(
     rawUrl: string,
     options: SecureFetchOptions,
 ): Promise<SecureFetchResult> {
     const parsedUrl = parseHttpsUrl(rawUrl);
+    const { address, family } = await resolveAndValidateHost(
+        parsedUrl.hostname,
+    );
     throw new SecureFetchError(
         'request_failed',
-        `not implemented for ${parsedUrl.hostname}`,
+        `not implemented (resolved ${address}/${family})`,
     );
 }

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -1,5 +1,6 @@
 import dns from 'dns/promises';
 import https from 'https';
+import * as ipaddr from 'ipaddr.js';
 import { LookupFunction } from 'net';
 import fetch, { FetchError } from 'node-fetch';
 
@@ -59,56 +60,17 @@ const parseHttpsUrl = (rawUrl: string): URL => {
     return parsedUrl;
 };
 
-const isPrivateIPv4 = (ip: string): boolean => {
-    const parts = ip.split('.').map(Number);
-    if (
-        parts.length !== 4 ||
-        parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
-    ) {
+// Returns true when the address must be blocked (non-routable, private,
+// loopback, link-local, multicast, reserved, or unparseable). Uses ipaddr.js
+// so that tunnelled ranges like 6to4 (2002:7f00::/16) and NAT64
+// (64:ff9b::/96) collapse to their IPv4 range via ipaddr.process(). Fail-closed:
+// if the address cannot be parsed it is treated as blocked.
+const isNonPublicAddress = (address: string): boolean => {
+    try {
+        return ipaddr.process(address).range() !== 'unicast';
+    } catch {
         return true; // unparseable — fail closed
     }
-    const [a, b] = parts;
-    if (a === 0) return true; // 0.0.0.0/8
-    if (a === 10) return true; // 10.0.0.0/8 RFC 1918
-    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-    if (a === 127) return true; // 127.0.0.0/8 loopback
-    if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (IMDS)
-    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 RFC 1918
-    if (a === 192 && b === 168) return true; // 192.168.0.0/16 RFC 1918
-    if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
-    return false;
-};
-
-const isPrivateIPv6 = (ip: string): boolean => {
-    const lower = ip.toLowerCase();
-    if (lower === '::1' || lower === '::') return true;
-    if (/^f[cd]/.test(lower)) return true; // fc00::/7 unique local
-    if (/^fe[89ab]/.test(lower)) return true; // fe80::/10 link-local
-    if (/^ff/.test(lower)) return true; // ff00::/8 multicast
-
-    const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-    if (mappedHex) {
-        const hi = parseInt(mappedHex[1], 16);
-        const lo = parseInt(mappedHex[2], 16);
-        return isPrivateIPv4(
-            `${Math.floor(hi / 256)}.${hi % 256}.${Math.floor(lo / 256)}.${
-                lo % 256
-            }`,
-        );
-    }
-    const mappedDotted = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (mappedDotted) return isPrivateIPv4(mappedDotted[1]);
-
-    const compat = lower.match(/^::(\d+\.\d+\.\d+\.\d+)$/);
-    if (compat) return isPrivateIPv4(compat[1]);
-
-    return false;
-};
-
-const isPrivateAddress = (address: string, family: number): boolean => {
-    if (family === 4) return isPrivateIPv4(address);
-    if (family === 6) return isPrivateIPv6(address);
-    return true; // unknown family — fail closed
 };
 
 const resolveAndValidateHost = async (
@@ -126,8 +88,8 @@ const resolveAndValidateHost = async (
     if (addresses.length === 0) {
         throw new SecureFetchError('blocked_ip', 'Unable to resolve hostname');
     }
-    for (const { address, family } of addresses) {
-        if (isPrivateAddress(address, family)) {
+    for (const { address } of addresses) {
+        if (isNonPublicAddress(address)) {
             throw new SecureFetchError(
                 'blocked_ip',
                 'Access to private/internal addresses is not allowed',
@@ -235,14 +197,18 @@ export async function secureFetch(
         .split(';')[0]
         .trim()
         .toLowerCase();
-    const allowed = options.allowedContentTypes.map((t) =>
-        t.split(';')[0].trim().toLowerCase(),
-    );
-    if (!allowed.includes(contentType)) {
-        throw new SecureFetchError(
-            'disallowed_content_type',
-            `Disallowed content-type: ${contentType || '(none)'}`,
+    // Empty allowlist = no content-type restriction (explicit opt-out; the proxy
+    // always passes a non-empty list). When non-empty, enforce a strict allowlist.
+    if (options.allowedContentTypes.length > 0) {
+        const allowed = options.allowedContentTypes.map((t) =>
+            t.split(';')[0].trim().toLowerCase(),
         );
+        if (!allowed.includes(contentType)) {
+            throw new SecureFetchError(
+                'disallowed_content_type',
+                `Disallowed content-type: ${contentType || '(none)'}`,
+            );
+        }
     }
 
     let bodyText: string;

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -35,9 +35,32 @@ export type SecureFetchResult = {
     truncated: boolean;
 };
 
+const parseHttpsUrl = (rawUrl: string): URL => {
+    if (!rawUrl) {
+        throw new SecureFetchError('invalid_url', 'URL is required');
+    }
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(rawUrl);
+    } catch {
+        throw new SecureFetchError('invalid_url', 'Invalid URL format');
+    }
+    if (parsedUrl.protocol !== 'https:') {
+        throw new SecureFetchError(
+            'non_https',
+            'Only HTTPS protocol is allowed',
+        );
+    }
+    return parsedUrl;
+};
+
 export async function secureFetch(
     rawUrl: string,
     options: SecureFetchOptions,
 ): Promise<SecureFetchResult> {
-    throw new SecureFetchError('request_failed', 'secureFetch not implemented');
+    const parsedUrl = parseHttpsUrl(rawUrl);
+    throw new SecureFetchError(
+        'request_failed',
+        `not implemented for ${parsedUrl.hostname}`,
+    );
 }

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -220,11 +220,45 @@ export async function secureFetch(
         );
     }
 
+    const contentLength = response.headers.get('content-length');
+    if (
+        contentLength &&
+        Number.parseInt(contentLength, 10) > options.maxResponseBytes
+    ) {
+        throw new SecureFetchError(
+            'too_large',
+            `Response too large (max ${options.maxResponseBytes} bytes)`,
+        );
+    }
+
     const contentType = (response.headers.get('content-type') ?? '')
         .split(';')[0]
         .trim()
         .toLowerCase();
-    const bodyText = await response.text();
+    const allowed = options.allowedContentTypes.map((t) =>
+        t.split(';')[0].trim().toLowerCase(),
+    );
+    if (!allowed.includes(contentType)) {
+        throw new SecureFetchError(
+            'disallowed_content_type',
+            `Disallowed content-type: ${contentType || '(none)'}`,
+        );
+    }
+
+    let bodyText: string;
+    try {
+        bodyText = await response.text();
+    } catch (error) {
+        // node-fetch's `size` option throws FetchError type 'max-size' when the
+        // streamed body exceeds the limit.
+        if (error instanceof FetchError && error.type === 'max-size') {
+            throw new SecureFetchError(
+                'too_large',
+                `Response too large (max ${options.maxResponseBytes} bytes)`,
+            );
+        }
+        throw new SecureFetchError('request_failed', 'Failed to read response');
+    }
 
     return {
         status: response.status,

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -1,0 +1,43 @@
+export type SecureFetchReason =
+    | 'non_https'
+    | 'blocked_ip'
+    | 'invalid_url'
+    | 'redirect'
+    | 'timeout'
+    | 'too_large'
+    | 'disallowed_content_type'
+    | 'request_failed';
+
+export class SecureFetchError extends Error {
+    public readonly reason: SecureFetchReason;
+
+    constructor(reason: SecureFetchReason, message: string) {
+        super(message);
+        this.name = 'SecureFetchError';
+        this.reason = reason;
+        Object.setPrototypeOf(this, SecureFetchError.prototype);
+    }
+}
+
+export type SecureFetchOptions = {
+    method: 'GET' | 'POST';
+    body?: string;
+    headers?: Record<string, string>;
+    timeoutMs: number;
+    maxResponseBytes: number;
+    allowedContentTypes: string[];
+};
+
+export type SecureFetchResult = {
+    status: number;
+    contentType: string;
+    bodyText: string;
+    truncated: boolean;
+};
+
+export async function secureFetch(
+    rawUrl: string,
+    options: SecureFetchOptions,
+): Promise<SecureFetchResult> {
+    throw new SecureFetchError('request_failed', 'secureFetch not implemented');
+}

--- a/packages/backend/src/utils/secureFetch/secureFetch.ts
+++ b/packages/backend/src/utils/secureFetch/secureFetch.ts
@@ -138,6 +138,8 @@ const resolveAndValidateHost = async (
     return { address, family: family === 6 ? 6 : 4 };
 };
 
+const MAX_TIMEOUT_MS = 30000;
+
 // HTTPS agent whose DNS lookup is pinned to a single pre-validated IP. This
 // defeats DNS rebinding between validation and socket open: the kernel never
 // resolves the hostname a second time.
@@ -170,6 +172,10 @@ export async function secureFetch(
     );
     const agent = createPinnedHttpsAgent(address, family);
 
+    const controller = new AbortController();
+    const effectiveTimeout = Math.min(options.timeoutMs, MAX_TIMEOUT_MS);
+    const timer = setTimeout(() => controller.abort(), effectiveTimeout);
+
     let response: import('node-fetch').Response;
     try {
         response = await fetch(rawUrl, {
@@ -178,9 +184,16 @@ export async function secureFetch(
             headers: options.headers,
             agent,
             redirect: 'manual',
+            signal: controller.signal as never,
             size: options.maxResponseBytes,
         });
     } catch (error) {
+        if (
+            controller.signal.aborted ||
+            (error instanceof FetchError && error.type === 'aborted')
+        ) {
+            throw new SecureFetchError('timeout', 'Request timed out');
+        }
         if (error instanceof FetchError) {
             throw new SecureFetchError(
                 'request_failed',
@@ -188,6 +201,8 @@ export async function secureFetch(
             );
         }
         throw new SecureFetchError('request_failed', 'Request failed');
+    } finally {
+        clearTimeout(timer);
     }
 
     // Validation only covered the initial URL; any redirect target is


### PR DESCRIPTION
Extracts the SSRF protections that were inlined in the geoJSON proxy into a reusable, method-generic `secureFetch` utility — the security core the external-fetch proxy is built on.

- **SSRF-safe fetch**: server-side DNS resolution + `ipaddr.js` blocking of loopback/private/link-local/metadata/6to4/NAT64/reserved IPs, a **DNS-pinned agent** (defeats rebinding), HTTPS-only, redirects disabled, and response size/timeout/content-type caps.
- **Refactors `geoJsonProxyController`** onto it, deleting ~150 lines of duplicated hand-rolled checks (behavioral parity preserved + a parity test harness added).
- No user-facing change on its own — pure foundation for the rest of the stack.

**Note:** 49 unit tests cover every blocked IP class, redirect, oversize, timeout, and content-type case.

---
**Stack:** Data App External Fetch Proxy — PR 1/6 · everything is gated behind the `enable-data-app-external-access` feature flag (default **off** → every code path locked).

_Linear: TODO — add ticket (`Closes: PROD-XXXX`)._
