### PR TITLE
feat(ai): tag GitLab repositories as @-mention context

### DIFF
--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -839,6 +839,7 @@ export const getGitlabProjects = async (
             pathWithNamespace: project.path_with_namespace,
             webUrl: project.web_url,
             defaultBranch: project.default_branch,
+            visibility: project.visibility,
         }));
     } catch (error) {
         throw new UnexpectedGitError(getErrorMessage(error));

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6136,8 +6136,28 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     );
                 }
             };
-        // The installation-browse path (buildRepoFs) is GitHub-App-only.
         const onRepoFsTiming = makeRepoFsTiming('github');
+        // The browse path supports GitHub (installation, user+org union) and
+        // GitLab (org install, single token). Determine the project's provider
+        // once so the listing/mounting/search callbacks pick the right backend.
+        let repoProviderPromise: Promise<'github' | 'gitlab' | null> | null =
+            null;
+        const getRepoProvider = () => {
+            if (!repoProviderPromise) {
+                repoProviderPromise = (async () => {
+                    const project = await this.projectModel.get(projectUuid);
+                    switch (project.dbtConnection.type) {
+                        case DbtProjectType.GITHUB:
+                            return 'github';
+                        case DbtProjectType.GITLAB:
+                            return 'gitlab';
+                        default:
+                            return null;
+                    }
+                })();
+            }
+            return repoProviderPromise;
+        };
         let installationAccessPromise: ReturnType<
             typeof this.aiWritebackService.getInstallationRepoReadAccess
         > | null = null;
@@ -6150,6 +6170,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     });
             }
             return installationAccessPromise;
