### PR TITLE
feat: Kanban board view for Ask AI Reviews

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -65,6 +65,7 @@ import styles from './AiAgentAdminReviewItemsTable.module.css';
 import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
 import { ReviewItemActions } from './ReviewItemActions';
 import {
+    DEFAULT_VISIBLE_ROOT_CAUSES,
     formatReviewDate,
     getActionLabel,
     getIssueTitle,
@@ -275,15 +276,6 @@ const rootCauseHelpOrder: AiAgentRootCause[] = [
     'not_a_failure',
     'ambiguous',
 ];
-
-const DEFAULT_HIDDEN_ROOT_CAUSES: AiAgentRootCause[] = [
-    'agent_configuration',
-    'runtime_reliability',
-];
-
-const DEFAULT_VISIBLE_ROOT_CAUSES = (
-    Object.keys(reviewRootCauseLabels) as AiAgentRootCause[]
-).filter((rootCause) => !DEFAULT_HIDDEN_ROOT_CAUSES.includes(rootCause));
 
 const ReviewConceptHelp = () => (
     <HoverCard

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -3,10 +3,12 @@ import {
     type AiAgentReviewRemediationEvent,
     type AiAgentReviewRemediationLiveState,
 } from '@lightdash/common';
-import { Anchor, Box } from '@mantine-8/core';
+import { Anchor, Box, Button } from '@mantine-8/core';
+import { IconMessages } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useMemo, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiAgentReviewItemActivity } from '../../hooks/useAiAgentAdmin';
 import styles from './RemediationActivityTimeline.module.css';
 
@@ -185,6 +187,18 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
                   : false,
     });
 
+    const workThreadUrl = useMemo(() => {
+        const r = reviewItem.remediation;
+        if (
+            r?.previewProjectUuid &&
+            r.previewAgentUuid &&
+            r.previewThreadUuid
+        ) {
+            return `/projects/${r.previewProjectUuid}/ai-agents/${r.previewAgentUuid}/threads/${r.previewThreadUuid}`;
+        }
+        return null;
+    }, [reviewItem.remediation]);
+
     const rows = useMemo<TimelineRow[]>(() => {
         if (!data || data.events.length === 0) {
             return [];
@@ -200,10 +214,33 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
                 ...eventRow(event, reviewItem),
             };
         });
-        return data.liveState
+        const liveRows = data.liveState
             ? [...eventRows, liveRow(data.liveState, data.liveMessage)]
             : eventRows;
-    }, [data, reviewItem]);
+        if (!workThreadUrl) return liveRows;
+        return [
+            ...liveRows,
+            {
+                key: 'test-fix-action',
+                label: 'Test fix',
+                when: '',
+                state: 'done' as const,
+                meta: (
+                    <Button
+                        component="a"
+                        href={workThreadUrl}
+                        size="compact-xs"
+                        variant="default"
+                        leftSection={
+                            <MantineIcon icon={IconMessages} size="xs" />
+                        }
+                    >
+                        Test fix
+                    </Button>
+                ),
+            },
+        ];
+    }, [data, reviewItem, workThreadUrl]);
 
     if (rows.length === 0) {
         return null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -111,7 +111,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                             </Button>
                         )}
 
