### PR TITLE
feat(ai-writeback): add ai_writeback.merged analytics event

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1469,10 +1469,35 @@ export type AiWritebackFailedEvent = BaseTrack & {
     };
 };
 
+// Fired when a user merges a write-back PR from the chat PR card. Only
+// successful merges are tracked — the merge endpoint throws on conflicts,
+// stale heads, or blocked branches, so this is a server-authoritative count of
+// PRs that actually landed (not merge-button clicks).
+export type AiWritebackMergedEvent = BaseTrack & {
+    event: 'ai_writeback.merged';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        prUrl: string;
+        // Parsed from the PR URL; null when it isn't a recognised
+        // github.com/owner/repo/pull/N link (e.g. a GitLab MR).
+        owner: string | null;
+        repo: string | null;
+        pullNumber: number | null;
+        // The merge commit SHA the provider returned, when available.
+        mergeCommitSha: string | null;
+        // Whether a dbt recompile was scheduled after the merge. Only
+        // git-connected projects re-clone on compile, so others are skipped.
+        compileScheduled: boolean;
+    };
+};
+
 export type AiWritebackEvent =
     | AiWritebackStartedEvent
     | AiWritebackCompletedEvent
-    | AiWritebackFailedEvent;
+    | AiWritebackFailedEvent
+    | AiWritebackMergedEvent;
 
 export type CommentsEvent = BaseTrack & {
     event:

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1014,6 +1014,83 @@ describe('AiWritebackService.mergePullRequest', () => {
             sha: 'sha-7',
         });
     });
