### PR TITLE
fix(scheduler): resolve dashboard slug to uuid in scheduler methods

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -9,6 +9,7 @@ import {
     OrganizationMemberRole,
     PossibleAbilities,
     ProjectMemberRole,
+    SchedulerFormat,
     SessionUser,
     type Account,
     type Dashboard,
@@ -94,12 +95,22 @@ const savedSqlModel = {
 
 const projectModel = {
     getCachedExploreNames: jest.fn(async () => []),
+    get: jest.fn(async () => ({ schedulerTimezone: 'UTC' })),
 };
 
 const schedulerModel = {
     getScheduler: jest.fn(),
     getProjectSchedulerRuns: jest.fn(),
     getSchedulers: jest.fn(),
+    createScheduler: jest.fn(),
+};
+
+const slackClient = {
+    joinChannels: jest.fn(async () => undefined),
+};
+
+const schedulerClient = {
+    generateDailyJobsForScheduler: jest.fn(async () => undefined),
 };
 
 const dashboardChartsResult = {
@@ -178,8 +189,8 @@ describe('DashboardService', () => {
         savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
         savedChartService: {} as SavedChartService, // Mock for test
         projectModel: projectModel as unknown as ProjectModel,
-        slackClient: {} as SlackClient,
-        schedulerClient: {} as SchedulerClient,
+        slackClient: slackClient as unknown as SlackClient,
+        schedulerClient: schedulerClient as unknown as SchedulerClient,
         catalogModel: {} as CatalogModel,
         organizationModel: {
             findColorPalette: jest.fn(async () => null),
@@ -923,6 +934,17 @@ describe('DashboardService', () => {
             ).not.toHaveBeenCalled();
         });
 
+        test('returns runs when the dashboard is addressed by slug', async () => {
+            const result = await service.getSchedulerRuns(
+                editorOwnUser,
+                dashboard.slug,
+                schedulerUuid,
+            );
+
+            expect(result).toBe(runsPayload);
+            expect(schedulerModel.getProjectSchedulerRuns).toHaveBeenCalled();
+        });
+
         test('throws NotFoundError when the scheduler belongs to a different dashboard', async () => {
             schedulerModel.getScheduler.mockResolvedValueOnce({
                 schedulerUuid,
@@ -1012,6 +1034,69 @@ describe('DashboardService', () => {
                         createdByUserUuids: [user.userUuid],
                     },
                 }),
+            );
+        });
+
+        test('resolves slug to uuid when filtering schedulers', async () => {
+            await service.getSchedulers(adminUser, dashboard.slug);
+
+            expect(schedulerModel.getSchedulers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    filters: {
+                        resourceType: 'dashboard',
+                        resourceUuids: [dashboard.uuid],
+                    },
+                }),
+            );
+        });
+    });
+
+    describe('createScheduler', () => {
+        const editorUser: SessionUser = {
+            ...user,
+            ability: defineUserAbility(
+                {
+                    ...user,
+                    role: OrganizationMemberRole.MEMBER,
+                },
+                [
+                    {
+                        projectUuid: dashboard.projectUuid,
+                        role: ProjectMemberRole.EDITOR,
+                        userUuid: user.userUuid,
+                        roleUuid: undefined,
+                    },
+                ],
+            ),
+        };
+        const newScheduler = {
+            name: 'My delivery',
+            format: SchedulerFormat.CSV,
+            cron: '0 9 * * *',
+            timezone: 'UTC',
+            includeLinks: true,
+            targets: [],
+            options: { formatted: true, limit: 'table' },
+        } as unknown as Parameters<typeof service.createScheduler>[2];
+
+        beforeEach(() => {
+            schedulerModel.createScheduler.mockImplementation(
+                async (input) => ({
+                    ...input,
+                    schedulerUuid: 'new-scheduler-uuid',
+                }),
+            );
+        });
+
+        test('creates the scheduler with the resolved uuid when addressed by slug', async () => {
+            await service.createScheduler(
+                editorUser,
+                dashboard.slug,
+                newScheduler,
+            );
+
+            expect(schedulerModel.createScheduler).toHaveBeenCalledWith(
+                expect.objectContaining({ dashboardUuid: dashboard.uuid }),
             );
         });
     });

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -2080,7 +2080,7 @@ export class DashboardService
             searchQuery,
             filters: {
                 resourceType: 'dashboard',
-                resourceUuids: [dashboardUuid],
+                resourceUuids: [dashboard.uuid],
                 ...(canManageAll
                     ? {}
                     : { createdByUserUuids: [user.userUuid] }),
@@ -2129,7 +2129,7 @@ export class DashboardService
         ) {
             throw new ForbiddenError();
         }
-        if (scheduler.dashboardUuid !== dashboardUuid) {
+        if (scheduler.dashboardUuid !== dashboard.uuid) {
             throw new NotFoundError('Scheduler not found');
         }
         return this.schedulerModel.getProjectSchedulerRuns({
@@ -2170,8 +2170,11 @@ export class DashboardService
             );
         }
 
-        const { projectUuid, organizationUuid } =
-            await this.checkCreateScheduledDeliveryAccess(user, dashboardUuid);
+        const dashboard = await this.checkCreateScheduledDeliveryAccess(
+            user,
+            dashboardUuid,
+        );
+        const { projectUuid, organizationUuid } = dashboard;
 
         if (newScheduler.format === SchedulerFormat.GSHEETS) {
             const auditedAbility = this.createAuditedAbility(user);
@@ -2191,7 +2194,7 @@ export class DashboardService
         const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,
             createdBy: user.userUuid,
-            dashboardUuid,
+            dashboardUuid: dashboard.uuid,
             savedChartUuid: null,
             savedSqlUuid: null,
         });


### PR DESCRIPTION
## Problem

Creating a **scheduled delivery for a dashboard** fails when the dashboard was opened via a **slug-based URL** rather than a UUID-based one. The backend crashes with:

```
invalid input syntax for type uuid: "<dashboard-slug>"
```

Dashboard routes accept either a UUID or a slug, resolved server-side via `dashboardModel.getByIdOrSlug`. Three `DashboardService` scheduler methods resolved the dashboard for the access check but then reused the **raw, unresolved** `dashboardUuid` param downstream:

- `createScheduler` inserted the slug into the `uuid`-typed `scheduler.dashboard_uuid` column → **the crash above**.
- `getSchedulers` filtered with the slug → wrong/empty results when accessed by slug.
- `getSchedulerRuns` compared the scheduler's real uuid against the slug → spurious `NotFoundError`.

Commit b3e7038c15 (#22807) fixed this slug-vs-UUID class across ~9 other `DashboardService` methods but missed these three; `getSchedulerRuns` was added later (#23076), reintroducing the pattern.

## Fix

Use the resolved `dashboard.uuid` (from `checkCreateScheduledDeliveryAccess` / `getByIdOrSlug`) instead of the raw param in all three methods.

## Testing

Added unit tests covering the slug-addressed path for `createScheduler`, `getSchedulers`, and `getSchedulerRuns`. All three failed before the fix (received the slug where the resolved uuid was expected) and pass after.

Closes: PROD-8375
Closes: #24476