-                        {workThreadUrl && (
+                        {workThreadUrl && mode !== 'drawer' && (
                             <Button
                                 component="a"
                                 href={workThreadUrl}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -1,0 +1,152 @@
+.toolbar {
+    flex-wrap: wrap;
+    align-items: center;
+}
+.card {
+    position: relative;
+    background: var(--mantine-color-body);
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    box-shadow: 0 1px 2px rgba(20, 22, 28, 0.04);
+    width: 100%;
+    transition:
+        border-color 120ms ease,
+        box-shadow 120ms ease;
+    overflow: hidden;
+}
+.card:has(.cardBody:hover),
+.card:has(.cardFooter:hover) {
+    border-color: var(--mantine-color-indigo-4);
+    box-shadow: 0 4px 14px rgba(80, 60, 180, 0.1);
+}
+.cardSelected {
+    border-color: var(--mantine-color-indigo-5);
+}
+.cardBody {
+    display: block;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+}
+.cardFooter {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-top: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
+    text-decoration: none;
+    transition: background 100ms ease;
+}
+.cardFooter:hover {
+    background: light-dark(
+        var(--mantine-color-gray-1),
+        var(--mantine-color-dark-5)
+    );
+}
+.startAction {
+    position: absolute;
+    top: var(--mantine-spacing-xs);
+    right: var(--mantine-spacing-xs);
+    opacity: 0;
+    transition: opacity 120ms ease;
+    background: var(--mantine-color-indigo-filled);
+}
+.card:hover .startAction {
+    opacity: 1;
+}
+.pulse {
+    animation: ldReviewPing 1.6s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+@keyframes ldReviewPing {
+    0% {
+        transform: scale(1);
+        opacity: 0.55;
+    }
+    70% {
+        transform: scale(2.6);
+        opacity: 0;
+    }
+    100% {
+        transform: scale(2.6);
+        opacity: 0;
+    }
+}
+.boardWrapper {
+    background: light-dark(
+        var(--mantine-color-gray-0),
+        var(--mantine-color-dark-6)
+    );
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-md);
+    min-height: 0;
+    flex: 1;
+}
+.board {
+    display: flex;
+    gap: var(--mantine-spacing-md);
+    align-items: stretch;
+    overflow-x: auto;
+    width: 100%;
+    min-height: 0;
+}
+.lane {
+    width: 320px;
+    flex: none;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.laneScroll {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--mantine-spacing-xs);
+    padding: 2px;
+}
+.spacer {
+    flex: 1;
+}
+.emptyLane {
+    border: 1px dashed
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-md);
+    text-align: center;
+}
+.laneOver {
+    background: light-dark(
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-dark-5)
+    );
+    outline: 1.5px dashed var(--mantine-color-indigo-4);
+    border-radius: var(--mantine-radius-md);
+}
+.cardGhost {
+    opacity: 0.4;
+    pointer-events: none;
+}
+.dragOverlayCard {
+    transform: rotate(2deg);
+    box-shadow: 0 8px 24px rgba(20, 22, 28, 0.18);
+    border-radius: var(--mantine-radius-md);
+    cursor: grabbing;
+}
+.dropPlaceholder {
+    height: 64px;
+    border: 1.5px dashed var(--mantine-color-indigo-4);
+    border-radius: var(--mantine-radius-md);
+    background: light-dark(
+        var(--mantine-color-indigo-0),
+        var(--mantine-color-dark-5)
+    );
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -1,0 +1,80 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { ReviewKanbanBoard } from './ReviewKanbanBoard';
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useAiAgentAdminReviewItems: () => ({ data: items }),
+    useAiAgentAdminAgents: () => ({ data: [] }),
+    useAiAgentReviewItemPrDiff: () => ({ data: null }),
+    useUpdateAiAgentReviewItemStatus: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+    useCreateAiAgentReviewItemWriteback: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../AgentNamePill', () => ({ AgentNamePill: () => null }));
+
+const items = [
+    {
+        uuid: 'a',
+        status: 'open',
+        primaryRootCause: 'ambiguous',
+        title: 'Triage me',
+        prWritebackStatus: null,
+        remediation: null,
+        linkedPrUrl: null,
+        agentUuid: null,
+        firstSeenAt: new Date('2026-06-01'),
+        writebackEligibility: { eligible: false, reason: 'no_fix_targets' },
+        latestFinding: {
+            fixTargets: [],
+            projectUuid: 'p',
+            agentUuid: 'ag',
+            threadUuid: 't',
+        },
+    },
+    {
+        uuid: 'b',
+        status: 'resolved',
+        primaryRootCause: 'semantic_layer',
+        title: 'All done',
+        prWritebackStatus: null,
+        remediation: null,
+        linkedPrUrl: null,
+        agentUuid: null,
+        firstSeenAt: new Date('2026-06-01'),
+        writebackEligibility: { eligible: false, reason: 'no_fix_targets' },
+        latestFinding: {
+            fixTargets: [],
+            targetRefs: [],
+            recommendation: null,
+            projectUuid: 'p',
+            agentUuid: 'ag',
+            threadUuid: 't',
+        },
+    },
+] as unknown as AiAgentReviewItemSummary[];
+
+describe('ReviewKanbanBoard', () => {
+    it('renders all four lanes with items bucketed correctly', () => {
+        renderWithProviders(<ReviewKanbanBoard onReviewItemSelect={vi.fn()} />);
+
+        expect(screen.getByText('Needs triage')).toBeInTheDocument();
+        expect(screen.getByText('To Do')).toBeInTheDocument();
+        expect(screen.getByText('In Progress')).toBeInTheDocument();
+        expect(screen.getByText('Done')).toBeInTheDocument();
+
+        // ambiguous open item → needs_triage lane; getIssueTitle returns 'Triage correction signal'
+        expect(
+            screen.getByText('Triage correction signal'),
+        ).toBeInTheDocument();
+        // resolved item → done lane; getIssueTitle falls back to item.title
+        expect(screen.getByText('All done')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -1,0 +1,486 @@
+import {
+    DndContext,
+    DragOverlay,
+    KeyboardSensor,
+    PointerSensor,
+    useDraggable,
+    useDroppable,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+    type DragOverEvent,
+    type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+    type AiAgentReviewItemSummary,
+    type AiAgentRootCause,
+} from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Button,
+    Divider,
+    Group,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { IconBox, IconTag } from '@tabler/icons-react';
+import { type FC, useDeferredValue, useMemo, useState } from 'react';
+import FilterFacet, {
+    type FilterFacetOption,
+} from '../../../../../components/common/FilterFacet';
+import { useProjects } from '../../../../../hooks/useProjects';
+import {
+    useAiAgentAdminReviewItems,
+    useCreateAiAgentReviewItemWriteback,
+    useUpdateAiAgentReviewItemStatus,
+} from '../../hooks/useAiAgentAdmin';
+import { type AiAgentAdminReviewItemPreviewTarget } from './AiAgentAdminReviewItemsTable';
+import { EXAMPLE_REVIEW_ITEMS } from './onboarding';
+import {
+    DEFAULT_VISIBLE_ROOT_CAUSES,
+    getIssueTitle,
+    reviewRootCauseLabels,
+} from './reviewItemDetails';
+import styles from './ReviewKanbanBoard.module.css';
+import { ReviewKanbanCard } from './ReviewKanbanCard';
+import {
+    BOARD_STATUSES,
+    getReviewLane,
+    getStartWritebackKind,
+    LANE_TARGET_STATUS,
+    partitionInProgress,
+    REVIEW_LANES,
+    type ReviewLane,
+} from './reviewLane';
+import { SearchFilter } from './SearchFilter';
+
+const VISIBLE_PER_LANE = 10;
+
+const LANE_IDS = new Set<string>(REVIEW_LANES.map((l) => l.id));
+
+type Props = {
+    selectedReviewItemUuid?: string | null;
+    onReviewItemSelect: (target: AiAgentAdminReviewItemPreviewTarget) => void;
+    showOnboardingExamples?: boolean;
+};
+
+const toTarget = (
+    item: AiAgentReviewItemSummary,
+): AiAgentAdminReviewItemPreviewTarget | null => {
+    const finding = item.latestFinding;
+    if (!finding) return null;
+    return {
+        projectUuid: finding.projectUuid,
+        agentUuid: finding.agentUuid,
+        threadUuid: finding.threadUuid,
+        reviewItemUuid: item.uuid,
+    };
+};
+
+type DraggableCardProps = {
+    item: AiAgentReviewItemSummary;
+    isSelected: boolean;
+    onSelect: () => void;
+};
+
+const DraggableCard: FC<DraggableCardProps> = ({
+    item,
+    isSelected,
+    onSelect,
+}) => {
+    const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+        id: item.uuid,
+    });
+
+    return (
+        <Box
+            ref={setNodeRef}
+            className={isDragging ? styles.cardGhost : undefined}
+            {...listeners}
+            {...attributes}
+        >
+            <ReviewKanbanCard
+                item={item}
+                isSelected={isSelected}
+                onSelect={onSelect}
+            />
+        </Box>
+    );
+};
+
+type DroppableLaneProps = {
+    laneId: ReviewLane;
+    isDraggingValidTarget: boolean;
+    children: React.ReactNode;
+};
+
+const DroppableLane: FC<DroppableLaneProps> = ({
+    laneId,
+    isDraggingValidTarget,
+    children,
+}) => {
+    const { setNodeRef, isOver } = useDroppable({ id: laneId });
+    const highlight = isOver && isDraggingValidTarget;
+
+    return (
+        <Box
+            ref={setNodeRef}
+            className={`${styles.laneScroll}${highlight ? ` ${styles.laneOver}` : ''}`}
+        >
+            {children}
+        </Box>
+    );
+};
+
+export const ReviewKanbanBoard: FC<Props> = ({
+    selectedReviewItemUuid,
+    onReviewItemSelect,
+    showOnboardingExamples = false,
+}) => {
+    const [search, setSearch] = useState<string | undefined>(undefined);
+    const deferredSearch = useDeferredValue(search);
+    const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
+        [],
+    );
+    const [selectedRootCauses, setSelectedRootCauses] = useState<
+        AiAgentRootCause[]
+    >(DEFAULT_VISIBLE_ROOT_CAUSES);
+    const { data } = useAiAgentAdminReviewItems({ statuses: BOARD_STATUSES });
+    const { data: projects } = useProjects();
+    const [expandedLanes, setExpandedLanes] = useState<
+        Partial<Record<ReviewLane, boolean>>
+    >({});
+    const [draggingItemUuid, setDraggingItemUuid] = useState<string | null>(
+        null,
+    );
+    const [overLaneId, setOverLaneId] = useState<ReviewLane | null>(null);
+
+    const updateStatus = useUpdateAiAgentReviewItemStatus();
+    const createWriteback = useCreateAiAgentReviewItemWriteback();
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+        useSensor(KeyboardSensor),
+    );
+
+    const projectsMap = useMemo(() => {
+        if (!projects) return new Map<string, { name: string }>();
+        return new Map(projects.map((p) => [p.projectUuid, p]));
+    }, [projects]);
+
+    const allItems = useMemo<AiAgentReviewItemSummary[]>(() => {
+        if (showOnboardingExamples && (!data || data.length === 0)) {
+            return EXAMPLE_REVIEW_ITEMS as AiAgentReviewItemSummary[];
+        }
+        return data ?? [];
+    }, [data, showOnboardingExamples]);
+
+    const searchFilteredItems = useMemo<AiAgentReviewItemSummary[]>(() => {
+        const q = deferredSearch?.trim().toLowerCase();
+        if (!q) return allItems;
+        return allItems.filter((item) =>
+            getIssueTitle(item).toLowerCase().includes(q),
+        );
+    }, [allItems, deferredSearch]);
+
+    const projectFilteredItems = useMemo<AiAgentReviewItemSummary[]>(() => {
+        if (selectedProjectUuids.length === 0) return searchFilteredItems;
+        const projectSet = new Set(selectedProjectUuids);
+        return searchFilteredItems.filter((item) => {
+            const projectUuid =
+                item.latestFinding?.projectUuid ?? item.projectUuid ?? null;
+            return projectUuid !== null && projectSet.has(projectUuid);
+        });
+    }, [searchFilteredItems, selectedProjectUuids]);
+
+    const items = useMemo<AiAgentReviewItemSummary[]>(() => {
+        if (selectedRootCauses.length === 0) return projectFilteredItems;
+        const rootCauseSet = new Set(selectedRootCauses);
+        return projectFilteredItems.filter((item) =>
+            rootCauseSet.has(item.primaryRootCause),
+        );
+    }, [projectFilteredItems, selectedRootCauses]);
+
+    const projectFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<string, number>();
+        for (const item of searchFilteredItems.filter((item) => {
+            if (selectedRootCauses.length === 0) return true;
+            return selectedRootCauses.includes(item.primaryRootCause);
+        })) {
+            const projectUuid =
+                item.latestFinding?.projectUuid ?? item.projectUuid ?? null;
+            if (!projectUuid) continue;
+            counts.set(projectUuid, (counts.get(projectUuid) ?? 0) + 1);
+        }
+        return Array.from(counts.entries())
+            .map(([projectUuid, count]) => ({
+                value: projectUuid,
+                label: projectsMap.get(projectUuid)?.name ?? 'Unknown project',
+                count,
+            }))
+            .sort(
+                (a, b) =>
+                    b.count - a.count ||
+                    String(a.label).localeCompare(String(b.label)),
+            );
+    }, [projectsMap, searchFilteredItems, selectedRootCauses]);
+
+    const rootCauseFacetOptions = useMemo((): FilterFacetOption[] => {
+        const counts = new Map<AiAgentRootCause, number>();
+        for (const item of projectFilteredItems) {
+            counts.set(
+                item.primaryRootCause,
+                (counts.get(item.primaryRootCause) ?? 0) + 1,
+            );
+        }
+        return (Object.keys(reviewRootCauseLabels) as AiAgentRootCause[])
+            .map((rootCause) => ({
+                value: rootCause,
+                label: reviewRootCauseLabels[rootCause],
+                count: counts.get(rootCause) ?? 0,
+            }))
+            .sort(
+                (a, b) =>
+                    b.count - a.count ||
+                    String(a.label).localeCompare(String(b.label)),
+            );
+    }, [projectFilteredItems]);
+
+    const lanes = useMemo(() => {
+        const byLane: Record<ReviewLane, AiAgentReviewItemSummary[]> = {
+            needs_triage: [],
+            todo: [],
+            in_progress: [],
+            done: [],
+        };
+        items.forEach((item) => byLane[getReviewLane(item)].push(item));
+        return byLane;
+    }, [items]);
+
+    // Resolve the item being dragged to check if a given lane is a valid target
+    const draggingItem = draggingItemUuid
+        ? (items.find((item) => item.uuid === draggingItemUuid) ?? null)
+        : null;
+
+    const isValidTarget = (laneId: ReviewLane): boolean => {
+        if (!draggingItem) return false;
+        const targetStatus = LANE_TARGET_STATUS[laneId];
+        return targetStatus !== null && targetStatus !== draggingItem.status;
+    };
+
+    const handleDragStart = ({ active }: DragStartEvent) => {
+        setDraggingItemUuid(String(active.id));
+    };
+
+    const handleDragOver = ({ over }: DragOverEvent) => {
+        const id = over?.id ? String(over.id) : null;
+        const next = id && LANE_IDS.has(id) ? (id as ReviewLane) : null;
+        setOverLaneId((prev) => (prev === next ? prev : next));
+    };
+
+    const handleDragEnd = ({ active, over }: DragEndEvent) => {
+        setDraggingItemUuid(null);
+        setOverLaneId(null);
+        if (!over) return;
+        if (!LANE_IDS.has(String(over.id))) return;
+        const targetLane = over.id as ReviewLane;
+        const draggedItem = items.find((item) => item.uuid === active.id);
+        if (!draggedItem) return;
+
+        const targetStatus = LANE_TARGET_STATUS[targetLane];
+        if (targetStatus === null) return;
+
+        if (targetStatus !== draggedItem.status) {
+            updateStatus.mutate({
+                fingerprint: draggedItem.fingerprint,
+                body: { status: targetStatus, dismissedReason: null },
+            });
+            if (targetLane === 'in_progress') {
+                const kind = getStartWritebackKind(draggedItem);
+                if (kind === 'mutate')
+                    createWriteback.mutate(draggedItem.fingerprint);
+            }
+        }
+    };
+
+    const handleDragCancel = () => {
+        setDraggingItemUuid(null);
+        setOverLaneId(null);
+    };
+
+    return (
+        <Stack gap="sm" style={{ minHeight: 0, flex: 1 }}>
+            <Group gap="sm" wrap="wrap" className={styles.toolbar}>
+                <SearchFilter
+                    search={search}
+                    setSearch={setSearch}
+                    placeholder="Search issues"
+                />
+                <FilterFacet
+                    label="Project"
+                    icon={IconBox}
+                    options={projectFacetOptions}
+                    selected={selectedProjectUuids}
+                    onChange={setSelectedProjectUuids}
+                    emptyLabel="No projects in current view"
+                    tooltipLabel="Filter by project"
+                />
+                <FilterFacet
+                    label="Cause"
+                    icon={IconTag}
+                    options={rootCauseFacetOptions}
+                    selected={selectedRootCauses}
+                    onChange={(values) =>
+                        setSelectedRootCauses(values as AiAgentRootCause[])
+                    }
+                    emptyLabel="No root causes in current view"
+                    tooltipLabel="Filter by root cause"
+                />
+            </Group>
+            <Box className={styles.boardWrapper}>
+                <DndContext
+                    sensors={sensors}
+                    onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
+                    onDragEnd={handleDragEnd}
+                    onDragCancel={handleDragCancel}
+                >
+                    <Box className={styles.board}>
+                        {REVIEW_LANES.map((lane) => {
+                            const all = lanes[lane.id];
+                            const isExpanded = expandedLanes[lane.id] ?? false;
+                            const displayed =
+                                isExpanded || all.length <= VISIBLE_PER_LANE
+                                    ? all
+                                    : all.slice(0, VISIBLE_PER_LANE);
+                            const hasMore = all.length > VISIBLE_PER_LANE;
+
+                            const { active, rest } =
+                                lane.id === 'in_progress'
+                                    ? partitionInProgress(displayed)
+                                    : { active: [], rest: displayed };
+                            const cards =
+                                lane.id === 'in_progress'
+                                    ? [...active, ...rest]
+                                    : displayed;
+
+                            return (
+                                <Box key={lane.id} className={styles.lane}>
+                                    <Group gap={8} px={4} pb="xs">
+                                        <Box
+                                            w={8}
+                                            h={8}
+                                            bg={`${lane.color}.5`}
+                                            style={{ borderRadius: 3 }}
+                                        />
+                                        <Text fz="sm" fw={650}>
+                                            {lane.label}
+                                        </Text>
+                                        <Badge
+                                            color="gray"
+                                            variant="light"
+                                            size="sm"
+                                        >
+                                            {all.length}
+                                        </Badge>
+                                    </Group>
+                                    <DroppableLane
+                                        laneId={lane.id}
+                                        isDraggingValidTarget={isValidTarget(
+                                            lane.id,
+                                        )}
+                                    >
+                                        {cards.length === 0 ? (
+                                            <Box className={styles.emptyLane}>
+                                                <Text fz="xs" c="dimmed">
+                                                    No issues
+                                                </Text>
+                                            </Box>
+                                        ) : (
+                                            <>
+                                                {cards.map((item, index) => {
+                                                    const showDivider =
+                                                        lane.id ===
+                                                            'in_progress' &&
+                                                        active.length > 0 &&
+                                                        index === active.length;
+                                                    const target =
+                                                        toTarget(item);
+                                                    return (
+                                                        <Box key={item.uuid}>
+                                                            {showDivider && (
+                                                                <Divider
+                                                                    my="xs"
+                                                                    label="Other"
+                                                                    labelPosition="left"
+                                                                />
+                                                            )}
+                                                            <DraggableCard
+                                                                item={item}
+                                                                isSelected={
+                                                                    selectedReviewItemUuid ===
+                                                                    item.uuid
+                                                                }
+                                                                onSelect={() => {
+                                                                    if (target)
+                                                                        onReviewItemSelect(
+                                                                            target,
+                                                                        );
+                                                                }}
+                                                            />
+                                                        </Box>
+                                                    );
+                                                })}
+                                                {hasMore && (
+                                                    <Button
+                                                        variant="subtle"
+                                                        size="xs"
+                                                        color="gray"
+                                                        fullWidth
+                                                        onClick={() =>
+                                                            setExpandedLanes(
+                                                                (prev) => ({
+                                                                    ...prev,
+                                                                    [lane.id]:
+                                                                        !isExpanded,
+                                                                }),
+                                                            )
+                                                        }
+                                                    >
+                                                        {isExpanded
+                                                            ? 'Show less'
+                                                            : `Show all (${all.length})`}
+                                                    </Button>
+                                                )}
+                                                {overLaneId === lane.id &&
+                                                    isValidTarget(lane.id) && (
+                                                        <Box
+                                                            className={
+                                                                styles.dropPlaceholder
+                                                            }
+                                                        />
+                                                    )}
+                                            </>
+                                        )}
+                                    </DroppableLane>
+                                </Box>
+                            );
+                        })}
+                    </Box>
+                    <DragOverlay>
+                        {draggingItem && (
+                            <Box className={styles.dragOverlayCard}>
+                                <ReviewKanbanCard
+                                    item={draggingItem}
+                                    isSelected={false}
+                                    onSelect={() => {}}
+                                />
+                            </Box>
+                        )}
+                    </DragOverlay>
+                </DndContext>
+            </Box>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -1,0 +1,216 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Button,
+    Group,
+    HoverCard,
+    Stack,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
+import {
+    IconArrowUpRight,
+    IconBox,
+    IconGitPullRequest,
+} from '@tabler/icons-react';
+import { type FC, useState } from 'react';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import {
+    useCreateAiAgentReviewItemWriteback,
+    useUpdateAiAgentReviewItemStatus,
+} from '../../hooks/useAiAgentAdmin';
+import { AiAgentIcon } from '../AiAgentIcon';
+import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
+import {
+    formatReviewDate,
+    getIssueTitle,
+    reviewRootCauseColors,
+    reviewRootCauseLabels,
+} from './reviewItemDetails';
+import styles from './ReviewKanbanBoard.module.css';
+import { getStartWritebackKind, parsePrNumber } from './reviewLane';
+import { ReviewPrHoverCard } from './ReviewPrHoverCard';
+
+type Props = {
+    item: AiAgentReviewItemSummary;
+    isSelected: boolean;
+    onSelect: (item: AiAgentReviewItemSummary) => void;
+};
+
+// ts-unused-exports:disable-next-line
+export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
+    const createWriteback = useCreateAiAgentReviewItemWriteback();
+    const updateStatus = useUpdateAiAgentReviewItemStatus();
+    const [previewOpen, setPreviewOpen] = useState(false);
+
+    const prNumber = parsePrNumber(item.linkedPrUrl);
+    const isAgentRunning =
+        item.prWritebackStatus === 'queued' ||
+        item.prWritebackStatus === 'running';
+
+    const startKind = getStartWritebackKind(item);
+
+    const remediation = item.remediation;
+    const hasPreview = Boolean(remediation?.previewProjectUuid);
+
+    const isPreviewBuilding =
+        remediation?.status === 'queued' || remediation?.status === 'running';
+
+    const previewHref =
+        remediation?.previewProjectUuid &&
+        remediation?.previewAgentUuid &&
+        remediation?.previewThreadUuid
+            ? `/projects/${remediation.previewProjectUuid}/ai-agents/${remediation.previewAgentUuid}/threads/${remediation.previewThreadUuid}`
+            : remediation?.previewProjectUuid
+              ? `/projects/${remediation.previewProjectUuid}/home`
+              : null;
+
+    return (
+        <Box
+            className={`${styles.card}${isSelected ? ` ${styles.cardSelected}` : ''}`}
+        >
+            <UnstyledButton
+                className={styles.cardBody}
+                p="sm"
+                onClick={() => onSelect(item)}
+            >
+                <Stack gap={8}>
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Text fz="sm" fw={550} lineClamp={2}>
+                            {getIssueTitle(item)}
+                        </Text>
+                        <Group gap={8} wrap="nowrap" align="center">
+                            {isAgentRunning && (
+                                <AiAgentIcon size={14} animated />
+                            )}
+                            <Text
+                                fz="xs"
+                                c="dimmed"
+                                style={{ whiteSpace: 'nowrap' }}
+                            >
+                                {formatReviewDate(item.firstSeenAt)}
+                            </Text>
+                        </Group>
+                    </Group>
+
+                    <Group gap={6} wrap="wrap">
+                        <CategoryBadge
+                            color={reviewRootCauseColors[item.primaryRootCause]}
+                            label={reviewRootCauseLabels[item.primaryRootCause]}
+                        />
+
+                        {prNumber !== null && (
+                            <HoverCard
+                                width={300}
+                                shadow="md"
+                                openDelay={150}
+                                withinPortal
+                            >
+                                <HoverCard.Target>
+                                    <Box>
+                                        <Badge
+                                            size="sm"
+                                            radius="sm"
+                                            variant="light"
+                                            color="green"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconGitPullRequest}
+                                                    size={11}
+                                                />
+                                            }
+                                        >
+                                            #{prNumber}
+                                        </Badge>
+                                    </Box>
+                                </HoverCard.Target>
+                                <HoverCard.Dropdown>
+                                    <ReviewPrHoverCard item={item} />
+                                </HoverCard.Dropdown>
+                            </HoverCard>
+                        )}
+                    </Group>
+                </Stack>
+            </UnstyledButton>
+
+            {hasPreview && !isPreviewBuilding && previewHref && (
+                <Box
+                    component="a"
+                    href={previewHref}
+                    onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                        e.stopPropagation()
+                    }
+                    className={styles.cardFooter}
+                >
+                    <Group gap={6} align="center">
+                        <MantineIcon icon={IconBox} size={13} />
+                        <Text fz="xs">Preview project</Text>
+                    </Group>
+                    <MantineIcon icon={IconArrowUpRight} size={14} />
+                </Box>
+            )}
+            {hasPreview && isPreviewBuilding && (
+                <Box className={styles.cardFooter}>
+                    <Group gap={6} align="center">
+                        <MantineIcon icon={IconBox} size={13} />
+                        <Text fz="xs">Preview project</Text>
+                    </Group>
+                    <Group gap={6} align="center">
+                        <Box
+                            pos="relative"
+                            w={7}
+                            h={7}
+                            bg="yellow.5"
+                            className={styles.pulse}
+                            style={{ borderRadius: '50%' }}
+                        />
+                        <Text fz="xs" c="dimmed">
+                            Building…
+                        </Text>
+                    </Group>
+                </Box>
+            )}
+
+            {startKind !== null && (
+                <Button
+                    size="compact-xs"
+                    radius="md"
+                    variant="filled"
+                    loading={createWriteback.isLoading}
+                    className={styles.startAction}
+                    onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        updateStatus.mutate({
+                            fingerprint: item.fingerprint,
+                            body: {
+                                status: 'in_progress',
+                                dismissedReason: null,
+                            },
+                        });
+                        if (startKind === 'modal') {
+                            setPreviewOpen(true);
+                        } else {
+                            createWriteback.mutate(item.fingerprint);
+                        }
+                    }}
+                >
+                    Start
+                </Button>
+            )}
+
+            {startKind === 'modal' && (
+                <ProjectContextWritebackModal
+                    fingerprint={item.fingerprint}
+                    opened={previewOpen}
+                    onClose={() => setPreviewOpen(false)}
+                />
+            )}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrHoverCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrHoverCard.tsx
@@ -1,0 +1,78 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { Anchor, Button, Group, Stack, Text } from '@mantine-8/core';
+import { IconGitPullRequest } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import {
+    useAiAgentReviewItemPrDiff,
+    useUpdateAiAgentReviewItemStatus,
+} from '../../hooks/useAiAgentAdmin';
+import { parsePrNumber } from './reviewLane';
+
+// ts-unused-exports:disable-next-line
+export const ReviewPrHoverCard: FC<{ item: AiAgentReviewItemSummary }> = ({
+    item,
+}) => {
+    const prNumber = parsePrNumber(item.linkedPrUrl);
+    const { data: diff } = useAiAgentReviewItemPrDiff(item.fingerprint, {
+        enabled: !!item.linkedPrUrl,
+    });
+    const updateStatus = useUpdateAiAgentReviewItemStatus();
+    const isDone =
+        item.status === 'resolved' ||
+        item.status === 'dismissed' ||
+        item.status === 'duplicate';
+
+    return (
+        <Stack gap="xs" w={280}>
+            <Text fz="xs" c="dimmed" fw={600}>
+                Verification
+            </Text>
+            <Text fz="sm" fw={600} lineClamp={2}>
+                {item.title}
+            </Text>
+            {item.linkedPrUrl && (
+                <Anchor
+                    href={item.linkedPrUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    fz="sm"
+                >
+                    <Group gap={6} wrap="nowrap">
+                        <MantineIcon icon={IconGitPullRequest} />
+                        Pull request #{prNumber}
+                    </Group>
+                </Anchor>
+            )}
+            {diff && (
+                <Group gap={8}>
+                    <Text fz="sm" c="green.7" fw={700}>
+                        +{diff.totalAdditions}
+                    </Text>
+                    <Text fz="sm" c="red.7" fw={700}>
+                        −{diff.totalDeletions}
+                    </Text>
+                </Group>
+            )}
+            {!isDone && (
+                <Button
+                    size="compact-xs"
+                    color="dark"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        updateStatus.mutate({
+                            fingerprint: item.fingerprint,
+                            body: {
+                                status: 'resolved',
+                                dismissedReason: null,
+                            },
+                        });
+                    }}
+                    loading={updateStatus.isLoading}
+                >
+                    Mark as done
+                </Button>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -202,6 +202,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
         ? getReviewReasoningText(selectedReviewItem)
         : null;
     const [showValidation, setShowValidation] = useState(false);
+    const [showConversation, setShowConversation] = useState(true);
     const previewProjectUuid =
         selectedReviewItem?.remediation?.previewProjectUuid ?? null;
 
@@ -679,13 +680,41 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                             threadUuid={threadUuid}
                         />
                     )}
-                    <AgentChatDisplay
-                        thread={threadData}
-                        projectUuid={projectUuid}
-                        agentUuid={agentUuid}
-                        showAddToEvalsButton={showAddToEvalsButton}
-                        renderArtifactsInline
-                    />
+                    <Box p="md" pt="sm">
+                        <UnstyledButton
+                            className={styles.sectionToggle}
+                            data-active={showConversation || undefined}
+                            onClick={() => setShowConversation((open) => !open)}
+                            aria-expanded={showConversation}
+                        >
+                            <Text
+                                size="10px"
+                                fw={700}
+                                tt="uppercase"
+                                lts={0.4}
+                                c="ldGray.7"
+                            >
+                                Evidence
+                            </Text>
+                            <MantineIcon
+                                icon={
+                                    showConversation
+                                        ? IconChevronDown
+                                        : IconChevronRight
+                                }
+                                size="xs"
+                            />
+                        </UnstyledButton>
+                        <Collapse in={showConversation}>
+                            <AgentChatDisplay
+                                thread={threadData}
+                                projectUuid={projectUuid}
+                                agentUuid={agentUuid}
+                                showAddToEvalsButton={showAddToEvalsButton}
+                                renderArtifactsInline
+                            />
+                        </Collapse>
+                    </Box>
                 </Box>
             )}
         </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -17,6 +17,15 @@ export const reviewRootCauseLabels: Record<AiAgentRootCause, string> = {
     ambiguous: 'Ambiguous',
 };
 