+        };
+        let gitlabAccessPromise: ReturnType<
+            typeof this.aiWritebackService.getGitlabInstallationRepoReadAccess
+        > | null = null;
+        const getGitlabAccess = () => {
+            if (!gitlabAccessPromise) {
+                gitlabAccessPromise =
+                    this.aiWritebackService.getGitlabInstallationRepoReadAccess(
+                        {
+                            user,
+                            projectUuid,
+                        },
+                    );
+            }
+            return gitlabAccessPromise;
         };
 
         const buildDbtRepoFs = async (): Promise<RepoFs> => {
@@ -6173,6 +6208,24 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             owner: string,
             repo: string,
         ): Promise<RepoFs> => {
+            if ((await getRepoProvider()) === 'gitlab') {
+                const access = await getGitlabAccess();
+                const { branch, token } = await access.resolveRepoAccess(
+                    owner,
+                    repo,
+                );
+                return new RepoFs(
+                    createGitlabRepoSource({
+                        owner,
+                        repo,
+                        branch,
+                        token,
+                        hostDomain: access.hostDomain,
+                        // No subPath => the whole repo is readable, root-relative.
+                        onTiming: makeRepoFsTiming('gitlab'),
+                    }),
+                );
+            }
             const access = await getInstallationAccess();
             // The token is per-repo: org-installation repos read with the
             // installation token, the user's own repos with their user token.
@@ -6205,6 +6258,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         project.dbtConnection.type === DbtProjectType.GITLAB;
                     return MountingRepoFileSystem.create({
                         listRepos: async () => {
+                            if ((await getRepoProvider()) === 'gitlab') {
+                                this.prometheusMetrics?.incrementRepoFsGitlabRequest(
+                                    'list',
+                                );
+                                return (await getGitlabAccess()).listRepos();
+                            }
                             this.prometheusMetrics?.incrementRepoFsGithubRequest(
                                 'list',
                             );
@@ -6214,6 +6273,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         buildDbtRepoFs,
                         buildRepoFs,
                         searchOwner: async (owner, query) => {
+                            // GitLab's RepoSource has no server-side code search
+                            // yet; the shell's grep falls back to reading files,
+                            // so there are no owner-wide search hits to surface.
+                            if ((await getRepoProvider()) === 'gitlab') {
+                                return [];
+                            }
                             const { installationToken, userToken } =
                                 await getInstallationAccess();
                             // Code search is token-scoped: the installation

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -6772,6 +6772,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 .replace(/\/+$/, '');
             repoFsRoot = raw === '' ? '.' : raw;
         }
+        // GitLab's repo source has no server-side code search, so the prompt
+        // must steer the agent off `search` (it returns nothing) toward a
+        // scoped single-repo grep. GitHub supports it.
+        const repoFsSupportsCodeSearch =
+            promptProject.dbtConnection.type !== DbtProjectType.GITLAB;
 
         const canUseContentTools =
             agentRevampEnabled &&
@@ -6826,6 +6831,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enablePreviewDeploySetup: aiPreviewDeploySetupEnabled,
             enableRepoDiscovery: repoDiscoveryEnabled,
             repoFsRoot,
+            repoFsSupportsCodeSearch,
             canRunSql,
             autoApproveSql: options.autoApproveSql ?? false,
             autoApproveSqlUserUuid: options.autoApproveSql

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -6,6 +6,7 @@ import {
     getErrorMessage,
     isUserWithOrg,
     MissingConfigError,
+    NotFoundError,
     ParameterError,
     PullRequestProvider,
     PullRequestSource,
@@ -29,6 +30,7 @@ import {
     listReposAccessibleToInstallation,
     listReposAccessibleToUser,
 } from '../../../clients/github/Github';
+import { getGitlabProjects } from '../../../clients/gitlab/Gitlab';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import type { GithubAppInstallationsModel } from '../../../models/GithubAppInstallations/GithubAppInstallationsModel';
@@ -562,6 +564,105 @@ export class AiWritebackService extends BaseService {
     }
 
     /**
+     * GitLab analog of {@link getInstallationRepoReadAccess}: the repositories
+     * the org's GitLab app install can read, for the `@`-mention picker and the
+     * agent's repo VFS. GitLab has no per-user account linking yet (the install
+     * acts as a single identity), so there's one token and no user/installation
+     * union. Only two-segment `namespace/project` paths are listed — the mount
+     * layer keys on `owner/repo` (as does the existing dbt-connection parsing),
+     * so deeper subgroups are skipped until the mount model is generalised.
+     */
+    async getGitlabInstallationRepoReadAccess({
+        user,
+        projectUuid,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+    }): Promise<{
+        token: string;
+        hostDomain: string;
+        listRepos: () => Promise<RepoListing[]>;
+        resolveRepoAccess: (
+            owner: string,
+            repo: string,
+        ) => Promise<{ branch: string; token: string }>;
+    }> {
+        const { project, organizationUuid } = await this.assertSourceCodeAccess(
+            {
+                user,
+                projectUuid,
+            },
+        );
+        if (project.dbtConnection.type !== DbtProjectType.GITLAB) {
+            throw new WritebackGitNotConnectedError(
+                PullRequestProvider.GITLAB,
+                'Project is not connected to GitLab',
+            );
+        }
+        const installation =
+            await this.gitlabProvider.resolveInstallation(organizationUuid);
+        if (installation.provider !== PullRequestProvider.GITLAB) {
+            throw new WritebackGitNotConnectedError(
+                PullRequestProvider.GITLAB,
+                'GitLab App is not installed for this organization',
+            );
+        }
+        const { token } = installation;
+        const { hostDomain } = parseGitlabConnection(project.dbtConnection);
+
+        // Build the repo map once and memoise it — listRepos and
+        // resolveRepoAccess share it, so the GitLab listing happens at most once.
+        let repoMapPromise: Promise<Map<string, RepoListing>> | null = null;
+        const loadRepoMap = () => {
+            if (!repoMapPromise) {
+                repoMapPromise = (async () => {
+                    const projects = await getGitlabProjects(token, hostDomain);
+                    const map = new Map<string, RepoListing>();
+                    projects.forEach(
+                        (p: {
+                            pathWithNamespace: string;
+                            defaultBranch: string | null;
+                            visibility: string;
+                        }) => {
+                            // The agent reads via the API path (path_with_namespace),
+                            // not the display name. Only two-segment paths fit the
+                            // owner/repo mount model; a project with no default
+                            // branch (empty repo) can't be read.
+                            const segments = p.pathWithNamespace.split('/');
+                            if (segments.length !== 2 || !p.defaultBranch)
+                                return;
+                            const [owner, repo] = segments;
+                            map.set(`${owner}/${repo}`, {
+                                owner,
+                                repo,
+                                defaultBranch: p.defaultBranch,
+                                private: p.visibility !== 'public',
+                            });
+                        },
+                    );
+                    return map;
+                })();
+            }
+            return repoMapPromise;
+        };
+
+        return {
+            token,
+            hostDomain,
+            listRepos: async () => [...(await loadRepoMap()).values()],
+            resolveRepoAccess: async (owner, repo) => {
+                const entry = (await loadRepoMap()).get(`${owner}/${repo}`);
+                if (!entry) {
+                    throw new NotFoundError(
+                        `GitLab repository ${owner}/${repo} is not accessible to this project's GitLab installation`,
+                    );
+                }
+                return { branch: entry.defaultBranch, token };
+            },
+        };
+    }
+
+    /**
      * List the project's source files for the chat input's `@`-mention file
      * picker. Reuses the same gated, GitHub-only read access as repoShell, and
      * returns paths relative to the dbt sub-folder — the same root the agent's
@@ -619,16 +720,24 @@ export class AiWritebackService extends BaseService {
         user: SessionUser;
         projectUuid: string;
     }): Promise<GitRepo[]> {
-        const access = await this.getInstallationRepoReadAccess({
+        const { project } = await this.assertSourceCodeAccess({
             user,
             projectUuid,
         });
+        const isGitlab = project.dbtConnection.type === DbtProjectType.GITLAB;
+        const access = isGitlab
+            ? await this.getGitlabInstallationRepoReadAccess({
+                  user,
+                  projectUuid,
+              })
+            : await this.getInstallationRepoReadAccess({ user, projectUuid });
         const repos = await access.listRepos();
         return repos.map(({ owner, repo, defaultBranch }) => ({
             name: repo,
             ownerLogin: owner,
             fullName: `${owner}/${repo}`,
             defaultBranch,
+            provider: isGitlab ? 'gitlab' : 'github',
         }));
     }
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -609,6 +609,12 @@ export class AiWritebackService extends BaseService {
         }
         const { token } = installation;
         const { hostDomain } = parseGitlabConnection(project.dbtConnection);
+        // The GitLab client is split on host format: makeGitlabRequest-based
+        // reads (createGitlabRepoSource) take a BARE domain and prepend https,
+        // while getGitlabProjects takes a FULL instance URL. Derive both from
+        // the connection's host_domain so gitlab.com and self-hosted both work.
+        const bareHost = hostDomain.replace(/^https?:\/\//, '');
+        const instanceUrl = `https://${bareHost}`;
 
         // Build the repo map once and memoise it — listRepos and
         // resolveRepoAccess share it, so the GitLab listing happens at most once.
@@ -616,7 +622,10 @@ export class AiWritebackService extends BaseService {
         const loadRepoMap = () => {
             if (!repoMapPromise) {
                 repoMapPromise = (async () => {
-                    const projects = await getGitlabProjects(token, hostDomain);
+                    const projects = await getGitlabProjects(
+                        token,
+                        instanceUrl,
+                    );
                     const map = new Map<string, RepoListing>();
                     projects.forEach(
                         (p: {
@@ -648,7 +657,7 @@ export class AiWritebackService extends BaseService {
 
         return {
             token,
-            hostDomain,
+            hostDomain: bareHost,
             listRepos: async () => [...(await loadRepoMap()).values()],
             resolveRepoAccess: async (owner, repo) => {
                 const entry = (await loadRepoMap()).get(`${owner}/${repo}`);

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -489,6 +489,7 @@ const getAgentMessages = (args: AiAgentArgs, availableExplores: Explore[]) => {
             siteUrl: args.siteUrl,
             enableRepoDiscovery: args.enableRepoDiscovery,
             repoFsRoot: args.repoFsRoot,
+            repoFsSupportsCodeSearch: args.repoFsSupportsCodeSearch,
             enableContentTools:
                 args.enableAgentRevamp &&
                 args.enableDataAccess &&

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -170,3 +170,44 @@ describe('getSystemPromptV2 change-validation policy', () => {
         );
     });
 });
+
+describe('getSystemPromptV2 repo-fs code search caveat', () => {
+    const repoFsArgs = {
+        availableExplores: [],
+        enableRepoDiscovery: true,
+        repoFsRoot: '.',
+    };
+
+    test('appends the no-search caveat when code search is unsupported (GitLab)', () => {
+        const content = promptText({
+            ...repoFsArgs,
+            repoFsSupportsCodeSearch: false,
+        });
+        expect(content).toContain(
+            "`search` is unavailable for this project's repositories",
+        );
+    });
+
+    test('omits the caveat when code search is supported (GitHub / default)', () => {
+        expect(
+            promptText({ ...repoFsArgs, repoFsSupportsCodeSearch: true }),
+        ).not.toContain(
+            "`search` is unavailable for this project's repositories",
+        );
+        // Default (arg omitted) is "supported", so no caveat either.
+        expect(promptText(repoFsArgs)).not.toContain(
+            "`search` is unavailable for this project's repositories",
+        );
+    });
+
+    test('never adds the caveat when repo discovery is off', () => {
+        const content = promptText({
+            availableExplores: [],
+            enableRepoDiscovery: false,
+            repoFsSupportsCodeSearch: false,
+        });
+        expect(content).not.toContain(
+            "`search` is unavailable for this project's repositories",
+        );
+    });
+});

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -14,7 +14,11 @@ import { getAiWritebackSection } from './systemV2AiWriteback';
 import { CONTENT_TOOLS_SECTION } from './systemV2ContentTools';
 import { DATA_ACCESS_DISABLED_SECTION } from './systemV2DataAccessDisabled';
 import { DATA_ACCESS_ENABLED_SECTION } from './systemV2DataAccessEnabled';
-import { REPO_FS_SECTION, repoFsRootHint } from './systemV2RepoFs';
+import {
+    REPO_FS_SECTION,
+    repoFsRootHint,
+    repoFsSearchCaveat,
+} from './systemV2RepoFs';
 import { getRunSqlSection } from './systemV2RunSql';
 import { SEARCH_SEMANTIC_LAYER_SECTION } from './systemV2SearchSemanticLayer';
 import { renderAvailableSkills } from './systemV2Skills';
@@ -35,6 +39,9 @@ export const getSystemPromptV2 = (args: {
     siteUrl?: string;
     enableRepoDiscovery?: boolean;
     repoFsRoot?: string | null;
+    // Whether the repo host supports server-side code search (GitHub yes,
+    // GitLab no). Defaults true; when false the prompt steers off `search`.
+    repoFsSupportsCodeSearch?: boolean;
     enableContentTools?: boolean;
     canRunSql?: boolean;
     warehouseType?: WarehouseTypes | null;
@@ -51,6 +58,7 @@ export const getSystemPromptV2 = (args: {
         siteUrl = '',
         enableRepoDiscovery = false,
         repoFsRoot = null,
+        repoFsSupportsCodeSearch = true,
         enableContentTools = false,
         canRunSql = false,
         warehouseType = null,
@@ -143,7 +151,9 @@ export const getSystemPromptV2 = (args: {
         .replace(
             '{{repo_fs_section}}',
             enableRepoDiscovery
-                ? REPO_FS_SECTION + repoFsRootHint(repoFsRoot)
+                ? REPO_FS_SECTION +
+                      repoFsRootHint(repoFsRoot) +
+                      repoFsSearchCaveat(repoFsSupportsCodeSearch)
                 : '',
         )
         .replace(

--- a/packages/backend/src/ee/services/ai/prompts/systemV2RepoFs.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2RepoFs.ts
@@ -38,3 +38,14 @@ export const repoFsRootHint = (root: string | null): string => {
             : '';
     return `\n\nThe \`/dbt\` mount is this project's governed dbt repository${provenance}. Its files are at the top of \`/dbt\` (e.g. \`ls /dbt/models\`, \`cat /dbt/dbt_project.yml\`).`;
 };
+
+/**
+ * Caveat appended when the repository host has no server-side code search
+ * (GitLab). The base section tells the agent to reach for `search` to look
+ * across repositories; that returns nothing here, so steer it to a scoped
+ * single-repo `grep` instead. Empty string when search is available (GitHub).
+ */
+export const repoFsSearchCaveat = (supportsCodeSearch: boolean): string =>
+    supportsCodeSearch
+        ? ''
+        : `\n\n**\`search\` is unavailable for this project's repositories** — the repository host does not provide server-side code search, so \`search\` returns no results here. Don't use it, and don't tell the user it's unavailable. To find a string, \`grep\`/\`rg\` **within a single repository** (e.g. \`grep -rln "orders" /dbt\`, or scope to one \`/owner/repo\`) — never an unscoped or cross-repo walk.`;

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -103,6 +103,9 @@ export type AiAgentArgs = AnyAiModel & {
     // dbt project root within the repo (from project_sub_path); '.' = repo root,
     // null when repo discovery is off or the project is not git-backed.
     repoFsRoot: string | null;
+    // Whether the repo host has server-side code search (GitHub yes, GitLab no).
+    // Drives whether the prompt tells the agent to use `search`.
+    repoFsSupportsCodeSearch: boolean;
     canRunSql: boolean;
     autoApproveSql: boolean;
     autoApproveSqlUserUuid: string | null;

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -139,6 +139,9 @@ export type GitRepo = {
     fullName: string;
     ownerLogin: string;
     defaultBranch: string;
+    // Which provider the repo lives on, so the UI can pick the right icon.
+    // Optional for back-compat with existing GitRepo producers (setup endpoints).
+    provider?: 'github' | 'gitlab';
 };
 
 export type GitFileEntry = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/contentMentions.tsx
@@ -14,6 +14,7 @@ import {
 import { Group, Text } from '@mantine-8/core';
 import {
     IconBrandGithub,
+    IconBrandGitlab,
     IconCircleCheck,
     IconFile,
     IconLayoutDashboard,
@@ -98,14 +99,15 @@ const REPOSITORY_MENTION_GROUP = 'repository';
 const REPOSITORY_MENTION_CONTENT_TYPE = 'repository';
 const MAX_REPOSITORY_SUGGESTIONS = 8;
 
-// A GitHub repository the org's installation can access. Like file mentions it
-// carries no context payload — picking it inserts `owner/repo` as plain text so
-// the agent reads that repository's mount directly (it's the user pre-selecting
-// which repo to focus on, so the agent doesn't have to ask).
+// A GitHub or GitLab repository the org's installation can access. Like file
+// mentions it carries no context payload — picking it inserts `owner/repo` as
+// plain text so the agent reads that repository's mount directly (it's the user
+// pre-selecting which repo to focus on, so the agent doesn't have to ask).
 export type RepositoryMentionSuggestionItem = SuggestionItem & {
     kind: 'repository';
     fullName: string;
     ownerLogin: string;
+    provider?: 'github' | 'gitlab';
     group: typeof REPOSITORY_MENTION_GROUP;
 };
 
@@ -223,6 +225,7 @@ const getRepositorySuggestions = async (
         kind: 'repository',
         fullName: repo.fullName,
         ownerLogin: repo.ownerLogin,
+        provider: repo.provider,
         group: REPOSITORY_MENTION_GROUP,
     }));
 };
@@ -522,7 +525,11 @@ const renderRepositoryMentionItem = (
         >
             <Group wrap="nowrap" gap="xs" w="100%">
                 <MantineIcon
-                    icon={IconBrandGithub}
+                    icon={
+                        item.provider === 'gitlab'
+                            ? IconBrandGitlab
+                            : IconBrandGithub
+                    }
                     size="sm"
                     color="ldGray.6"
                 />


### PR DESCRIPTION
## Problem

The recently-merged file/repository `@`-mention feature (#24437) lets users tag a repository in the AI agent chat as typed context — but only **GitHub** repositories. For a project connected to GitLab, the agent could read the project's own dbt repo (mounted at `/dbt`), but users couldn't tag and explore **other** GitLab repos the org's GitLab app can access.

## What this does

The `repository` context type and the agent-prompt serialization were already source-agnostic (`{ fullName }` → "mounted at `/owner/repo`"). Two halves were GitHub-only; this wires GitLab into both:

- **Listing** (`AiWritebackService.listProjectRepositories`) — now branches on the project's dbt connection provider. For GitLab projects it enumerates the org install's accessible projects via the existing `getGitlabProjects()` for the mention picker.
- **Reading** (`AiAgentService` repo VFS) — `buildRepoFs` / `listRepos` / `searchOwner` are now provider-aware. A tagged GitLab repo is mounted with `createGitlabRepoSource`, so the agent's `exploreRepo` tool can actually read any tagged GitLab repo — not just the dbt one.

Supporting changes:
- New `getGitlabInstallationRepoReadAccess()` — a GitLab analog of `getInstallationRepoReadAccess` (single org token; GitLab has no per-user account linking yet, so no user/installation union).
- `GitRepo.provider` field so the frontend can pick the right icon; the mention dropdown now shows a GitLab icon for GitLab repos.
- `getGitlabProjects()` now returns `visibility` (for the `private` flag).

## Scope / follow-ups (intentional first pass)

- **Two-segment paths only.** Only `namespace/project` GitLab paths are listed. The arbitrary-repo mount layer keys on `owner/repo` (2 segments), and the existing dbt-connection parsing (`splitOwnerRepo`) already assumes this — so deeper nested subgroups (`group/subgroup/project`) are skipped for now. Generalising the mount resolver to N-segment GitLab namespaces is a follow-up. (A nested *dbt* repo is unaffected — `/dbt` sidesteps owner/repo parsing.)
- **Persisted-chip icon.** The mention dropdown icon is provider-aware, but the persisted chip in the user bubble still renders the GitHub icon, because the stored `repository` context item carries only `fullName` (no provider). Threading provider through the context type is a follow-up.
- **Code search.** GitLab's `RepoSource` has no server-side code search yet, so `searchOwner` returns no hits for GitLab (the shell's `grep` still works by reading files). Matches existing GitLab repoFs behaviour.

## Testing

- Backend + frontend typecheck clean; existing mention unit tests pass (9/9).
- **Live GitLab end-to-end not yet run** — needs a GitLab-connected project + GitLab app install in the dev env. Wanted eyes on the approach first; happy to run the live pass (tag a GitLab repo → confirm it lists, persists, serializes, and `exploreRepo` reads it) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)