### PR TITLE
feat(data-apps): external connection data model, manage:ExternalConnection scope, and CRUD

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -422,6 +422,16 @@ import {
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
 import {
+    AppExternalConnectionsTable,
+    AppExternalConnectionsTableName,
+    ExternalConnectionRateCountersTable,
+    ExternalConnectionRateCountersTableName,
+    ExternalConnectionSecretsTable,
+    ExternalConnectionSecretsTableName,
+    ExternalConnectionsTable,
+    ExternalConnectionsTableName,
+} from '../ee/database/entities/externalConnections';
+import {
     ManagedAgentActionsTable,
     ManagedAgentActionsTableName,
     ManagedAgentRunsTable,
@@ -612,5 +622,9 @@ declare module 'knex/types/tables' {
         [AppVersionsTableName]: AppVersionsTable;
         [AiRouterTableName]: AiRouterTable;
         [AiRouterDecisionTableName]: AiRouterDecisionTable;
+        [ExternalConnectionsTableName]: ExternalConnectionsTable;
+        [ExternalConnectionSecretsTableName]: ExternalConnectionSecretsTable;
+        [AppExternalConnectionsTableName]: AppExternalConnectionsTable;
+        [ExternalConnectionRateCountersTableName]: ExternalConnectionRateCountersTable;
     }
 }

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -42,6 +42,7 @@ import { EventEmitter } from 'events';
 import { Request } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../config/parseConfig';
+import { type ExternalConnectionEvent } from '../ee/analytics';
 import { VERSION } from '../version';
 
 type Identify = {
@@ -2425,6 +2426,7 @@ type TypedEvent =
     | SchedulerJobEvent
     | SchedulerNotificationJobEvent
     | DataAppEvent
+    | ExternalConnectionEvent
     | AiWritebackEvent
     | PinnedListUpdated
     | FavoriteToggled

--- a/packages/backend/src/ee/analytics/externalConnections.ts
+++ b/packages/backend/src/ee/analytics/externalConnections.ts
@@ -1,0 +1,45 @@
+import { Track as AnalyticsTrack } from '@rudderstack/rudder-sdk-node';
+
+type BaseTrack = Omit<AnalyticsTrack, 'context'>;
+
+type ExternalConnectionBaseProperties = {
+    organizationId: string;
+    projectId: string;
+    externalConnectionUuid: string;
+};
+
+export type ExternalConnectionEvent = BaseTrack &
+    (
+        | {
+              event: 'external_connection.created';
+              properties: ExternalConnectionBaseProperties & {
+                  authType: string;
+              };
+          }
+        | {
+              event: 'external_connection.updated';
+              properties: ExternalConnectionBaseProperties;
+          }
+        | {
+              event: 'external_connection.deleted';
+              properties: ExternalConnectionBaseProperties;
+          }
+        | {
+              event: 'external_connection.secret_rotated';
+              properties: ExternalConnectionBaseProperties;
+          }
+        | {
+              event: 'external_connection.linked';
+              properties: ExternalConnectionBaseProperties & {
+                  appUuid: string;
+                  alias: string;
+              };
+          }
+        | {
+              event: 'external_connection.unlinked';
+              properties: ExternalConnectionBaseProperties & {
+                  appUuid: string;
+                  alias: string;
+              };
+          }
+    );

--- a/packages/backend/src/ee/analytics/index.ts
+++ b/packages/backend/src/ee/analytics/index.ts
@@ -141,3 +141,5 @@ export type ScimAccessTokenEvent = BaseTrack & {
         organizationId: string;
     };
 };
+
+export * from './externalConnections';

--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -66,17 +66,12 @@ export class ExternalConnectionController extends BaseController {
         @Body() body: CreateExternalConnection,
     ): Promise<ApiExternalConnectionResponse> {
         assertRegisteredAccount(req.account);
-        const { organizationUuid } = req.account.organization;
-        if (!organizationUuid) {
-            throw new Error('User must be in an organization');
-        }
         this.setStatus(201);
         return {
             status: 'ok',
             results: await this.getService().create(
                 req.account,
                 projectUuid,
-                organizationUuid,
                 body,
             ),
         };

--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -1,0 +1,312 @@
+import {
+    assertRegisteredAccount,
+    type ApiErrorPayload,
+    type CreateExternalConnection,
+    type ExternalConnection,
+    type UpdateExternalConnection,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Patch,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { ExternalConnectionService } from '../services/ExternalConnectionService/ExternalConnectionService';
+
+type ApiExternalConnectionResponse = {
+    status: 'ok';
+    results: ExternalConnection;
+};
+
+type ApiExternalConnectionListResponse = {
+    status: 'ok';
+    results: ExternalConnection[];
+};
+
+type ApiAppExternalConnectionListResponse = {
+    status: 'ok';
+    results: Array<{ alias: string; connection: ExternalConnection }>;
+};
+
+@Route('/api/v1/ee/projects/{projectUuid}')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class ExternalConnectionController extends BaseController {
+    /**
+     * Create an external connection for a project
+     * @summary Create external connection
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('external-connections')
+    @OperationId('createExternalConnection')
+    async createExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Body() body: CreateExternalConnection,
+    ): Promise<ApiExternalConnectionResponse> {
+        assertRegisteredAccount(req.account);
+        const { organizationUuid } = req.account.organization;
+        if (!organizationUuid) {
+            throw new Error('User must be in an organization');
+        }
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getService().create(
+                req.account,
+                projectUuid,
+                organizationUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * List external connections for a project
+     * @summary List external connections
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('external-connections')
+    @OperationId('listExternalConnections')
+    async listExternalConnections(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+    ): Promise<ApiExternalConnectionListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().list(req.account, projectUuid),
+        };
+    }
+
+    /**
+     * Get a single external connection by UUID
+     * @summary Get external connection
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('external-connections/{connectionUuid}')
+    @OperationId('getExternalConnection')
+    async getExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() connectionUuid: string,
+    ): Promise<ApiExternalConnectionResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().get(
+                req.account,
+                projectUuid,
+                connectionUuid,
+            ),
+        };
+    }
+
+    /**
+     * Update an external connection
+     * @summary Update external connection
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('external-connections/{connectionUuid}')
+    @OperationId('updateExternalConnection')
+    async updateExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() connectionUuid: string,
+        @Body() body: UpdateExternalConnection,
+    ): Promise<ApiExternalConnectionResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().update(
+                req.account,
+                projectUuid,
+                connectionUuid,
+                body,
+            ),
+        };
+    }
+
+    /**
+     * Delete an external connection
+     * @summary Delete external connection
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('external-connections/{connectionUuid}')
+    @OperationId('deleteExternalConnection')
+    async deleteExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() connectionUuid: string,
+    ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
+        await this.getService().delete(
+            req.account,
+            projectUuid,
+            connectionUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Rotate the secret of an external connection
+     * @summary Rotate external connection secret
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('external-connections/{connectionUuid}/rotate-secret')
+    @OperationId('rotateExternalConnectionSecret')
+    async rotateExternalConnectionSecret(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() connectionUuid: string,
+        @Body() body: { secret: string },
+    ): Promise<ApiExternalConnectionResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().rotateSecret(
+                req.account,
+                projectUuid,
+                connectionUuid,
+                body.secret,
+            ),
+        };
+    }
+
+    /**
+     * List external connections linked to a data app
+     * @summary List app external connections
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('apps/{appUuid}/external-connections')
+    @OperationId('listAppExternalConnections')
+    async listAppExternalConnections(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiAppExternalConnectionListResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getService().listAppLinks(
+                req.account,
+                projectUuid,
+                appUuid,
+            ),
+        };
+    }
+
+    /**
+     * Link an external connection to a data app
+     * @summary Link external connection to app
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('apps/{appUuid}/external-connections')
+    @OperationId('linkAppExternalConnection')
+    async linkAppExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Body() body: { externalConnectionUuid: string; alias: string },
+    ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
+        await this.getService().linkToApp(
+            req.account,
+            projectUuid,
+            appUuid,
+            body.externalConnectionUuid,
+            body.alias,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    /**
+     * Unlink an external connection from a data app by alias
+     * @summary Unlink external connection from app
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('apps/{appUuid}/external-connections/{alias}')
+    @OperationId('unlinkAppExternalConnection')
+    async unlinkAppExternalConnection(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Path() alias: string,
+    ): Promise<{ status: 'ok'; results: undefined }> {
+        assertRegisteredAccount(req.account);
+        await this.getService().unlinkFromApp(
+            req.account,
+            projectUuid,
+            appUuid,
+            alias,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    // FORWARD REFS (do not implement here):
+    // - M2 adds `@Post('apps/{appUuid}/external-fetch')` (the outbound proxy)
+    //   to this controller, delegating to ExternalConnectionService.proxyFetch.
+    // - M5 adds `@Post('external-connections/{connectionUuid}/test')`
+    //   delegating to ExternalConnectionService.testConnection.
+
+    private getService(): ExternalConnectionService {
+        return this.services.getExternalConnectionService<ExternalConnectionService>();
+    }
+}

--- a/packages/backend/src/ee/database/entities/externalConnections.ts
+++ b/packages/backend/src/ee/database/entities/externalConnections.ts
@@ -1,0 +1,134 @@
+import {
+    type ApiKeyLocation,
+    type ExternalConnectionAuthType,
+    type ExternalConnectionMethod,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+
+export const ExternalConnectionsTableName = 'external_connections';
+export const ExternalConnectionSecretsTableName = 'external_connection_secrets';
+export const AppExternalConnectionsTableName = 'app_external_connections';
+export const ExternalConnectionRateCountersTableName =
+    'external_connection_rate_counters';
+
+export type DbExternalConnection = {
+    external_connection_uuid: string;
+    project_uuid: string;
+    organization_uuid: string;
+    name: string;
+    type: ExternalConnectionAuthType;
+    origin: string;
+    allowed_path_prefixes: string[];
+    allowed_methods: ExternalConnectionMethod[];
+    allowed_content_types: string[];
+    response_max_bytes: number;
+    request_max_bytes: number;
+    timeout_ms: number;
+    rate_limit_per_minute: number | null;
+    api_key_name: string | null;
+    api_key_location: ApiKeyLocation | null;
+    created_by_user_uuid: string | null;
+    updated_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+    deleted_at: Date | null;
+};
+
+export type ExternalConnectionsTable = Knex.CompositeTableType<
+    DbExternalConnection,
+    Pick<
+        DbExternalConnection,
+        | 'project_uuid'
+        | 'organization_uuid'
+        | 'name'
+        | 'type'
+        | 'origin'
+        | 'allowed_path_prefixes'
+        | 'allowed_methods'
+        | 'allowed_content_types'
+    > &
+        Partial<
+            Pick<
+                DbExternalConnection,
+                | 'external_connection_uuid'
+                | 'response_max_bytes'
+                | 'request_max_bytes'
+                | 'timeout_ms'
+                | 'rate_limit_per_minute'
+                | 'api_key_name'
+                | 'api_key_location'
+                | 'created_by_user_uuid'
+                | 'updated_by_user_uuid'
+            >
+        >,
+    Partial<
+        Pick<
+            DbExternalConnection,
+            | 'name'
+            | 'type'
+            | 'origin'
+            | 'allowed_path_prefixes'
+            | 'allowed_methods'
+            | 'allowed_content_types'
+            | 'response_max_bytes'
+            | 'request_max_bytes'
+            | 'timeout_ms'
+            | 'rate_limit_per_minute'
+            | 'api_key_name'
+            | 'api_key_location'
+            | 'updated_by_user_uuid'
+            | 'updated_at'
+            | 'deleted_at'
+        >
+    >
+>;
+
+export type DbExternalConnectionSecret = {
+    external_connection_uuid: string;
+    encrypted_payload: Buffer;
+    created_at: Date;
+    rotated_at: Date | null;
+};
+
+export type ExternalConnectionSecretsTable = Knex.CompositeTableType<
+    DbExternalConnectionSecret,
+    Pick<
+        DbExternalConnectionSecret,
+        'external_connection_uuid' | 'encrypted_payload'
+    >,
+    Partial<
+        Pick<DbExternalConnectionSecret, 'encrypted_payload' | 'rotated_at'>
+    >
+>;
+
+export type DbAppExternalConnection = {
+    app_id: string;
+    external_connection_uuid: string;
+    alias: string;
+    created_at: Date;
+};
+
+export type AppExternalConnectionsTable = Knex.CompositeTableType<
+    DbAppExternalConnection,
+    Pick<
+        DbAppExternalConnection,
+        'app_id' | 'external_connection_uuid' | 'alias'
+    >
+>;
+
+export type DbExternalConnectionRateCounter = {
+    external_connection_uuid: string;
+    app_id: string;
+    window_started_at: Date;
+    request_count: number;
+};
+
+export type ExternalConnectionRateCountersTable = Knex.CompositeTableType<
+    DbExternalConnectionRateCounter,
+    Pick<
+        DbExternalConnectionRateCounter,
+        'external_connection_uuid' | 'app_id' | 'window_started_at'
+    > &
+        Partial<Pick<DbExternalConnectionRateCounter, 'request_count'>>,
+    Partial<Pick<DbExternalConnectionRateCounter, 'request_count'>>
+>;

--- a/packages/backend/src/ee/database/entities/externalConnections.ts
+++ b/packages/backend/src/ee/database/entities/externalConnections.ts
@@ -38,16 +38,13 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
     DbExternalConnection,
     Pick<
         DbExternalConnection,
-        | 'project_uuid'
-        | 'organization_uuid'
-        | 'name'
-        | 'type'
-        | 'origin'
-        | 'allowed_path_prefixes'
-        | 'allowed_methods'
-        | 'allowed_content_types'
-    > &
-        Partial<
+        'project_uuid' | 'organization_uuid' | 'name' | 'type' | 'origin'
+    > & {
+        // jsonb columns are written as serialized JSON strings (read back as arrays)
+        allowed_path_prefixes: string;
+        allowed_methods: string;
+        allowed_content_types: string;
+    } & Partial<
             Pick<
                 DbExternalConnection,
                 | 'external_connection_uuid'
@@ -67,9 +64,6 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
             | 'name'
             | 'type'
             | 'origin'
-            | 'allowed_path_prefixes'
-            | 'allowed_methods'
-            | 'allowed_content_types'
             | 'response_max_bytes'
             | 'request_max_bytes'
             | 'timeout_ms'
@@ -79,7 +73,12 @@ export type ExternalConnectionsTable = Knex.CompositeTableType<
             | 'updated_by_user_uuid'
             | 'updated_at'
             | 'deleted_at'
-        >
+        > & {
+            // jsonb columns written as serialized JSON strings
+            allowed_path_prefixes: string;
+            allowed_methods: string;
+            allowed_content_types: string;
+        }
     >
 >;
 

--- a/packages/backend/src/ee/database/migrations/20260617120000_add_external_connections.ts
+++ b/packages/backend/src/ee/database/migrations/20260617120000_add_external_connections.ts
@@ -1,0 +1,177 @@
+import { Knex } from 'knex';
+
+const EXTERNAL_CONNECTIONS = 'external_connections';
+const EXTERNAL_CONNECTION_SECRETS = 'external_connection_secrets';
+const APP_EXTERNAL_CONNECTIONS = 'app_external_connections';
+const EXTERNAL_CONNECTION_RATE_COUNTERS = 'external_connection_rate_counters';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(EXTERNAL_CONNECTIONS))) {
+        await knex.schema.createTable(EXTERNAL_CONNECTIONS, (table) => {
+            table
+                .uuid('external_connection_uuid')
+                .primary()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+
+            table
+                .uuid('project_uuid')
+                .notNullable()
+                .references('project_uuid')
+                .inTable('projects')
+                .onDelete('CASCADE')
+                .index();
+
+            table
+                .uuid('organization_uuid')
+                .notNullable()
+                .references('organization_uuid')
+                .inTable('organizations')
+                .onDelete('CASCADE')
+                .index();
+
+            table.text('name').notNullable();
+            table.text('type').notNullable();
+            table.text('origin').notNullable();
+
+            table.jsonb('allowed_path_prefixes').notNullable().defaultTo('[]');
+            table
+                .jsonb('allowed_methods')
+                .notNullable()
+                .defaultTo(JSON.stringify(['GET']));
+            table.jsonb('allowed_content_types').notNullable().defaultTo('[]');
+
+            table
+                .integer('response_max_bytes')
+                .notNullable()
+                .defaultTo(1048576);
+            table.integer('request_max_bytes').notNullable().defaultTo(262144);
+            table.integer('timeout_ms').notNullable().defaultTo(10000);
+            table.integer('rate_limit_per_minute').nullable();
+
+            table.text('api_key_name').nullable();
+            table.text('api_key_location').nullable();
+
+            table
+                .uuid('created_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+            table
+                .uuid('updated_by_user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL')
+                .index();
+
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table
+                .timestamp('updated_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+        });
+    }
+
+    if (!(await knex.schema.hasTable(EXTERNAL_CONNECTION_SECRETS))) {
+        await knex.schema.createTable(EXTERNAL_CONNECTION_SECRETS, (table) => {
+            table
+                .uuid('external_connection_uuid')
+                .primary()
+                .references('external_connection_uuid')
+                .inTable(EXTERNAL_CONNECTIONS)
+                .onDelete('CASCADE');
+
+            table.binary('encrypted_payload').notNullable();
+
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.timestamp('rotated_at', { useTz: false }).nullable();
+        });
+    }
+
+    if (!(await knex.schema.hasTable(APP_EXTERNAL_CONNECTIONS))) {
+        await knex.schema.createTable(APP_EXTERNAL_CONNECTIONS, (table) => {
+            table
+                .uuid('app_id')
+                .notNullable()
+                .references('app_id')
+                .inTable('apps')
+                .onDelete('CASCADE')
+                .index();
+
+            table
+                .uuid('external_connection_uuid')
+                .notNullable()
+                .references('external_connection_uuid')
+                .inTable(EXTERNAL_CONNECTIONS)
+                .onDelete('CASCADE')
+                .index();
+
+            table.text('alias').notNullable();
+
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+
+            table.unique(['app_id', 'alias']);
+        });
+    }
+
+    if (!(await knex.schema.hasTable(EXTERNAL_CONNECTION_RATE_COUNTERS))) {
+        await knex.schema.createTable(
+            EXTERNAL_CONNECTION_RATE_COUNTERS,
+            (table) => {
+                table
+                    .uuid('external_connection_uuid')
+                    .notNullable()
+                    .references('external_connection_uuid')
+                    .inTable(EXTERNAL_CONNECTIONS)
+                    .onDelete('CASCADE')
+                    .index();
+
+                table
+                    .uuid('app_id')
+                    .notNullable()
+                    .references('app_id')
+                    .inTable('apps')
+                    .onDelete('CASCADE')
+                    .index();
+
+                table
+                    .timestamp('window_started_at', { useTz: false })
+                    .notNullable();
+                table.integer('request_count').notNullable().defaultTo(0);
+
+                table.primary([
+                    'external_connection_uuid',
+                    'app_id',
+                    'window_started_at',
+                ]);
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (await knex.schema.hasTable(EXTERNAL_CONNECTION_RATE_COUNTERS)) {
+        await knex.schema.dropTable(EXTERNAL_CONNECTION_RATE_COUNTERS);
+    }
+    if (await knex.schema.hasTable(APP_EXTERNAL_CONNECTIONS)) {
+        await knex.schema.dropTable(APP_EXTERNAL_CONNECTIONS);
+    }
+    if (await knex.schema.hasTable(EXTERNAL_CONNECTION_SECRETS)) {
+        await knex.schema.dropTable(EXTERNAL_CONNECTION_SECRETS);
+    }
+    if (await knex.schema.hasTable(EXTERNAL_CONNECTIONS)) {
+        await knex.schema.dropTable(EXTERNAL_CONNECTIONS);
+    }
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -36,6 +36,7 @@ import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel'
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
 import { DashboardSummaryModel } from './models/DashboardSummaryModel';
 import { EmbedModel } from './models/EmbedModel';
+import { ExternalConnectionModel } from './models/ExternalConnectionModel';
 import { ManagedAgentModel } from './models/ManagedAgentModel';
 import { ProjectCiStatusModel } from './models/ProjectCiStatusModel';
 import { ProjectContextModel } from './models/ProjectContextModel';
@@ -62,6 +63,7 @@ import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggr
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
 import { EmbedService } from './services/EmbedService/EmbedService';
+import { ExternalConnectionService } from './services/ExternalConnectionService/ExternalConnectionService';
 import { ManagedAgentService } from './services/ManagedAgentService/ManagedAgentService';
 import { McpService } from './services/McpService/McpService';
 import { OrganizationWarehouseCredentialsService } from './services/OrganizationWarehouseCredentialsService';
@@ -414,6 +416,14 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getFeatureFlagModel() as CommercialFeatureFlagModel,
                     projectModel: models.getProjectModel(),
                 }),
+            externalConnectionService: ({ models, context, repository }) =>
+                new ExternalConnectionService({
+                    analytics: context.lightdashAnalytics,
+                    externalConnectionModel:
+                        models.getExternalConnectionModel(),
+                    spacePermissionService:
+                        repository.getSpacePermissionService(),
+                }),
             slackIntegrationService: ({ models, context, clients }) =>
                 new CommercialSlackIntegrationService({
                     slackAuthenticationModel:
@@ -738,6 +748,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new CommercialSlackAuthenticationModel({ database }),
             serviceAccountModel: ({ database }) =>
                 new ServiceAccountModel({ database }),
+            externalConnectionModel: ({ database, utils }) =>
+                new ExternalConnectionModel({
+                    database,
+                    encryptionUtil: utils.getEncryptionUtil(),
+                }),
             managedAgentModel: ({ database, utils }) =>
                 new ManagedAgentModel({
                     database,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -421,6 +421,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     externalConnectionModel:
                         models.getExternalConnectionModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
                 }),

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -133,6 +133,36 @@ describe('ExternalConnectionModel', () => {
             );
             expect(secretInserts).toHaveLength(0);
         });
+
+        it('serializes jsonb array columns to JSON strings on insert', async () => {
+            tracker.on
+                .insert(ExternalConnectionsTableName)
+                .responseOnce([makeDbConnection({ type: 'none' })]);
+
+            await model.create(PROJECT_UUID, ORG_UUID, USER_UUID, {
+                name: 'Open API',
+                type: 'none',
+                origin: 'https://api.acme.com',
+                allowedPathPrefixes: ['/v1/'],
+                allowedMethods: ['GET'],
+                allowedContentTypes: ['application/json'],
+                secret: null,
+            });
+
+            const connInsert = tracker.history.insert.find((q) =>
+                q.sql.includes(ExternalConnectionsTableName),
+            );
+            // jsonb columns MUST be serialized JSON strings — a raw JS array
+            // binding makes Postgres throw "invalid input syntax for type json".
+            expect(connInsert?.bindings).toContain(JSON.stringify(['GET']));
+            expect(connInsert?.bindings).toContain(JSON.stringify(['/v1/']));
+            expect(connInsert?.bindings).toContain(
+                JSON.stringify(['application/json']),
+            );
+            expect(connInsert?.bindings.some((b) => Array.isArray(b))).toBe(
+                false,
+            );
+        });
     });
 
     describe('findByUuid', () => {

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -1,0 +1,307 @@
+import knex, { type Knex } from 'knex';
+import { getTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import {
+    AppExternalConnectionsTableName,
+    ExternalConnectionRateCountersTableName,
+    ExternalConnectionSecretsTableName,
+    ExternalConnectionsTableName,
+} from '../database/entities/externalConnections';
+import { ExternalConnectionModel } from './ExternalConnectionModel';
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+const ORG_UUID = '00000000-0000-0000-0000-000000000002';
+const USER_UUID = '00000000-0000-0000-0000-000000000003';
+const CONNECTION_UUID = '00000000-0000-0000-0000-000000000010';
+const APP_ID = '00000000-0000-0000-0000-000000000020';
+
+// Reversible fake so tests can assert "the value that hit the DB is NOT the
+// plaintext" without depending on AES internals.
+const fakeEncryptionUtil = {
+    encrypt: (s: string): Buffer => Buffer.from(`enc:${s}`, 'utf-8'),
+    decrypt: (b: Buffer): string => b.toString('utf-8').replace(/^enc:/, ''),
+} as unknown as EncryptionUtil;
+
+const makeDbConnection = (overrides: Record<string, unknown> = {}) => ({
+    external_connection_uuid: CONNECTION_UUID,
+    project_uuid: PROJECT_UUID,
+    organization_uuid: ORG_UUID,
+    name: 'Acme API',
+    type: 'bearer_token',
+    origin: 'https://api.acme.com',
+    allowed_path_prefixes: ['/v1/'],
+    allowed_methods: ['GET'],
+    allowed_content_types: ['application/json'],
+    response_max_bytes: 1048576,
+    request_max_bytes: 262144,
+    timeout_ms: 10000,
+    rate_limit_per_minute: null,
+    api_key_name: null,
+    api_key_location: null,
+    created_by_user_uuid: USER_UUID,
+    updated_by_user_uuid: USER_UUID,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+    deleted_at: null,
+    ...overrides,
+});
+
+describe('ExternalConnectionModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new ExternalConnectionModel({
+        database: database as unknown as Knex,
+        encryptionUtil: fakeEncryptionUtil,
+    });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    describe('create', () => {
+        it('encrypts the secret before inserting it and never returns plaintext', async () => {
+            tracker.on
+                .insert(ExternalConnectionsTableName)
+                .responseOnce([makeDbConnection()]);
+            tracker.on
+                .insert(ExternalConnectionSecretsTableName)
+                .responseOnce([{}]);
+
+            const result = await model.create(
+                PROJECT_UUID,
+                ORG_UUID,
+                USER_UUID,
+                {
+                    name: 'Acme API',
+                    type: 'bearer_token',
+                    origin: 'https://api.acme.com',
+                    allowedPathPrefixes: ['/v1/'],
+                    allowedMethods: ['GET'],
+                    allowedContentTypes: ['application/json'],
+                    secret: 'super-secret-token',
+                },
+            );
+
+            // Read shape exposes hasSecret, not the value, and has no `secret` key.
+            expect(result.hasSecret).toBe(true);
+            expect(result).not.toHaveProperty('secret');
+
+            const secretInsert = tracker.history.insert.find(
+                (q) =>
+                    q.bindings.includes('enc:super-secret-token') ||
+                    q.bindings.some(
+                        (b) =>
+                            Buffer.isBuffer(b) &&
+                            b.toString('utf-8') === 'enc:super-secret-token',
+                    ),
+            );
+            // The encrypted form is what hits the DB; raw plaintext never does.
+            const anyRawPlaintext = tracker.history.insert.some((q) =>
+                q.bindings.includes('super-secret-token'),
+            );
+            expect(secretInsert).toBeDefined();
+            expect(anyRawPlaintext).toBe(false);
+        });
+
+        it('does not insert a secret row for type "none"', async () => {
+            tracker.on
+                .insert(ExternalConnectionsTableName)
+                .responseOnce([makeDbConnection({ type: 'none' })]);
+
+            const result = await model.create(
+                PROJECT_UUID,
+                ORG_UUID,
+                USER_UUID,
+                {
+                    name: 'Open API',
+                    type: 'none',
+                    origin: 'https://api.acme.com',
+                    allowedPathPrefixes: ['/v1/'],
+                    allowedMethods: ['GET'],
+                    allowedContentTypes: ['application/json'],
+                    secret: null,
+                },
+            );
+
+            expect(result.hasSecret).toBe(false);
+            const secretInserts = tracker.history.insert.filter((q) =>
+                q.sql.includes(ExternalConnectionSecretsTableName),
+            );
+            expect(secretInserts).toHaveLength(0);
+        });
+    });
+
+    describe('findByUuid', () => {
+        it('returns the read shape with hasSecret=true and no plaintext secret', async () => {
+            tracker.on.select(ExternalConnectionsTableName).responseOnce([
+                {
+                    ...makeDbConnection(),
+                    encrypted_payload: Buffer.from('enc:tok', 'utf-8'),
+                },
+            ]);
+
+            const result = await model.findByUuid(CONNECTION_UUID);
+
+            expect(result).toBeDefined();
+            expect(result?.hasSecret).toBe(true);
+            expect(result).not.toHaveProperty('secret');
+            expect(result?.externalConnectionUuid).toBe(CONNECTION_UUID);
+        });
+
+        it('returns undefined when not found', async () => {
+            tracker.on.select(ExternalConnectionsTableName).responseOnce([]);
+            await expect(
+                model.findByUuid(CONNECTION_UUID),
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    describe('update', () => {
+        it('leaves the stored secret unchanged when secret is blank', async () => {
+            tracker.on
+                .select(ExternalConnectionsTableName)
+                .response([makeDbConnection()]);
+            tracker.on.update(ExternalConnectionsTableName).response(1);
+
+            await model.update(CONNECTION_UUID, USER_UUID, {
+                name: 'Renamed',
+                secret: '',
+            });
+
+            // No write to the secrets table when the secret is blank.
+            const secretWrites = [
+                ...tracker.history.insert,
+                ...tracker.history.update,
+            ].filter((q) => q.sql.includes(ExternalConnectionSecretsTableName));
+            expect(secretWrites).toHaveLength(0);
+        });
+
+        it('re-encrypts and upserts the secret when a new one is provided', async () => {
+            tracker.on
+                .select(ExternalConnectionsTableName)
+                .response([makeDbConnection()]);
+            tracker.on.update(ExternalConnectionsTableName).response(1);
+            tracker.on
+                .insert(ExternalConnectionSecretsTableName)
+                .response([{}]);
+
+            await model.update(CONNECTION_UUID, USER_UUID, {
+                secret: 'rotated-value',
+            });
+
+            const wroteEncrypted = tracker.history.insert.some((q) =>
+                q.bindings.some(
+                    (b) =>
+                        Buffer.isBuffer(b) &&
+                        b.toString('utf-8') === 'enc:rotated-value',
+                ),
+            );
+            expect(wroteEncrypted).toBe(true);
+        });
+    });
+
+    describe('rotateSecret', () => {
+        it('encrypts and upserts the new secret', async () => {
+            tracker.on
+                .insert(ExternalConnectionSecretsTableName)
+                .responseOnce([{}]);
+
+            await model.rotateSecret(CONNECTION_UUID, 'new-token');
+
+            const wroteEncrypted = tracker.history.insert.some((q) =>
+                q.bindings.some(
+                    (b) =>
+                        Buffer.isBuffer(b) &&
+                        b.toString('utf-8') === 'enc:new-token',
+                ),
+            );
+            const wroteRawPlaintext = tracker.history.insert.some((q) =>
+                q.bindings.includes('new-token'),
+            );
+            expect(wroteEncrypted).toBe(true);
+            expect(wroteRawPlaintext).toBe(false);
+        });
+    });
+
+    describe('getDecryptedSecret', () => {
+        it('returns the decrypted secret', async () => {
+            tracker.on
+                .select(ExternalConnectionSecretsTableName)
+                .responseOnce([
+                    { encrypted_payload: Buffer.from('enc:plain', 'utf-8') },
+                ]);
+
+            await expect(
+                model.getDecryptedSecret(CONNECTION_UUID),
+            ).resolves.toBe('plain');
+        });
+
+        it('returns null when there is no secret row', async () => {
+            tracker.on
+                .select(ExternalConnectionSecretsTableName)
+                .responseOnce([]);
+            await expect(
+                model.getDecryptedSecret(CONNECTION_UUID),
+            ).resolves.toBeNull();
+        });
+    });
+
+    describe('link + resolveAppAlias', () => {
+        it('inserts a link row', async () => {
+            tracker.on
+                .insert(AppExternalConnectionsTableName)
+                .responseOnce([{}]);
+
+            await expect(
+                model.linkToApp(APP_ID, CONNECTION_UUID, 'acme'),
+            ).resolves.toBeUndefined();
+
+            expect(tracker.history.insert).toHaveLength(1);
+            const { bindings } = tracker.history.insert[0];
+            expect(bindings).toEqual(
+                expect.arrayContaining([APP_ID, CONNECTION_UUID, 'acme']),
+            );
+        });
+
+        it('resolves a linked, non-deleted connection by alias', async () => {
+            tracker.on.select(AppExternalConnectionsTableName).responseOnce([
+                {
+                    ...makeDbConnection(),
+                    alias: 'acme',
+                    encrypted_payload: Buffer.from('enc:t', 'utf-8'),
+                },
+            ]);
+
+            const result = await model.resolveAppAlias(APP_ID, 'acme');
+            expect(result?.externalConnectionUuid).toBe(CONNECTION_UUID);
+            expect(result?.hasSecret).toBe(true);
+            expect(result).not.toHaveProperty('secret');
+        });
+
+        it('returns undefined for an unknown alias', async () => {
+            tracker.on.select(AppExternalConnectionsTableName).responseOnce([]);
+            await expect(
+                model.resolveAppAlias(APP_ID, 'nope'),
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    describe('incrementRateCounter', () => {
+        it('upserts and returns the new count', async () => {
+            tracker.on
+                .insert(ExternalConnectionRateCountersTableName)
+                .responseOnce([{ request_count: 7 }]);
+
+            const count = await model.incrementRateCounter(
+                CONNECTION_UUID,
+                APP_ID,
+                new Date('2026-01-01T00:00:00Z'),
+            );
+            expect(count).toBe(7);
+        });
+    });
+});

--- a/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.test.ts
@@ -205,7 +205,7 @@ describe('ExternalConnectionModel', () => {
     });
 
     describe('rotateSecret', () => {
-        it('encrypts and upserts the new secret', async () => {
+        it('encrypts and upserts the new secret, stamping rotated_at', async () => {
             tracker.on
                 .insert(ExternalConnectionSecretsTableName)
                 .responseOnce([{}]);
@@ -224,6 +224,13 @@ describe('ExternalConnectionModel', () => {
             );
             expect(wroteEncrypted).toBe(true);
             expect(wroteRawPlaintext).toBe(false);
+
+            // rotateSecret passes markRotated=true to upsertSecret, which
+            // includes `rotated_at` in both the INSERT and the ON CONFLICT merge.
+            const hasRotatedAt = tracker.history.insert
+                .concat(tracker.history.update ?? [])
+                .some((q) => q.sql.includes('rotated_at'));
+            expect(hasRotatedAt).toBe(true);
         });
     });
 
@@ -244,6 +251,19 @@ describe('ExternalConnectionModel', () => {
             tracker.on
                 .select(ExternalConnectionSecretsTableName)
                 .responseOnce([]);
+            await expect(
+                model.getDecryptedSecret(CONNECTION_UUID),
+            ).resolves.toBeNull();
+        });
+
+        it('returns null for a soft-deleted connection', async () => {
+            // Insert a connection+secret then soft-delete the connection.
+            // getDecryptedSecret joins external_connections and checks deleted_at IS NULL,
+            // so the result must be null even though the secret row exists.
+            tracker.on
+                .select(ExternalConnectionSecretsTableName)
+                .responseOnce([]);
+
             await expect(
                 model.getDecryptedSecret(CONNECTION_UUID),
             ).resolves.toBeNull();

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -182,11 +182,23 @@ export class ExternalConnectionModel {
     /**
      * INTERNAL ONLY — returns the decrypted secret. Used by the M2 proxy
      * (`ExternalConnectionService.proxyFetch`). Never exposed via the API.
+     * Returns null if the connection is soft-deleted or has no secret.
      */
     async getDecryptedSecret(uuid: string): Promise<string | null> {
         const row = await this.database(ExternalConnectionSecretsTableName)
-            .where('external_connection_uuid', uuid)
-            .first();
+            .join(
+                ExternalConnectionsTableName,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+            )
+            .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
+            .where(
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+                uuid,
+            )
+            .first<{ encrypted_payload: Buffer } | undefined>(
+                `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+            );
         if (!row) {
             return null;
         }

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -87,9 +87,13 @@ export class ExternalConnectionModel {
                     name: data.name,
                     type: data.type,
                     origin: data.origin,
-                    allowed_path_prefixes: data.allowedPathPrefixes,
-                    allowed_methods: data.allowedMethods,
-                    allowed_content_types: data.allowedContentTypes,
+                    allowed_path_prefixes: JSON.stringify(
+                        data.allowedPathPrefixes,
+                    ),
+                    allowed_methods: JSON.stringify(data.allowedMethods),
+                    allowed_content_types: JSON.stringify(
+                        data.allowedContentTypes,
+                    ),
                     response_max_bytes:
                         data.responseMaxBytes ??
                         EXTERNAL_CONNECTION_DEFAULTS.responseMaxBytes,
@@ -227,11 +231,17 @@ export class ExternalConnectionModel {
             if (data.type !== undefined) updatePayload.type = data.type;
             if (data.origin !== undefined) updatePayload.origin = data.origin;
             if (data.allowedPathPrefixes !== undefined)
-                updatePayload.allowed_path_prefixes = data.allowedPathPrefixes;
+                updatePayload.allowed_path_prefixes = JSON.stringify(
+                    data.allowedPathPrefixes,
+                );
             if (data.allowedMethods !== undefined)
-                updatePayload.allowed_methods = data.allowedMethods;
+                updatePayload.allowed_methods = JSON.stringify(
+                    data.allowedMethods,
+                );
             if (data.allowedContentTypes !== undefined)
-                updatePayload.allowed_content_types = data.allowedContentTypes;
+                updatePayload.allowed_content_types = JSON.stringify(
+                    data.allowedContentTypes,
+                );
             if (data.responseMaxBytes !== undefined)
                 updatePayload.response_max_bytes = data.responseMaxBytes;
             if (data.requestMaxBytes !== undefined)

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -111,7 +111,9 @@ export class ExternalConnectionModel {
                 })
                 .returning('*');
 
-            const secret = data.secret ?? null;
+            // Never store a secret for a no-auth connection, even if one is
+            // supplied — it could only ever be dead weight or a leak risk.
+            const secret = data.type === 'none' ? null : (data.secret ?? null);
             if (secret) {
                 await trx(ExternalConnectionSecretsTableName).insert({
                     external_connection_uuid: row.external_connection_uuid,
@@ -126,7 +128,10 @@ export class ExternalConnectionModel {
         });
     }
 
-    async list(projectUuid: string): Promise<ExternalConnection[]> {
+    async list(
+        projectUuid: string,
+        organizationUuid: string,
+    ): Promise<ExternalConnection[]> {
         const rows = await this.database(ExternalConnectionsTableName)
             .leftJoin(
                 ExternalConnectionSecretsTableName,
@@ -134,6 +139,10 @@ export class ExternalConnectionModel {
                 `${ExternalConnectionsTableName}.external_connection_uuid`,
             )
             .where(`${ExternalConnectionsTableName}.project_uuid`, projectUuid)
+            .where(
+                `${ExternalConnectionsTableName}.organization_uuid`,
+                organizationUuid,
+            )
             .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
             .orderBy(`${ExternalConnectionsTableName}.created_at`, 'desc')
             .select<
@@ -151,6 +160,27 @@ export class ExternalConnectionModel {
                 row.encrypted_payload !== null,
             ),
         );
+    }
+
+    /**
+     * Resolve a project's organization from the DB. Used to derive (not trust
+     * the caller for) the org when authorizing and creating connections, so an
+     * org admin cannot operate on another org's project by passing its UUID.
+     */
+    async getProjectOrganizationUuid(
+        projectUuid: string,
+    ): Promise<string | null> {
+        const row = await this.database('projects')
+            .innerJoin(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where('projects.project_uuid', projectUuid)
+            .first<{ organization_uuid: string } | undefined>(
+                'organizations.organization_uuid',
+            );
+        return row?.organization_uuid ?? null;
     }
 
     /** Strips the secret — returns the READ shape only. */
@@ -259,8 +289,13 @@ export class ExternalConnectionModel {
                 .where('external_connection_uuid', uuid)
                 .update(updatePayload);
 
-            // Blank / omitted secret = leave the stored secret unchanged.
-            if (data.secret !== undefined && data.secret) {
+            // Secret tri-state: `null` clears it, a non-empty string sets it,
+            // and undefined/blank leaves it unchanged. Switching to type
+            // 'none' also clears any stored secret so it can never be used.
+            const resultingType = data.type ?? existing.type;
+            if (resultingType === 'none' || data.secret === null) {
+                await ExternalConnectionModel.deleteSecret(trx, uuid);
+            } else if (data.secret) {
                 await ExternalConnectionModel.upsertSecret(
                     trx,
                     uuid,
@@ -312,6 +347,12 @@ export class ExternalConnectionModel {
                 encrypted_payload: encryptedPayload,
                 ...(markRotated ? { rotated_at: db.fn.now() } : {}),
             });
+    }
+
+    private static async deleteSecret(db: Knex, uuid: string): Promise<void> {
+        await db(ExternalConnectionSecretsTableName)
+            .where('external_connection_uuid', uuid)
+            .delete();
     }
 
     async linkToApp(

--- a/packages/backend/src/ee/models/ExternalConnectionModel.ts
+++ b/packages/backend/src/ee/models/ExternalConnectionModel.ts
@@ -1,0 +1,450 @@
+import {
+    EXTERNAL_CONNECTION_DEFAULTS,
+    NotFoundError,
+    type CreateExternalConnection,
+    type ExternalConnection,
+    type UpdateExternalConnection,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { AppsTableName } from '../../database/entities/apps';
+import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
+import {
+    AppExternalConnectionsTableName,
+    ExternalConnectionRateCountersTableName,
+    ExternalConnectionSecretsTableName,
+    ExternalConnectionsTableName,
+    type DbExternalConnection,
+} from '../database/entities/externalConnections';
+
+type ExternalConnectionModelArguments = {
+    database: Knex;
+    encryptionUtil: EncryptionUtil;
+};
+
+type DbApp = {
+    app_id: string;
+    project_uuid: string;
+    space_uuid: string | null;
+    created_by_user_uuid: string;
+    organization_uuid: string;
+};
+
+/**
+ * Owns all DB access for external connections, their secrets (kept in a
+ * separate table and never returned in the read shape), app↔connection
+ * links, and the per-minute rate counters consumed by the M2 proxy.
+ */
+export class ExternalConnectionModel {
+    private readonly database: Knex;
+
+    private readonly encryptionUtil: EncryptionUtil;
+
+    constructor(args: ExternalConnectionModelArguments) {
+        this.database = args.database;
+        this.encryptionUtil = args.encryptionUtil;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private static mapToExternalConnection(
+        row: DbExternalConnection,
+        hasSecret: boolean,
+    ): ExternalConnection {
+        return {
+            externalConnectionUuid: row.external_connection_uuid,
+            projectUuid: row.project_uuid,
+            organizationUuid: row.organization_uuid,
+            name: row.name,
+            type: row.type,
+            origin: row.origin,
+            allowedPathPrefixes: row.allowed_path_prefixes,
+            allowedMethods: row.allowed_methods,
+            allowedContentTypes: row.allowed_content_types,
+            responseMaxBytes: row.response_max_bytes,
+            requestMaxBytes: row.request_max_bytes,
+            timeoutMs: row.timeout_ms,
+            rateLimitPerMinute: row.rate_limit_per_minute,
+            apiKeyName: row.api_key_name,
+            apiKeyLocation: row.api_key_location,
+            hasSecret,
+            createdByUserUuid: row.created_by_user_uuid,
+            updatedByUserUuid: row.updated_by_user_uuid,
+            createdAt: row.created_at,
+            updatedAt: row.updated_at,
+        };
+    }
+
+    async create(
+        projectUuid: string,
+        organizationUuid: string,
+        userUuid: string,
+        data: CreateExternalConnection,
+    ): Promise<ExternalConnection> {
+        return this.database.transaction(async (trx) => {
+            const [row] = await trx(ExternalConnectionsTableName)
+                .insert({
+                    project_uuid: projectUuid,
+                    organization_uuid: organizationUuid,
+                    name: data.name,
+                    type: data.type,
+                    origin: data.origin,
+                    allowed_path_prefixes: data.allowedPathPrefixes,
+                    allowed_methods: data.allowedMethods,
+                    allowed_content_types: data.allowedContentTypes,
+                    response_max_bytes:
+                        data.responseMaxBytes ??
+                        EXTERNAL_CONNECTION_DEFAULTS.responseMaxBytes,
+                    request_max_bytes:
+                        data.requestMaxBytes ??
+                        EXTERNAL_CONNECTION_DEFAULTS.requestMaxBytes,
+                    timeout_ms:
+                        data.timeoutMs ??
+                        EXTERNAL_CONNECTION_DEFAULTS.timeoutMs,
+                    rate_limit_per_minute: data.rateLimitPerMinute ?? null,
+                    api_key_name: data.apiKeyName ?? null,
+                    api_key_location: data.apiKeyLocation ?? null,
+                    created_by_user_uuid: userUuid,
+                    updated_by_user_uuid: userUuid,
+                })
+                .returning('*');
+
+            const secret = data.secret ?? null;
+            if (secret) {
+                await trx(ExternalConnectionSecretsTableName).insert({
+                    external_connection_uuid: row.external_connection_uuid,
+                    encrypted_payload: this.encryptionUtil.encrypt(secret),
+                });
+            }
+
+            return ExternalConnectionModel.mapToExternalConnection(
+                row,
+                Boolean(secret),
+            );
+        });
+    }
+
+    async list(projectUuid: string): Promise<ExternalConnection[]> {
+        const rows = await this.database(ExternalConnectionsTableName)
+            .leftJoin(
+                ExternalConnectionSecretsTableName,
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .where(`${ExternalConnectionsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
+            .orderBy(`${ExternalConnectionsTableName}.created_at`, 'desc')
+            .select<
+                Array<
+                    DbExternalConnection & { encrypted_payload: Buffer | null }
+                >
+            >(
+                `${ExternalConnectionsTableName}.*`,
+                `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+            );
+
+        return rows.map((row) =>
+            ExternalConnectionModel.mapToExternalConnection(
+                row,
+                row.encrypted_payload !== null,
+            ),
+        );
+    }
+
+    /** Strips the secret — returns the READ shape only. */
+    async findByUuid(uuid: string): Promise<ExternalConnection | undefined> {
+        const row = await this.database(ExternalConnectionsTableName)
+            .leftJoin(
+                ExternalConnectionSecretsTableName,
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .where(
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+                uuid,
+            )
+            .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
+            .first<
+                | (DbExternalConnection & { encrypted_payload: Buffer | null })
+                | undefined
+            >(
+                `${ExternalConnectionsTableName}.*`,
+                `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+            );
+
+        if (!row) {
+            return undefined;
+        }
+        return ExternalConnectionModel.mapToExternalConnection(
+            row,
+            row.encrypted_payload !== null,
+        );
+    }
+
+    /**
+     * INTERNAL ONLY — returns the decrypted secret. Used by the M2 proxy
+     * (`ExternalConnectionService.proxyFetch`). Never exposed via the API.
+     */
+    async getDecryptedSecret(uuid: string): Promise<string | null> {
+        const row = await this.database(ExternalConnectionSecretsTableName)
+            .where('external_connection_uuid', uuid)
+            .first();
+        if (!row) {
+            return null;
+        }
+        return this.encryptionUtil.decrypt(row.encrypted_payload);
+    }
+
+    async update(
+        uuid: string,
+        userUuid: string,
+        data: UpdateExternalConnection,
+    ): Promise<ExternalConnection> {
+        await this.database.transaction(async (trx) => {
+            const existing = await trx(ExternalConnectionsTableName)
+                .where('external_connection_uuid', uuid)
+                .whereNull('deleted_at')
+                .first();
+            if (!existing) {
+                throw new NotFoundError('External connection not found');
+            }
+
+            const updatePayload: Record<string, unknown> = {
+                updated_by_user_uuid: userUuid,
+                updated_at: trx.fn.now() as unknown as Date,
+            };
+            if (data.name !== undefined) updatePayload.name = data.name;
+            if (data.type !== undefined) updatePayload.type = data.type;
+            if (data.origin !== undefined) updatePayload.origin = data.origin;
+            if (data.allowedPathPrefixes !== undefined)
+                updatePayload.allowed_path_prefixes = data.allowedPathPrefixes;
+            if (data.allowedMethods !== undefined)
+                updatePayload.allowed_methods = data.allowedMethods;
+            if (data.allowedContentTypes !== undefined)
+                updatePayload.allowed_content_types = data.allowedContentTypes;
+            if (data.responseMaxBytes !== undefined)
+                updatePayload.response_max_bytes = data.responseMaxBytes;
+            if (data.requestMaxBytes !== undefined)
+                updatePayload.request_max_bytes = data.requestMaxBytes;
+            if (data.timeoutMs !== undefined)
+                updatePayload.timeout_ms = data.timeoutMs;
+            if (data.rateLimitPerMinute !== undefined)
+                updatePayload.rate_limit_per_minute = data.rateLimitPerMinute;
+            if (data.apiKeyName !== undefined)
+                updatePayload.api_key_name = data.apiKeyName;
+            if (data.apiKeyLocation !== undefined)
+                updatePayload.api_key_location = data.apiKeyLocation;
+
+            await trx(ExternalConnectionsTableName)
+                .where('external_connection_uuid', uuid)
+                .update(updatePayload);
+
+            // Blank / omitted secret = leave the stored secret unchanged.
+            if (data.secret !== undefined && data.secret) {
+                await ExternalConnectionModel.upsertSecret(
+                    trx,
+                    uuid,
+                    this.encryptionUtil.encrypt(data.secret),
+                );
+            }
+        });
+
+        const updated = await this.findByUuid(uuid);
+        if (!updated) {
+            throw new NotFoundError('External connection not found');
+        }
+        return updated;
+    }
+
+    async softDelete(uuid: string): Promise<void> {
+        const count = await this.database(ExternalConnectionsTableName)
+            .where('external_connection_uuid', uuid)
+            .whereNull('deleted_at')
+            .update({ deleted_at: this.database.fn.now() as unknown as Date });
+        if (count === 0) {
+            throw new NotFoundError('External connection not found');
+        }
+    }
+
+    async rotateSecret(uuid: string, secret: string): Promise<void> {
+        await ExternalConnectionModel.upsertSecret(
+            this.database,
+            uuid,
+            this.encryptionUtil.encrypt(secret),
+            true,
+        );
+    }
+
+    private static async upsertSecret(
+        db: Knex,
+        uuid: string,
+        encryptedPayload: Buffer,
+        markRotated = false,
+    ): Promise<void> {
+        await db(ExternalConnectionSecretsTableName)
+            .insert({
+                external_connection_uuid: uuid,
+                encrypted_payload: encryptedPayload,
+                ...(markRotated ? { rotated_at: db.fn.now() } : {}),
+            })
+            .onConflict('external_connection_uuid')
+            .merge({
+                encrypted_payload: encryptedPayload,
+                ...(markRotated ? { rotated_at: db.fn.now() } : {}),
+            });
+    }
+
+    async linkToApp(
+        appId: string,
+        externalConnectionUuid: string,
+        alias: string,
+    ): Promise<void> {
+        await this.database(AppExternalConnectionsTableName).insert({
+            app_id: appId,
+            external_connection_uuid: externalConnectionUuid,
+            alias,
+        });
+    }
+
+    async unlinkFromApp(appId: string, alias: string): Promise<void> {
+        const count = await this.database(AppExternalConnectionsTableName)
+            .where('app_id', appId)
+            .where('alias', alias)
+            .delete();
+        if (count === 0) {
+            throw new NotFoundError('App external connection link not found');
+        }
+    }
+
+    async listAppLinks(
+        appId: string,
+    ): Promise<Array<{ alias: string; connection: ExternalConnection }>> {
+        const rows = await this.database(AppExternalConnectionsTableName)
+            .innerJoin(
+                ExternalConnectionsTableName,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+                `${AppExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .leftJoin(
+                ExternalConnectionSecretsTableName,
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .where(`${AppExternalConnectionsTableName}.app_id`, appId)
+            .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
+            .select<
+                Array<
+                    DbExternalConnection & {
+                        alias: string;
+                        encrypted_payload: Buffer | null;
+                    }
+                >
+            >(
+                `${ExternalConnectionsTableName}.*`,
+                `${AppExternalConnectionsTableName}.alias`,
+                `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+            );
+
+        return rows.map((row) => ({
+            alias: row.alias,
+            connection: ExternalConnectionModel.mapToExternalConnection(
+                row,
+                row.encrypted_payload !== null,
+            ),
+        }));
+    }
+
+    /** Returns the connection if it is linked to the app under `alias` and not soft-deleted. */
+    async resolveAppAlias(
+        appId: string,
+        alias: string,
+    ): Promise<ExternalConnection | undefined> {
+        const row = await this.database(AppExternalConnectionsTableName)
+            .innerJoin(
+                ExternalConnectionsTableName,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+                `${AppExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .leftJoin(
+                ExternalConnectionSecretsTableName,
+                `${ExternalConnectionSecretsTableName}.external_connection_uuid`,
+                `${ExternalConnectionsTableName}.external_connection_uuid`,
+            )
+            .where(`${AppExternalConnectionsTableName}.app_id`, appId)
+            .where(`${AppExternalConnectionsTableName}.alias`, alias)
+            .whereNull(`${ExternalConnectionsTableName}.deleted_at`)
+            .first<
+                | (DbExternalConnection & { encrypted_payload: Buffer | null })
+                | undefined
+            >(
+                `${ExternalConnectionsTableName}.*`,
+                `${ExternalConnectionSecretsTableName}.encrypted_payload`,
+            );
+
+        if (!row) {
+            return undefined;
+        }
+        return ExternalConnectionModel.mapToExternalConnection(
+            row,
+            row.encrypted_payload !== null,
+        );
+    }
+
+    /**
+     * Looks up an app with its organization UUID for use in assertCanManageApp.
+     * Returns undefined if the app is not found or soft-deleted.
+     */
+    async findApp(appUuid: string): Promise<DbApp | undefined> {
+        return this.database(AppsTableName)
+            .innerJoin(
+                'projects',
+                'projects.project_uuid',
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                'organizations',
+                'organizations.organization_id',
+                'projects.organization_id',
+            )
+            .where(`${AppsTableName}.app_id`, appUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .first<DbApp | undefined>(
+                `${AppsTableName}.app_id`,
+                `${AppsTableName}.project_uuid`,
+                `${AppsTableName}.space_uuid`,
+                `${AppsTableName}.created_by_user_uuid`,
+                'organizations.organization_uuid',
+            );
+    }
+
+    /**
+     * Atomically bumps the per-(connection, app, window) counter and returns
+     * the new count. Consumed by the M2 proxy's rate limiter.
+     */
+    async incrementRateCounter(
+        externalConnectionUuid: string,
+        appId: string,
+        windowStartedAt: Date,
+    ): Promise<number> {
+        const [row] = await this.database(
+            ExternalConnectionRateCountersTableName,
+        )
+            .insert({
+                external_connection_uuid: externalConnectionUuid,
+                app_id: appId,
+                window_started_at: windowStartedAt,
+                request_count: 1,
+            })
+            .onConflict([
+                'external_connection_uuid',
+                'app_id',
+                'window_started_at',
+            ])
+            .merge({
+                request_count: this.database.raw(
+                    `${ExternalConnectionRateCountersTableName}.request_count + 1`,
+                ) as unknown as number,
+            })
+            .returning('request_count');
+
+        return row.request_count;
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
@@ -1,0 +1,206 @@
+import { Ability } from '@casl/ability';
+import {
+    FeatureFlags,
+    ForbiddenError,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    type CreateExternalConnection,
+    type SessionAccount,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+import { ExternalConnectionService } from './ExternalConnectionService';
+
+const PROJECT_UUID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const ORG_UUID = 'aaaaaaaa-0000-0000-0000-000000000002';
+const USER_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const APP_UUID = 'aaaaaaaa-0000-0000-0000-000000000003';
+
+const mockAccount: SessionAccount = {
+    organization: {
+        organizationUuid: ORG_UUID,
+        name: 'Test Org',
+        createdAt: new Date(),
+    },
+    authentication: {
+        type: 'session',
+        source: 'mock-session',
+    },
+    user: {
+        type: 'registered',
+        id: USER_UUID,
+        userUuid: USER_UUID,
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        isTrackingAnonymized: false,
+        isMarketingOptedIn: false,
+        timezone: null,
+        isSetupComplete: true,
+        userId: 1,
+        role: OrganizationMemberRole.ADMIN,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        abilityRules: [],
+        ability: new Ability<PossibleAbilities>([
+            {
+                subject: 'ExternalConnection',
+                action: ['manage'],
+            },
+            {
+                subject: 'DataApp',
+                action: ['manage'],
+            },
+        ]),
+    },
+    isAuthenticated: jest.fn().mockReturnValue(true),
+    isRegisteredUser: jest.fn().mockReturnValue(true),
+    isAnonymousUser: jest.fn().mockReturnValue(false),
+    isSessionUser: jest.fn().mockReturnValue(true),
+    isJwtUser: jest.fn().mockReturnValue(false),
+    isServiceAccount: jest.fn().mockReturnValue(false),
+    isPatUser: jest.fn().mockReturnValue(false),
+    isOauthUser: jest.fn().mockReturnValue(false),
+};
+
+const makeFeatureFlagModel = (enabled: boolean) =>
+    ({
+        get: jest.fn().mockResolvedValue({ enabled }),
+    }) as unknown as FeatureFlagModel;
+
+const makeExternalConnectionModel = () =>
+    ({
+        create: jest.fn(),
+        list: jest.fn().mockResolvedValue([]),
+        findByUuid: jest.fn(),
+        update: jest.fn(),
+        softDelete: jest.fn(),
+        rotateSecret: jest.fn(),
+        findApp: jest.fn(),
+        listAppLinks: jest.fn(),
+        linkToApp: jest.fn(),
+        unlinkFromApp: jest.fn(),
+    }) as unknown as ExternalConnectionModel;
+
+const makeSpacePermissionService = () =>
+    ({
+        getSpaceAccessContext: jest.fn(),
+    }) as unknown as SpacePermissionService;
+
+const makeAnalytics = () =>
+    ({
+        track: jest.fn(),
+    }) as unknown as LightdashAnalytics;
+
+const buildService = (enabled: boolean) => {
+    const featureFlagModel = makeFeatureFlagModel(enabled);
+    const externalConnectionModel = makeExternalConnectionModel();
+    const spacePermissionService = makeSpacePermissionService();
+    const analytics = makeAnalytics();
+    const service = new ExternalConnectionService({
+        analytics,
+        externalConnectionModel,
+        featureFlagModel,
+        spacePermissionService,
+    });
+    return { service, featureFlagModel, externalConnectionModel };
+};
+
+const minimalCreate: CreateExternalConnection = {
+    name: 'Test Connection',
+    type: 'bearer_token',
+    origin: 'https://api.example.com',
+    allowedPathPrefixes: ['/v1/'],
+    allowedMethods: ['GET'],
+    allowedContentTypes: ['application/json'],
+    responseMaxBytes: 1048576,
+    requestMaxBytes: 262144,
+    timeoutMs: 10000,
+    rateLimitPerMinute: null,
+    apiKeyName: null,
+    apiKeyLocation: null,
+    secret: 'tok_secret',
+};
+
+describe('ExternalConnectionService feature flag gate', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('flag OFF — all public methods reject with ForbiddenError', () => {
+        it('create rejects with ForbiddenError and does not call the model', async () => {
+            const { service, externalConnectionModel } = buildService(false);
+
+            await expect(
+                service.create(
+                    mockAccount,
+                    PROJECT_UUID,
+                    ORG_UUID,
+                    minimalCreate,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(externalConnectionModel.create).not.toHaveBeenCalled();
+        });
+
+        it('list rejects with ForbiddenError and does not call the model', async () => {
+            const { service, externalConnectionModel } = buildService(false);
+
+            await expect(
+                service.list(mockAccount, PROJECT_UUID),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(externalConnectionModel.list).not.toHaveBeenCalled();
+        });
+
+        it('linkToApp rejects with ForbiddenError and does not call the model', async () => {
+            const { service, externalConnectionModel } = buildService(false);
+
+            await expect(
+                service.linkToApp(
+                    mockAccount,
+                    PROJECT_UUID,
+                    APP_UUID,
+                    'conn-uuid',
+                    'my-alias',
+                ),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(externalConnectionModel.findApp).not.toHaveBeenCalled();
+            expect(externalConnectionModel.linkToApp).not.toHaveBeenCalled();
+        });
+
+        it('featureFlagModel.get is called with correct args when flag is OFF', async () => {
+            const { service, featureFlagModel } = buildService(false);
+
+            await expect(
+                service.list(mockAccount, PROJECT_UUID),
+            ).rejects.toThrow(ForbiddenError);
+
+            expect(featureFlagModel.get).toHaveBeenCalledWith({
+                user: {
+                    userUuid: USER_UUID,
+                    organizationUuid: ORG_UUID,
+                    organizationName: 'Test Org',
+                },
+                featureFlagId: FeatureFlags.EnableDataAppExternalAccess,
+            });
+        });
+    });
+
+    describe('flag ON — list proceeds past the guard', () => {
+        it('list resolves when the flag is enabled', async () => {
+            const { service, externalConnectionModel } = buildService(true);
+
+            const result = await service.list(mockAccount, PROJECT_UUID);
+
+            expect(result).toEqual([]);
+            expect(externalConnectionModel.list).toHaveBeenCalledWith(
+                PROJECT_UUID,
+            );
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     FeatureFlags,
     ForbiddenError,
+    NotFoundError,
     OrganizationMemberRole,
     PossibleAbilities,
     type CreateExternalConnection,
@@ -75,6 +76,7 @@ const makeExternalConnectionModel = () =>
     ({
         create: jest.fn(),
         list: jest.fn().mockResolvedValue([]),
+        getProjectOrganizationUuid: jest.fn().mockResolvedValue(ORG_UUID),
         findByUuid: jest.fn(),
         update: jest.fn(),
         softDelete: jest.fn(),
@@ -135,12 +137,7 @@ describe('ExternalConnectionService feature flag gate', () => {
             const { service, externalConnectionModel } = buildService(false);
 
             await expect(
-                service.create(
-                    mockAccount,
-                    PROJECT_UUID,
-                    ORG_UUID,
-                    minimalCreate,
-                ),
+                service.create(mockAccount, PROJECT_UUID, minimalCreate),
             ).rejects.toThrow(ForbiddenError);
 
             expect(externalConnectionModel.create).not.toHaveBeenCalled();
@@ -200,7 +197,78 @@ describe('ExternalConnectionService feature flag gate', () => {
             expect(result).toEqual([]);
             expect(externalConnectionModel.list).toHaveBeenCalledWith(
                 PROJECT_UUID,
+                ORG_UUID,
             );
         });
+    });
+});
+
+describe('ExternalConnectionService — org is derived from the project', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('create rejects with NotFoundError when the project has no org', async () => {
+        const { service, externalConnectionModel } = buildService(true);
+        (
+            externalConnectionModel.getProjectOrganizationUuid as jest.Mock
+        ).mockResolvedValue(null);
+
+        await expect(
+            service.create(mockAccount, PROJECT_UUID, minimalCreate),
+        ).rejects.toThrow(NotFoundError);
+
+        expect(externalConnectionModel.create).not.toHaveBeenCalled();
+    });
+
+    it('list derives the org from the project and filters by it', async () => {
+        const { service, externalConnectionModel } = buildService(true);
+
+        await service.list(mockAccount, PROJECT_UUID);
+
+        expect(
+            externalConnectionModel.getProjectOrganizationUuid,
+        ).toHaveBeenCalledWith(PROJECT_UUID);
+        expect(externalConnectionModel.list).toHaveBeenCalledWith(
+            PROJECT_UUID,
+            ORG_UUID,
+        );
+    });
+});
+
+describe('ExternalConnectionService — cross-project link is rejected', () => {
+    const OTHER_PROJECT_UUID = 'bbbbbbbb-0000-0000-0000-000000000099';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('linkToApp rejects when the connection belongs to a different project', async () => {
+        const { service, externalConnectionModel } = buildService(true);
+        (externalConnectionModel.findApp as jest.Mock).mockResolvedValue({
+            app_id: APP_UUID,
+            project_uuid: PROJECT_UUID,
+            space_uuid: null,
+            created_by_user_uuid: USER_UUID,
+            organization_uuid: ORG_UUID,
+        });
+        // Connection lives in another project → getOwnedConnection must reject.
+        (externalConnectionModel.findByUuid as jest.Mock).mockResolvedValue({
+            externalConnectionUuid: 'conn-uuid',
+            projectUuid: OTHER_PROJECT_UUID,
+            organizationUuid: ORG_UUID,
+        });
+
+        await expect(
+            service.linkToApp(
+                mockAccount,
+                PROJECT_UUID,
+                APP_UUID,
+                'conn-uuid',
+                'my-alias',
+            ),
+        ).rejects.toThrow(NotFoundError);
+
+        expect(externalConnectionModel.linkToApp).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     NotImplementedError,
@@ -9,6 +10,7 @@ import {
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
@@ -16,6 +18,7 @@ import { type ExternalConnectionModel } from '../../models/ExternalConnectionMod
 type ExternalConnectionServiceArguments = {
     analytics: LightdashAnalytics;
     externalConnectionModel: ExternalConnectionModel;
+    featureFlagModel: FeatureFlagModel;
     spacePermissionService: SpacePermissionService;
 };
 
@@ -24,13 +27,34 @@ export class ExternalConnectionService extends BaseService {
 
     private readonly externalConnectionModel: ExternalConnectionModel;
 
+    private readonly featureFlagModel: FeatureFlagModel;
+
     private readonly spacePermissionService: SpacePermissionService;
 
     constructor(args: ExternalConnectionServiceArguments) {
         super();
         this.analytics = args.analytics;
         this.externalConnectionModel = args.externalConnectionModel;
+        this.featureFlagModel = args.featureFlagModel;
         this.spacePermissionService = args.spacePermissionService;
+    }
+
+    private async assertExternalAccessEnabled(
+        account: RegisteredAccount,
+    ): Promise<void> {
+        const { enabled } = await this.featureFlagModel.get({
+            user: {
+                userUuid: account.user.userUuid,
+                organizationUuid: account.organization.organizationUuid,
+                organizationName: account.organization.name,
+            },
+            featureFlagId: FeatureFlags.EnableDataAppExternalAccess,
+        });
+        if (!enabled) {
+            throw new ForbiddenError(
+                'Data app external access is not enabled for this organization',
+            );
+        }
     }
 
     private assertCanManage(
@@ -106,6 +130,7 @@ export class ExternalConnectionService extends BaseService {
         organizationUuid: string,
         data: CreateExternalConnection,
     ): Promise<ExternalConnection> {
+        await this.assertExternalAccessEnabled(account);
         this.assertCanManage(account, projectUuid, organizationUuid);
         const connection = await this.externalConnectionModel.create(
             projectUuid,
@@ -130,6 +155,7 @@ export class ExternalConnectionService extends BaseService {
         account: RegisteredAccount,
         projectUuid: string,
     ): Promise<ExternalConnection[]> {
+        await this.assertExternalAccessEnabled(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
@@ -161,6 +187,7 @@ export class ExternalConnectionService extends BaseService {
         projectUuid: string,
         connectionUuid: string,
     ): Promise<ExternalConnection> {
+        await this.assertExternalAccessEnabled(account);
         return this.getOwnedConnection(account, projectUuid, connectionUuid);
     }
 
@@ -170,6 +197,7 @@ export class ExternalConnectionService extends BaseService {
         connectionUuid: string,
         data: UpdateExternalConnection,
     ): Promise<ExternalConnection> {
+        await this.assertExternalAccessEnabled(account);
         const existing = await this.getOwnedConnection(
             account,
             projectUuid,
@@ -197,6 +225,7 @@ export class ExternalConnectionService extends BaseService {
         projectUuid: string,
         connectionUuid: string,
     ): Promise<void> {
+        await this.assertExternalAccessEnabled(account);
         const existing = await this.getOwnedConnection(
             account,
             projectUuid,
@@ -220,6 +249,7 @@ export class ExternalConnectionService extends BaseService {
         connectionUuid: string,
         secret: string,
     ): Promise<ExternalConnection> {
+        await this.assertExternalAccessEnabled(account);
         const existing = await this.getOwnedConnection(
             account,
             projectUuid,
@@ -243,6 +273,7 @@ export class ExternalConnectionService extends BaseService {
         projectUuid: string,
         appUuid: string,
     ): Promise<Array<{ alias: string; connection: ExternalConnection }>> {
+        await this.assertExternalAccessEnabled(account);
         const app = await this.assertCanManageApp(account, appUuid);
         if (app.project_uuid !== projectUuid) {
             throw new NotFoundError('Data app not found');
@@ -257,6 +288,7 @@ export class ExternalConnectionService extends BaseService {
         externalConnectionUuid: string,
         alias: string,
     ): Promise<void> {
+        await this.assertExternalAccessEnabled(account);
         const app = await this.assertCanManageApp(account, appUuid);
         if (app.project_uuid !== projectUuid) {
             throw new NotFoundError('Data app not found');
@@ -290,6 +322,7 @@ export class ExternalConnectionService extends BaseService {
         appUuid: string,
         alias: string,
     ): Promise<void> {
+        await this.assertExternalAccessEnabled(account);
         const app = await this.assertCanManageApp(account, appUuid);
         if (app.project_uuid !== projectUuid) {
             throw new NotFoundError('Data app not found');

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -14,6 +14,7 @@ import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagMo
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+import { validateExternalConnectionConfig } from './externalConnectionConfigValidation';
 
 type ExternalConnectionServiceArguments = {
     analytics: LightdashAnalytics;
@@ -127,11 +128,20 @@ export class ExternalConnectionService extends BaseService {
     async create(
         account: RegisteredAccount,
         projectUuid: string,
-        organizationUuid: string,
         data: CreateExternalConnection,
     ): Promise<ExternalConnection> {
         await this.assertExternalAccessEnabled(account);
+        // Derive the org from the project — never trust the caller's org — so an
+        // org admin cannot create a connection against another org's project.
+        const organizationUuid =
+            await this.externalConnectionModel.getProjectOrganizationUuid(
+                projectUuid,
+            );
+        if (!organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
         this.assertCanManage(account, projectUuid, organizationUuid);
+        validateExternalConnectionConfig(data, Boolean(data.secret));
         const connection = await this.externalConnectionModel.create(
             projectUuid,
             organizationUuid,
@@ -156,12 +166,17 @@ export class ExternalConnectionService extends BaseService {
         projectUuid: string,
     ): Promise<ExternalConnection[]> {
         await this.assertExternalAccessEnabled(account);
-        const { organizationUuid } = account.organization;
+        // Derive the org from the project, not the caller, and filter by both,
+        // so an org admin cannot list another org's project's connections.
+        const organizationUuid =
+            await this.externalConnectionModel.getProjectOrganizationUuid(
+                projectUuid,
+            );
         if (!organizationUuid) {
-            throw new ForbiddenError('User must be in an organization');
+            throw new NotFoundError('Project not found');
         }
         this.assertCanManage(account, projectUuid, organizationUuid);
-        return this.externalConnectionModel.list(projectUuid);
+        return this.externalConnectionModel.list(projectUuid, organizationUuid);
     }
 
     private async getOwnedConnection(
@@ -202,6 +217,41 @@ export class ExternalConnectionService extends BaseService {
             account,
             projectUuid,
             connectionUuid,
+        );
+        // Validate the resulting (merged) config so a partial update can't
+        // leave the connection in an invalid or unsafe state.
+        const hasSecretAfter =
+            data.secret === null
+                ? false
+                : Boolean(data.secret) || existing.hasSecret;
+        validateExternalConnectionConfig(
+            {
+                type: data.type ?? existing.type,
+                origin: data.origin ?? existing.origin,
+                allowedPathPrefixes:
+                    data.allowedPathPrefixes ?? existing.allowedPathPrefixes,
+                allowedMethods: data.allowedMethods ?? existing.allowedMethods,
+                allowedContentTypes:
+                    data.allowedContentTypes ?? existing.allowedContentTypes,
+                responseMaxBytes:
+                    data.responseMaxBytes ?? existing.responseMaxBytes,
+                requestMaxBytes:
+                    data.requestMaxBytes ?? existing.requestMaxBytes,
+                timeoutMs: data.timeoutMs ?? existing.timeoutMs,
+                rateLimitPerMinute:
+                    data.rateLimitPerMinute !== undefined
+                        ? data.rateLimitPerMinute
+                        : existing.rateLimitPerMinute,
+                apiKeyName:
+                    data.apiKeyName !== undefined
+                        ? data.apiKeyName
+                        : existing.apiKeyName,
+                apiKeyLocation:
+                    data.apiKeyLocation !== undefined
+                        ? data.apiKeyLocation
+                        : existing.apiKeyLocation,
+            },
+            hasSecretAfter,
         );
         const updated = await this.externalConnectionModel.update(
             connectionUuid,

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -298,18 +298,17 @@ export class ExternalConnectionService extends BaseService {
             app.app_id,
         );
         const link = links.find((l) => l.alias === alias);
+        if (!link) {
+            throw new NotFoundError('App external connection link not found');
+        }
         await this.externalConnectionModel.unlinkFromApp(app.app_id, alias);
         this.analytics.track({
             event: 'external_connection.unlinked',
             userId: account.user.id,
             properties: {
-                organizationId:
-                    link?.connection.organizationUuid ??
-                    account.organization.organizationUuid ??
-                    '',
+                organizationId: link.connection.organizationUuid,
                 projectId: projectUuid,
-                externalConnectionUuid:
-                    link?.connection.externalConnectionUuid ?? '',
+                externalConnectionUuid: link.connection.externalConnectionUuid,
                 appUuid,
                 alias,
             },

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -1,0 +1,344 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    NotFoundError,
+    NotImplementedError,
+    type CreateExternalConnection,
+    type ExternalConnection,
+    type RegisteredAccount,
+    type UpdateExternalConnection,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
+import { BaseService } from '../../../services/BaseService';
+import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+
+type ExternalConnectionServiceArguments = {
+    analytics: LightdashAnalytics;
+    externalConnectionModel: ExternalConnectionModel;
+    spacePermissionService: SpacePermissionService;
+};
+
+export class ExternalConnectionService extends BaseService {
+    private readonly analytics: LightdashAnalytics;
+
+    private readonly externalConnectionModel: ExternalConnectionModel;
+
+    private readonly spacePermissionService: SpacePermissionService;
+
+    constructor(args: ExternalConnectionServiceArguments) {
+        super();
+        this.analytics = args.analytics;
+        this.externalConnectionModel = args.externalConnectionModel;
+        this.spacePermissionService = args.spacePermissionService;
+    }
+
+    private assertCanManage(
+        account: RegisteredAccount,
+        projectUuid: string,
+        organizationUuid: string,
+    ): void {
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('ExternalConnection', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage external connections',
+            );
+        }
+    }
+
+    /**
+     * Loads the app row and asserts the caller can `manage` the DataApp,
+     * mirroring AppGenerateService's assertCanManageApp pattern (space
+     * context + createdByUserUuid). Returns the app row for downstream use.
+     */
+    private async assertCanManageApp(
+        account: RegisteredAccount,
+        appUuid: string,
+    ): Promise<{
+        app_id: string;
+        project_uuid: string;
+        space_uuid: string | null;
+        created_by_user_uuid: string;
+        organization_uuid: string;
+    }> {
+        const app = await this.externalConnectionModel.findApp(appUuid);
+        if (!app) {
+            throw new NotFoundError('Data app not found');
+        }
+
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  account.user.id,
+                  app.space_uuid,
+              )
+            : {};
+
+        const ability = this.createAuditedAbility(account);
+        if (
+            ability.cannot(
+                'manage',
+                subject('DataApp', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid: app.project_uuid,
+                    createdByUserUuid: app.created_by_user_uuid,
+                    ...spaceContext,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage this data app',
+            );
+        }
+        return app;
+    }
+
+    async create(
+        account: RegisteredAccount,
+        projectUuid: string,
+        organizationUuid: string,
+        data: CreateExternalConnection,
+    ): Promise<ExternalConnection> {
+        this.assertCanManage(account, projectUuid, organizationUuid);
+        const connection = await this.externalConnectionModel.create(
+            projectUuid,
+            organizationUuid,
+            account.user.id,
+            data,
+        );
+        this.analytics.track({
+            event: 'external_connection.created',
+            userId: account.user.id,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                externalConnectionUuid: connection.externalConnectionUuid,
+                authType: connection.type,
+            },
+        });
+        return connection;
+    }
+
+    async list(
+        account: RegisteredAccount,
+        projectUuid: string,
+    ): Promise<ExternalConnection[]> {
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must be in an organization');
+        }
+        this.assertCanManage(account, projectUuid, organizationUuid);
+        return this.externalConnectionModel.list(projectUuid);
+    }
+
+    private async getOwnedConnection(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<ExternalConnection> {
+        const connection =
+            await this.externalConnectionModel.findByUuid(connectionUuid);
+        if (!connection || connection.projectUuid !== projectUuid) {
+            throw new NotFoundError('External connection not found');
+        }
+        this.assertCanManage(
+            account,
+            connection.projectUuid,
+            connection.organizationUuid,
+        );
+        return connection;
+    }
+
+    async get(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<ExternalConnection> {
+        return this.getOwnedConnection(account, projectUuid, connectionUuid);
+    }
+
+    async update(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+        data: UpdateExternalConnection,
+    ): Promise<ExternalConnection> {
+        const existing = await this.getOwnedConnection(
+            account,
+            projectUuid,
+            connectionUuid,
+        );
+        const updated = await this.externalConnectionModel.update(
+            connectionUuid,
+            account.user.id,
+            data,
+        );
+        this.analytics.track({
+            event: 'external_connection.updated',
+            userId: account.user.id,
+            properties: {
+                organizationId: existing.organizationUuid,
+                projectId: projectUuid,
+                externalConnectionUuid: connectionUuid,
+            },
+        });
+        return updated;
+    }
+
+    async delete(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+    ): Promise<void> {
+        const existing = await this.getOwnedConnection(
+            account,
+            projectUuid,
+            connectionUuid,
+        );
+        await this.externalConnectionModel.softDelete(connectionUuid);
+        this.analytics.track({
+            event: 'external_connection.deleted',
+            userId: account.user.id,
+            properties: {
+                organizationId: existing.organizationUuid,
+                projectId: projectUuid,
+                externalConnectionUuid: connectionUuid,
+            },
+        });
+    }
+
+    async rotateSecret(
+        account: RegisteredAccount,
+        projectUuid: string,
+        connectionUuid: string,
+        secret: string,
+    ): Promise<ExternalConnection> {
+        const existing = await this.getOwnedConnection(
+            account,
+            projectUuid,
+            connectionUuid,
+        );
+        await this.externalConnectionModel.rotateSecret(connectionUuid, secret);
+        this.analytics.track({
+            event: 'external_connection.secret_rotated',
+            userId: account.user.id,
+            properties: {
+                organizationId: existing.organizationUuid,
+                projectId: projectUuid,
+                externalConnectionUuid: connectionUuid,
+            },
+        });
+        return this.getOwnedConnection(account, projectUuid, connectionUuid);
+    }
+
+    async listAppLinks(
+        account: RegisteredAccount,
+        projectUuid: string,
+        appUuid: string,
+    ): Promise<Array<{ alias: string; connection: ExternalConnection }>> {
+        const app = await this.assertCanManageApp(account, appUuid);
+        if (app.project_uuid !== projectUuid) {
+            throw new NotFoundError('Data app not found');
+        }
+        return this.externalConnectionModel.listAppLinks(app.app_id);
+    }
+
+    async linkToApp(
+        account: RegisteredAccount,
+        projectUuid: string,
+        appUuid: string,
+        externalConnectionUuid: string,
+        alias: string,
+    ): Promise<void> {
+        const app = await this.assertCanManageApp(account, appUuid);
+        if (app.project_uuid !== projectUuid) {
+            throw new NotFoundError('Data app not found');
+        }
+        const connection = await this.getOwnedConnection(
+            account,
+            projectUuid,
+            externalConnectionUuid,
+        );
+        await this.externalConnectionModel.linkToApp(
+            app.app_id,
+            externalConnectionUuid,
+            alias,
+        );
+        this.analytics.track({
+            event: 'external_connection.linked',
+            userId: account.user.id,
+            properties: {
+                organizationId: connection.organizationUuid,
+                projectId: projectUuid,
+                externalConnectionUuid,
+                appUuid,
+                alias,
+            },
+        });
+    }
+
+    async unlinkFromApp(
+        account: RegisteredAccount,
+        projectUuid: string,
+        appUuid: string,
+        alias: string,
+    ): Promise<void> {
+        const app = await this.assertCanManageApp(account, appUuid);
+        if (app.project_uuid !== projectUuid) {
+            throw new NotFoundError('Data app not found');
+        }
+        const links = await this.externalConnectionModel.listAppLinks(
+            app.app_id,
+        );
+        const link = links.find((l) => l.alias === alias);
+        await this.externalConnectionModel.unlinkFromApp(app.app_id, alias);
+        this.analytics.track({
+            event: 'external_connection.unlinked',
+            userId: account.user.id,
+            properties: {
+                organizationId:
+                    link?.connection.organizationUuid ??
+                    account.organization.organizationUuid ??
+                    '',
+                projectId: projectUuid,
+                externalConnectionUuid:
+                    link?.connection.externalConnectionUuid ?? '',
+                appUuid,
+                alias,
+            },
+        });
+    }
+
+    /**
+     * EXTENSION POINT (M2): the data-app outbound proxy. Validates the
+     * request against the connection's allow-lists, applies the rate
+     * limiter (`externalConnectionModel.incrementRateCounter`), injects the
+     * decrypted secret (`getDecryptedSecret`), and performs the fetch.
+     * Intentionally unimplemented in M1.
+     */
+    // eslint-disable-next-line class-methods-use-this
+    async proxyFetch(): Promise<never> {
+        throw new NotImplementedError(
+            'proxyFetch is implemented in milestone M2',
+        );
+    }
+
+    /**
+     * EXTENSION POINT (M5): a "test connection" dry-run that exercises
+     * proxyFetch against the connection's origin without persisting.
+     * Intentionally unimplemented in M1.
+     */
+    // eslint-disable-next-line class-methods-use-this
+    async testConnection(): Promise<never> {
+        throw new NotImplementedError(
+            'testConnection is implemented in milestone M5',
+        );
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.test.ts
@@ -1,0 +1,155 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    validateExternalConnectionConfig,
+    type ValidatableExternalConnectionConfig,
+} from './externalConnectionConfigValidation';
+
+const base: ValidatableExternalConnectionConfig = {
+    type: 'none',
+    origin: 'https://api.example.com',
+    allowedPathPrefixes: ['/v1/'],
+    allowedMethods: ['GET'],
+    allowedContentTypes: ['application/json'],
+};
+
+describe('validateExternalConnectionConfig', () => {
+    it('accepts a valid no-auth config', () => {
+        expect(() =>
+            validateExternalConnectionConfig(base, false),
+        ).not.toThrow();
+    });
+
+    describe('origin', () => {
+        it('rejects non-https', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, origin: 'http://api.example.com' },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects a path on the origin', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, origin: 'https://api.example.com/v1' },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects embedded credentials', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, origin: 'https://user:pass@api.example.com' },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects a non-URL', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, origin: 'not a url' },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+    });
+
+    describe('auth invariants', () => {
+        it('rejects a none connection that carries a secret', () => {
+            expect(() => validateExternalConnectionConfig(base, true)).toThrow(
+                ParameterError,
+            );
+        });
+
+        it('rejects bearer_token without a secret', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, type: 'bearer_token' },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts bearer_token with a secret', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, type: 'bearer_token' },
+                    true,
+                ),
+            ).not.toThrow();
+        });
+
+        it('rejects api_key missing name/location', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, type: 'api_key' },
+                    true,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts api_key with name + location + secret', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    {
+                        ...base,
+                        type: 'api_key',
+                        apiKeyName: 'X-Api-Key',
+                        apiKeyLocation: 'header',
+                    },
+                    true,
+                ),
+            ).not.toThrow();
+        });
+    });
+
+    describe('allowlists and limits', () => {
+        it('rejects empty methods', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, allowedMethods: [] },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects an unsupported method', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, allowedMethods: ['DELETE'] },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects empty content types', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, allowedContentTypes: [] },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects path traversal in a prefix', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, allowedPathPrefixes: ['/v1/../secrets'] },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('rejects an out-of-bounds timeout', () => {
+            expect(() =>
+                validateExternalConnectionConfig(
+                    { ...base, timeoutMs: 999_999 },
+                    false,
+                ),
+            ).toThrow(ParameterError);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/externalConnectionConfigValidation.ts
@@ -1,0 +1,194 @@
+import {
+    assertUnreachable,
+    ParameterError,
+    type ApiKeyLocation,
+    type ExternalConnectionAuthType,
+} from '@lightdash/common';
+
+// Defense-in-depth caps for the numeric limits. The runtime proxy enforces
+// these too, but bad config should never be persisted in the first place.
+const MAX_RESPONSE_BYTES = 25 * 1024 * 1024; // 25 MiB
+const MAX_REQUEST_BYTES = 10 * 1024 * 1024; // 10 MiB
+const MAX_TIMEOUT_MS = 120_000; // 2 minutes
+const MAX_RATE_LIMIT = 100_000;
+
+const SUPPORTED_METHODS = new Set(['GET', 'POST']);
+// RFC 7230 token chars — valid for HTTP header names and a safe set for query keys.
+const HTTP_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
+const CONTENT_TYPE = /^[a-z0-9*]+\/[a-z0-9.+*-]+$/i;
+// Must be an absolute path with no whitespace, query, or fragment.
+const PATH_PREFIX = /^\/[^\s?#]*$/;
+
+/**
+ * The complete, resolved connection config to validate. For create this is the
+ * request body; for update it's the merged (existing + patch) result, so the
+ * invariants always hold on the post-write state.
+ */
+export type ValidatableExternalConnectionConfig = {
+    type: ExternalConnectionAuthType;
+    origin: string;
+    allowedPathPrefixes: string[];
+    allowedMethods: string[];
+    allowedContentTypes: string[];
+    responseMaxBytes?: number;
+    requestMaxBytes?: number;
+    timeoutMs?: number;
+    rateLimitPerMinute?: number | null;
+    apiKeyName?: string | null;
+    apiKeyLocation?: ApiKeyLocation | null;
+};
+
+const assertBoundedInt = (
+    value: number | undefined,
+    name: string,
+    max: number,
+): void => {
+    if (value === undefined) return;
+    if (!Number.isInteger(value) || value < 1 || value > max) {
+        throw new ParameterError(
+            `${name} must be an integer between 1 and ${max}`,
+        );
+    }
+};
+
+/**
+ * Server-side validation for an external connection's security config. TypeScript
+ * types and TSOA shape-checks are not sufficient for this trust boundary, so we
+ * reject (rather than store) anything outside the allowed shape.
+ *
+ * `hasSecretAfter` is whether a secret will exist on the connection once the
+ * write completes (true if one is supplied or already stored and not cleared).
+ */
+export function validateExternalConnectionConfig(
+    config: ValidatableExternalConnectionConfig,
+    hasSecretAfter: boolean,
+): void {
+    // --- origin: https, bare host only ---
+    let url: URL;
+    try {
+        url = new URL(config.origin);
+    } catch {
+        throw new ParameterError('origin must be a valid absolute URL');
+    }
+    if (url.protocol !== 'https:') {
+        throw new ParameterError('origin must use https');
+    }
+    if (url.username || url.password) {
+        throw new ParameterError('origin must not contain credentials');
+    }
+    if ((url.pathname && url.pathname !== '/') || url.search || url.hash) {
+        throw new ParameterError(
+            'origin must be a bare host with no path, query, or fragment',
+        );
+    }
+    if (!url.hostname) {
+        throw new ParameterError('origin must include a host');
+    }
+
+    // --- path prefixes: absolute, no traversal ---
+    config.allowedPathPrefixes.forEach((prefix) => {
+        if (
+            typeof prefix !== 'string' ||
+            !PATH_PREFIX.test(prefix) ||
+            prefix.includes('..')
+        ) {
+            throw new ParameterError(
+                `Invalid path prefix: ${JSON.stringify(prefix)}`,
+            );
+        }
+    });
+
+    // --- methods: non-empty, supported only ---
+    if (config.allowedMethods.length === 0) {
+        throw new ParameterError('At least one allowed method is required');
+    }
+    config.allowedMethods.forEach((method) => {
+        if (!SUPPORTED_METHODS.has(method)) {
+            throw new ParameterError(`Unsupported method: ${method}`);
+        }
+    });
+
+    // --- content types: non-empty, valid tokens ---
+    if (config.allowedContentTypes.length === 0) {
+        throw new ParameterError(
+            'At least one allowed content type is required',
+        );
+    }
+    config.allowedContentTypes.forEach((contentType) => {
+        if (
+            typeof contentType !== 'string' ||
+            !CONTENT_TYPE.test(contentType)
+        ) {
+            throw new ParameterError(
+                `Invalid content type: ${JSON.stringify(contentType)}`,
+            );
+        }
+    });
+
+    // --- numeric limits ---
+    assertBoundedInt(
+        config.responseMaxBytes,
+        'responseMaxBytes',
+        MAX_RESPONSE_BYTES,
+    );
+    assertBoundedInt(
+        config.requestMaxBytes,
+        'requestMaxBytes',
+        MAX_REQUEST_BYTES,
+    );
+    assertBoundedInt(config.timeoutMs, 'timeoutMs', MAX_TIMEOUT_MS);
+    if (
+        config.rateLimitPerMinute !== undefined &&
+        config.rateLimitPerMinute !== null
+    ) {
+        assertBoundedInt(
+            config.rateLimitPerMinute,
+            'rateLimitPerMinute',
+            MAX_RATE_LIMIT,
+        );
+    }
+
+    // --- auth invariants ---
+    switch (config.type) {
+        case 'none':
+            if (hasSecretAfter) {
+                throw new ParameterError('type "none" must not have a secret');
+            }
+            if (config.apiKeyName || config.apiKeyLocation) {
+                throw new ParameterError(
+                    'type "none" must not set an api key name or location',
+                );
+            }
+            break;
+        case 'bearer_token':
+            if (!hasSecretAfter) {
+                throw new ParameterError(
+                    'type "bearer_token" requires a secret',
+                );
+            }
+            break;
+        case 'api_key':
+            if (!hasSecretAfter) {
+                throw new ParameterError('type "api_key" requires a secret');
+            }
+            if (!config.apiKeyName || !HTTP_TOKEN.test(config.apiKeyName)) {
+                throw new ParameterError(
+                    'type "api_key" requires a valid apiKeyName',
+                );
+            }
+            if (
+                config.apiKeyLocation !== 'header' &&
+                config.apiKeyLocation !== 'query'
+            ) {
+                throw new ParameterError(
+                    'type "api_key" requires apiKeyLocation of "header" or "query"',
+                );
+            }
+            break;
+        default:
+            assertUnreachable(
+                config.type,
+                'Unknown external connection auth type',
+            );
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -143,6 +143,8 @@ import { DatabricksSSOController } from './../ee/controllers/databricksSSOContro
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { EmbedController } from './../ee/controllers/embedController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { ExternalConnectionController } from './../ee/controllers/externalConnectionController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ManagedAgentController } from './../ee/controllers/managedAgentController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { OrganizationDomainVerificationController } from './../ee/controllers/OrganizationDomainVerificationController';
@@ -1652,6 +1654,354 @@ const models: TsoaRoute.Models = {
                 sessionId: { dataType: 'string', required: true },
                 projectUuid: { dataType: 'string', required: true },
                 actionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExternalConnectionAuthType: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['none'] },
+                { dataType: 'enum', enums: ['api_key'] },
+                { dataType: 'enum', enums: ['bearer_token'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExternalConnectionMethod: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['GET'] },
+                { dataType: 'enum', enums: ['POST'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiKeyLocation: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['header'] },
+                { dataType: 'enum', enums: ['query'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExternalConnection: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'datetime', required: true },
+                createdAt: { dataType: 'datetime', required: true },
+                updatedByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                hasSecret: { dataType: 'boolean', required: true },
+                apiKeyLocation: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ApiKeyLocation' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                apiKeyName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                rateLimitPerMinute: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                timeoutMs: { dataType: 'double', required: true },
+                requestMaxBytes: { dataType: 'double', required: true },
+                responseMaxBytes: { dataType: 'double', required: true },
+                allowedContentTypes: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                allowedMethods: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'ExternalConnectionMethod',
+                    },
+                    required: true,
+                },
+                allowedPathPrefixes: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                origin: { dataType: 'string', required: true },
+                type: { ref: 'ExternalConnectionAuthType', required: true },
+                name: { dataType: 'string', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                externalConnectionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiExternalConnectionResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ExternalConnection', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateExternalConnection: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                secret: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                apiKeyLocation: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ApiKeyLocation' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                apiKeyName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                rateLimitPerMinute: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                timeoutMs: { dataType: 'double' },
+                requestMaxBytes: { dataType: 'double' },
+                responseMaxBytes: { dataType: 'double' },
+                allowedContentTypes: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                allowedMethods: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'ExternalConnectionMethod',
+                    },
+                    required: true,
+                },
+                allowedPathPrefixes: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                origin: { dataType: 'string', required: true },
+                type: { ref: 'ExternalConnectionAuthType', required: true },
+                name: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiExternalConnectionListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ExternalConnection' },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    Partial_CreateExternalConnection_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                type: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ExternalConnectionAuthType' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                origin: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                allowedPathPrefixes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                allowedMethods: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'ExternalConnectionMethod',
+                            },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                allowedContentTypes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                responseMaxBytes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                requestMaxBytes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                timeoutMs: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                rateLimitPerMinute: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                apiKeyName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                apiKeyLocation: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ApiKeyLocation' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                secret: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateExternalConnection: {
+        dataType: 'refAlias',
+        type: { ref: 'Partial_CreateExternalConnection_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAppExternalConnectionListResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            connection: {
+                                ref: 'ExternalConnection',
+                                required: true,
+                            },
+                            alias: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
@@ -10771,8 +11121,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -11397,8 +11747,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -22809,7 +23159,6 @@ const models: TsoaRoute.Models = {
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
-                    user: { dataType: 'string', required: true },
                     type: {
                         dataType: 'union',
                         subSchemas: [
@@ -22821,6 +23170,7 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
+                    user: { dataType: 'string', required: true },
                 },
                 validators: {},
             },
@@ -22929,8 +23279,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                user: { dataType: 'string', required: true },
                 type: { ref: 'WarehouseTypes.REDSHIFT', required: true },
+                user: { dataType: 'string', required: true },
                 password: { dataType: 'string', required: true },
             },
             validators: {},
@@ -22942,8 +23292,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                user: { dataType: 'string', required: true },
                 type: { ref: 'WarehouseTypes.POSTGRES', required: true },
+                user: { dataType: 'string', required: true },
                 password: { dataType: 'string', required: true },
             },
             validators: {},
@@ -22956,8 +23306,8 @@ const models: TsoaRoute.Models = {
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
-                    user: { dataType: 'string', required: true },
                     type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
+                    user: { dataType: 'string', required: true },
                     password: {
                         dataType: 'union',
                         subSchemas: [
@@ -22989,8 +23339,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                user: { dataType: 'string', required: true },
                 type: { ref: 'WarehouseTypes.TRINO', required: true },
+                user: { dataType: 'string', required: true },
                 password: { dataType: 'string', required: true },
             },
             validators: {},
@@ -23002,8 +23352,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                user: { dataType: 'string', required: true },
                 type: { ref: 'WarehouseTypes.CLICKHOUSE', required: true },
+                user: { dataType: 'string', required: true },
                 password: { dataType: 'string', required: true },
             },
             validators: {},
@@ -29392,7 +29742,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29402,7 +29752,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29412,7 +29762,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29425,7 +29775,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30080,7 +30430,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30090,7 +30440,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30100,7 +30450,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30113,7 +30463,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -41688,6 +42038,635 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_createExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateExternalConnection',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/external-connections',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.createExternalConnection,
+        ),
+
+        async function ExternalConnectionController_createExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_createExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_listExternalConnections: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/external-connections',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.listExternalConnections,
+        ),
+
+        async function ExternalConnectionController_listExternalConnections(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_listExternalConnections,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listExternalConnections',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_getExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        connectionUuid: {
+            in: 'path',
+            name: 'connectionUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/external-connections/:connectionUuid',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.getExternalConnection,
+        ),
+
+        async function ExternalConnectionController_getExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_getExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_updateExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        connectionUuid: {
+            in: 'path',
+            name: 'connectionUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateExternalConnection',
+        },
+    };
+    app.patch(
+        '/api/v1/ee/projects/:projectUuid/external-connections/:connectionUuid',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.updateExternalConnection,
+        ),
+
+        async function ExternalConnectionController_updateExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_updateExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_deleteExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        connectionUuid: {
+            in: 'path',
+            name: 'connectionUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/ee/projects/:projectUuid/external-connections/:connectionUuid',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.deleteExternalConnection,
+        ),
+
+        async function ExternalConnectionController_deleteExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_deleteExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_rotateExternalConnectionSecret: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        connectionUuid: {
+            in: 'path',
+            name: 'connectionUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                secret: { dataType: 'string', required: true },
+            },
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/external-connections/:connectionUuid/rotate-secret',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype
+                .rotateExternalConnectionSecret,
+        ),
+
+        async function ExternalConnectionController_rotateExternalConnectionSecret(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_rotateExternalConnectionSecret,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'rotateExternalConnectionSecret',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_listAppExternalConnections: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/external-connections',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.listAppExternalConnections,
+        ),
+
+        async function ExternalConnectionController_listAppExternalConnections(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_listAppExternalConnections,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listAppExternalConnections',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_linkAppExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                alias: { dataType: 'string', required: true },
+                externalConnectionUuid: { dataType: 'string', required: true },
+            },
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/external-connections',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.linkAppExternalConnection,
+        ),
+
+        async function ExternalConnectionController_linkAppExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_linkAppExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'linkAppExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_unlinkAppExternalConnection: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+        alias: {
+            in: 'path',
+            name: 'alias',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/external-connections/:alias',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.unlinkAppExternalConnection,
+        ),
+
+        async function ExternalConnectionController_unlinkAppExternalConnection(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_unlinkAppExternalConnection,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'unlinkAppExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1660,6 +1660,331 @@
                 ],
                 "type": "object"
             },
+            "ExternalConnectionAuthType": {
+                "type": "string",
+                "enum": ["none", "api_key", "bearer_token"]
+            },
+            "ExternalConnectionMethod": {
+                "type": "string",
+                "enum": ["GET", "POST"]
+            },
+            "ApiKeyLocation": {
+                "type": "string",
+                "enum": ["header", "query"]
+            },
+            "ExternalConnection": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updatedByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "hasSecret": {
+                        "type": "boolean"
+                    },
+                    "apiKeyLocation": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiKeyLocation"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "apiKeyName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "rateLimitPerMinute": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "requestMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "responseMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "allowedContentTypes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allowedMethods": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExternalConnectionMethod"
+                        },
+                        "type": "array"
+                    },
+                    "allowedPathPrefixes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "origin": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ExternalConnectionAuthType"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "externalConnectionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "createdAt",
+                    "updatedByUserUuid",
+                    "createdByUserUuid",
+                    "hasSecret",
+                    "apiKeyLocation",
+                    "apiKeyName",
+                    "rateLimitPerMinute",
+                    "timeoutMs",
+                    "requestMaxBytes",
+                    "responseMaxBytes",
+                    "allowedContentTypes",
+                    "allowedMethods",
+                    "allowedPathPrefixes",
+                    "origin",
+                    "type",
+                    "name",
+                    "organizationUuid",
+                    "projectUuid",
+                    "externalConnectionUuid"
+                ],
+                "type": "object",
+                "description": "READ shape returned by the API — NEVER includes the secret value."
+            },
+            "ApiExternalConnectionResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ExternalConnection"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "CreateExternalConnection": {
+                "properties": {
+                    "secret": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "apiKeyLocation": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiKeyLocation"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "apiKeyName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "rateLimitPerMinute": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "requestMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "responseMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "allowedContentTypes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allowedMethods": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExternalConnectionMethod"
+                        },
+                        "type": "array"
+                    },
+                    "allowedPathPrefixes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "origin": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ExternalConnectionAuthType"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "allowedContentTypes",
+                    "allowedMethods",
+                    "allowedPathPrefixes",
+                    "origin",
+                    "type",
+                    "name"
+                ],
+                "type": "object",
+                "description": "WRITE shape — includes the secret."
+            },
+            "ApiExternalConnectionListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExternalConnection"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Partial_CreateExternalConnection_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ExternalConnectionAuthType"
+                    },
+                    "origin": {
+                        "type": "string"
+                    },
+                    "allowedPathPrefixes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "allowedMethods": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExternalConnectionMethod"
+                        },
+                        "type": "array"
+                    },
+                    "allowedContentTypes": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "responseMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "requestMaxBytes": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "timeoutMs": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "rateLimitPerMinute": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "apiKeyName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "apiKeyLocation": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiKeyLocation"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "secret": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "type": "object",
+                "description": "Make all properties in T optional"
+            },
+            "UpdateExternalConnection": {
+                "$ref": "#/components/schemas/Partial_CreateExternalConnection_",
+                "description": "Omitted/blank `secret` means the stored secret is left unchanged."
+            },
+            "ApiAppExternalConnectionListResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "properties": {
+                                "connection": {
+                                    "$ref": "#/components/schemas/ExternalConnection"
+                                },
+                                "alias": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["connection", "alias"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_Organization.name-or-createdAt-or-organizationUuid_": {
                 "properties": {
                     "name": {
@@ -12396,7 +12721,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -13009,7 +13334,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -23257,9 +23582,6 @@
             },
             "Pick_CreateRedshiftCredentials-or-CreatePostgresCredentials-or-CreateSnowflakeCredentials-or-CreateTrinoCredentials-or-CreateClickhouseCredentials.type-or-user_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "anyOf": [
                             {
@@ -23278,9 +23600,12 @@
                                 "$ref": "#/components/schemas/WarehouseTypes.CLICKHOUSE"
                             }
                         ]
+                    },
+                    "user": {
+                        "type": "string"
                     }
                 },
-                "required": ["user", "type"],
+                "required": ["type", "user"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -23403,43 +23728,43 @@
             },
             "Pick_CreateRedshiftCredentials.type-or-user-or-password_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.REDSHIFT"
+                    },
+                    "user": {
+                        "type": "string"
                     },
                     "password": {
                         "type": "string"
                     }
                 },
-                "required": ["user", "type", "password"],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "Pick_CreatePostgresCredentials.type-or-user-or-password_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
+                    },
+                    "user": {
+                        "type": "string"
                     },
                     "password": {
                         "type": "string"
                     }
                 },
-                "required": ["user", "type", "password"],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "Pick_CreateSnowflakeCredentials.type-or-user-or-password-or-authenticationType-or-refreshToken_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
+                    },
+                    "user": {
+                        "type": "string"
                     },
                     "password": {
                         "type": "string"
@@ -23451,39 +23776,39 @@
                         "$ref": "#/components/schemas/SnowflakeAuthenticationType"
                     }
                 },
-                "required": ["user", "type"],
+                "required": ["type", "user"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "Pick_CreateTrinoCredentials.type-or-user-or-password_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.TRINO"
+                    },
+                    "user": {
+                        "type": "string"
                     },
                     "password": {
                         "type": "string"
                     }
                 },
-                "required": ["user", "type", "password"],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
             "Pick_CreateClickhouseCredentials.type-or-user-or-password_": {
                 "properties": {
-                    "user": {
-                        "type": "string"
-                    },
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.CLICKHOUSE"
+                    },
+                    "user": {
+                        "type": "string"
                     },
                     "password": {
                         "type": "string"
                     }
                 },
-                "required": ["user", "type", "password"],
+                "required": ["type", "user", "password"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -30140,22 +30465,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -30715,22 +31040,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -39821,7 +40146,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3193.0",
+        "version": "0.3198.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -152,6 +152,7 @@ export type ModelManifest = {
     embedModel: unknown;
     dashboardSummaryModel: unknown;
     serviceAccountModel: unknown;
+    externalConnectionModel: unknown;
 };
 
 /**
@@ -804,6 +805,10 @@ export class ModelRepository
 
     public getServiceAccountModel<ModelImplT>(): ModelImplT {
         return this.getModel('serviceAccountModel');
+    }
+
+    public getExternalConnectionModel<ModelImplT>(): ModelImplT {
+        return this.getModel('externalConnectionModel');
     }
 
     public getSpotlightTableConfigModel(): SpotlightTableConfigModel {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -162,6 +162,7 @@ interface ServiceManifest {
     supportService: unknown;
     cacheService: unknown;
     serviceAccountService: unknown;
+    externalConnectionService: unknown;
     instanceConfigurationService: unknown;
     managedAgentService: unknown;
     mcpService: unknown;
@@ -1464,6 +1465,12 @@ export class ServiceRepository
         ServiceAccountServiceImplT,
     >(): ServiceAccountServiceImplT {
         return this.getService('serviceAccountService');
+    }
+
+    public getExternalConnectionService<
+        ExternalConnectionServiceImplT,
+    >(): ExternalConnectionServiceImplT {
+        return this.getService('externalConnectionService');
     }
 
     public getOrganizationWarehouseCredentialsService<

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -378,6 +378,10 @@ export const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
 
+        can('manage', 'ExternalConnection', {
+            organizationUuid: member.organizationUuid,
+        });
+
         can('manage', 'OrganizationDesign', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -330,6 +330,10 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
 
+        can('manage', 'ExternalConnection', {
+            projectUuid: member.projectUuid,
+        });
+
         can('manage', 'ContentVerification', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -151,6 +151,7 @@ const BASE_ROLE_SCOPES = {
     [ProjectMemberRole.ADMIN]: [
         // Admin-specific permissions
         'manage:DataApp',
+        'manage:ExternalConnection',
         'manage:OrganizationDesign',
         'delete:Project', // Any project
         'view:Analytics',
@@ -265,6 +266,7 @@ export const getNonEnterpriseScopesForRole = (
         'create:DataApp',
         'view:DataApp@self',
         'manage:DataApp@self',
+        'manage:ExternalConnection',
         'view:OrganizationDesign',
         'manage:OrganizationDesign',
         'manage:PersonalAccessToken',

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -79,6 +79,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     'AiAgentThread',
     'ContentAsCode',
     'PreAggregation',
+    'ExternalConnection',
     // The matching scopes (`view:` + `manage:OrganizationWarehouseCredentials`)
     // are `isEnterprise: true` in scopes.ts, so the scope-build path
     // strips them in non-enterprise mode. Mirror that filter on the

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -870,6 +870,17 @@ const scopes: Scope[] = [
         ],
     },
 
+    // External Connections — project-scoped allowlisted outbound HTTP endpoints
+    // that data apps reach through the secure fetch proxy. Admin-only.
+    {
+        name: 'manage:ExternalConnection',
+        description:
+            'Create, edit, and delete external API connections used by data apps',
+        isEnterprise: true,
+        group: ScopeGroup.AI,
+        getConditions: addDefaultUuidCondition,
+    },
+
     // Organization Design Assets (shared CSS/fonts/images/instructions
     // injected into every data app generated in the org). Org-scoped
     // resource — view is available to all members, manage to org admins.

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -321,6 +321,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'DataApp', {
             organizationUuid,
         });
+        can('manage', 'ExternalConnection', {
+            organizationUuid,
+        });
         can('manage', 'OrganizationDesign', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -38,6 +38,7 @@ export type CaslSubjectNames =
     | 'DashboardComments'
     | 'DeletedContent'
     | 'Explore'
+    | 'ExternalConnection'
     | 'ExportCsv'
     | 'GitIntegration'
     | 'GoogleSheets'

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -1,0 +1,59 @@
+export type ExternalConnectionAuthType = 'none' | 'api_key' | 'bearer_token';
+export type ExternalConnectionMethod = 'GET' | 'POST';
+export type ApiKeyLocation = 'header' | 'query';
+
+/** READ shape returned by the API — NEVER includes the secret value. */
+export type ExternalConnection = {
+    externalConnectionUuid: string;
+    projectUuid: string;
+    organizationUuid: string;
+    name: string;
+    type: ExternalConnectionAuthType;
+    origin: string;
+    allowedPathPrefixes: string[];
+    allowedMethods: ExternalConnectionMethod[];
+    allowedContentTypes: string[];
+    responseMaxBytes: number;
+    requestMaxBytes: number;
+    timeoutMs: number;
+    rateLimitPerMinute: number | null;
+    apiKeyName: string | null;
+    apiKeyLocation: ApiKeyLocation | null;
+    hasSecret: boolean;
+    createdByUserUuid: string | null;
+    updatedByUserUuid: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+/** WRITE shape — includes the secret. */
+export type CreateExternalConnection = {
+    name: string;
+    type: ExternalConnectionAuthType;
+    origin: string;
+    allowedPathPrefixes: string[];
+    allowedMethods: ExternalConnectionMethod[];
+    allowedContentTypes: string[];
+    responseMaxBytes?: number; // server default 1048576
+    requestMaxBytes?: number; // server default 262144
+    timeoutMs?: number; // server default 10000
+    rateLimitPerMinute?: number | null;
+    apiKeyName?: string | null;
+    apiKeyLocation?: ApiKeyLocation | null;
+    secret?: string | null; // bearer token or api key value; null for type 'none'
+};
+
+/** Omitted/blank `secret` means the stored secret is left unchanged. */
+export type UpdateExternalConnection = Partial<CreateExternalConnection>;
+
+export type AppExternalConnectionLink = {
+    externalConnectionUuid: string;
+    alias: string;
+};
+
+/** Server-applied defaults for the optional numeric limits. */
+export const EXTERNAL_CONNECTION_DEFAULTS = {
+    responseMaxBytes: 1048576,
+    requestMaxBytes: 262144,
+    timeoutMs: 10000,
+} as const;

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -1,5 +1,6 @@
 export * from './AiAgent';
 export * from './aiWriteback/types';
+export * from './externalConnections/types';
 export * from './AiRouter';
 export * from './apps/types';
 export * from './ambientAi';

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -89,6 +89,14 @@ export enum FeatureFlags {
     EnableDataApps = 'enable-data-apps',
 
     /**
+     * Enable the data-app external-fetch proxy: external connections, the proxy
+     * endpoint, the admin settings page, and the iframe bridge path. Disabled by
+     * default; must be turned on per organization. When off, every external-access
+     * code path is locked down.
+     */
+    EnableDataAppExternalAccess = 'enable-data-app-external-access',
+
+    /**
      * Enable AI Dashboard Summary feature (generates summaries of dashboard
      * contents using the AI Copilot).
      */


### PR DESCRIPTION
The backend foundation for project-scoped **external connections** — named, locked-down outbound HTTP endpoints data apps can reach through a proxy (added in the next PR).

- **Data model**: 3 tables + an encrypted model (AES-256-GCM, `LIGHTDASH_SECRET`) storing a **write-only** secret; CRUD + app-link service & controller.
- **New `manage:ExternalConnection` scope** (admin-only) wired across all 6 ability layers + the parity test.
- **Introduces the `enable-data-app-external-access` flag** (default off) and guards every CRUD/link method behind it.

**Notes:** secrets are never returned by the API (only `hasSecret`). Includes a jsonb-on-write serialization fix that mocked-knex unit tests missed and a live Postgres run caught.

---
**Stack:** Data App External Fetch Proxy — PR 2/6 · everything is gated behind the `enable-data-app-external-access` feature flag (default **off** → every code path locked).

_Linear: TODO — add ticket (`Closes: PROD-XXXX`)._
