### PR TITLE
fix: improve SCIM group patch error logging and invalid user reporting

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -1697,12 +1697,24 @@ export class ScimService extends BaseService {
             return this.convertLightdashGroupToScimGroup(updatedGroup);
         } catch (error) {
             if (error instanceof ScimError) {
+                this.logger.error('SCIM: Group patch failed with SCIM error', {
+                    organizationUuid,
+                    groupUuid,
+                    detail: error.message,
+                    status: error.status,
+                    scimType: error.scimType,
+                });
                 throw error;
             }
             if (
                 error instanceof ParameterError ||
                 error instanceof InvalidScimPatchRequest
             ) {
+                this.logger.error('SCIM: Invalid group patch request', {
+                    organizationUuid,
+                    groupUuid,
+                    detail: error.message,
+                });
                 throw new ScimError({
                     detail: error.message,
                     status: 400,
@@ -1710,6 +1722,14 @@ export class ScimService extends BaseService {
                 });
             }
             if (error instanceof NotFoundError) {
+                this.logger.error(
+                    'SCIM: Group not found while patching group',
+                    {
+                        organizationUuid,
+                        groupUuid,
+                        detail: error.message,
+                    },
+                );
                 throw new ScimError({
                     detail: `Group with UUID ${groupUuid} not found`,
                     status: 404,
@@ -1717,6 +1737,14 @@ export class ScimService extends BaseService {
                 });
             }
             if (error instanceof AlreadyExistsError) {
+                this.logger.error(
+                    'SCIM: Group patch conflicts with existing group',
+                    {
+                        organizationUuid,
+                        groupUuid,
+                        detail: error.message,
+                    },
+                );
                 throw new ScimError({
                     detail: error.message,
                     status: 409,

--- a/packages/backend/src/models/GroupsModel.ts
+++ b/packages/backend/src/models/GroupsModel.ts
@@ -18,6 +18,7 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { uniq } from 'lodash';
+import difference from 'lodash/difference';
 import differenceBy from 'lodash/differenceBy';
 import { DatabaseError } from 'pg';
 import { DbEmail, EmailTableName } from '../database/entities/emails';
@@ -523,6 +524,7 @@ export class GroupsModel {
                     const newMembers = await trx
                         .select([
                             'groups.group_uuid',
+                            'users.user_uuid',
                             'users.user_id',
                             'organization_memberships.organization_id',
                         ])
@@ -544,13 +546,21 @@ export class GroupsModel {
                         .andWhere('groups.group_uuid', groupUuid);
 
                     if (newMembers.length !== membersToAdd.length) {
+                        const invalidUserUuids = difference(
+                            membersToAdd.map((member) => member.userUuid),
+                            newMembers.map((member) => member.user_uuid),
+                        ).join(', ');
                         throw new ParameterError(
-                            'Some provided user UUIDs are invalid',
+                            `Some provided user UUIDs are invalid: ${invalidUserUuids}`,
                         );
                     }
 
                     await trx('group_memberships')
-                        .insert(newMembers)
+                        .insert(
+                            newMembers.map(
+                                ({ user_uuid: _userUuid, ...member }) => member,
+                            ),
+                        )
                         .onConflict()
                         .ignore();
                 }


### PR DESCRIPTION
Closes:

### Description:

Improves error visibility and error messaging for SCIM group patch operations.

When a SCIM group patch request fails, structured log entries are now emitted for each error case (SCIM errors, invalid requests, not found, and conflicts), including the `organizationUuid`, `groupUuid`, and error details to aid in debugging.

Additionally, when users cannot be added to a group due to invalid UUIDs, the error message now includes the specific UUIDs that failed validation rather than a generic message. The query used to resolve members has also been updated to include `user_uuid` in the selection so it can be used for this comparison, and is then stripped out before the insert to avoid writing unexpected data.