### PR TITLE
feat(data-apps): external-fetch proxy endpoint

### DIFF
--- a/packages/backend/src/ee/analytics/externalConnections.ts
+++ b/packages/backend/src/ee/analytics/externalConnections.ts
@@ -42,4 +42,26 @@ export type ExternalConnectionEvent = BaseTrack &
                   alias: string;
               };
           }
+        | {
+              event: 'external_connection.fetch';
+              userId: string;
+              properties: {
+                  organizationId: string;
+                  projectId: string;
+                  appUuid: string;
+                  externalConnectionUuid: string;
+                  connectionAlias: string;
+                  method: 'GET' | 'POST';
+                  path: string;
+                  status: number | null;
+                  outcome:
+                      | 'ok'
+                      | 'rejected'
+                      | 'rate_limited'
+                      | 'upstream_error';
+                  durationMs: number;
+                  requestBytes: number;
+                  responseBytes: number;
+              };
+          }
     );

--- a/packages/backend/src/ee/controllers/externalConnectionController.ts
+++ b/packages/backend/src/ee/controllers/externalConnectionController.ts
@@ -3,6 +3,8 @@ import {
     type ApiErrorPayload,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalFetchRequest,
+    type ExternalFetchResponse,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import {
@@ -21,6 +23,7 @@ import {
     SuccessResponse,
 } from '@tsoa/runtime';
 import express from 'express';
+import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -42,6 +45,11 @@ type ApiExternalConnectionListResponse = {
 type ApiAppExternalConnectionListResponse = {
     status: 'ok';
     results: Array<{ alias: string; connection: ExternalConnection }>;
+};
+
+type ApiExternalFetchResponse = {
+    status: 'ok';
+    results: ExternalFetchResponse;
 };
 
 @Route('/api/v1/ee/projects/{projectUuid}')
@@ -295,11 +303,38 @@ export class ExternalConnectionController extends BaseController {
         return { status: 'ok', results: undefined };
     }
 
-    // FORWARD REFS (do not implement here):
-    // - M2 adds `@Post('apps/{appUuid}/external-fetch')` (the outbound proxy)
-    //   to this controller, delegating to ExternalConnectionService.proxyFetch.
-    // - M5 adds `@Post('external-connections/{connectionUuid}/test')`
-    //   delegating to ExternalConnectionService.testConnection.
+    /**
+     * Proxy an outbound HTTP request from a data app through a configured,
+     * authorized connection alias. The app never sees the connection's secret
+     * or origin — only the alias + a relative path.
+     * @summary External fetch proxy for data apps
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('apps/{appUuid}/external-fetch')
+    @OperationId('externalFetch')
+    async externalFetch(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Body() body: ExternalFetchRequest,
+    ): Promise<ApiExternalFetchResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results = await this.getService().proxyFetch(
+            toSessionUser(req.account),
+            projectUuid,
+            appUuid,
+            body,
+        );
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    // M5 adds `@Post('external-connections/{connectionUuid}/test')`
+    // delegating to ExternalConnectionService.testConnection.
 
     private getService(): ExternalConnectionService {
         return this.services.getExternalConnectionService<ExternalConnectionService>();

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -422,6 +422,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     externalConnectionModel:
                         models.getExternalConnectionModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
+                    appModel: models.getAppModel(),
                     spacePermissionService:
                         repository.getSpacePermissionService(),
                 }),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -77,6 +77,7 @@ import type { SavedChartService } from '../../../services/SavedChartsService/Sav
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
+import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
 import {
     classifyClaudeCliFailure,
     ClaudeGenerationError,
@@ -256,19 +257,17 @@ export class AppGenerateService extends BaseService {
             organization_uuid: string;
         },
     ): Promise<void> {
-        const spaceContext = app.space_uuid
-            ? await this.spacePermissionService.getSpaceAccessContext(
-                  user.userUuid,
-                  app.space_uuid,
-              )
-            : {};
-        this.assertDataAppAbility(
+        await assertUserCanViewApp(
+            {
+                auditedAbility: this.createAuditedAbility(user),
+                getSpaceAccessContext: (userUuid, spaceUuid) =>
+                    this.spacePermissionService.getSpaceAccessContext(
+                        userUuid,
+                        spaceUuid,
+                    ),
+            },
             user,
-            'view',
-            app.organization_uuid,
-            app.project_uuid,
-            'Insufficient permissions to access this data app',
-            { ...spaceContext, createdByUserUuid: app.created_by_user_uuid },
+            app,
         );
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/appAuthz.ts
@@ -1,0 +1,50 @@
+import { subject, type Ability } from '@casl/ability';
+import { ForbiddenError, type SessionUser } from '@lightdash/common';
+import { type CaslAuditWrapper } from '../../../logging/caslAuditWrapper';
+
+export type AppViewAuthzApp = {
+    project_uuid: string;
+    space_uuid: string | null;
+    created_by_user_uuid: string;
+    organization_uuid: string;
+};
+
+export type AppViewAuthzDeps = {
+    auditedAbility: CaslAuditWrapper<Ability>;
+    getSpaceAccessContext: (
+        userUuid: string,
+        spaceUuid: string,
+    ) => Promise<Record<string, unknown>>;
+};
+
+export async function userCanViewApp(
+    deps: AppViewAuthzDeps,
+    user: SessionUser,
+    app: AppViewAuthzApp,
+): Promise<boolean> {
+    const spaceContext = app.space_uuid
+        ? await deps.getSpaceAccessContext(user.userUuid, app.space_uuid)
+        : {};
+    return deps.auditedAbility.can(
+        'view',
+        subject('DataApp', {
+            organizationUuid: app.organization_uuid,
+            projectUuid: app.project_uuid,
+            ...spaceContext,
+            createdByUserUuid: app.created_by_user_uuid,
+        }),
+    );
+}
+
+export async function assertCanViewApp(
+    deps: AppViewAuthzDeps,
+    user: SessionUser,
+    app: AppViewAuthzApp,
+): Promise<void> {
+    const allowed = await userCanViewApp(deps, user, app);
+    if (!allowed) {
+        throw new ForbiddenError(
+            'Insufficient permissions to access this data app',
+        );
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
@@ -97,15 +97,22 @@ const makeAnalytics = () =>
         track: jest.fn(),
     }) as unknown as LightdashAnalytics;
 
+const makeAppModel = () =>
+    ({
+        getApp: jest.fn(),
+    }) as unknown as import('../../../models/AppModel').AppModel;
+
 const buildService = (enabled: boolean) => {
     const featureFlagModel = makeFeatureFlagModel(enabled);
     const externalConnectionModel = makeExternalConnectionModel();
     const spacePermissionService = makeSpacePermissionService();
     const analytics = makeAnalytics();
+    const appModel = makeAppModel();
     const service = new ExternalConnectionService({
         analytics,
         externalConnectionModel,
         featureFlagModel,
+        appModel,
         spacePermissionService,
     });
     return { service, featureFlagModel, externalConnectionModel };

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -383,6 +383,36 @@ describe('ExternalConnectionService.proxyFetch', () => {
         expect(res.body).toBe('not json{');
     });
 
+    it('rejects a GET when the serialized query string exceeds requestMaxBytes', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ requestMaxBytes: 10 }),
+        });
+        // A query string longer than 10 bytes should be rejected before secureFetch.
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method: 'GET',
+                path: '/v1/today',
+                query: { city: 'this-is-a-very-long-city-name' },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('maps a malformed connection origin to a generic ParameterError (no stack exposed)', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ origin: 'not-a-valid-url' }),
+        });
+        const promise = service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        await expect(promise).rejects.toBeInstanceOf(ParameterError);
+        // The raw TypeError from new URL() must not reach the client.
+        const err = await promise.catch((e) => e);
+        expect(err.message).not.toMatch(/Invalid URL/i);
+    });
+
     it('emits an audit event without bodies or secrets', async () => {
         const { service, analytics } = buildService({
             connection: baseConnection({ type: 'bearer_token' }),

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -1,0 +1,412 @@
+import {
+    ForbiddenError,
+    ParameterError,
+    type ExternalConnection,
+    type SessionUser,
+} from '@lightdash/common';
+import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
+import * as secureFetchModule from '../../../utils/secureFetch/secureFetch';
+import { ExternalConnectionService } from './ExternalConnectionService';
+
+jest.mock('../../../utils/secureFetch/secureFetch');
+
+const mockSecureFetch = jest.mocked(secureFetchModule.secureFetch);
+
+const baseConnection = (
+    overrides: Partial<ExternalConnection> = {},
+): ExternalConnection => ({
+    externalConnectionUuid: 'conn-1',
+    projectUuid: 'proj-1',
+    organizationUuid: 'org-1',
+    name: 'Weather API',
+    type: 'none',
+    origin: 'https://api.example.com',
+    allowedPathPrefixes: ['/v1/'],
+    allowedMethods: ['GET', 'POST'],
+    allowedContentTypes: ['application/json'],
+    responseMaxBytes: 1_000_000,
+    requestMaxBytes: 10_000,
+    timeoutMs: 5_000,
+    rateLimitPerMinute: null,
+    apiKeyName: null,
+    apiKeyLocation: null,
+    hasSecret: false,
+    createdByUserUuid: 'user-1',
+    updatedByUserUuid: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+});
+
+const baseApp = () => ({
+    app_id: 'app-1',
+    project_uuid: 'proj-1',
+    space_uuid: null,
+    created_by_user_uuid: 'user-1',
+    organization_uuid: 'org-1',
+});
+
+const user = {
+    userUuid: 'user-1',
+    organizationUuid: 'org-1',
+    ability: { can: () => true },
+} as unknown as SessionUser;
+
+function buildService(opts: {
+    connection?: ExternalConnection | undefined;
+    secret?: string | null;
+    canView?: boolean;
+    rateCount?: number;
+}) {
+    const externalConnectionModel = {
+        resolveAppAlias: jest.fn().mockResolvedValue(opts.connection),
+        getDecryptedSecret: jest.fn().mockResolvedValue(opts.secret ?? null),
+        incrementRateCounter: jest.fn().mockResolvedValue(opts.rateCount ?? 1),
+    };
+    const appModel = {
+        getApp: jest.fn().mockResolvedValue(baseApp()),
+    };
+    const projectModel = {
+        getSummary: jest.fn().mockResolvedValue({ organizationUuid: 'org-1' }),
+    };
+    const spacePermissionService = {
+        getSpaceAccessContext: jest.fn().mockResolvedValue({}),
+    };
+    const analytics = { track: jest.fn() };
+
+    const service = new ExternalConnectionService({
+        externalConnectionModel,
+        appModel,
+        projectModel,
+        spacePermissionService,
+        analytics,
+    } as never);
+
+    // Force the CASL view decision deterministically.
+    jest.spyOn(
+        service as unknown as { createAuditedAbility: () => unknown },
+        'createAuditedAbility',
+    ).mockReturnValue({
+        can: () => opts.canView ?? true,
+        cannot: () => !(opts.canView ?? true),
+    });
+
+    return { service, externalConnectionModel, appModel, analytics };
+}
+
+beforeEach(() => {
+    mockSecureFetch.mockReset();
+    mockSecureFetch.mockResolvedValue({
+        status: 200,
+        contentType: 'application/json',
+        bodyText: '{"ok":true}',
+        truncated: false,
+    });
+});
+
+describe('ExternalConnectionService.proxyFetch', () => {
+    it('rejects when the alias is not linked to the app', async () => {
+        const { service } = buildService({ connection: undefined });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('throws ForbiddenError when the user cannot view the app', async () => {
+        const { service } = buildService({
+            connection: baseConnection(),
+            canView: false,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('rejects a method not in the connection allowlist', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ allowedMethods: ['GET'] }),
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method: 'POST',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('rejects an absolute URL in path', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: 'https://evil.com/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('rejects .. traversal in path', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/../admin',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('rejects encoded-host //evil.com', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '//evil.com/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('rejects a path matching no allowed prefix', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ allowedPathPrefixes: ['/v1/'] }),
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/admin/secrets',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+    });
+
+    it('happy GET: calls secureFetch with the server-built URL and no body', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+        const res = await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/today',
+            query: { city: 'oslo' },
+        });
+        expect(mockSecureFetch).toHaveBeenCalledTimes(1);
+        const [url, opts] = mockSecureFetch.mock.calls[0];
+        expect(url).toBe('https://api.example.com/v1/today?city=oslo');
+        expect(opts.method).toBe('GET');
+        expect(opts.body).toBeUndefined();
+        expect(opts.timeoutMs).toBe(5_000);
+        expect(opts.maxResponseBytes).toBe(1_000_000);
+        expect(opts.allowedContentTypes).toEqual(['application/json']);
+        expect(res).toEqual({
+            status: 200,
+            contentType: 'application/json',
+            body: { ok: true },
+            truncated: false,
+        });
+    });
+
+    it('GET is never rate-limited even when a limit is set', async () => {
+        const { service, externalConnectionModel } = buildService({
+            connection: baseConnection({ rateLimitPerMinute: 1 }),
+            rateCount: 99,
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        expect(
+            externalConnectionModel.incrementRateCounter,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('happy POST: server sets Content-Type and serializes the body', async () => {
+        const { service } = buildService({ connection: baseConnection() });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            method: 'POST',
+            path: '/v1/echo',
+            body: { hello: 'world' },
+        });
+        const [, opts] = mockSecureFetch.mock.calls[0];
+        expect(opts.method).toBe('POST');
+        expect(opts.body).toBe('{"hello":"world"}');
+        expect(opts.headers!['Content-Type']).toBe('application/json');
+    });
+
+    it('POST over requestMaxBytes is rejected', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ requestMaxBytes: 5 }),
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method: 'POST',
+                path: '/v1/echo',
+                body: { hello: 'world' },
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('injects a bearer token into the Authorization header', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ type: 'bearer_token' }),
+            secret: 'tok_abc',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        const [, opts] = mockSecureFetch.mock.calls[0];
+        expect(opts.headers!.Authorization).toBe('Bearer tok_abc');
+    });
+
+    it('injects an api_key into a header', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'api_key',
+                apiKeyName: 'X-Api-Key',
+                apiKeyLocation: 'header',
+            }),
+            secret: 'sec_123',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        const [url, opts] = mockSecureFetch.mock.calls[0];
+        expect(opts.headers!['X-Api-Key']).toBe('sec_123');
+        expect(url).not.toContain('sec_123');
+    });
+
+    it('injects an api_key into the query string', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'api_key',
+                apiKeyName: 'apikey',
+                apiKeyLocation: 'query',
+            }),
+            secret: 'sec_q',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+            query: { a: '1' },
+        });
+        const [url, opts] = mockSecureFetch.mock.calls[0];
+        expect(new URL(url).searchParams.get('apikey')).toBe('sec_q');
+        expect(opts.headers!.Authorization).toBeUndefined();
+    });
+
+    it.each([['blocked_ip'], ['redirect'], ['too_large'], ['timeout']])(
+        'maps SecureFetchError(%s) to a ParameterError with no raw detail',
+        async (reason) => {
+            const { service } = buildService({ connection: baseConnection() });
+            mockSecureFetch.mockRejectedValueOnce(
+                new SecureFetchError(
+                    reason as never,
+                    `internal: connect to 10.0.0.1`,
+                ),
+            );
+            const promise = service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            });
+            await expect(promise).rejects.toBeInstanceOf(ParameterError);
+            const err = await promise.catch((e) => e);
+            expect(err.message).not.toMatch(/10\.0\.0\.1/);
+        },
+    );
+
+    it('rate-limits the 2nd POST over the limit with a 429-class error', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ rateLimitPerMinute: 1 }),
+            rateCount: 2,
+        });
+        const promise = service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            method: 'POST',
+            path: '/v1/x',
+            body: {},
+        });
+        await expect(promise).rejects.toMatchObject({ statusCode: 429 });
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('uses DEFAULT 60/min when rateLimitPerMinute is null', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ rateLimitPerMinute: null }),
+            rateCount: 61,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                method: 'POST',
+                path: '/v1/x',
+                body: {},
+            }),
+        ).rejects.toMatchObject({ statusCode: 429 });
+    });
+
+    it('parses non-JSON content type as a raw string', async () => {
+        mockSecureFetch.mockResolvedValueOnce({
+            status: 200,
+            contentType: 'text/plain',
+            bodyText: 'plain text',
+            truncated: false,
+        });
+        const { service } = buildService({
+            connection: baseConnection({
+                allowedContentTypes: ['text/plain'],
+            }),
+        });
+        const res = await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        expect(res.body).toBe('plain text');
+    });
+
+    it('falls back to raw string when JSON content fails to parse', async () => {
+        mockSecureFetch.mockResolvedValueOnce({
+            status: 200,
+            contentType: 'application/json',
+            bodyText: 'not json{',
+            truncated: false,
+        });
+        const { service } = buildService({ connection: baseConnection() });
+        const res = await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            path: '/v1/x',
+        });
+        expect(res.body).toBe('not json{');
+    });
+
+    it('emits an audit event without bodies or secrets', async () => {
+        const { service, analytics } = buildService({
+            connection: baseConnection({ type: 'bearer_token' }),
+            secret: 'tok_secret',
+        });
+        await service.proxyFetch(user, 'proj-1', 'app-1', {
+            connectionAlias: 'weather',
+            method: 'POST',
+            path: '/v1/x',
+            body: { secret_payload: 'do-not-log' },
+        });
+        expect(analytics.track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'external_connection.fetch',
+                properties: expect.objectContaining({
+                    method: 'POST',
+                    path: '/v1/x',
+                    status: 200,
+                    outcome: 'ok',
+                }),
+            }),
+        );
+        const tracked = JSON.stringify(analytics.track.mock.calls);
+        expect(tracked).not.toContain('tok_secret');
+        expect(tracked).not.toContain('do-not-log');
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -221,18 +221,30 @@ describe('ExternalConnectionService.proxyFetch', () => {
         });
     });
 
-    it('GET is never rate-limited even when a limit is set', async () => {
+    it('GET is rate-limited like every other method', async () => {
         const { service, externalConnectionModel } = buildService({
-            connection: baseConnection({ rateLimitPerMinute: 1 }),
-            rateCount: 99,
+            connection: baseConnection({ rateLimitPerMinute: 5 }),
+            rateCount: 1,
         });
         await service.proxyFetch(user, 'proj-1', 'app-1', {
             connectionAlias: 'weather',
             path: '/v1/x',
         });
-        expect(
-            externalConnectionModel.incrementRateCounter,
-        ).not.toHaveBeenCalled();
+        expect(externalConnectionModel.incrementRateCounter).toHaveBeenCalled();
+    });
+
+    it('rejects a GET over the rate limit with a 429-class error', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ rateLimitPerMinute: 1 }),
+            rateCount: 2,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toMatchObject({ statusCode: 429 });
+        expect(mockSecureFetch).not.toHaveBeenCalled();
     });
 
     it('happy POST: server sets Content-Type and serializes the body', async () => {
@@ -312,6 +324,56 @@ describe('ExternalConnectionService.proxyFetch', () => {
         const [url, opts] = mockSecureFetch.mock.calls[0];
         expect(new URL(url).searchParams.get('apikey')).toBe('sec_q');
         expect(opts.headers!.Authorization).toBeUndefined();
+    });
+
+    it('fails closed when a bearer_token connection has no stored secret', async () => {
+        const { service } = buildService({
+            connection: baseConnection({ type: 'bearer_token' }),
+            secret: null,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when an api_key connection has no stored secret', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'api_key',
+                apiKeyName: 'X-Api-Key',
+                apiKeyLocation: 'header',
+            }),
+            secret: null,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+    });
+
+    it('rejects an api_key configured to inject a forbidden header (Host)', async () => {
+        const { service } = buildService({
+            connection: baseConnection({
+                type: 'api_key',
+                apiKeyName: 'Host',
+                apiKeyLocation: 'header',
+            }),
+            secret: 'sec',
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
     });
 
     it.each([['blocked_ip'], ['redirect'], ['too_large'], ['timeout']])(

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.proxy.test.ts
@@ -4,6 +4,7 @@ import {
     type ExternalConnection,
     type SessionUser,
 } from '@lightdash/common';
+import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { SecureFetchError } from '../../../utils/secureFetch/secureFetch';
 import * as secureFetchModule from '../../../utils/secureFetch/secureFetch';
 import { ExternalConnectionService } from './ExternalConnectionService';
@@ -57,7 +58,14 @@ function buildService(opts: {
     secret?: string | null;
     canView?: boolean;
     rateCount?: number;
+    flagEnabled?: boolean;
 }) {
+    const featureFlagModel = {
+        get: jest.fn().mockResolvedValue({
+            id: 'enable-data-app-external-access',
+            enabled: opts.flagEnabled ?? true,
+        }),
+    } as unknown as FeatureFlagModel;
     const externalConnectionModel = {
         resolveAppAlias: jest.fn().mockResolvedValue(opts.connection),
         getDecryptedSecret: jest.fn().mockResolvedValue(opts.secret ?? null),
@@ -76,6 +84,7 @@ function buildService(opts: {
 
     const service = new ExternalConnectionService({
         externalConnectionModel,
+        featureFlagModel,
         appModel,
         projectModel,
         spacePermissionService,
@@ -91,7 +100,13 @@ function buildService(opts: {
         cannot: () => !(opts.canView ?? true),
     });
 
-    return { service, externalConnectionModel, appModel, analytics };
+    return {
+        service,
+        featureFlagModel,
+        externalConnectionModel,
+        appModel,
+        analytics,
+    };
 }
 
 beforeEach(() => {
@@ -438,5 +453,23 @@ describe('ExternalConnectionService.proxyFetch', () => {
         const tracked = JSON.stringify(analytics.track.mock.calls);
         expect(tracked).not.toContain('tok_secret');
         expect(tracked).not.toContain('do-not-log');
+    });
+
+    it('rejects with ForbiddenError when the feature flag is disabled', async () => {
+        const { service, externalConnectionModel } = buildService({
+            connection: baseConnection(),
+            flagEnabled: false,
+        });
+        await expect(
+            service.proxyFetch(user, 'proj-1', 'app-1', {
+                connectionAlias: 'weather',
+                path: '/v1/x',
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(mockSecureFetch).not.toHaveBeenCalled();
+        expect(externalConnectionModel.resolveAppAlias).not.toHaveBeenCalled();
+        expect(
+            externalConnectionModel.getDecryptedSecret,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -11,14 +11,15 @@ import {
     type ExternalConnectionMethod,
     type ExternalFetchRequest,
     type ExternalFetchResponse,
+    type LightdashUser,
     type RegisteredAccount,
     type SessionUser,
     type UpdateExternalConnection,
 } from '@lightdash/common';
 import { performance } from 'node:perf_hooks';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
-import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { type AppModel } from '../../../models/AppModel';
+import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import {
@@ -65,15 +66,14 @@ export class ExternalConnectionService extends BaseService {
         this.spacePermissionService = args.spacePermissionService;
     }
 
-    private async assertExternalAccessEnabled(
-        account: RegisteredAccount,
+    private async assertExternalAccessEnabledForUser(
+        user: Pick<
+            LightdashUser,
+            'userUuid' | 'organizationUuid' | 'organizationName'
+        >,
     ): Promise<void> {
         const { enabled } = await this.featureFlagModel.get({
-            user: {
-                userUuid: account.user.userUuid,
-                organizationUuid: account.organization.organizationUuid,
-                organizationName: account.organization.name,
-            },
+            user,
             featureFlagId: FeatureFlags.EnableDataAppExternalAccess,
         });
         if (!enabled) {
@@ -81,6 +81,16 @@ export class ExternalConnectionService extends BaseService {
                 'Data app external access is not enabled for this organization',
             );
         }
+    }
+
+    private async assertExternalAccessEnabled(
+        account: RegisteredAccount,
+    ): Promise<void> {
+        return this.assertExternalAccessEnabledForUser({
+            userUuid: account.user.userUuid,
+            organizationUuid: account.organization.organizationUuid,
+            organizationName: account.organization.name,
+        });
     }
 
     private assertCanManage(
@@ -429,6 +439,8 @@ export class ExternalConnectionService extends BaseService {
         appUuid: string,
         req: ExternalFetchRequest,
     ): Promise<ExternalFetchResponse> {
+        await this.assertExternalAccessEnabledForUser(user);
+
         const start = performance.now();
 
         // 1. Load app + authorize VIEW (same authz as reading the app).

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -4,22 +4,42 @@ import {
     ForbiddenError,
     NotFoundError,
     NotImplementedError,
+    ParameterError,
+    TooManyRequestsError,
     type CreateExternalConnection,
     type ExternalConnection,
+    type ExternalConnectionMethod,
+    type ExternalFetchRequest,
+    type ExternalFetchResponse,
     type RegisteredAccount,
+    type SessionUser,
     type UpdateExternalConnection,
 } from '@lightdash/common';
+import { performance } from 'node:perf_hooks';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { type AppModel } from '../../../models/AppModel';
 import { BaseService } from '../../../services/BaseService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import {
+    secureFetch,
+    SecureFetchError,
+} from '../../../utils/secureFetch/secureFetch';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
+import { assertCanViewApp } from '../AppGenerateService/appAuthz';
 import { validateExternalConnectionConfig } from './externalConnectionConfigValidation';
+import {
+    buildOutboundUrl,
+    computeMinuteWindow,
+    normalizeAndValidatePath,
+    serializeRequestBody,
+} from './proxyValidation';
 
 type ExternalConnectionServiceArguments = {
     analytics: LightdashAnalytics;
     externalConnectionModel: ExternalConnectionModel;
     featureFlagModel: FeatureFlagModel;
+    appModel: AppModel;
     spacePermissionService: SpacePermissionService;
 };
 
@@ -30,13 +50,18 @@ export class ExternalConnectionService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly appModel: AppModel;
+
     private readonly spacePermissionService: SpacePermissionService;
+
+    private static readonly DEFAULT_RATE_LIMIT_PER_MINUTE = 60;
 
     constructor(args: ExternalConnectionServiceArguments) {
         super();
         this.analytics = args.analytics;
         this.externalConnectionModel = args.externalConnectionModel;
         this.featureFlagModel = args.featureFlagModel;
+        this.appModel = args.appModel;
         this.spacePermissionService = args.spacePermissionService;
     }
 
@@ -398,24 +423,286 @@ export class ExternalConnectionService extends BaseService {
         });
     }
 
+    async proxyFetch(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        req: ExternalFetchRequest,
+    ): Promise<ExternalFetchResponse> {
+        const start = performance.now();
+
+        // 1. Load app + authorize VIEW (same authz as reading the app).
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await assertCanViewApp(
+            {
+                auditedAbility: this.createAuditedAbility(user),
+                getSpaceAccessContext: (userUuid, spaceUuid) =>
+                    this.spacePermissionService.getSpaceAccessContext(
+                        userUuid,
+                        spaceUuid,
+                    ),
+            },
+            user,
+            app,
+        );
+
+        // 2. Resolve the alias → connection (must be linked to this app).
+        const connection = await this.externalConnectionModel.resolveAppAlias(
+            app.app_id,
+            req.connectionAlias,
+        );
+        if (!connection) {
+            throw new ForbiddenError(
+                'This app is not linked to the requested connection',
+            );
+        }
+
+        // 3. Method allowlist.
+        const method: ExternalConnectionMethod = req.method ?? 'GET';
+        if (!connection.allowedMethods.includes(method)) {
+            throw new ParameterError(
+                `Method ${method} is not allowed by this connection`,
+            );
+        }
+
+        // 4. Rate limit — non-GET only. Window math is injected/testable.
+        if (method !== 'GET') {
+            const limit =
+                connection.rateLimitPerMinute ??
+                ExternalConnectionService.DEFAULT_RATE_LIMIT_PER_MINUTE;
+            const window = computeMinuteWindow(new Date());
+            const count =
+                await this.externalConnectionModel.incrementRateCounter(
+                    connection.externalConnectionUuid,
+                    app.app_id,
+                    window,
+                );
+            if (count > limit) {
+                this.trackFetch({
+                    user,
+                    projectUuid,
+                    appUuid: app.app_id,
+                    connectionAlias: req.connectionAlias,
+                    connection,
+                    method,
+                    path: req.path,
+                    status: null,
+                    outcome: 'rate_limited',
+                    start,
+                    requestBytes: 0,
+                    responseBytes: 0,
+                });
+                throw new TooManyRequestsError(
+                    'Rate limit exceeded for this connection',
+                );
+            }
+        }
+
+        // 5. Resolve the secret (only what the auth type needs).
+        const secret =
+            connection.type === 'none'
+                ? null
+                : await this.externalConnectionModel.getDecryptedSecret(
+                      connection.externalConnectionUuid,
+                  );
+
+        // 6. Shared execution path (reused by M5 testConnection).
+        let result: {
+            response: ExternalFetchResponse;
+            requestBytes: number;
+            responseBytes: number;
+        };
+        try {
+            result = await this.executeExternalFetch(connection, secret, {
+                method,
+                path: req.path,
+                query: req.query,
+                body: req.body,
+            });
+        } catch (error) {
+            const outcome =
+                error instanceof ParameterError ? 'rejected' : 'upstream_error';
+            this.trackFetch({
+                user,
+                projectUuid,
+                appUuid: app.app_id,
+                connectionAlias: req.connectionAlias,
+                connection,
+                method,
+                path: req.path,
+                status: null,
+                outcome,
+                start,
+                requestBytes: 0,
+                responseBytes: 0,
+            });
+            throw error;
+        }
+
+        // 7. Audit success — never bodies, never the secret.
+        this.trackFetch({
+            user,
+            projectUuid,
+            appUuid: app.app_id,
+            connectionAlias: req.connectionAlias,
+            connection,
+            method,
+            path: req.path,
+            status: result.response.status,
+            outcome: 'ok',
+            start,
+            requestBytes: result.requestBytes,
+            responseBytes: result.responseBytes,
+        });
+
+        return result.response;
+    }
+
     /**
-     * EXTENSION POINT (M2): the data-app outbound proxy. Validates the
-     * request against the connection's allow-lists, applies the rate
-     * limiter (`externalConnectionModel.incrementRateCounter`), injects the
-     * decrypted secret (`getDecryptedSecret`), and performs the fetch.
-     * Intentionally unimplemented in M1.
+     * Validate + build + inject + fetch + bound. NO authz, NO rate limit, NO
+     * alias resolution — those live in the caller so M5's testConnection can
+     * reuse this exact path with an admin-supplied connection.
      */
     // eslint-disable-next-line class-methods-use-this
-    async proxyFetch(): Promise<never> {
-        throw new NotImplementedError(
-            'proxyFetch is implemented in milestone M2',
+    private async executeExternalFetch(
+        connection: ExternalConnection,
+        secret: string | null,
+        req: {
+            method: ExternalConnectionMethod;
+            path: string;
+            query?: Record<string, string>;
+            body?: unknown;
+        },
+    ): Promise<{
+        response: ExternalFetchResponse;
+        requestBytes: number;
+        responseBytes: number;
+    }> {
+        // Validate + normalize the path against the allowlist.
+        const validatedPath = normalizeAndValidatePath(
+            req.path,
+            connection.allowedPathPrefixes,
         );
+
+        // Start from the app's query; add api_key-in-query if configured.
+        const query: Record<string, string> = { ...(req.query ?? {}) };
+        const headers: Record<string, string> = {};
+
+        if (connection.type === 'bearer_token') {
+            if (secret) headers.Authorization = `Bearer ${secret}`;
+        } else if (connection.type === 'api_key') {
+            if (secret && connection.apiKeyName) {
+                if (connection.apiKeyLocation === 'header') {
+                    headers[connection.apiKeyName] = secret;
+                } else if (connection.apiKeyLocation === 'query') {
+                    query[connection.apiKeyName] = secret;
+                }
+            }
+        }
+        // type === 'none' → no auth injected.
+
+        // Build the outbound URL server-side (host pinned to origin).
+        const url = buildOutboundUrl(connection.origin, validatedPath, query);
+
+        // Non-GET body: server-serialized JSON with server-set Content-Type.
+        let body: string | undefined;
+        let requestBytes = 0;
+        if (req.method !== 'GET') {
+            const serialized = serializeRequestBody(req.body);
+            if (serialized.bytes > connection.requestMaxBytes) {
+                throw new ParameterError(
+                    `Request body exceeds the maximum of ${connection.requestMaxBytes} bytes`,
+                );
+            }
+            body = serialized.json;
+            requestBytes = serialized.bytes;
+            headers['Content-Type'] = 'application/json';
+        }
+
+        // Delegate to the SSRF-hardened fetch.
+        let fetched;
+        try {
+            fetched = await secureFetch(url, {
+                method: req.method,
+                body,
+                headers,
+                timeoutMs: connection.timeoutMs,
+                maxResponseBytes: connection.responseMaxBytes,
+                allowedContentTypes: connection.allowedContentTypes,
+            });
+        } catch (error) {
+            // Map SecureFetchError → ParameterError with NO raw upstream detail.
+            if (error instanceof SecureFetchError) {
+                throw new ParameterError(
+                    `Upstream request was blocked (${error.reason})`,
+                );
+            }
+            throw new ParameterError('Upstream request failed');
+        }
+
+        // Parse body by content type.
+        const isJson = fetched.contentType
+            .toLowerCase()
+            .includes('application/json');
+        let parsedBody: unknown = fetched.bodyText;
+        if (isJson) {
+            try {
+                parsedBody = JSON.parse(fetched.bodyText);
+            } catch {
+                parsedBody = fetched.bodyText; // fall back to raw string
+            }
+        }
+
+        return {
+            response: {
+                status: fetched.status,
+                contentType: fetched.contentType,
+                body: parsedBody,
+                truncated: fetched.truncated,
+            },
+            requestBytes,
+            responseBytes: Buffer.byteLength(fetched.bodyText, 'utf8'),
+        };
+    }
+
+    private trackFetch(args: {
+        user: SessionUser;
+        projectUuid: string;
+        appUuid: string;
+        connectionAlias: string;
+        connection: ExternalConnection;
+        method: ExternalConnectionMethod;
+        path: string;
+        status: number | null;
+        outcome: 'ok' | 'rejected' | 'rate_limited' | 'upstream_error';
+        start: number;
+        requestBytes: number;
+        responseBytes: number;
+    }): void {
+        this.analytics.track({
+            event: 'external_connection.fetch',
+            userId: args.user.userUuid,
+            properties: {
+                organizationId: args.connection.organizationUuid,
+                projectId: args.projectUuid,
+                appUuid: args.appUuid,
+                externalConnectionUuid: args.connection.externalConnectionUuid,
+                connectionAlias: args.connectionAlias,
+                method: args.method,
+                path: args.path,
+                status: args.status,
+                outcome: args.outcome,
+                durationMs: Math.round(performance.now() - args.start),
+                requestBytes: args.requestBytes,
+                responseBytes: args.responseBytes,
+            },
+        });
     }
 
     /**
      * EXTENSION POINT (M5): a "test connection" dry-run that exercises
      * proxyFetch against the connection's origin without persisting.
-     * Intentionally unimplemented in M1.
+     * Intentionally unimplemented in M1/M2.
      */
     // eslint-disable-next-line class-methods-use-this
     async testConnection(): Promise<never> {

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -30,6 +30,7 @@ import { type ExternalConnectionModel } from '../../models/ExternalConnectionMod
 import { assertCanViewApp } from '../AppGenerateService/appAuthz';
 import { validateExternalConnectionConfig } from './externalConnectionConfigValidation';
 import {
+    assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
     normalizeAndValidatePath,
@@ -477,37 +478,36 @@ export class ExternalConnectionService extends BaseService {
             );
         }
 
-        // 4. Rate limit — non-GET only. Window math is injected/testable.
-        if (method !== 'GET') {
-            const limit =
-                connection.rateLimitPerMinute ??
-                ExternalConnectionService.DEFAULT_RATE_LIMIT_PER_MINUTE;
-            const window = computeMinuteWindow(new Date());
-            const count =
-                await this.externalConnectionModel.incrementRateCounter(
-                    connection.externalConnectionUuid,
-                    app.app_id,
-                    window,
-                );
-            if (count > limit) {
-                this.trackFetch({
-                    user,
-                    projectUuid,
-                    appUuid: app.app_id,
-                    connectionAlias: req.connectionAlias,
-                    connection,
-                    method,
-                    path: req.path,
-                    status: null,
-                    outcome: 'rate_limited',
-                    start,
-                    requestBytes: 0,
-                    responseBytes: 0,
-                });
-                throw new TooManyRequestsError(
-                    'Rate limit exceeded for this connection',
-                );
-            }
+        // 4. Rate limit — all methods, including GET. Reads still spend
+        //    Lightdash egress and upstream quota under the injected auth, so an
+        //    app viewer must not be able to drive unlimited GETs.
+        const limit =
+            connection.rateLimitPerMinute ??
+            ExternalConnectionService.DEFAULT_RATE_LIMIT_PER_MINUTE;
+        const window = computeMinuteWindow(new Date());
+        const count = await this.externalConnectionModel.incrementRateCounter(
+            connection.externalConnectionUuid,
+            app.app_id,
+            window,
+        );
+        if (count > limit) {
+            this.trackFetch({
+                user,
+                projectUuid,
+                appUuid: app.app_id,
+                connectionAlias: req.connectionAlias,
+                connection,
+                method,
+                path: req.path,
+                status: null,
+                outcome: 'rate_limited',
+                start,
+                requestBytes: 0,
+                responseBytes: 0,
+            });
+            throw new TooManyRequestsError(
+                'Rate limit exceeded for this connection',
+            );
         }
 
         // 5. Resolve the secret (only what the auth type needs).
@@ -609,14 +609,32 @@ export class ExternalConnectionService extends BaseService {
         const headers: Record<string, string> = {};
 
         if (connection.type === 'bearer_token') {
-            if (secret) headers.Authorization = `Bearer ${secret}`;
+            // Fail closed: an authenticated connection must never fall through
+            // to an unauthenticated upstream call.
+            if (!secret) {
+                throw new ParameterError(
+                    'Connection is missing its bearer token',
+                );
+            }
+            headers.Authorization = `Bearer ${secret}`;
         } else if (connection.type === 'api_key') {
-            if (secret && connection.apiKeyName) {
-                if (connection.apiKeyLocation === 'header') {
-                    headers[connection.apiKeyName] = secret;
-                } else if (connection.apiKeyLocation === 'query') {
-                    query[connection.apiKeyName] = secret;
-                }
+            if (!secret || !connection.apiKeyName) {
+                throw new ParameterError(
+                    'Connection is missing its api key configuration',
+                );
+            }
+            if (connection.apiKeyLocation === 'header') {
+                // Stored config controls this header name, and the proxy is
+                // where it becomes an outbound request — reject sensitive and
+                // hop-by-hop headers (Host, Cookie, Content-Length, ...).
+                assertSafeApiKeyHeaderName(connection.apiKeyName);
+                headers[connection.apiKeyName] = secret;
+            } else if (connection.apiKeyLocation === 'query') {
+                query[connection.apiKeyName] = secret;
+            } else {
+                throw new ParameterError(
+                    'Connection has an invalid api key location',
+                );
             }
         }
         // type === 'none' → no auth injected.
@@ -634,7 +652,10 @@ export class ExternalConnectionService extends BaseService {
 
         // Cap the serialized query string length for all methods (incl. GET).
         const urlObj = new URL(url);
-        if (urlObj.search.length > connection.requestMaxBytes) {
+        if (
+            Buffer.byteLength(urlObj.search, 'utf8') >
+            connection.requestMaxBytes
+        ) {
             throw new ParameterError(
                 `Query string exceeds the maximum of ${connection.requestMaxBytes} bytes`,
             );

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -520,8 +520,10 @@ export class ExternalConnectionService extends BaseService {
                 body: req.body,
             });
         } catch (error) {
-            const outcome =
-                error instanceof ParameterError ? 'rejected' : 'upstream_error';
+            const isKnown =
+                error instanceof ParameterError ||
+                error instanceof SecureFetchError;
+            const outcome = isKnown ? 'rejected' : 'upstream_error';
             this.trackFetch({
                 user,
                 projectUuid,
@@ -536,7 +538,13 @@ export class ExternalConnectionService extends BaseService {
                 requestBytes: 0,
                 responseBytes: 0,
             });
-            throw error;
+            if (error instanceof ParameterError) {
+                throw error;
+            }
+            // Map any unexpected error (e.g. malformed origin, serialization
+            // failure) to a generic ParameterError — no stack or upstream detail
+            // reaches the client.
+            throw new ParameterError('Proxy request failed');
         }
 
         // 7. Audit success — never bodies, never the secret.
@@ -602,7 +610,23 @@ export class ExternalConnectionService extends BaseService {
         // type === 'none' → no auth injected.
 
         // Build the outbound URL server-side (host pinned to origin).
-        const url = buildOutboundUrl(connection.origin, validatedPath, query);
+        let url: string;
+        try {
+            url = buildOutboundUrl(connection.origin, validatedPath, query);
+        } catch (error) {
+            if (error instanceof ParameterError) {
+                throw error;
+            }
+            throw new ParameterError('Failed to build outbound URL');
+        }
+
+        // Cap the serialized query string length for all methods (incl. GET).
+        const urlObj = new URL(url);
+        if (urlObj.search.length > connection.requestMaxBytes) {
+            throw new ParameterError(
+                `Query string exceeds the maximum of ${connection.requestMaxBytes} bytes`,
+            );
+        }
 
         // Non-GET body: server-serialized JSON with server-set Content-Type.
         let body: string | undefined;
@@ -658,6 +682,8 @@ export class ExternalConnectionService extends BaseService {
                 status: fetched.status,
                 contentType: fetched.contentType,
                 body: parsedBody,
+                // Reserved for future use; always false in v1 — oversize responses
+                // are rejected (SecureFetchError too_large), not truncated.
                 truncated: fetched.truncated,
             },
             requestBytes,

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -1,0 +1,191 @@
+import { ParameterError } from '@lightdash/common';
+import {
+    buildOutboundUrl,
+    computeMinuteWindow,
+    normalizeAndValidatePath,
+    serializeRequestBody,
+} from './proxyValidation';
+
+describe('normalizeAndValidatePath', () => {
+    const prefixes = ['/v1/', '/public/data'];
+
+    it('accepts a path that prefix-matches an allowlisted prefix', () => {
+        expect(normalizeAndValidatePath('/v1/users', prefixes)).toBe(
+            '/v1/users',
+        );
+    });
+
+    it('accepts an exact prefix match', () => {
+        expect(normalizeAndValidatePath('/public/data', prefixes)).toBe(
+            '/public/data',
+        );
+    });
+
+    it('rejects a path that matches no prefix', () => {
+        expect(() => normalizeAndValidatePath('/admin', prefixes)).toThrow(
+            ParameterError,
+        );
+    });
+
+    it('rejects an absolute http URL', () => {
+        expect(() =>
+            normalizeAndValidatePath('http://evil.com/v1/x', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects an absolute https URL', () => {
+        expect(() =>
+            normalizeAndValidatePath('https://evil.com/v1/x', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects a protocol-relative //host (leading double slash)', () => {
+        expect(() =>
+            normalizeAndValidatePath('//evil.com/v1/x', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects a scheme-relative path with backslashes', () => {
+        expect(() =>
+            normalizeAndValidatePath('/v1\\..\\..\\etc', prefixes),
+        ).toThrow(ParameterError);
+        expect(() =>
+            normalizeAndValidatePath('\\\\evil.com\\x', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects raw .. traversal', () => {
+        expect(() =>
+            normalizeAndValidatePath('/v1/../admin', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects percent-encoded .. (%2e%2e) traversal', () => {
+        expect(() =>
+            normalizeAndValidatePath('/v1/%2e%2e/admin', prefixes),
+        ).toThrow(ParameterError);
+        expect(() =>
+            normalizeAndValidatePath('/v1/%2E%2E/admin', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects encoded path separators used to smuggle a host (%2f%2f)', () => {
+        expect(() =>
+            normalizeAndValidatePath('/%2f%2fevil.com', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects an @ that could be read as userinfo when re-parsed', () => {
+        expect(() =>
+            normalizeAndValidatePath('/v1/x@evil.com', prefixes),
+        ).toThrow(ParameterError);
+    });
+
+    it('rejects an embedded NUL or control char', () => {
+        // eslint-disable-next-line no-control-regex
+        expect(() => normalizeAndValidatePath('/v1/x\x00y', prefixes)).toThrow(
+            ParameterError,
+        );
+    });
+
+    it('requires a leading slash', () => {
+        expect(() => normalizeAndValidatePath('v1/users', prefixes)).toThrow(
+            ParameterError,
+        );
+    });
+
+    it('strips a query string from the path (query is passed separately)', () => {
+        expect(normalizeAndValidatePath('/v1/users?evil=1', prefixes)).toBe(
+            '/v1/users',
+        );
+    });
+});
+
+describe('buildOutboundUrl', () => {
+    it('joins origin + path and serializes query via URLSearchParams', () => {
+        const url = buildOutboundUrl('https://api.example.com', '/v1/users', {
+            page: '2',
+            q: 'a b&c',
+        });
+        expect(url).toBe('https://api.example.com/v1/users?page=2&q=a+b%26c');
+    });
+
+    it('handles an origin with a trailing slash without doubling', () => {
+        const url = buildOutboundUrl(
+            'https://api.example.com/',
+            '/v1/users',
+            undefined,
+        );
+        expect(url).toBe('https://api.example.com/v1/users');
+    });
+
+    it('handles an origin that includes a base path', () => {
+        const url = buildOutboundUrl(
+            'https://api.example.com/base',
+            '/v1/x',
+            undefined,
+        );
+        expect(url).toBe('https://api.example.com/base/v1/x');
+    });
+
+    it('keeps the host pinned to the origin even if path looks hostlike', () => {
+        // path is already validated, but URL construction must not be fooled
+        const url = buildOutboundUrl(
+            'https://api.example.com',
+            '/v1/evil.com',
+            undefined,
+        );
+        expect(new URL(url).host).toBe('api.example.com');
+    });
+
+    it('omits the query string when query is empty', () => {
+        const url = buildOutboundUrl('https://api.example.com', '/v1/x', {});
+        expect(url).toBe('https://api.example.com/v1/x');
+    });
+});
+
+describe('computeMinuteWindow', () => {
+    it('floors a Date to the start of its minute (UTC)', () => {
+        const d = new Date('2026-06-17T10:23:45.678Z');
+        expect(computeMinuteWindow(d).toISOString()).toBe(
+            '2026-06-17T10:23:00.000Z',
+        );
+    });
+
+    it('is stable across two calls in the same minute', () => {
+        const a = computeMinuteWindow(new Date('2026-06-17T10:23:01.000Z'));
+        const b = computeMinuteWindow(new Date('2026-06-17T10:23:59.999Z'));
+        expect(a.getTime()).toBe(b.getTime());
+    });
+
+    it('advances to the next window at the minute boundary', () => {
+        const a = computeMinuteWindow(new Date('2026-06-17T10:23:59.999Z'));
+        const b = computeMinuteWindow(new Date('2026-06-17T10:24:00.000Z'));
+        expect(b.getTime() - a.getTime()).toBe(60_000);
+    });
+});
+
+describe('serializeRequestBody', () => {
+    it('serializes an object to JSON and reports byte length', () => {
+        const { json, bytes } = serializeRequestBody({ a: 1 });
+        expect(json).toBe('{"a":1}');
+        expect(bytes).toBe(Buffer.byteLength('{"a":1}', 'utf8'));
+    });
+
+    it('treats undefined body as an empty object', () => {
+        const { json } = serializeRequestBody(undefined);
+        expect(json).toBe('{}');
+    });
+
+    it('counts multibyte characters by UTF-8 byte length', () => {
+        const { bytes } = serializeRequestBody({ s: 'é' });
+        // {"s":"é"} -> 'é' is 2 bytes in UTF-8
+        expect(bytes).toBe(Buffer.byteLength('{"s":"é"}', 'utf8'));
+    });
+
+    it('throws ParameterError on a value that cannot be JSON-serialized', () => {
+        const circular: Record<string, unknown> = {};
+        circular.self = circular;
+        expect(() => serializeRequestBody(circular)).toThrow(ParameterError);
+    });
+});

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -99,6 +99,40 @@ describe('normalizeAndValidatePath', () => {
             '/v1/users',
         );
     });
+
+    describe('segment-aware prefix matching', () => {
+        const segmentPrefixes = ['/v1/users'];
+
+        it('rejects a path that starts with the prefix but continues with non-separator chars', () => {
+            expect(() =>
+                normalizeAndValidatePath('/v1/users-admin', segmentPrefixes),
+            ).toThrow(ParameterError);
+            expect(() =>
+                normalizeAndValidatePath('/v1/usersecrets', segmentPrefixes),
+            ).toThrow(ParameterError);
+            expect(() =>
+                normalizeAndValidatePath('/v1/usersxxx', segmentPrefixes),
+            ).toThrow(ParameterError);
+        });
+
+        it('accepts the exact prefix', () => {
+            expect(normalizeAndValidatePath('/v1/users', segmentPrefixes)).toBe(
+                '/v1/users',
+            );
+        });
+
+        it('accepts the prefix with a trailing slash', () => {
+            expect(
+                normalizeAndValidatePath('/v1/users/', segmentPrefixes),
+            ).toBe('/v1/users/');
+        });
+
+        it('accepts a path that extends the prefix after a slash', () => {
+            expect(
+                normalizeAndValidatePath('/v1/users/123', segmentPrefixes),
+            ).toBe('/v1/users/123');
+        });
+    });
 });
 
 describe('buildOutboundUrl', () => {
@@ -141,6 +175,51 @@ describe('buildOutboundUrl', () => {
     it('omits the query string when query is empty', () => {
         const url = buildOutboundUrl('https://api.example.com', '/v1/x', {});
         expect(url).toBe('https://api.example.com/v1/x');
+    });
+
+    describe('self-enforces origin host invariant (defense-in-depth SSRF)', () => {
+        // These tests call buildOutboundUrl DIRECTLY, bypassing normalizeAndValidatePath,
+        // to prove the builder defends independently against host-escaping paths.
+
+        it('throws on a path that looks like "@evil.com"', () => {
+            expect(() =>
+                buildOutboundUrl(
+                    'https://api.example.com',
+                    '@evil.com',
+                    undefined,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('throws on a path that looks like "//evil.com"', () => {
+            expect(() =>
+                buildOutboundUrl(
+                    'https://api.example.com',
+                    '//evil.com',
+                    undefined,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('throws on a path that looks like "https://evil.com"', () => {
+            expect(() =>
+                buildOutboundUrl(
+                    'https://api.example.com',
+                    'https://evil.com',
+                    undefined,
+                ),
+            ).toThrow(ParameterError);
+        });
+
+        it('throws on a path that looks like "\\\\evil.com"', () => {
+            expect(() =>
+                buildOutboundUrl(
+                    'https://api.example.com',
+                    '\\\\evil.com',
+                    undefined,
+                ),
+            ).toThrow(ParameterError);
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.test.ts
@@ -1,5 +1,6 @@
 import { ParameterError } from '@lightdash/common';
 import {
+    assertSafeApiKeyHeaderName,
     buildOutboundUrl,
     computeMinuteWindow,
     normalizeAndValidatePath,
@@ -267,4 +268,31 @@ describe('serializeRequestBody', () => {
         circular.self = circular;
         expect(() => serializeRequestBody(circular)).toThrow(ParameterError);
     });
+});
+
+describe('assertSafeApiKeyHeaderName', () => {
+    it('accepts a normal api key header', () => {
+        expect(() => assertSafeApiKeyHeaderName('X-Api-Key')).not.toThrow();
+    });
+
+    it.each([
+        ['Host'],
+        ['host'],
+        ['Cookie'],
+        ['Authorization'],
+        ['Content-Length'],
+        ['Transfer-Encoding'],
+        ['Connection'],
+    ])('rejects the sensitive/hop-by-hop header %s', (name) => {
+        expect(() => assertSafeApiKeyHeaderName(name)).toThrow(ParameterError);
+    });
+
+    it.each([['Bad Header'], ['x:y'], ['has\nnewline'], ['']])(
+        'rejects the invalid token %j',
+        (name) => {
+            expect(() => assertSafeApiKeyHeaderName(name)).toThrow(
+                ParameterError,
+            );
+        },
+    );
 });

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -1,0 +1,130 @@
+import { ParameterError } from '@lightdash/common';
+
+// Reject anything that could escape the configured origin or smuggle a host.
+// The decoded path must be a plain, host-free, relative path that prefix-matches
+// one of the connection's allowlisted prefixes.
+export function normalizeAndValidatePath(
+    rawPath: string,
+    allowedPathPrefixes: string[],
+): string {
+    if (typeof rawPath !== 'string' || rawPath.length === 0) {
+        throw new ParameterError('path is required');
+    }
+
+    // Strip a query string if the caller jammed one onto the path — query
+    // params are supplied separately and serialized server-side.
+    const [pathOnly] = rawPath.split('?', 1);
+
+    // Control characters (incl. NUL, CR, LF, tab) are never legal in a path.
+    // eslint-disable-next-line no-control-regex
+    if (/[\x00-\x1f\x7f]/.test(pathOnly)) {
+        throw new ParameterError('path contains control characters');
+    }
+
+    // Backslashes are never legal and can be normalized to slashes by some
+    // HTTP stacks, enabling traversal/host smuggling. Reject outright.
+    if (pathOnly.includes('\\')) {
+        throw new ParameterError('path must not contain backslashes');
+    }
+
+    // Must be a relative path beginning with exactly one slash. A leading
+    // "//" is protocol-relative and resolves to an attacker host.
+    if (!pathOnly.startsWith('/') || pathOnly.startsWith('//')) {
+        throw new ParameterError(
+            'path must be a relative path starting with /',
+        );
+    }
+
+    // No scheme (absolute URL). Anything matching "scheme:" up front is rejected.
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(pathOnly)) {
+        throw new ParameterError('path must not be an absolute URL');
+    }
+
+    // Decode percent-encoding so encoded traversal/host tricks are caught.
+    // A malformed encoding (decodeURIComponent throws) is itself rejected.
+    let decoded: string;
+    try {
+        decoded = decodeURIComponent(pathOnly);
+    } catch {
+        throw new ParameterError('path contains invalid percent-encoding');
+    }
+
+    // After decoding, re-run the host-smuggling checks on the decoded form.
+    if (
+        decoded.includes('\\') ||
+        decoded.startsWith('//') ||
+        /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)
+    ) {
+        throw new ParameterError('path resolves to a host or absolute URL');
+    }
+
+    // No userinfo/host markers. An '@' lets "/x@evil.com" be reinterpreted as
+    // userinfo when concatenated into a URL string.
+    if (decoded.includes('@')) {
+        throw new ParameterError('path must not contain @');
+    }
+
+    // Path traversal in either raw or decoded form.
+    const segments = decoded.split('/');
+    if (segments.some((s) => s === '..')) {
+        throw new ParameterError('path must not contain .. traversal');
+    }
+
+    // Prefix allowlist match against the decoded, host-free path.
+    const matches = allowedPathPrefixes.some((prefix) =>
+        decoded.startsWith(prefix),
+    );
+    if (!matches) {
+        throw new ParameterError('path is not allowed by this connection');
+    }
+
+    // Return the decoded path; buildOutboundUrl re-encodes via the URL API.
+    return decoded;
+}
+
+// Build the outbound URL entirely server-side. The host always comes from
+// `origin`; the validated, host-free `path` is appended; query params are
+// serialized with URLSearchParams. We never string-concat a user-supplied host.
+export function buildOutboundUrl(
+    origin: string,
+    validatedPath: string,
+    query: Record<string, string> | undefined,
+): string {
+    const base = origin.endsWith('/') ? origin.slice(0, -1) : origin;
+    const url = new URL(`${base}${validatedPath}`);
+    if (query) {
+        const params = new URLSearchParams();
+        for (const [key, value] of Object.entries(query)) {
+            params.append(key, value);
+        }
+        const qs = params.toString();
+        if (qs) {
+            url.search = qs;
+        }
+    }
+    return url.toString();
+}
+
+// Floor a Date to the start of its minute. The caller injects the Date so the
+// window is deterministic and unit-testable — we never call Date.now() in the
+// fetch path.
+export function computeMinuteWindow(now: Date): Date {
+    return new Date(Math.floor(now.getTime() / 60_000) * 60_000);
+}
+
+export function serializeRequestBody(body: unknown): {
+    json: string;
+    bytes: number;
+} {
+    let json: string;
+    try {
+        json = JSON.stringify(body ?? {});
+    } catch {
+        throw new ParameterError('Request body is not JSON-serializable');
+    }
+    // JSON.stringify can return undefined (e.g. a bare function); coerce.
+    if (json === undefined) {
+        json = '{}';
+    }
+    return { json, bytes: Buffer.byteLength(json, 'utf8') };
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -159,3 +159,38 @@ export function serializeRequestBody(body: unknown): {
     }
     return { json, bytes: Buffer.byteLength(json, 'utf8') };
 }
+
+// Header names an api_key must never be injected under: they let stored config
+// control request routing/framing or overwrite the proxy's own security
+// headers (host pinning, content-type, auth). The api_key header name is
+// admin-supplied config, and the proxy is where it becomes an outbound
+// request — so reject sensitive and hop-by-hop headers here, even though
+// write-time validation also runs.
+const FORBIDDEN_API_KEY_HEADERS = new Set([
+    'host',
+    'authorization',
+    'cookie',
+    'content-length',
+    'content-type',
+    'connection',
+    'transfer-encoding',
+    'te',
+    'trailer',
+    'upgrade',
+    'keep-alive',
+    'expect',
+    'proxy-authorization',
+    'proxy-connection',
+]);
+
+// RFC 7230 token chars.
+const HTTP_HEADER_TOKEN = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
+
+export function assertSafeApiKeyHeaderName(name: string): void {
+    if (!HTTP_HEADER_TOKEN.test(name)) {
+        throw new ParameterError('api key header name is not a valid token');
+    }
+    if (FORBIDDEN_API_KEY_HEADERS.has(name.toLowerCase())) {
+        throw new ParameterError(`api key header "${name}" is not allowed`);
+    }
+}

--- a/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/proxyValidation.ts
@@ -71,9 +71,12 @@ export function normalizeAndValidatePath(
     }
 
     // Prefix allowlist match against the decoded, host-free path.
-    const matches = allowedPathPrefixes.some((prefix) =>
-        decoded.startsWith(prefix),
-    );
+    // Use segment-aware matching so /v1/users does not allow /v1/users-admin.
+    const matches = allowedPathPrefixes.some((prefix) => {
+        if (decoded === prefix) return true;
+        const boundary = prefix.endsWith('/') ? prefix : `${prefix}/`;
+        return decoded.startsWith(boundary);
+    });
     if (!matches) {
         throw new ParameterError('path is not allowed by this connection');
     }
@@ -90,8 +93,36 @@ export function buildOutboundUrl(
     validatedPath: string,
     query: Record<string, string> | undefined,
 ): string {
+    // Defense-in-depth: reject obviously hostile path shapes before parsing.
+    // These can escape the origin host or smuggle credentials during URL
+    // construction, even if they survived normalizeAndValidatePath.
+    if (validatedPath.includes('\\') || validatedPath.startsWith('//')) {
+        throw new ParameterError(
+            'Resolved URL host does not match the connection origin',
+        );
+    }
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(validatedPath)) {
+        throw new ParameterError(
+            'Resolved URL host does not match the connection origin',
+        );
+    }
+    if (validatedPath.includes('@')) {
+        throw new ParameterError(
+            'Resolved URL host does not match the connection origin',
+        );
+    }
+
+    const originUrl = new URL(origin);
     const base = origin.endsWith('/') ? origin.slice(0, -1) : origin;
     const url = new URL(`${base}${validatedPath}`);
+
+    // Final check: the constructed URL's host must still match the origin.
+    if (url.protocol !== originUrl.protocol || url.host !== originUrl.host) {
+        throw new ParameterError(
+            'Resolved URL host does not match the connection origin',
+        );
+    }
+
     if (query) {
         const params = new URLSearchParams();
         for (const [key, value] of Object.entries(query)) {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2007,6 +2007,57 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExternalFetchResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                truncated: { dataType: 'boolean', required: true },
+                body: { dataType: 'any', required: true },
+                contentType: { dataType: 'string', required: true },
+                status: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiExternalFetchResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ExternalFetchResponse', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.string_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { dataType: 'string' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExternalFetchRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                body: { dataType: 'any' },
+                query: { ref: 'Record_string.string_' },
+                path: { dataType: 'string', required: true },
+                method: { ref: 'ExternalConnectionMethod' },
+                connectionAlias: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Organization.name-or-createdAt-or-organizationUuid_': {
         dataType: 'refAlias',
         type: {
@@ -3418,16 +3469,6 @@ const models: TsoaRoute.Models = {
             'HOUR_OF_DAY_NUM',
             'MINUTE_OF_HOUR_NUM',
         ],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Record_string.string_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {},
-            additionalProperties: { dataType: 'string' },
-            validators: {},
-        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CustomFormatType: {
@@ -42662,6 +42703,79 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'unlinkAppExternalConnection',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExternalConnectionController_externalFetch: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ExternalFetchRequest',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/external-fetch',
+        ...fetchMiddlewares<RequestHandler>(ExternalConnectionController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExternalConnectionController.prototype.externalFetch,
+        ),
+
+        async function ExternalConnectionController_externalFetch(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExternalConnectionController_externalFetch,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExternalConnectionController>(
+                        ExternalConnectionController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'externalFetch',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1985,6 +1985,64 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "ExternalFetchResponse": {
+                "properties": {
+                    "truncated": {
+                        "type": "boolean"
+                    },
+                    "body": {},
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["truncated", "body", "contentType", "status"],
+                "type": "object"
+            },
+            "ApiExternalFetchResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ExternalFetchResponse"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "Record_string.string_": {
+                "properties": {},
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "ExternalFetchRequest": {
+                "properties": {
+                    "body": {},
+                    "query": {
+                        "$ref": "#/components/schemas/Record_string.string_"
+                    },
+                    "path": {
+                        "type": "string"
+                    },
+                    "method": {
+                        "$ref": "#/components/schemas/ExternalConnectionMethod"
+                    },
+                    "connectionAlias": {
+                        "type": "string"
+                    }
+                },
+                "required": ["path", "connectionAlias"],
+                "type": "object"
+            },
             "Pick_Organization.name-or-createdAt-or-organizationUuid_": {
                 "properties": {
                     "name": {
@@ -3547,14 +3605,6 @@
                     "MINUTE_OF_HOUR_NUM"
                 ],
                 "type": "string"
-            },
-            "Record_string.string_": {
-                "properties": {},
-                "additionalProperties": {
-                    "type": "string"
-                },
-                "type": "object",
-                "description": "Construct a type with a set of properties K of type T"
             },
             "CustomFormatType": {
                 "enum": [

--- a/packages/common/src/ee/externalConnections/types.ts
+++ b/packages/common/src/ee/externalConnections/types.ts
@@ -57,3 +57,18 @@ export const EXTERNAL_CONNECTION_DEFAULTS = {
     requestMaxBytes: 262144,
     timeoutMs: 10000,
 } as const;
+
+export type ExternalFetchRequest = {
+    connectionAlias: string;
+    method?: ExternalConnectionMethod;
+    path: string;
+    query?: Record<string, string>;
+    body?: unknown;
+};
+
+export type ExternalFetchResponse = {
+    status: number;
+    contentType: string;
+    body: unknown;
+    truncated: boolean;
+};

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -520,6 +520,20 @@ export class GoogleSheetsTransientError extends LightdashError {
     }
 }
 
+export class TooManyRequestsError extends LightdashError {
+    constructor(
+        message = 'Too many requests',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'TooManyRequestsError',
+            statusCode: 429,
+            data,
+        });
+    }
+}
+
 export class GoogleSheetsQuotaError extends LightdashError {
     constructor(
         message = 'Google Sheets API quota exceeded. The sync will be retried automatically.',


### PR DESCRIPTION
Adds the proxy endpoint itself — the one place data can leave to an admin-allowlisted origin.

- **`POST …/apps/{appUuid}/external-fetch`**: resolves the per-app connection alias, authorizes (can-view-app + app-is-linked), validates method/path/query/body, injects the secret server-side, fetches via `secureFetch`, returns a bounded response.
- **GET open; POST is per-connection opt-in** with a minimal non-GET rate limit; structured errors only — no upstream host or secret ever leaks back.
- **Hardened path handling**: segment-aware prefix matching + a `buildOutboundUrl` host-invariant re-check so a request can't smuggle a different host (defense-in-depth on top of `secureFetch`).

**Notes:** flag-gated. Exhaustive security tests (traversal, encoded-host, private-IP, oversize, method-not-allowed, rate-limit). The `executeExternalFetch` core is reused by the test endpoint in PR 6.

---
**Stack:** Data App External Fetch Proxy — PR 3/6 · everything is gated behind the `enable-data-app-external-access` feature flag (default **off** → every code path locked).

_Linear: TODO — add ticket (`Closes: PROD-XXXX`)._
