### PR TITLE
feat: skeleton loading for the Reviews board

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -23,6 +23,13 @@
 .cardSelected {
     border-color: var(--mantine-color-indigo-5);
 }
+.cardSkeleton {
+    background: var(--mantine-color-body);
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-4));
+    border-radius: var(--mantine-radius-md);
+    opacity: 0.7;
+}
 .cardBody {
     display: block;
     width: 100%;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -44,6 +44,7 @@ import {
 } from './reviewItemDetails';
 import styles from './ReviewKanbanBoard.module.css';
 import { ReviewKanbanCard } from './ReviewKanbanCard';
+import { ReviewKanbanCardSkeleton } from './ReviewKanbanCardSkeleton';
 import {
     BOARD_STATUSES,
     getReviewLane,
@@ -56,6 +57,9 @@ import {
 import { SearchFilter } from './SearchFilter';
 
 const VISIBLE_PER_LANE = 10;
+
+// Staggered skeleton counts per lane so the loading board reads naturally.
+const SKELETON_COUNTS = [3, 2, 2, 1];
 
 const LANE_IDS = new Set<string>(REVIEW_LANES.map((l) => l.id));
 
@@ -146,7 +150,9 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]
     >(DEFAULT_VISIBLE_ROOT_CAUSES);
-    const { data } = useAiAgentAdminReviewItems({ statuses: BOARD_STATUSES });
+    const { data, isLoading } = useAiAgentAdminReviewItems({
+        statuses: BOARD_STATUSES,
+    });
     const { data: projects } = useProjects();
     const [expandedLanes, setExpandedLanes] = useState<
         Partial<Record<ReviewLane, boolean>>
@@ -175,6 +181,9 @@ export const ReviewKanbanBoard: FC<Props> = ({
         }
         return data ?? [];
     }, [data, showOnboardingExamples]);
+
+    // Skeletons only on the genuine first load (keepPreviousData keeps refetches silent).
+    const showSkeletons = isLoading && allItems.length === 0;
 
     const searchFilteredItems = useMemo<AiAgentReviewItemSummary[]>(() => {
         const q = deferredSearch?.trim().toLowerCase();
@@ -347,7 +356,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     onDragCancel={handleDragCancel}
                 >
                     <Box className={styles.board}>
-                        {REVIEW_LANES.map((lane) => {
+                        {REVIEW_LANES.map((lane, laneIndex) => {
                             const all = lanes[lane.id];
                             const isExpanded = expandedLanes[lane.id] ?? false;
                             const displayed =
@@ -391,7 +400,18 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                             lane.id,
                                         )}
                                     >
-                                        {cards.length === 0 ? (
+                                        {showSkeletons ? (
+                                            Array.from({
+                                                length:
+                                                    SKELETON_COUNTS[
+                                                        laneIndex
+                                                    ] ?? 2,
+                                            }).map((_, i) => (
+                                                <ReviewKanbanCardSkeleton
+                                                    key={i}
+                                                />
+                                            ))
+                                        ) : cards.length === 0 ? (
                                             <Box className={styles.emptyLane}>
                                                 <Text fz="xs" c="dimmed">
                                                     No issues

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCardSkeleton.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCardSkeleton.tsx
@@ -1,0 +1,17 @@
+import { Box, Group, Skeleton, Stack } from '@mantine-8/core';
+import { type FC } from 'react';
+import styles from './ReviewKanbanBoard.module.css';
+
+/** Subtle placeholder card shown while the board's first page of items loads. */
+export const ReviewKanbanCardSkeleton: FC = () => (
+    <Box className={styles.cardSkeleton}>
+        <Stack gap={10} p="sm">
+            <Skeleton height={9} radius="xl" width="85%" />
+            <Skeleton height={9} radius="xl" width="55%" />
+            <Group justify="space-between" align="center" mt={2}>
+                <Skeleton height={18} radius="sm" width={84} />
+                <Skeleton height={22} circle />
+            </Group>
+        </Stack>
+    </Box>
+);


### PR DESCRIPTION
## What

Adds a subtle skeleton loading state to the Ask AI Reviews Kanban board. On the **genuine first load** (no cached data), each lane shows a few placeholder cards with a soft shimmer instead of the empty "No issues" state, so the board reads as loading rather than empty.

Stacked on #24486 (triage), which is stacked on the merged assignee + Kanban work.

## Details

- `ReviewKanbanCardSkeleton` — a card-shaped placeholder (two title lines, a badge block, an avatar circle) at reduced opacity for a quiet, chic look. Reuses the card's border/radius tokens.
- Shown only when `isLoading && allItems.length === 0`. Because the board's query uses `keepPreviousData`, this never flickers on background refetches — only the true cold load.
- Staggered counts per lane (`[3, 2, 2, 1]`) so the loading board looks natural rather than uniform.

## Regression analysis

- Purely additive and presentation-only — no data, query, or interaction changes.
- The empty "No issues" state still shows once loading completes with zero items; skeletons never replace real content.

## Testing

- Board render test still passes (the mock returns data with no `isLoading`, so `showSkeletons` is false and real cards render as before).
- Typecheck + lint clean.

---

_No Linear ticket linked — opening per author request (stacked follow-up)._
