### PR TITLE
fix: gracefully handle empty AI agent prompts (PROD-8361)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5437,6 +5437,13 @@ export class AiAgentService extends BaseService {
         return { relevantVerifiedAnswers: verifiedArtifacts };
     }
 
+    static stripSlackMentions(text: string): string {
+        return text.replaceAll(/<@U\d+\w*?>/g, '').trim();
+    }
+
+    private static readonly EMPTY_PROMPT_WELCOME =
+        "Hi! 👋 What would you like to know? Ask me a question about your data and I'll take a look.";
+
     static createRelevantArtifactsMessage(
         artifacts: {
             chartConfig: Record<string, unknown>;
@@ -5654,12 +5661,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const messagesWithToolCalls = await Promise.all(
             threadMessages.map(async (message, index) => {
-                const messages: ModelMessage[] = [
-                    {
-                        role: 'user',
-                        content: message.prompt,
-                    } satisfies UserModelMessage,
-                ];
+                const messages: ModelMessage[] =
+                    message.prompt.trim().length > 0
+                        ? [
+                              {
+                                  role: 'user',
+                                  content: message.prompt,
+                              } satisfies UserModelMessage,
+                          ]
+                        : [];
 
                 const pinnedContextMessage =
                     AiAgentService.createPinnedContextMessage(
@@ -5750,6 +5760,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         const history = messagesWithToolCalls.flat();
 
         if (!options.compaction) {
+            if (history.length === 0) {
+                return [
+                    {
+                        role: 'user',
+                        content:
+                            "The user hasn't asked anything yet. Greet them and ask what they'd like to know about their data.",
+                    } satisfies UserModelMessage,
+                ];
+            }
             return history;
         }
 
@@ -7267,12 +7286,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
         }
 
-        const slackTagRegex = /<@U\d+\w*?>/g;
-
         const uuid = await this.aiAgentModel.createSlackPrompt({
             threadUuid,
             createdByUserUuid: data.userUuid,
-            prompt: data.prompt.replaceAll(slackTagRegex, '').trim(),
+            prompt: AiAgentService.stripSlackMentions(data.prompt),
             slackUserId: data.slackUserId,
             slackChannelId: data.slackChannelId,
             promptSlackTs: data.promptSlackTs,
@@ -8259,6 +8276,18 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         let agent: AiAgent | undefined;
         if (thread.agentUuid) {
             agent = await this.getAgent(user, thread.agentUuid);
+        }
+
+        if (slackPrompt.prompt.trim().length === 0) {
+            const welcomeText = AiAgentService.EMPTY_PROMPT_WELCOME;
+            await this.slackClient.updateMessage({
+                organizationUuid: slackPrompt.organizationUuid,
+                text: welcomeText,
+                blocks: getMarkdownBlocks(welcomeText),
+                channelId: slackPrompt.slackChannelId,
+                messageTs: slackPrompt.response_slack_ts,
+            });
+            return;
         }
 
         let response: string | undefined;
@@ -11302,6 +11331,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         botId: context.botId,
                     });
                 }
+            }
+
+            if (
+                AiAgentService.stripSlackMentions(event.text ?? '').length === 0
+            ) {
+                const welcomeText = AiAgentService.EMPTY_PROMPT_WELCOME;
+                await say({
+                    username: agentConfig.name,
+                    thread_ts: event.thread_ts ?? event.ts,
+                    text: welcomeText,
+                    blocks: getMarkdownBlocks(welcomeText),
+                });
+                return;
             }
 
             [slackPromptUuid, createdThread] = await this.createSlackPrompt({

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AgentSidebar.tsx
@@ -42,40 +42,51 @@ const ThreadNavLink: FC<ThreadNavLinkProps> = ({
     isActive,
     projectUuid,
     showAgentName = false,
-}) => (
-    <NavLink
-        color="gray"
-        component={Link}
-        key={thread.uuid}
-        to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
-        px="xs"
-        py={rem(4)}
-        className={classes.threadNavLink}
-        label={
-            <Text truncate="end" size="xs" fw={500} c="ldGray.9">
-                {thread.title || thread.firstMessage.message}
-            </Text>
-        }
-        description={
-            showAgentName ? (
-                <AgentNamePill
-                    name={thread.agentName}
-                    imageUrl={thread.agentImageUrl}
-                    variant="inline"
-                />
-            ) : undefined
-        }
-        active={isActive}
-        rightSection={
-            thread.createdFrom === 'slack' && (
-                <Tooltip label={'Threads created in slack are read only'}>
-                    <IconBrandSlack size={18} stroke={1} />
-                </Tooltip>
-            )
-        }
-        viewTransition
-    />
-);
+}) => {
+    const threadTitle = (thread.title || thread.firstMessage.message).trim();
+    const hasTitle = threadTitle.length > 0;
+
+    return (
+        <NavLink
+            color="gray"
+            component={Link}
+            key={thread.uuid}
+            to={`/projects/${projectUuid}/ai-agents/${thread.agentUuid}/threads/${thread.uuid}`}
+            px="xs"
+            py={rem(4)}
+            className={classes.threadNavLink}
+            label={
+                <Text
+                    truncate="end"
+                    size="xs"
+                    fw={500}
+                    c={hasTitle ? 'ldGray.9' : 'dimmed'}
+                    fs={hasTitle ? undefined : 'italic'}
+                >
+                    {hasTitle ? threadTitle : 'Untitled thread'}
+                </Text>
+            }
+            description={
+                showAgentName ? (
+                    <AgentNamePill
+                        name={thread.agentName}
+                        imageUrl={thread.agentImageUrl}
+                        variant="inline"
+                    />
+                ) : undefined
+            }
+            active={isActive}
+            rightSection={
+                thread.createdFrom === 'slack' && (
+                    <Tooltip label={'Threads created in slack are read only'}>
+                        <IconBrandSlack size={18} stroke={1} />
+                    </Tooltip>
+                )
+            }
+            viewTransition
+        />
+    );
+};
 
 type ThreadListProps = {
     projectUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -389,6 +389,14 @@ const AssistantBubbleContent: FC<{
         !isStreaming && !streamingError && !message.message && !isPending;
     const shouldShowRetry = hasError || hasNoResponse || !!streamingError;
 
+    const isBenignEmptyResponse = hasNoResponse && !hasError && !streamingError;
+    const noticeTitle = isBenignEmptyResponse
+        ? 'No response'
+        : displayErrorTitle;
+    const noticeMessage = isBenignEmptyResponse
+        ? 'The agent finished without a response. You can try again.'
+        : displayErrorMessage;
+
     const baseMessageContent =
         isStreaming && streamingState
             ? streamingState.content
@@ -500,10 +508,10 @@ const AssistantBubbleContent: FC<{
                         >
                             <Stack gap={4}>
                                 <Text size="sm" fw={500} c="dimmed">
-                                    {displayErrorTitle}
+                                    {noticeTitle}
                                 </Text>
                                 <Text size="xs" c="dimmed">
-                                    {displayErrorMessage}
+                                    {noticeMessage}
                                 </Text>
                             </Stack>
                         </Alert>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
@@ -26,6 +26,20 @@
     }
 }
 
+.emptyMessageCard {
+    border-style: dashed;
+
+    @mixin light {
+        background-color: transparent;
+        border-color: var(--mantine-color-ldGray-3);
+    }
+
+    @mixin dark {
+        background-color: transparent;
+        border-color: var(--mantine-color-ldGray-7);
+    }
+}
+
 .markdown {
     background-color: transparent;
     font-size: 0.8125rem;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -44,6 +44,7 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
     const app = useApp();
     const showUserName =
         !!name && app.user?.data?.userUuid !== message.user.uuid;
+    const isEmptyMessage = message.message.trim().length === 0;
     const { matchedKeys, segments } = buildContentReferenceSegments(
         message.message,
         message.context,
@@ -107,9 +108,15 @@ export const UserBubble: FC<Props> = ({ message, isActive = false }) => {
                 px="sm"
                 withBorder
                 color="white"
-                className={styles.messageCard}
+                className={`${styles.messageCard} ${
+                    isEmptyMessage ? styles.emptyMessageCard : ''
+                }`}
             >
-                {hasInlineReferences && projectUuid ? (
+                {isEmptyMessage ? (
+                    <Text size="xs" fs="italic" c="dimmed">
+                        No message
+                    </Text>
+                ) : hasInlineReferences && projectUuid ? (
                     <Box className={`${styles.markdown} ${styles.messageText}`}>
                         {segments.map((segment, idx) => {
                             if (segment.type === 'text') {


### PR DESCRIPTION
Closes: PROD-8361
Closes: #24443

### Description

A bare Slack `@mention` (no question once the bot tag is stripped) produced an empty prompt, which serialised to an empty LLM message and threw `text content blocks must be non-empty` / `at least one message is required`. The web UI also rendered blank user bubbles and empty sidebar titles for those threads.

**Backend** (`AiAgentService.ts`)
- Short-circuit content-less `@mentions` with a friendly welcome instead of persisting an empty prompt and running the agent.
- Guard `generateSlackPromptReply` as a reliable chokepoint — any empty prompt that still reaches generation replies with the welcome rather than crashing.
- `getChatHistoryFromThreadMessages` skips empty user turns and never returns an empty message list (falls back to a single greeting turn).

**Frontend**
- Empty user messages render a dashed "No message" placeholder.
- Threads with no title show "Untitled thread" in the sidebar.
- Benign empty assistant responses show "No response" instead of a misleading failure notice.