+const DEFAULT_HIDDEN_ROOT_CAUSES: AiAgentRootCause[] = [
+    'agent_configuration',
+    'runtime_reliability',
+];
+
+export const DEFAULT_VISIBLE_ROOT_CAUSES = (
+    Object.keys(reviewRootCauseLabels) as AiAgentRootCause[]
+).filter((rootCause) => !DEFAULT_HIDDEN_ROOT_CAUSES.includes(rootCause));
+
 export const reviewRootCauseColors: Record<AiAgentRootCause, string> = {
     semantic_layer: 'indigo',
     project_context: 'violet',
@@ -111,7 +120,9 @@ const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
     }
 };
 
-const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
+export const isTriageReviewItem = (
+    reviewItem: AiAgentReviewItemSummary,
+): boolean =>
     reviewItem.primaryRootCause === 'ambiguous' ||
     reviewItem.latestFinding?.fixTargets.includes('feedback_needed') === true;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewLane.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewLane.test.ts
@@ -1,0 +1,159 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    getReviewLane,
+    getStartWritebackKind,
+    LANE_TARGET_STATUS,
+    parsePrNumber,
+    partitionInProgress,
+} from './reviewLane';
+
+const base = (
+    overrides: Partial<AiAgentReviewItemSummary>,
+): AiAgentReviewItemSummary =>
+    ({
+        status: 'open',
+        primaryRootCause: 'semantic_layer',
+        prWritebackStatus: null,
+        remediation: null,
+        linkedPrUrl: null,
+        latestFinding: { fixTargets: [] },
+        ...overrides,
+    }) as unknown as AiAgentReviewItemSummary;
+
+describe('getReviewLane', () => {
+    it('open + ambiguous → needs_triage', () => {
+        expect(
+            getReviewLane(
+                base({ status: 'open', primaryRootCause: 'ambiguous' }),
+            ),
+        ).toBe('needs_triage');
+    });
+    it('open + feedback_needed fixTarget → needs_triage', () => {
+        expect(
+            getReviewLane(
+                base({
+                    status: 'open',
+                    latestFinding: { fixTargets: ['feedback_needed'] } as never,
+                }),
+            ),
+        ).toBe('needs_triage');
+    });
+    it('open + actionable → todo', () => {
+        expect(getReviewLane(base({ status: 'open' }))).toBe('todo');
+    });
+    it('in_progress status → in_progress', () => {
+        expect(getReviewLane(base({ status: 'in_progress' }))).toBe(
+            'in_progress',
+        );
+    });
+    it('open with writeback in flight stays in todo — lane is status-driven', () => {
+        expect(
+            getReviewLane(
+                base({ status: 'open', prWritebackStatus: 'running' }),
+            ),
+        ).toBe('todo');
+    });
+    it('open with remediation pr_open stays in todo — lane is status-driven', () => {
+        expect(
+            getReviewLane(
+                base({
+                    status: 'open',
+                    remediation: { status: 'pr_open' } as never,
+                }),
+            ),
+        ).toBe('todo');
+    });
+    it.each(['resolved', 'dismissed', 'duplicate'] as const)(
+        '%s → done',
+        (status) => {
+            expect(getReviewLane(base({ status }))).toBe('done');
+        },
+    );
+});
+
+describe('parsePrNumber', () => {
+    it('extracts a PR number from a GitHub url', () => {
+        expect(parsePrNumber('https://github.com/lightdash/x/pull/853')).toBe(
+            853,
+        );
+    });
+    it('returns null for no url', () => {
+        expect(parsePrNumber(null)).toBeNull();
+    });
+});
+
+describe('partitionInProgress', () => {
+    it('splits writeback-running items into active', () => {
+        const a = base({ status: 'in_progress', prWritebackStatus: 'running' });
+        const b = base({ status: 'in_progress' });
+        const { active, rest } = partitionInProgress([a, b]);
+        expect(active).toEqual([a]);
+        expect(rest).toEqual([b]);
+    });
+});
+
+describe('LANE_TARGET_STATUS', () => {
+    it('maps each lane to the expected status', () => {
+        expect(LANE_TARGET_STATUS.needs_triage).toBeNull();
+        expect(LANE_TARGET_STATUS.todo).toBe('open');
+        expect(LANE_TARGET_STATUS.in_progress).toBe('in_progress');
+        expect(LANE_TARGET_STATUS.done).toBe('resolved');
+    });
+});
+
+describe('getStartWritebackKind', () => {
+    const eligible = (overrides: Partial<AiAgentReviewItemSummary>) =>
+        base({
+            writebackEligibility: { eligible: true } as never,
+            ...overrides,
+        });
+
+    it('returns modal for project_context eligible item without PR', () => {
+        expect(
+            getStartWritebackKind(
+                eligible({ primaryRootCause: 'project_context' }),
+            ),
+        ).toBe('modal');
+    });
+    it('returns mutate for semantic_layer eligible item without PR', () => {
+        expect(
+            getStartWritebackKind(
+                eligible({ primaryRootCause: 'semantic_layer' }),
+            ),
+        ).toBe('mutate');
+    });
+    it('returns null when writeback is in flight', () => {
+        expect(
+            getStartWritebackKind(
+                eligible({
+                    primaryRootCause: 'semantic_layer',
+                    prWritebackStatus: 'queued',
+                }),
+            ),
+        ).toBeNull();
+    });
+    it('returns null when PR is already linked', () => {
+        expect(
+            getStartWritebackKind(
+                eligible({
+                    primaryRootCause: 'semantic_layer',
+                    linkedPrUrl: 'https://github.com/org/repo/pull/1',
+                }),
+            ),
+        ).toBeNull();
+    });
+    it('returns null when not eligible', () => {
+        expect(
+            getStartWritebackKind(
+                base({
+                    primaryRootCause: 'semantic_layer',
+                    writebackEligibility: {
+                        eligible: false,
+                        reason: 'no_fix_targets',
+                    } as never,
+                }),
+            ),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewLane.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewLane.ts
@@ -1,0 +1,102 @@
+import {
+    type AiAgentReviewItemStatus,
+    type AiAgentReviewItemSummary,
+    type AiAgentReviewRemediationStatus,
+} from '@lightdash/common';
+import { isTriageReviewItem } from './reviewItemDetails';
+
+export type ReviewLane = 'needs_triage' | 'todo' | 'in_progress' | 'done';
+
+// ts-unused-exports:disable-next-line
+export const REVIEW_LANES: { id: ReviewLane; label: string; color: string }[] =
+    [
+        { id: 'needs_triage', label: 'Needs triage', color: 'gray' },
+        { id: 'todo', label: 'To Do', color: 'indigo' },
+        { id: 'in_progress', label: 'In Progress', color: 'yellow' },
+        { id: 'done', label: 'Done', color: 'green' },
+    ];
+
+// ts-unused-exports:disable-next-line
+export const BOARD_STATUSES: AiAgentReviewItemStatus[] = [
+    'open',
+    'in_progress',
+    'resolved',
+    'dismissed',
+    'duplicate',
+];
+
+const ACTIVE_REMEDIATION_STATUSES: AiAgentReviewRemediationStatus[] = [
+    'queued',
+    'running',
+    'pr_open',
+    'preview_ready',
+];
+
+const isWritebackInFlight = (item: AiAgentReviewItemSummary): boolean =>
+    item.prWritebackStatus === 'queued' ||
+    item.prWritebackStatus === 'running' ||
+    (item.remediation !== null &&
+        ACTIVE_REMEDIATION_STATUSES.includes(item.remediation.status));
+
+export const getReviewLane = (item: AiAgentReviewItemSummary): ReviewLane => {
+    if (
+        item.status === 'resolved' ||
+        item.status === 'dismissed' ||
+        item.status === 'duplicate'
+    ) {
+        return 'done';
+    }
+    if (item.status === 'in_progress') {
+        return 'in_progress';
+    }
+    return isTriageReviewItem(item) ? 'needs_triage' : 'todo';
+};
+
+// ts-unused-exports:disable-next-line
+export const LANE_TARGET_STATUS: Record<
+    ReviewLane,
+    AiAgentReviewItemStatus | null
+> = {
+    needs_triage: null,
+    todo: 'open',
+    in_progress: 'in_progress',
+    done: 'resolved',
+};
+
+// ts-unused-exports:disable-next-line
+export const getStartWritebackKind = (
+    item: AiAgentReviewItemSummary,
+): 'modal' | 'mutate' | null => {
+    if (
+        !item.writebackEligibility.eligible ||
+        item.linkedPrUrl ||
+        item.prWritebackStatus === 'queued' ||
+        item.prWritebackStatus === 'running'
+    ) {
+        return null;
+    }
+    if (item.primaryRootCause === 'project_context') {
+        return 'modal';
+    }
+    if (item.primaryRootCause === 'semantic_layer') {
+        return 'mutate';
+    }
+    return null;
+};
+
+export const parsePrNumber = (url: string | null): number | null => {
+    if (!url) return null;
+    const match = url.match(/\/pull\/(\d+)/);
+    return match ? Number(match[1]) : null;
+};
+
+export const partitionInProgress = (
+    items: AiAgentReviewItemSummary[],
+): { active: AiAgentReviewItemSummary[]; rest: AiAgentReviewItemSummary[] } => {
+    const active: AiAgentReviewItemSummary[] = [];
+    const rest: AiAgentReviewItemSummary[] = [];
+    items.forEach((item) => {
+        (isWritebackInFlight(item) ? active : rest).push(item);
+    });
+    return { active, rest };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
@@ -53,6 +53,10 @@ vi.mock('../AiAgentAdminReviewItemsTable', () => ({
     },
 }));
 
+vi.mock('../ReviewKanbanBoard', () => ({
+    ReviewKanbanBoard: () => <div>Board view</div>,
+}));
+
 vi.mock('../ThreadPreviewSidebar', () => ({
     ThreadPreviewSidebar: (props: {
         threadUuid: string;
@@ -67,6 +71,7 @@ vi.mock('../ThreadPreviewSidebar', () => ({
 describe('AiReviewsSettingsPage', () => {
     beforeEach(() => {
         mockTable.mockReset();
+        localStorage.clear();
     });
 
     it('opens the drawer after selecting a finding from the table', async () => {
@@ -83,6 +88,8 @@ describe('AiReviewsSettingsPage', () => {
             </MemoryRouter>,
         );
 
+        // Board is the default view; switch to the table for this flow.
+        await user.click(screen.getByText('Table'));
         await user.click(screen.getByRole('button', { name: 'Open review' }));
 
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,5 +1,13 @@
-import { Button, Drawer, Group, Stack, Text } from '@mantine-8/core';
-import { IconRoute } from '@tabler/icons-react';
+import {
+    Button,
+    Drawer,
+    Group,
+    SegmentedControl,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { useLocalStorage } from '@mantine-8/hooks';
+import { IconLayoutKanban, IconRoute, IconTable } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
@@ -12,6 +20,7 @@ import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
 } from '../AiAgentAdminReviewItemsTable';
 import { REVIEWS_TOUR_STEPS } from '../onboarding';
+import { ReviewKanbanBoard } from '../ReviewKanbanBoard';
 import { ThreadPreviewSidebar } from '../ThreadPreviewSidebar';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 import drawerClasses from './ThreadPreviewDrawer.module.css';
@@ -50,6 +59,11 @@ export const AiReviewsSettingsPage = () => {
         startTour,
         closeTour,
     } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v1' });
+
+    const [view, setView] = useLocalStorage<'board' | 'table'>({
+        key: 'ld.aiReviews.view',
+        defaultValue: 'board',
+    });
 
     const updateReviewSearchParams = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget | null,
@@ -96,15 +110,46 @@ export const AiReviewsSettingsPage = () => {
                             { title: 'Reviews', active: true },
                         ]}
                     />
-                    <Button
-                        variant="subtle"
-                        color="gray"
-                        size="compact-xs"
-                        leftSection={<MantineIcon icon={IconRoute} />}
-                        onClick={startTour}
-                    >
-                        Take the tour
-                    </Button>
+                    <Group gap="xs">
+                        <SegmentedControl
+                            size="xs"
+                            value={view}
+                            onChange={(value) =>
+                                setView(value as 'board' | 'table')
+                            }
+                            data={[
+                                {
+                                    value: 'board',
+                                    label: (
+                                        <Group gap={6} wrap="nowrap">
+                                            <MantineIcon
+                                                icon={IconLayoutKanban}
+                                            />
+                                            Board
+                                        </Group>
+                                    ),
+                                },
+                                {
+                                    value: 'table',
+                                    label: (
+                                        <Group gap={6} wrap="nowrap">
+                                            <MantineIcon icon={IconTable} />
+                                            Table
+                                        </Group>
+                                    ),
+                                },
+                            ]}
+                        />
+                        <Button
+                            variant="subtle"
+                            color="gray"
+                            size="compact-xs"
+                            leftSection={<MantineIcon icon={IconRoute} />}
+                            onClick={startTour}
+                        >
+                            Take the tour
+                        </Button>
+                    </Group>
                 </Group>
 
                 <Text c="dimmed" fz="sm" maw={760}>
@@ -124,11 +169,19 @@ export const AiReviewsSettingsPage = () => {
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
-            <AiAgentAdminReviewItemsTable
-                selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
-                onReviewItemSelect={handleReviewItemSelect}
-                showOnboardingExamples={isTourOpen}
-            />
+            {view === 'board' ? (
+                <ReviewKanbanBoard
+                    selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
+                    onReviewItemSelect={handleReviewItemSelect}
+                    showOnboardingExamples={isTourOpen}
+                />
+            ) : (
+                <AiAgentAdminReviewItemsTable
+                    selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
+                    onReviewItemSelect={handleReviewItemSelect}
+                    showOnboardingExamples={isTourOpen}
+                />
+            )}
 
             <GuidedTour
                 steps={REVIEWS_TOUR_STEPS}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
@@ -127,6 +127,28 @@
     animation-direction: alternate-reverse;
 }
 
+.animated {
+    filter: none;
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.66),
+        inset 0 -4px 10px rgba(94, 76, 255, 0.24),
+        0 2px 6px rgba(152, 54, 255, 0.22),
+        0 0 0 1px color-mix(in oklch, #9836ff 36%, transparent);
+    animation: ai-agent-icon-morph 6s ease infinite;
+}
+
+.animated::before,
+.animated::after {
+    opacity: 1;
+    animation: ai-agent-icon-drift 2.4s cubic-bezier(0.45, 0, 0.55, 1) 280ms
+        infinite alternate;
+}
+
+.animated::after {
+    animation-duration: 2.6s;
+    animation-direction: alternate-reverse;
+}
+
 @keyframes ai-agent-icon-morph {
     0% {
         background-position: 43% 0%;
@@ -154,7 +176,10 @@
 @media (prefers-reduced-motion: reduce) {
     .root,
     .root::before,
-    .root::after {
+    .root::after,
+    .animated,
+    .animated::before,
+    .animated::after {
         animation: none !important;
         transition: opacity 120ms ease;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
@@ -4,6 +4,7 @@ import styles from './AiAgentIcon.module.css';
 type Props = {
     size?: number | string;
     muted?: boolean;
+    animated?: boolean;
     className?: string;
     style?: CSSProperties;
 };
@@ -11,6 +12,7 @@ type Props = {
 export const AiAgentIcon: FC<Props> = ({
     size = 16,
     muted = false,
+    animated = false,
     className,
     style,
 }) => {
@@ -19,7 +21,12 @@ export const AiAgentIcon: FC<Props> = ({
     return (
         <span
             aria-hidden="true"
-            className={[styles.root, muted && styles.muted, className]
+            className={[
+                styles.root,
+                muted && styles.muted,
+                animated && styles.animated,
+                className,
+            ]
                 .filter(Boolean)
                 .join(' ')}
             style={


### PR DESCRIPTION
## What

Adds a **Kanban board view** to the Ask AI › Reviews admin page, alongside the existing table. A `Board` / `Table` segmented control switches between them; **Board is the default** (persisted to `localStorage`). Both views share the same data hook, filters, search, and the URL-driven detail drawer, so deep-links and the onboarding tour keep working unchanged.

## Design

- **Status-driven lanes.** `getReviewLane()` buckets each review item into one of four lanes — Needs triage / To Do / In Progress / Done — derived **purely from `status`** (plus the existing triage predicate for open items). This makes drag-and-drop stable: a card stays where you drop it.
- **PR lifecycle decoupled from the lane.** Starting a fix opens a PR as an independent background process. Moving a card between lanes never cancels or detaches an in-flight PR — the card just lives where you put it (still showing live progress).

## What's new

**Cards**
- Title, age, root-cause badge, **PR chip** with a verification hover popover (diff, checks, "Mark as done"), a **preview-environment footer** (link + "Building…"), and an **animated `AiAgentIcon`** while a writeback is in flight.
- Hover **"Start"** on eligible To Do cards kicks off the fix — semantic-layer fires the writeback directly; project-context opens the diff-preview modal.
- Per-lane card cap (~10) with a **"Show all"** expander; contained board wrapper.

**Drag & drop** (`@dnd-kit`, already a dependency)
- Dragging between lanes changes the underlying `status`; dropping into In Progress auto-starts the PR for semantic-layer findings (no modal mid-drag).
- `DragOverlay` (card follows the cursor) + a drop-placeholder gap in the hovered lane. "Needs triage" is a read-only inbox (not a drop target).

**Filters** — project + root-cause facets and search on the board, matching the table's defaults (shared `DEFAULT_VISIBLE_ROOT_CAUSES`).

**Detail sidebar** — "Test fix" moved into the Activity timeline; the conversation is now framed as an **"Evidence"** section, expanded by default.

## Regression analysis

- **Additive.** The board is a new presentation behind the same admin route and AI-features gating — no new feature flag. The table view remains one click away and is **behaviorally unchanged**.
- **Shared constants moved, not changed.** `DEFAULT_HIDDEN_ROOT_CAUSES` / `DEFAULT_VISIBLE_ROOT_CAUSES` moved from the table component into `reviewItemDetails.ts` (single source of truth); the table imports them with identical values — same default filtering.
- **Lane derivation only affects the board.** `getReviewLane()` is consumed solely by the new board; the table reads `status` directly, so the status-driven change has no table impact.
- **No backend changes.** The `review-items` endpoint already accepts all five `AiAgentReviewItemStatus` values; the board just requests them all.
- **Detail-sidebar changes are guarded for all modes.** The "Evidence" conversation collapse wraps the always-rendered thread outside the review-item/findings/eval branches, so non-review-item sidebars are unaffected.

## Testing

- Unit: `reviewLane.test.ts` (lane derivation for every lane + each in-flight trigger, `LANE_TARGET_STATUS`, `getStartWritebackKind`, `parsePrNumber`, `partitionInProgress`).
- Render: `ReviewKanbanBoard.test.tsx` (lanes render with correct bucketing).
- Existing table/sidebar tests still pass; typecheck + lint clean on all changed files.

Screenshots (light/dark + a drag) to follow.

---

_No Linear ticket linked — opening per author request._
