### PR TITLE
feat: remove merge PR button from agentic writeback diff viewer

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
@@ -133,8 +133,7 @@ const PullRequestViewMenu: FC<{
     prUrl: string;
     previewUrl: string | null;
     commitSha: string | null;
-    ciChecks: CiChecks | null;
-}> = ({ projectUuid, prUrl, previewUrl, commitSha, ciChecks }) => {
+}> = ({ projectUuid, prUrl, previewUrl, commitSha }) => {
     const [diffOpened, setDiffOpened] = useState(false);
 
     return (
@@ -191,7 +190,6 @@ const PullRequestViewMenu: FC<{
                 projectUuid={projectUuid}
                 prUrl={prUrl}
                 commitSha={commitSha}
-                ciChecks={ciChecks}
                 opened={diffOpened}
                 onClose={() => setDiffOpened(false)}
             />
@@ -619,7 +617,6 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                                     : (metadata.previewUrl ?? null)
                             }
                             commitSha={metadata.commitSha ?? null}
-                            ciChecks={ciChecks ?? null}
                         />
                         <PullRequestActionButtons
                             ciChecks={ciChecks ?? null}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/WritebackDiffModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/WritebackDiffModal.tsx
@@ -1,4 +1,3 @@
-import { type CiChecks } from '@lightdash/common';
 import {
     Box,
     Center,
@@ -22,9 +21,7 @@ import DiffsWorkerUrl from '@pierre/diffs/worker/worker.js?worker&url';
 import { IconFileDiff } from '@tabler/icons-react';
 import { useMemo, useState, type CSSProperties, type FC } from 'react';
 import MantineModal from '../../../../../../components/common/MantineModal';
-import { useMergePullRequest } from '../../../hooks/useMergePullRequest';
 import { usePullRequestDiff } from '../../../hooks/usePullRequestDiff';
-import { isMergeable } from './pullRequestActions';
 
 // Tokenize with both Pierre themes; the diff renders via CSS `light-dark()`.
 // Writeback PRs touch dbt YAML/SQL plus the odd markdown doc, so cover those.
@@ -201,36 +198,15 @@ export const WritebackDiffModal: FC<{
     projectUuid: string;
     prUrl: string;
     commitSha: string | null;
-    ciChecks: CiChecks | null;
     opened: boolean;
     onClose: () => void;
-}> = ({ projectUuid, prUrl, commitSha, ciChecks, opened, onClose }) => {
+}> = ({ projectUuid, prUrl, commitSha, opened, onClose }) => {
     const { data, isInitialLoading, isError } = usePullRequestDiff(
         projectUuid,
         prUrl,
         commitSha,
         opened,
     );
-    const { mutate: merge, isLoading: isMerging } =
-        useMergePullRequest(projectUuid);
-
-    // Offer the merge from the viewer only while the PR is still actionable;
-    // disable (rather than hide) when not yet mergeable so the action is
-    // discoverable. Reviewing the diff is itself the confirmation, so this
-    // merges directly and closes on success.
-    const isOpen = !!ciChecks && !ciChecks.merged && ciChecks.state === 'open';
-    const mergeProps = isOpen
-        ? {
-              confirmLabel: 'Merge PR',
-              confirmDisabled: !isMergeable(ciChecks),
-              confirmLoading: isMerging,
-              onConfirm: () =>
-                  merge(
-                      { prUrl, sha: commitSha },
-                      { onSuccess: () => onClose() },
-                  ),
-          }
-        : {};
 
     return (
         <MantineModal
@@ -241,7 +217,6 @@ export const WritebackDiffModal: FC<{
             size="90%"
             bodyScrollAreaMaxHeight={BODY_MAX_HEIGHT}
             cancelLabel={false}
-            {...mergeProps}
         >
             {isInitialLoading ? (
                 <Center p="xl">


### PR DESCRIPTION
The diff viewer modal no longer offers an in-viewer "Merge PR" action; merging stays available from the PR card's action buttons.


Claude-Session: https://claude.ai/code/session_01DmTnarCbfCxKwht9uwuQZy

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