+
+    const userWithOrg = { userUuid: 'u1', organizationUuid: ORG } as AnyType;
+
+    it('tracks ai_writeback.merged with the parsed PR context on a successful git merge', async () => {
+        const track = jest.fn();
+        const { service } = setup({ analytics: { track } as AnyType });
+        await service.mergePullRequest({ ...mergeArgs, user: userWithOrg });
+        expect(track).toHaveBeenCalledTimes(1);
+        expect(track).toHaveBeenCalledWith({
+            event: 'ai_writeback.merged',
+            userId: 'u1',
+            properties: {
+                organizationId: ORG,
+                projectId: 'p1',
+                prUrl: PR_7,
+                owner: 'acme',
+                repo: 'analytics',
+                pullNumber: 7,
+                mergeCommitSha: 'sha-7',
+                compileScheduled: true,
+            },
+        });
+    });
+
+    it('tracks the merge with compileScheduled=false for a non-git project', async () => {
+        const track = jest.fn();
+        const { service } = setup({
+            analytics: { track } as AnyType,
+            projectModel: {
+                get: jest.fn().mockResolvedValue(nonGitProject()),
+            } as AnyType,
+        });
+        await service.mergePullRequest({ ...mergeArgs, user: userWithOrg });
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'ai_writeback.merged',
+                properties: expect.objectContaining({
+                    compileScheduled: false,
+                }),
+            }),
+        );
+    });
+
+    it('does not track ai_writeback.merged when the PR was not merged', async () => {
+        const track = jest.fn();
+        const { service } = setup({
+            analytics: { track } as AnyType,
+            ciService: {
+                mergePullRequest: jest
+                    .fn()
+                    .mockResolvedValue({ merged: false, sha: null }),
+            } as AnyType,
+        });
+        await service.mergePullRequest({ ...mergeArgs, user: userWithOrg });
+        expect(track).not.toHaveBeenCalled();
+    });
+
+    it('leaves owner/repo/pullNumber null when the PR URL is not a github.com link', async () => {
+        const track = jest.fn();
+        const { service } = setup({ analytics: { track } as AnyType });
+        await service.mergePullRequest({
+            ...mergeArgs,
+            user: userWithOrg,
+            prUrl: 'https://gitlab.com/acme/analytics/-/merge_requests/3',
+        });
+        expect(track).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: 'ai_writeback.merged',
+                properties: expect.objectContaining({
+                    owner: null,
+                    repo: null,
+                    pullNumber: null,
+                    prUrl: 'https://gitlab.com/acme/analytics/-/merge_requests/3',
+                }),
+            }),
+        );
+    });
 });
 
 describe('mergeSourceCodeRepoAccess', () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -102,6 +102,7 @@ import {
     parseGithubConnection,
     parseGitlabConnection,
     parsePullNumber,
+    parsePullRequestUrl,
     progressTextForStage,
     resolvePrMetadataValue,
     resolveSandboxDbtVersion,
@@ -278,9 +279,9 @@ export class AiWritebackService extends BaseService {
      * Merge a write-back PR, then auto-sync the dbt project so the merged
      * change goes live without a manual refresh. Delegates the merge itself to
      * {@link CiService} (which owns the PR write guard), and on a successful
-     * merge schedules a recompile. The agent is told the sync runs
-     * automatically via the post-merge follow-up prompt, so it doesn't need to
-     * call `syncDbtProject` to kick one off.
+     * merge schedules a recompile and fires the `ai_writeback.merged` event. The
+     * agent is told the sync runs automatically via the post-merge follow-up
+     * prompt, so it doesn't need to call `syncDbtProject` to kick one off.
      */
     async mergePullRequest(args: {
         user: SessionUser;
@@ -290,9 +291,58 @@ export class AiWritebackService extends BaseService {
     }): Promise<MergePullRequestResult> {
         const result = await this.ciService.mergePullRequest(args);
         if (result.merged) {
-            await this.scheduleCompileAfterMerge(args.user, args.projectUuid);
+            const compileScheduled = await this.scheduleCompileAfterMerge(
+                args.user,
+                args.projectUuid,
+            );
+            this.trackMerged(args.user, args.projectUuid, {
+                prUrl: args.prUrl,
+                mergeCommitSha: result.sha,
+                compileScheduled,
+            });
         }
         return result;
+    }
+
+    /**
+     * Fire the `ai_writeback.merged` event after a successful merge. Best-effort
+     * and self-contained: a successful merge is irreversible, so analytics never
+     * throws back into the merge flow. Owner/repo/pullNumber are parsed from the
+     * PR URL where possible (github.com links), and left null otherwise.
+     */
+    private trackMerged(
+        user: SessionUser,
+        projectUuid: string,
+        properties: {
+            prUrl: string;
+            mergeCommitSha: string | null;
+            compileScheduled: boolean;
+        },
+    ): void {
+        let parsed: {
+            owner: string;
+            repo: string;
+            pullNumber: number;
+        } | null = null;
+        try {
+            parsed = parsePullRequestUrl(properties.prUrl);
+        } catch {
+            parsed = null;
+        }
+        this.analytics.track({
+            event: 'ai_writeback.merged',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid ?? '',
+                projectId: projectUuid,
+                prUrl: properties.prUrl,
+                owner: parsed?.owner ?? null,
+                repo: parsed?.repo ?? null,
+                pullNumber: parsed?.pullNumber ?? null,
+                mergeCommitSha: properties.mergeCommitSha,
+                compileScheduled: properties.compileScheduled,
+            },
+        });
     }
 
     /**
@@ -305,11 +355,11 @@ export class AiWritebackService extends BaseService {
     private async scheduleCompileAfterMerge(
         user: SessionUser,
         projectUuid: string,
-    ): Promise<void> {
+    ): Promise<boolean> {
         try {
             const project = await this.projectModel.get(projectUuid);
             if (!isGitProjectType(project.dbtConnection)) {
-                return;
+                return false;
             }
             // skipPermissionCheck: the merge already passed the manage:SourceCode
             // guard, so this system-initiated recompile shouldn't fail for a user
@@ -324,12 +374,14 @@ export class AiWritebackService extends BaseService {
             this.logger.info(
                 `Scheduled dbt compile (job ${jobUuid}) after writeback PR merge for project ${projectUuid}`,
             );
+            return true;
         } catch (error) {
             this.logger.error(
                 `Failed to schedule dbt compile after writeback PR merge for project ${projectUuid}: ${getErrorMessage(
                     error,
                 )}`,
             );
+            return false;
         }
     }
 

--- a/scripts/dev-fast-start.sh
+++ b/scripts/dev-fast-start.sh
@@ -134,9 +134,18 @@ if test -f .env.development.local; then
     # was first written (e.g. after stop-all the next start lands on a free slot).
     # A stale PGPORT/PORT silently points PM2 at a dead container, and the API
     # crash-loops on "Error migrating graphile worker" (its first DB op at boot).
+    # Upsert: update the key in place if present, otherwise append it. The append
+    # path matters when the file was created secrets-only (e.g. dev-op-pull.sh ran
+    # before the ports block was written) — without it the slot ports, PGHOST, and
+    # LD_INSTANCE_ID stay missing, the ecosystem falls back to the docker host
+    # "db-dev" and the generic "lightdash" name, and the API crash-loops.
     reconcile_env() {
         local key="$1" val="$2" cur
-        grep -q "^${key}=" .env.development.local || return 0
+        if ! grep -q "^${key}=" .env.development.local; then
+            printf '%s=%s\n' "$key" "$val" >> .env.development.local
+            ENV_PORTS_CHANGED=1
+            return 0
+        fi
         cur="$(grep "^${key}=" .env.development.local | head -1 | cut -d= -f2-)"
         [ "$cur" = "$val" ] && return 0
         awk -v k="$key" -v v="$val" 'BEGIN{FS=OFS="="} $1==k{print k"="v; next} {print}' \
@@ -148,6 +157,10 @@ if test -f .env.development.local; then
     # or wrong (e.g. the heredoc expanded it before the slot env was sourced), ecosystem
     # defaults to "lightdash" and collides with another worktree's generic stack.
     reconcile_env LD_INSTANCE_ID "${LD_INSTANCE_ID}"
+    # PGHOST must be reconciled too: a secrets-only file inherits the docker host
+    # "db-dev" from .env.development, which is unreachable from the host and makes
+    # the API crash-loop on its first DB op.
+    reconcile_env PGHOST localhost
     reconcile_env PGPORT "${LD_PG_PORT}"
     reconcile_env PORT "${PORT}"
     reconcile_env FE_PORT "${FE_PORT}"
@@ -159,6 +172,16 @@ if test -f .env.development.local; then
     reconcile_env SITE_URL "http://localhost:${FE_PORT}"
     reconcile_env INTERNAL_LIGHTDASH_HOST "http://localhost:${FE_PORT}"
     reconcile_env LIGHTDASH_API_URL "http://localhost:${PORT}"
+    # Infra keys the create-branch writes; reconcile them so a secrets-only file
+    # (created before the ports block) is brought up to a complete, host-reachable
+    # config rather than inheriting docker-internal defaults from .env.development.
+    reconcile_env S3_ENDPOINT "http://localhost:9000"
+    reconcile_env HEADLESS_BROWSER_HOST localhost
+    reconcile_env HEADLESS_BROWSER_PORT 3001
+    reconcile_env EMAIL_SMTP_HOST localhost
+    reconcile_env EMAIL_SMTP_PORT 1025
+    reconcile_env LDPAT ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+    reconcile_env DBT_DEMO_DIR "$(pwd)/examples/full-jaffle-shop-demo"
     if [ "$ENV_PORTS_CHANGED" = 1 ]; then
         echo "OK: env file reconciled to slot ports (PGPORT=${LD_PG_PORT} PORT=${PORT} FE_PORT=${FE_PORT})"
     else


### PR DESCRIPTION
Closes: <!-- add Linear ticket / issue if there is one -->

### Description:

Adds a first-class analytics event for when a user merges an AI write-back PR from the chat PR card. Previously the write-back run lifecycle was instrumented (`ai_writeback.started` / `.completed` / `.failed`) but merging the resulting PR was not, so "how many write-back PRs actually get merged?" wasn't answerable from product analytics.

**`ai_writeback.merged`** fires in `AiWritebackService.mergePullRequest`, but only after the provider confirms the merge — the merge endpoint throws on conflicts, stale heads, and blocked branches, so this is a server-authoritative count of PRs that *actually landed*, not merge-button clicks.

Properties:
- `organizationId`, `projectId`, `prUrl`
- `owner` / `repo` / `pullNumber` — parsed from the PR URL, left `null` for non-`github.com` links (e.g. GitLab MRs) so analytics never throws into the irreversible merge
- `mergeCommitSha` — the provider's merge commit SHA when returned
- `compileScheduled` — whether the post-merge dbt recompile was scheduled (git projects only)

`scheduleCompileAfterMerge` now returns a `boolean` so the event can report whether a recompile was kicked off.

### Tests

Extended `AiWritebackService.test.ts` (`mergePullRequest` describe):
- fires `ai_writeback.merged` with the full parsed payload on a successful git merge
- `compileScheduled: false` for a non-git project
- does **not** fire when the merge didn't happen (`merged: false`)
- `owner`/`repo`/`pullNumber` are `null` for a non-`github.com` PR URL

All 33 tests in the suite pass; backend typecheck and lint clean.

### Dev tooling fix (second commit)

Unrelated to the feature but bundled here: `scripts/dev-fast-start.sh`'s `reconcile_env` was update-only, so a `.env.development.local` created secrets-first (ports block never written) left `PGHOST`/`LD_INSTANCE_ID` absent — the API then crash-looped against the docker host `db-dev` under a generic `lightdash-*` PM2 name. `reconcile_env` now upserts missing keys and reconciles `PGHOST` + the infra keys, so a secrets-only env file self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)