### PR TITLE
feat(settings): persist sidebar collapse state

### DIFF
--- a/packages/frontend/src/hooks/settings/CLAUDE.md
+++ b/packages/frontend/src/hooks/settings/CLAUDE.md
@@ -52,7 +52,7 @@ if (isMyFeatureEnabled && ability?.can('manage', 'Organization')) {
 The sidebar's search is data-driven (no DOM walking) and its state lives directly in `Settings.tsx`:
 
 - `search` (raw, feeds the input) plus a debounced copy (feeds `filterSettingsNavigation`). The search resets on navigation, computed during render so it never lags the route change.
-- `isSidebarCollapsed` — a plain `useState` toggling the collapsible panel; not persisted.
+- `isSidebarCollapsed` — persisted with localStorage in `Settings.tsx`.
 
 `SettingsNavigation` takes `sections` + `searchQuery`. Group expansion stays uncontrolled via Mantine's `defaultOpened` (open on the active route, or forced open while filtering); the nav remounts on the filtering toggle so `defaultOpened` re-evaluates. Matching label text is highlighted with Mantine's `<Highlight>`.
 </sidebarInteraction>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -10,7 +10,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { useDebouncedValue } from '@mantine-8/hooks';
+import { useDebouncedValue, useLocalStorage } from '@mantine-8/hooks';
 import {
     IconLayoutSidebarLeftCollapse,
     IconLayoutSidebarLeftExpand,
@@ -83,11 +83,17 @@ import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
 import classes from './Settings.module.css';
 
+const SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY = 'settings:sidebar-collapsed';
+
 const Settings: FC = () => {
     const context = useSettingsContext();
     const sections = useSettingsNavigation(context);
 
-    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [isSidebarCollapsed, setIsSidebarCollapsed] =
+        useLocalStorage<boolean>({
+            key: SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY,
+            defaultValue: false,
+        });
     const [search, setSearch] = useState('');
     const [debouncedSearch] = useDebouncedValue(search, 200);
 


### PR DESCRIPTION
## Summary
- Persist the settings sidebar collapsed state in localStorage
- Add a dedicated storage key in `Settings.tsx`
- Update the settings hook notes to reflect the persisted behavior

## Testing
- Not run (not requested)