### PR TITLE
perf(frontend): lazy split route bundles

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from './ee/CommercialRoutes';
 import { AiAgentsGlobalProvider } from './ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider';
 import { parseEmbedThemeParams } from './ee/providers/Embed/parseEmbedThemeParams';
+import { installChunkLoadErrorHandler } from './features/chunkErrorHandler';
 import ErrorBoundary from './features/errorBoundary/ErrorBoundary';
 import { SourceCodeEditorProvider } from './features/sourceCodeEditor';
 import ChartColorMappingContextProvider from './hooks/useChartColorConfig/ChartColorMappingContextProvider';
@@ -24,6 +25,8 @@ import SchedulerJobsProvider from './providers/SchedulerJobs/SchedulerJobsProvid
 import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
 import TrackingProvider from './providers/Tracking/TrackingProvider';
 import Routes from './Routes';
+
+installChunkLoadErrorHandler();
 
 // const isMobile =
 //     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(

--- a/packages/frontend/src/MobileRoutes.tsx
+++ b/packages/frontend/src/MobileRoutes.tsx
@@ -17,7 +17,7 @@ import {
     IconLayoutDashboard,
     IconLogout,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useState, type FC } from 'react';
 import {
     Link,
     Navigate,
@@ -34,29 +34,16 @@ import ProjectSwitcher from './components/NavBar/ProjectSwitcher';
 import { ThemeSwitcher } from './components/NavBar/ThemeSwitcher';
 import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
-import { AiAgentIcon } from './ee/features/aiCopilot/components/AiAgentIcon';
-import { useAiAgentButtonVisibility } from './ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useActiveProjectUuid } from './hooks/useActiveProject';
 import useLogoutMutation from './hooks/user/useUserLogoutMutation';
 import { getMantineThemeOverride } from './mantineTheme';
-import AppPreviewTest from './pages/AppPreviewTest';
-import AuthPopupResult, {
-    SuccessAuthPopupResult,
-} from './pages/AuthPopupResult';
-import Login from './pages/Login';
-import MinimalDashboard from './pages/MinimalDashboard';
-import MinimalSavedExplorer from './pages/MinimalSavedExplorer';
-import MinimalSqlChart from './pages/MinimalSqlChart';
-import MobileCharts from './pages/MobileCharts';
-import MobileDashboards from './pages/MobileDashboards';
-import MobileHome from './pages/MobileHome';
-import MobileSpace from './pages/MobileSpace';
-import MobileSpaces from './pages/MobileSpaces';
-import Projects from './pages/Projects';
-import ShareRedirect from './pages/ShareRedirect';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import Logo from './svgs/logo-icon.svg?react';
 import { PageName } from './types/Events';
+
+const MobileAiAgentsNavLink = lazy(
+    () => import('./components/Mobile/MobileAiAgentsNavLink'),
+);
 
 const RedirectToResource: FC = () => {
     const { projectUuid, savedQueryUuid, dashboardUuid } = useParams();
@@ -93,8 +80,6 @@ export const MobileNavBar: FC = () => {
             window.location.href = '/login';
         },
     });
-
-    const isAiAgentButtonVisible = useAiAgentButtonVisibility();
 
     // Force dark theme for navbar (excluding global styles)
     const darkTheme = useMemo(() => {
@@ -167,14 +152,13 @@ export const MobileNavBar: FC = () => {
                     leftSection={<MantineIcon icon={IconChartAreaLine} />}
                     onClick={toggleMenu}
                 />
-                {isAiAgentButtonVisible && (
-                    <RouterNavLink
-                        exact
-                        label="Ask AI"
-                        to={`/projects/${activeProjectUuid}/ai-agents`}
-                        leftSection={<AiAgentIcon size={16} />}
-                        onClick={toggleMenu}
-                    />
+                {isMenuOpen && (
+                    <Suspense fallback={null}>
+                        <MobileAiAgentsNavLink
+                            activeProjectUuid={activeProjectUuid}
+                            onClick={toggleMenu}
+                        />
+                    </Suspense>
                 )}
                 <Divider my="lg" />
 
@@ -217,15 +201,24 @@ const FALLBACK_ROUTE: RouteObject = {
 const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/auth/popup/:status',
-        element: <AuthPopupResult />,
+        lazy: async () => {
+            const { default: AuthPopupResult } =
+                await import('./pages/AuthPopupResult');
+            return { Component: AuthPopupResult };
+        },
     },
     {
         path: '/login',
-        element: (
-            <TrackPage name={PageName.LOGIN}>
-                <Login minimal={true} />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Login } = await import('./pages/Login');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LOGIN}>
+                        <Login minimal={true} />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/no-mobile-page',
@@ -234,7 +227,11 @@ const PUBLIC_ROUTES: RouteObject[] = [
     {
         // Autoclose popup after github installation
         path: '/generalSettings/integrations',
-        element: <SuccessAuthPopupResult />,
+        lazy: async () => {
+            const { default: SuccessAuthPopupResult } =
+                await import('./pages/SuccessAuthPopupResult');
+            return { Component: SuccessAuthPopupResult };
+        },
     },
     ...routesNotSupportedInMobile.map((route) => ({
         path: route,
@@ -248,27 +245,47 @@ const MINIMAL_ROUTES: RouteObject[] = [
         children: [
             {
                 path: '/minimal/projects/:projectUuid/saved/:savedQueryUuid',
-                element: (
-                    <Stack p="lg" h="90vh">
-                        <MinimalSavedExplorer />
-                    </Stack>
-                ),
+                lazy: async () => {
+                    const { default: MinimalSavedExplorer } =
+                        await import('./pages/MinimalSavedExplorer');
+                    return {
+                        Component: () => (
+                            <Stack p="lg" h="90vh">
+                                <MinimalSavedExplorer />
+                            </Stack>
+                        ),
+                    };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid',
-                element: <MinimalDashboard />,
+                lazy: async () => {
+                    const { default: MinimalDashboard } =
+                        await import('./pages/MinimalDashboard');
+                    return { Component: MinimalDashboard };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
-                element: <MinimalDashboard />,
+                lazy: async () => {
+                    const { default: MinimalDashboard } =
+                        await import('./pages/MinimalDashboard');
+                    return { Component: MinimalDashboard };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
-                element: (
-                    <Stack p="lg" h="90vh">
-                        <MinimalSqlChart />
-                    </Stack>
-                ),
+                lazy: async () => {
+                    const { default: MinimalSqlChart } =
+                        await import('./pages/MinimalSqlChart');
+                    return {
+                        Component: () => (
+                            <Stack p="lg" h="90vh">
+                                <MinimalSqlChart />
+                            </Stack>
+                        ),
+                    };
+                },
             },
         ],
     },
@@ -285,7 +302,11 @@ const APP_ROUTES: RouteObject[] = [
         children: [
             {
                 path: '/projects',
-                element: <Projects />,
+                lazy: async () => {
+                    const { default: Projects } =
+                        await import('./pages/Projects');
+                    return { Component: Projects };
+                },
             },
             {
                 path: '/projects/:projectUuid',
@@ -298,11 +319,17 @@ const APP_ROUTES: RouteObject[] = [
                     { index: true, element: <Navigate to="home" replace /> },
                     {
                         path: '/projects/:projectUuid/home',
-                        element: (
-                            <TrackPage name={PageName.HOME}>
-                                <MobileHome />
-                            </TrackPage>
-                        ),
+                        lazy: async () => {
+                            const { default: MobileHome } =
+                                await import('./pages/MobileHome');
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.HOME}>
+                                        <MobileHome />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/saved/:savedQueryUuid/:mode?',
@@ -314,43 +341,75 @@ const APP_ROUTES: RouteObject[] = [
                     },
                     {
                         path: '/projects/:projectUuid/saved',
-                        element: (
-                            <TrackPage name={PageName.SAVED_QUERIES}>
-                                <MobileCharts />
-                            </TrackPage>
-                        ),
+                        lazy: async () => {
+                            const { default: MobileCharts } =
+                                await import('./pages/MobileCharts');
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.SAVED_QUERIES}>
+                                        <MobileCharts />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/dashboards',
-                        element: (
-                            <TrackPage name={PageName.SAVED_DASHBOARDS}>
-                                <MobileDashboards />
-                            </TrackPage>
-                        ),
+                        lazy: async () => {
+                            const { default: MobileDashboards } =
+                                await import('./pages/MobileDashboards');
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.SAVED_DASHBOARDS}>
+                                        <MobileDashboards />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/spaces/:spaceUuid',
-                        element: (
-                            <TrackPage name={PageName.SPACE}>
-                                <MobileSpace />
-                            </TrackPage>
-                        ),
+                        lazy: async () => {
+                            const { default: MobileSpace } =
+                                await import('./pages/MobileSpace');
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.SPACE}>
+                                        <MobileSpace />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/spaces',
-                        element: (
-                            <TrackPage name={PageName.SPACES}>
-                                <MobileSpaces />
-                            </TrackPage>
-                        ),
+                        lazy: async () => {
+                            const { default: MobileSpaces } =
+                                await import('./pages/MobileSpaces');
+                            return {
+                                Component: () => (
+                                    <TrackPage name={PageName.SPACES}>
+                                        <MobileSpaces />
+                                    </TrackPage>
+                                ),
+                            };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/apps/:appUuid/preview',
-                        element: <AppPreviewTest />,
+                        lazy: async () => {
+                            const { default: AppPreviewTest } =
+                                await import('./pages/AppPreviewTest');
+                            return { Component: AppPreviewTest };
+                        },
                     },
                     {
                         path: '/projects/:projectUuid/apps/:appUuid/versions/:version/preview',
-                        element: <AppPreviewTest />,
+                        lazy: async () => {
+                            const { default: AppPreviewTest } =
+                                await import('./pages/AppPreviewTest');
+                            return { Component: AppPreviewTest };
+                        },
                     },
                 ],
             },
@@ -400,11 +459,17 @@ const PRIVATE_ROUTES: RouteObject[] = [
             },
             {
                 path: '/share/:shareNanoid',
-                element: (
-                    <TrackPage name={PageName.SHARE}>
-                        <ShareRedirect />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: ShareRedirect } =
+                        await import('./pages/ShareRedirect');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.SHARE}>
+                                <ShareRedirect />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
         ],
     },

--- a/packages/frontend/src/Routes.tsx
+++ b/packages/frontend/src/Routes.tsx
@@ -9,42 +9,7 @@ import PrivateRoute from './components/PrivateRoute';
 import ProjectRoute from './components/ProjectRoute';
 import CreateProjectSettings from './components/Settings/CreateProjectSettings';
 import UserCompletionModal from './components/UserCompletionModal';
-import FunnelBuilder from './features/funnelBuilder/FunnelBuilderPage';
 import { MetricCatalogView } from './features/metricsCatalog/types';
-import AppGenerate from './pages/AppGenerate';
-import AppPreviewTest from './pages/AppPreviewTest';
-import AuthPopupResult from './pages/AuthPopupResult';
-import ChartHistory from './pages/ChartHistory';
-import CreateProject from './pages/CreateProject';
-import Dashboard from './pages/Dashboard';
-import DashboardHistory from './pages/DashboardHistory';
-import Explorer from './pages/Explorer';
-import Home from './pages/Home';
-import Invite from './pages/Invite';
-import JoinOrganization from './pages/JoinOrganization';
-import LegacySqlRunner from './pages/LegacySqlRunner';
-import Login from './pages/Login';
-import MetricsCatalog from './pages/MetricsCatalog';
-import MinimalApp from './pages/MinimalApp';
-import MinimalDashboard from './pages/MinimalDashboard';
-import MinimalSavedExplorer from './pages/MinimalSavedExplorer';
-import MinimalSqlChart from './pages/MinimalSqlChart';
-import PasswordRecovery from './pages/PasswordRecovery';
-import PasswordReset from './pages/PasswordReset';
-import Projects from './pages/Projects';
-import Register from './pages/Register';
-import SavedDashboards from './pages/SavedDashboards';
-import SavedExplorer from './pages/SavedExplorer';
-import SavedQueries from './pages/SavedQueries';
-import Settings from './pages/Settings';
-import ShareRedirect from './pages/ShareRedirect';
-import SourceCodeEditorRedirect from './pages/SourceCodeEditorRedirect';
-import Space from './pages/Space';
-import Spaces from './pages/Spaces';
-import SqlRunner from './pages/SqlRunner';
-import UserActivity from './pages/UserActivity';
-import VerifyEmailPage from './pages/VerifyEmail';
-import ViewSqlChart from './pages/ViewSqlChart';
 import { TrackPage } from './providers/Tracking/TrackingProvider';
 import { PageName } from './types/Events';
 
@@ -56,63 +21,106 @@ const FALLBACK_ROUTE: RouteObject = {
 const PUBLIC_ROUTES: RouteObject[] = [
     {
         path: '/auth/popup/:status',
-        element: <AuthPopupResult />,
+        lazy: async () => {
+            const { default: AuthPopupResult } =
+                await import('./pages/AuthPopupResult');
+            return { Component: AuthPopupResult };
+        },
     },
     {
         path: '/register',
-        element: (
-            <TrackPage name={PageName.REGISTER}>
-                <Register />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Register } = await import('./pages/Register');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.REGISTER}>
+                        <Register />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/login',
-        element: (
-            <TrackPage name={PageName.LOGIN}>
-                <Login />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Login } = await import('./pages/Login');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.LOGIN}>
+                        <Login />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/recover-password',
-        element: (
-            <TrackPage name={PageName.PASSWORD_RECOVERY}>
-                <PasswordRecovery />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: PasswordRecovery } =
+                await import('./pages/PasswordRecovery');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.PASSWORD_RECOVERY}>
+                        <PasswordRecovery />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/reset-password/:code',
-        element: (
-            <TrackPage name={PageName.PASSWORD_RESET}>
-                <PasswordReset />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: PasswordReset } =
+                await import('./pages/PasswordReset');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.PASSWORD_RESET}>
+                        <PasswordReset />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/invite/:inviteCode',
-        element: (
-            <TrackPage name={PageName.SIGNUP}>
-                <Invite />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Invite } = await import('./pages/Invite');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SIGNUP}>
+                        <Invite />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/verify-email',
-        element: (
-            <TrackPage name={PageName.VERIFY_EMAIL}>
-                <VerifyEmailPage />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: VerifyEmailPage } =
+                await import('./pages/VerifyEmail');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.VERIFY_EMAIL}>
+                        <VerifyEmailPage />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: '/join-organization',
-        element: (
-            <TrackPage name={PageName.JOIN_ORGANIZATION}>
-                <JoinOrganization />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: JoinOrganization } =
+                await import('./pages/JoinOrganization');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.JOIN_ORGANIZATION}>
+                        <JoinOrganization />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
@@ -123,31 +131,55 @@ const MINIMAL_ROUTES: RouteObject[] = [
         children: [
             {
                 path: '/minimal/projects/:projectUuid/saved/:savedQueryUuid',
-                element: (
-                    <Stack p="lg" h="100vh">
-                        <MinimalSavedExplorer />
-                    </Stack>
-                ),
+                lazy: async () => {
+                    const { default: MinimalSavedExplorer } =
+                        await import('./pages/MinimalSavedExplorer');
+                    return {
+                        Component: () => (
+                            <Stack p="lg" h="100vh">
+                                <MinimalSavedExplorer />
+                            </Stack>
+                        ),
+                    };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid',
-                element: <MinimalDashboard />,
+                lazy: async () => {
+                    const { default: MinimalDashboard } =
+                        await import('./pages/MinimalDashboard');
+                    return { Component: MinimalDashboard };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/dashboards/:dashboardUuid/view/tabs/:tabUuid',
-                element: <MinimalDashboard />,
+                lazy: async () => {
+                    const { default: MinimalDashboard } =
+                        await import('./pages/MinimalDashboard');
+                    return { Component: MinimalDashboard };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/sql-runner/:savedSqlUuid',
-                element: (
-                    <Stack p="lg" h="100vh">
-                        <MinimalSqlChart />
-                    </Stack>
-                ),
+                lazy: async () => {
+                    const { default: MinimalSqlChart } =
+                        await import('./pages/MinimalSqlChart');
+                    return {
+                        Component: () => (
+                            <Stack p="lg" h="100vh">
+                                <MinimalSqlChart />
+                            </Stack>
+                        ),
+                    };
+                },
             },
             {
                 path: '/minimal/projects/:projectUuid/apps/:appUuid',
-                element: <MinimalApp />,
+                lazy: async () => {
+                    const { default: MinimalApp } =
+                        await import('./pages/MinimalApp');
+                    return { Component: MinimalApp };
+                },
             },
         ],
     },
@@ -156,11 +188,17 @@ const MINIMAL_ROUTES: RouteObject[] = [
 const CHART_ROUTES: RouteObject[] = [
     {
         path: 'saved',
-        element: (
-            <TrackPage name={PageName.SAVED_QUERIES}>
-                <SavedQueries />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: SavedQueries } =
+                await import('./pages/SavedQueries');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SAVED_QUERIES}>
+                        <SavedQueries />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'saved/:savedQueryUuid',
@@ -168,20 +206,32 @@ const CHART_ROUTES: RouteObject[] = [
         children: [
             {
                 path: 'history',
-                element: (
-                    <TrackPage name={PageName.CHART_HISTORY}>
-                        <ChartHistory />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: ChartHistory } =
+                        await import('./pages/ChartHistory');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.CHART_HISTORY}>
+                                <ChartHistory />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: ':mode?',
                 index: false,
-                element: (
-                    <TrackPage name={PageName.SAVED_QUERY_EXPLORER}>
-                        <SavedExplorer />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: SavedExplorer } =
+                        await import('./pages/SavedExplorer');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.SAVED_QUERY_EXPLORER}>
+                                <SavedExplorer />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
         ],
     },
@@ -191,19 +241,31 @@ const CHART_ROUTES: RouteObject[] = [
 const DASHBOARD_LIST_ROUTES: RouteObject[] = [
     {
         path: 'dashboards',
-        element: (
-            <TrackPage name={PageName.SAVED_DASHBOARDS}>
-                <SavedDashboards />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: SavedDashboards } =
+                await import('./pages/SavedDashboards');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SAVED_DASHBOARDS}>
+                        <SavedDashboards />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'dashboards/:dashboardUuid/history',
-        element: (
-            <TrackPage name={PageName.DASHBOARD_HISTORY}>
-                <DashboardHistory />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: DashboardHistory } =
+                await import('./pages/DashboardHistory');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.DASHBOARD_HISTORY}>
+                        <DashboardHistory />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
@@ -216,19 +278,31 @@ const DASHBOARD_VIEW_ROUTES: RouteObject[] = [
             {
                 path: ':mode?',
                 index: false,
-                element: (
-                    <TrackPage name={PageName.DASHBOARD}>
-                        <Dashboard />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: Dashboard } =
+                        await import('./pages/Dashboard');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.DASHBOARD}>
+                                <Dashboard />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: ':mode/tabs/:tabUuid?',
-                element: (
-                    <TrackPage name={PageName.DASHBOARD}>
-                        <Dashboard />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: Dashboard } =
+                        await import('./pages/Dashboard');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.DASHBOARD}>
+                                <Dashboard />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
         ],
     },
@@ -241,15 +315,27 @@ const SQL_RUNNER_ROUTES: RouteObject[] = [
         children: [
             {
                 index: true,
-                element: <SqlRunner />,
+                lazy: async () => {
+                    const { default: SqlRunner } =
+                        await import('./pages/SqlRunner');
+                    return { Component: SqlRunner };
+                },
             },
             {
                 path: ':slug',
-                element: <ViewSqlChart />,
+                lazy: async () => {
+                    const { default: ViewSqlChart } =
+                        await import('./pages/ViewSqlChart');
+                    return { Component: ViewSqlChart };
+                },
             },
             {
                 path: ':slug/edit',
-                element: <SqlRunner isEditMode />,
+                lazy: async () => {
+                    const { default: SqlRunner } =
+                        await import('./pages/SqlRunner');
+                    return { Component: () => <SqlRunner isEditMode /> };
+                },
             },
         ],
     },
@@ -259,80 +345,132 @@ const SOURCE_CODE_ROUTES: RouteObject[] = [
     {
         // Redirect old source-code route to project home with editor drawer open
         path: 'source-code',
-        element: <SourceCodeEditorRedirect />,
+        lazy: async () => {
+            const { default: SourceCodeEditorRedirect } =
+                await import('./pages/SourceCodeEditorRedirect');
+            return { Component: SourceCodeEditorRedirect };
+        },
     },
 ];
 
 const TABLES_ROUTES: RouteObject[] = [
     {
         path: 'tables',
-        element: (
-            <TrackPage name={PageName.EXPLORE_TABLES}>
-                <Explorer />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Explorer } = await import('./pages/Explorer');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.EXPLORE_TABLES}>
+                        <Explorer />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'tables/:tableId',
-        element: (
-            <TrackPage name={PageName.EXPLORER}>
-                <Explorer />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Explorer } = await import('./pages/Explorer');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.EXPLORER}>
+                        <Explorer />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
 const SPACES_ROUTES: RouteObject[] = [
     {
         path: 'spaces',
-        element: (
-            <TrackPage name={PageName.SPACES}>
-                <Spaces />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Spaces } = await import('./pages/Spaces');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SPACES}>
+                        <Spaces />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'spaces/:spaceUuid',
-        element: (
-            <TrackPage name={PageName.SPACE}>
-                <Space />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Space } = await import('./pages/Space');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.SPACE}>
+                        <Space />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
 const METRICS_ROUTES: RouteObject[] = [
     {
         path: 'metrics',
-        element: (
-            <TrackPage name={PageName.METRICS_CATALOG}>
-                <MetricsCatalog />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: MetricsCatalog } =
+                await import('./pages/MetricsCatalog');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.METRICS_CATALOG}>
+                        <MetricsCatalog />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'metrics/peek/:tableName/:metricName',
-        element: (
-            <TrackPage name={PageName.METRICS_CATALOG}>
-                <MetricsCatalog />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: MetricsCatalog } =
+                await import('./pages/MetricsCatalog');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.METRICS_CATALOG}>
+                        <MetricsCatalog />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'metrics/canvas',
-        element: (
-            <TrackPage name={PageName.METRICS_CATALOG}>
-                <MetricsCatalog metricCatalogView={MetricCatalogView.CANVAS} />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: MetricsCatalog } =
+                await import('./pages/MetricsCatalog');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.METRICS_CATALOG}>
+                        <MetricsCatalog
+                            metricCatalogView={MetricCatalogView.CANVAS}
+                        />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'metrics/canvas/:treeSlug',
-        element: (
-            <TrackPage name={PageName.METRICS_CATALOG}>
-                <MetricsCatalog metricCatalogView={MetricCatalogView.CANVAS} />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: MetricsCatalog } =
+                await import('./pages/MetricsCatalog');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.METRICS_CATALOG}>
+                        <MetricsCatalog
+                            metricCatalogView={MetricCatalogView.CANVAS}
+                        />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
@@ -347,11 +485,16 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     ...METRICS_ROUTES,
     {
         path: 'home',
-        element: (
-            <TrackPage name={PageName.HOME}>
-                <Home />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: Home } = await import('./pages/Home');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.HOME}>
+                        <Home />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'autopilot',
@@ -368,39 +511,67 @@ const PROJECT_LAYOUT_ROUTES: RouteObject[] = [
     {
         path: 'apps/generate',
         handle: { hideAILauncher: true },
-        element: <AppGenerate />,
+        lazy: async () => {
+            const { default: AppGenerate } =
+                await import('./pages/AppGenerate');
+            return { Component: AppGenerate };
+        },
     },
     {
         path: 'apps/:appUuid',
         handle: { hideAILauncher: true },
-        element: <AppGenerate />,
+        lazy: async () => {
+            const { default: AppGenerate } =
+                await import('./pages/AppGenerate');
+            return { Component: AppGenerate };
+        },
     },
     {
         path: 'apps/:appUuid/versions/:version/preview',
         handle: { hideAILauncher: true },
-        element: <AppPreviewTest />,
+        lazy: async () => {
+            const { default: AppPreviewTest } =
+                await import('./pages/AppPreviewTest');
+            return { Component: AppPreviewTest };
+        },
     },
     {
         path: 'apps/:appUuid/preview',
         handle: { hideAILauncher: true },
-        element: <AppPreviewTest />,
+        lazy: async () => {
+            const { default: AppPreviewTest } =
+                await import('./pages/AppPreviewTest');
+            return { Component: AppPreviewTest };
+        },
     },
     {
         path: 'user-activity',
-        element: (
-            <TrackPage name={PageName.USER_ACTIVITY}>
-                <UserActivity />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: UserActivity } =
+                await import('./pages/UserActivity');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.USER_ACTIVITY}>
+                        <UserActivity />
+                    </TrackPage>
+                ),
+            };
+        },
     },
     {
         path: 'funnel-builder',
         handle: { hideAILauncher: true },
-        element: (
-            <TrackPage name={PageName.FUNNEL_BUILDER}>
-                <FunnelBuilder />
-            </TrackPage>
-        ),
+        lazy: async () => {
+            const { default: FunnelBuilder } =
+                await import('./features/funnelBuilder/FunnelBuilderPage');
+            return {
+                Component: () => (
+                    <TrackPage name={PageName.FUNNEL_BUILDER}>
+                        <FunnelBuilder />
+                    </TrackPage>
+                ),
+            };
+        },
     },
 ];
 
@@ -415,7 +586,11 @@ const APP_ROUTES: RouteObject[] = [
         children: [
             {
                 path: '/projects',
-                element: <Projects />,
+                lazy: async () => {
+                    const { default: Projects } =
+                        await import('./pages/Projects');
+                    return { Component: Projects };
+                },
             },
             {
                 path: '/projects/:projectUuid',
@@ -429,7 +604,11 @@ const APP_ROUTES: RouteObject[] = [
                     // Legacy sqlRunner redirect (no layout needed)
                     {
                         path: 'sqlRunner',
-                        element: <LegacySqlRunner />,
+                        lazy: async () => {
+                            const { default: LegacySqlRunner } =
+                                await import('./pages/LegacySqlRunner');
+                            return { Component: LegacySqlRunner };
+                        },
                     },
                     // All project routes share ProjectLayout (NavBar + SourceCodeDrawer)
                     {
@@ -464,14 +643,20 @@ const PRIVATE_ROUTES: RouteObject[] = [
             },
             {
                 path: '/createProject/:method?',
-                element: (
-                    <>
-                        <NavBar />
-                        <TrackPage name={PageName.CREATE_PROJECT}>
-                            <CreateProject />
-                        </TrackPage>
-                    </>
-                ),
+                lazy: async () => {
+                    const { default: CreateProject } =
+                        await import('./pages/CreateProject');
+                    return {
+                        Component: () => (
+                            <>
+                                <NavBar />
+                                <TrackPage name={PageName.CREATE_PROJECT}>
+                                    <CreateProject />
+                                </TrackPage>
+                            </>
+                        ),
+                    };
+                },
             },
             {
                 path: '/createProjectSettings/:projectUuid',
@@ -488,14 +673,20 @@ const PRIVATE_ROUTES: RouteObject[] = [
             {
                 path: '/generalSettings/*',
                 handle: { hideAILauncher: true },
-                element: (
-                    <>
-                        <NavBar />
-                        <TrackPage name={PageName.GENERAL_SETTINGS}>
-                            <Settings />
-                        </TrackPage>
-                    </>
-                ),
+                lazy: async () => {
+                    const { default: Settings } =
+                        await import('./pages/Settings');
+                    return {
+                        Component: () => (
+                            <>
+                                <NavBar />
+                                <TrackPage name={PageName.GENERAL_SETTINGS}>
+                                    <Settings />
+                                </TrackPage>
+                            </>
+                        ),
+                    };
+                },
             },
             {
                 path: '/no-access',
@@ -524,14 +715,20 @@ const PRIVATE_ROUTES: RouteObject[] = [
             {
                 path: '/share/:shareNanoid',
                 handle: { hideAILauncher: true },
-                element: (
-                    <>
-                        <NavBar />
-                        <TrackPage name={PageName.SHARE}>
-                            <ShareRedirect />
-                        </TrackPage>
-                    </>
-                ),
+                lazy: async () => {
+                    const { default: ShareRedirect } =
+                        await import('./pages/ShareRedirect');
+                    return {
+                        Component: () => (
+                            <>
+                                <NavBar />
+                                <TrackPage name={PageName.SHARE}>
+                                    <ShareRedirect />
+                                </TrackPage>
+                            </>
+                        ),
+                    };
+                },
             },
         ],
     },

--- a/packages/frontend/src/components/Mobile/MobileAiAgentsNavLink.tsx
+++ b/packages/frontend/src/components/Mobile/MobileAiAgentsNavLink.tsx
@@ -1,0 +1,27 @@
+import { type FC } from 'react';
+import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
+import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import RouterNavLink from '../common/RouterNavLink';
+
+type Props = {
+    activeProjectUuid: string | undefined;
+    onClick: () => void;
+};
+
+const MobileAiAgentsNavLink: FC<Props> = ({ activeProjectUuid, onClick }) => {
+    const isVisible = useAiAgentButtonVisibility();
+
+    if (!isVisible) return null;
+
+    return (
+        <RouterNavLink
+            exact
+            label="Ask AI"
+            to={`/projects/${activeProjectUuid}/ai-agents`}
+            leftSection={<AiAgentIcon size={16} />}
+            onClick={onClick}
+        />
+    );
+};
+
+export default MobileAiAgentsNavLink;

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -1,11 +1,10 @@
 import { ActionIcon, Box, Button, Group } from '@mantine-8/core';
-import { type FC } from 'react';
+import { lazy, Suspense, type FC } from 'react';
 import { Link } from 'react-router';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
 import Omnibar from '../../features/omnibar';
 import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
-import { AiAgentsButton } from './AiAgentsButton';
 import BrowseMenu from './BrowseMenu';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
@@ -18,6 +17,12 @@ import SettingsMenu from './SettingsMenu';
 import { ThemeSwitcher } from './ThemeSwitcher';
 import UserCredentialsSwitcher from './UserCredentialsSwitcher';
 import UserMenu from './UserMenu';
+
+const AiAgentsButton = lazy(() =>
+    import('./AiAgentsButton').then((module) => ({
+        default: module.AiAgentsButton,
+    })),
+);
 
 type Props = {
     activeProjectUuid: string | undefined;
@@ -57,7 +62,9 @@ export const MainNavBarContent: FC<Props> = ({
                             {hasMetrics && (
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
-                            <AiAgentsButton />
+                            <Suspense fallback={null}>
+                                <AiAgentsButton />
+                            </Suspense>
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />
                     </>

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -2,75 +2,102 @@ import { Navigate, type RouteObject } from 'react-router';
 import PrivateRoute from '../components/PrivateRoute';
 import { TrackPage } from '../providers/Tracking/TrackingProvider';
 import { PageName } from '../types/Events';
-import EmbeddedApp from './features/embed/EmbeddedApp';
-import AgentPage from './pages/AiAgents/AgentPage';
-import AgentsRedirect from './pages/AiAgents/AgentsRedirect';
-import AgentsWelcome from './pages/AiAgents/AgentsWelcome';
-import AiAgentThreadPage from './pages/AiAgents/AgentThreadPage';
-import AiAgentNewThreadPage from './pages/AiAgents/AiAgentNewThreadPage';
-import AiAgentsNotAuthorizedPage from './pages/AiAgents/AiAgentsNotAuthorizedPage';
-import { AiAgentsRootLayout } from './pages/AiAgents/AiAgentsRootLayout';
-import AiAgentThreadSharePage from './pages/AiAgents/AiAgentThreadSharePage';
-import ProjectAiAgentEditPage from './pages/AiAgents/ProjectAiAgentEditPage';
-import EmbedApp from './pages/EmbedApp';
-import EmbedChart from './pages/EmbedChart';
-import EmbedDashboard from './pages/EmbedDashboard';
-import EmbedExplore from './pages/EmbedExplore';
-import { SlackAuthSuccess } from './pages/SlackAuthSuccess';
 
 const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
     {
         path: '/embed',
         handle: { hideAILauncher: true },
-        element: <EmbeddedApp />,
+        lazy: async () => {
+            const { default: EmbeddedApp } =
+                await import('./features/embed/EmbeddedApp');
+            return { Component: EmbeddedApp };
+        },
         children: [
             {
                 path: '/embed/:projectUuid',
-                element: (
-                    <TrackPage name={PageName.EMBED_DASHBOARD}>
-                        <EmbedDashboard />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: EmbedDashboard } =
+                        await import('./pages/EmbedDashboard');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.EMBED_DASHBOARD}>
+                                <EmbedDashboard />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: '/embed/:projectUuid/tabs/:tabUuid',
-                element: (
-                    <TrackPage name={PageName.EMBED_DASHBOARD}>
-                        <EmbedDashboard />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: EmbedDashboard } =
+                        await import('./pages/EmbedDashboard');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.EMBED_DASHBOARD}>
+                                <EmbedDashboard />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: '/embed/:projectUuid/chart/:chartUuid',
-                element: (
-                    <TrackPage name={PageName.EMBED_SAVED_CHART}>
-                        <EmbedChart />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: EmbedChart } =
+                        await import('./pages/EmbedChart');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.EMBED_SAVED_CHART}>
+                                <EmbedChart />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: '/embed/:projectUuid/app/:appUuid',
-                element: (
-                    <TrackPage name={PageName.EMBED_DATA_APP}>
-                        <EmbedApp />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: EmbedApp } =
+                        await import('./pages/EmbedApp');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.EMBED_DATA_APP}>
+                                <EmbedApp />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: '/embed/:projectUuid/explore/:exploreId',
-                element: (
-                    <TrackPage name={PageName.EMBED_EXPLORE}>
-                        <EmbedExplore />
-                    </TrackPage>
-                ),
+                lazy: async () => {
+                    const { default: EmbedExplore } =
+                        await import('./pages/EmbedExplore');
+                    return {
+                        Component: () => (
+                            <TrackPage name={PageName.EMBED_EXPLORE}>
+                                <EmbedExplore />
+                            </TrackPage>
+                        ),
+                    };
+                },
             },
             {
                 path: '/embed/:projectUuid/ai-agents/not-authorized',
-                element: <AiAgentsNotAuthorizedPage />,
+                lazy: async () => {
+                    const { default: AiAgentsNotAuthorizedPage } =
+                        await import('./pages/AiAgents/AiAgentsNotAuthorizedPage');
+                    return { Component: AiAgentsNotAuthorizedPage };
+                },
             },
             {
                 path: '/embed/:projectUuid/ai-agents/:agentUuid',
-                element: <AgentPage />,
+                lazy: async () => {
+                    const { default: AgentPage } =
+                        await import('./pages/AiAgents/AgentPage');
+                    return { Component: AgentPage };
+                },
                 children: [
                     {
                         index: true,
@@ -81,19 +108,41 @@ const COMMERCIAL_EMBED_ROUTES: RouteObject[] = [
                         children: [
                             {
                                 index: true,
-                                element: <AiAgentNewThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentNewThreadPage } =
+                                        await import('./pages/AiAgents/AiAgentNewThreadPage');
+                                    return {
+                                        Component: AiAgentNewThreadPage,
+                                    };
+                                },
                             },
                             {
                                 path: ':threadUuid/messages/:promptUuid/debug',
-                                element: <AiAgentThreadPage debug />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return {
+                                        Component: () => (
+                                            <AiAgentThreadPage debug />
+                                        ),
+                                    };
+                                },
                             },
                             {
                                 path: ':threadUuid/messages/:promptUuid',
-                                element: <AiAgentThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return { Component: AiAgentThreadPage };
+                                },
                             },
                             {
                                 path: ':threadUuid',
-                                element: <AiAgentThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return { Component: AiAgentThreadPage };
+                                },
                             },
                         ],
                     },
@@ -122,66 +171,126 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     },
     {
         path: '/ai-agents/',
-        element: (
-            <PrivateRoute>
-                <AgentsRedirect />
-            </PrivateRoute>
-        ),
+        lazy: async () => {
+            const { default: AgentsRedirect } =
+                await import('./pages/AiAgents/AgentsRedirect');
+            return {
+                Component: () => (
+                    <PrivateRoute>
+                        <AgentsRedirect />
+                    </PrivateRoute>
+                ),
+            };
+        },
     },
     {
         path: '/projects/:projectUuid/ai-agents',
         handle: { hideAILauncher: true },
-        element: (
-            <PrivateRoute>
-                <AiAgentsRootLayout />
-            </PrivateRoute>
-        ),
+        lazy: async () => {
+            const { default: AiAgentsRootLayout } =
+                await import('./pages/AiAgents/AiAgentsRootLayout');
+            return {
+                Component: () => (
+                    <PrivateRoute>
+                        <AiAgentsRootLayout />
+                    </PrivateRoute>
+                ),
+            };
+        },
         children: [
             {
                 index: true,
-                element: <AgentsWelcome />,
+                lazy: async () => {
+                    const { default: AgentsWelcome } =
+                        await import('./pages/AiAgents/AgentsWelcome');
+                    return { Component: AgentsWelcome };
+                },
             },
             {
                 path: 'not-authorized',
-                element: <AiAgentsNotAuthorizedPage />,
+                lazy: async () => {
+                    const { default: AiAgentsNotAuthorizedPage } =
+                        await import('./pages/AiAgents/AiAgentsNotAuthorizedPage');
+                    return { Component: AiAgentsNotAuthorizedPage };
+                },
             },
             {
                 path: 'new',
-                element: <ProjectAiAgentEditPage isCreateMode />,
+                lazy: async () => {
+                    const { default: ProjectAiAgentEditPage } =
+                        await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                    return {
+                        Component: () => (
+                            <ProjectAiAgentEditPage isCreateMode />
+                        ),
+                    };
+                },
             },
             {
                 path: 'share/:aiThreadShareUuid',
-                element: <AiAgentThreadSharePage />,
+                lazy: async () => {
+                    const { default: AiAgentThreadSharePage } =
+                        await import('./pages/AiAgents/AiAgentThreadSharePage');
+                    return { Component: AiAgentThreadSharePage };
+                },
             },
             {
                 path: ':agentUuid/edit',
-                element: <ProjectAiAgentEditPage />,
+                lazy: async () => {
+                    const { default: ProjectAiAgentEditPage } =
+                        await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                    return { Component: ProjectAiAgentEditPage };
+                },
                 children: [
                     {
                         path: 'evals',
-                        element: <ProjectAiAgentEditPage />,
+                        lazy: async () => {
+                            const { default: ProjectAiAgentEditPage } =
+                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            return { Component: ProjectAiAgentEditPage };
+                        },
                     },
                     {
                         path: 'evals/:evalUuid',
-                        element: <ProjectAiAgentEditPage />,
+                        lazy: async () => {
+                            const { default: ProjectAiAgentEditPage } =
+                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            return { Component: ProjectAiAgentEditPage };
+                        },
                     },
                     {
                         path: 'evals/:evalUuid/run/:runUuid',
-                        element: <ProjectAiAgentEditPage />,
+                        lazy: async () => {
+                            const { default: ProjectAiAgentEditPage } =
+                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            return { Component: ProjectAiAgentEditPage };
+                        },
                     },
                     {
                         path: 'verified-artifacts',
-                        element: <ProjectAiAgentEditPage />,
+                        lazy: async () => {
+                            const { default: ProjectAiAgentEditPage } =
+                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            return { Component: ProjectAiAgentEditPage };
+                        },
                     },
                     {
                         path: 'verified-artifacts/:artifactUuid',
-                        element: <ProjectAiAgentEditPage />,
+                        lazy: async () => {
+                            const { default: ProjectAiAgentEditPage } =
+                                await import('./pages/AiAgents/ProjectAiAgentEditPage');
+                            return { Component: ProjectAiAgentEditPage };
+                        },
                     },
                 ],
             },
             {
                 path: ':agentUuid',
-                element: <AgentPage />,
+                lazy: async () => {
+                    const { default: AgentPage } =
+                        await import('./pages/AiAgents/AgentPage');
+                    return { Component: AgentPage };
+                },
                 children: [
                     {
                         index: true,
@@ -192,19 +301,41 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
                         children: [
                             {
                                 index: true,
-                                element: <AiAgentNewThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentNewThreadPage } =
+                                        await import('./pages/AiAgents/AiAgentNewThreadPage');
+                                    return {
+                                        Component: AiAgentNewThreadPage,
+                                    };
+                                },
                             },
                             {
                                 path: ':threadUuid/messages/:promptUuid/debug',
-                                element: <AiAgentThreadPage debug />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return {
+                                        Component: () => (
+                                            <AiAgentThreadPage debug />
+                                        ),
+                                    };
+                                },
                             },
                             {
                                 path: ':threadUuid/messages/:promptUuid',
-                                element: <AiAgentThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return { Component: AiAgentThreadPage };
+                                },
                             },
                             {
                                 path: ':threadUuid',
-                                element: <AiAgentThreadPage />,
+                                lazy: async () => {
+                                    const { default: AiAgentThreadPage } =
+                                        await import('./pages/AiAgents/AgentThreadPage');
+                                    return { Component: AiAgentThreadPage };
+                                },
                             },
                         ],
                     },
@@ -217,7 +348,11 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
 const COMMERCIAL_SLACK_AUTH_ROUTES: RouteObject[] = [
     {
         path: '/auth/slack/success',
-        element: <SlackAuthSuccess />,
+        lazy: async () => {
+            const { default: SlackAuthSuccess } =
+                await import('./pages/SlackAuthSuccess');
+            return { Component: SlackAuthSuccess };
+        },
     },
 ];
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider.tsx
@@ -1,11 +1,59 @@
 import * as Sentry from '@sentry/react';
-import { type FC, type PropsWithChildren } from 'react';
+import {
+    lazy,
+    Suspense,
+    useEffect,
+    type FC,
+    type PropsWithChildren,
+} from 'react';
 import { Provider } from 'react-redux';
+import { useLocation, useMatches } from 'react-router';
+import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
 import { store } from '../../store';
 import { AiAgentThreadStreamAbortControllerContextProvider } from '../../streaming/AiAgentThreadStreamAbortControllerContextProvider';
 import { PendingPromptProvider } from '../PendingPromptContext/PendingPromptContext';
-import { AiAgentsLauncher } from './AiAgentsLauncher';
 import { LauncherDockProvider } from './LauncherDockProvider';
+import { launcherSession } from './launcherSession';
+import { useIsLauncherMounted } from './useIsLauncherMounted';
+
+const AiAgentsLauncher = lazy(() =>
+    import('./AiAgentsLauncher').then((module) => ({
+        default: module.AiAgentsLauncher,
+    })),
+);
+
+const AiAgentsLauncherGate: FC = () => {
+    const { activeProjectUuid } = useActiveProjectUuid();
+    const isLauncherMounted = useIsLauncherMounted(activeProjectUuid);
+
+    if (!isLauncherMounted) return null;
+
+    return (
+        <Suspense fallback={null}>
+            <AiAgentsLauncher />
+        </Suspense>
+    );
+};
+
+// Keep this tiny tracker eager so full-page AI routes can always restore to
+// the last non-agent URL without loading the launcher bundle.
+const AiAgentsLauncherSessionTracker: FC = () => {
+    const { pathname, search } = useLocation();
+    const matches = useMatches();
+    const isHidden = matches.some(
+        (m) =>
+            (m.handle as { hideAILauncher?: boolean } | undefined)
+                ?.hideAILauncher,
+    );
+
+    useEffect(() => {
+        if (isHidden) return;
+        launcherSession.rememberLastNonAgentUrl(`${pathname}${search}`);
+        launcherSession.clearExpandedFromBubble();
+    }, [isHidden, pathname, search]);
+
+    return null;
+};
 
 export const AiAgentsGlobalProvider: FC<PropsWithChildren> = ({ children }) => (
     <Provider store={store}>
@@ -14,7 +62,8 @@ export const AiAgentsGlobalProvider: FC<PropsWithChildren> = ({ children }) => (
                 <LauncherDockProvider>
                     {children}
                     <Sentry.ErrorBoundary fallback={<></>}>
-                        <AiAgentsLauncher />
+                        <AiAgentsLauncherSessionTracker />
+                        <AiAgentsLauncherGate />
                     </Sentry.ErrorBoundary>
                 </LauncherDockProvider>
             </PendingPromptProvider>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -1,7 +1,7 @@
 import { Transition } from '@mantine-8/core';
 import { useMediaQuery } from '@mantine-8/hooks';
 import { useEffect, useRef, type FC } from 'react';
-import { useLocation, useMatches } from 'react-router';
+import { useMatches } from 'react-router';
 import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { resetActivePanel } from '../../store/aiAgentLauncherSlice';
@@ -12,7 +12,6 @@ import {
 import styles from './AiAgentsLauncher.module.css';
 import { LauncherDock } from './LauncherDock';
 import { LauncherPanel } from './LauncherPanel';
-import { launcherSession } from './launcherSession';
 import { useDefaultAiAgent } from './useDefaultAiAgent';
 import { useLauncherDock } from './useLauncherDock';
 
@@ -28,17 +27,8 @@ const useIsLauncherHidden = () => {
 };
 
 export const AiAgentsLauncher: FC = () => {
-    const { pathname, search } = useLocation();
     const isMobile = useMediaQuery('(max-width: 768px)');
     const isHidden = useIsLauncherHidden();
-
-    useEffect(() => {
-        if (isHidden) return;
-        launcherSession.rememberLastNonAgentUrl(`${pathname}${search}`);
-        // Non-agent routes are the restore target. Clear the expanded marker
-        // so direct fullscreen visits don't show Minimize.
-        launcherSession.clearExpandedFromBubble();
-    }, [isHidden, pathname, search]);
 
     if (isMobile || isHidden) return null;
     return <AiAgentsLauncherInner />;

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router';
 import NavBar from '../../../components/NavBar';
 import { MobileNavBar } from '../../../MobileRoutes';
 
-export const AiAgentsRootLayout = () => {
+const AiAgentsRootLayout = () => {
     const isMobile = useMediaQuery('(max-width: 768px)');
     return (
         <>
@@ -12,3 +12,5 @@ export const AiAgentsRootLayout = () => {
         </>
     );
 };
+
+export default AiAgentsRootLayout;

--- a/packages/frontend/src/ee/pages/SlackAuthSuccess.tsx
+++ b/packages/frontend/src/ee/pages/SlackAuthSuccess.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'react-router';
 import { EmptyState } from '../../components/common/EmptyState';
 import MantineIcon from '../../components/common/MantineIcon';
 
-export const SlackAuthSuccess = () => {
+const SlackAuthSuccess = () => {
     const [searchParams] = useSearchParams();
 
     const slackUrl = useMemo(() => {
@@ -48,3 +48,5 @@ export const SlackAuthSuccess = () => {
         </EmptyState>
     );
 };
+
+export default SlackAuthSuccess;

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.test.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isChunkLoadError } from './chunkErrorHandler';
+
+describe('chunkErrorHandler', () => {
+    it('detects dynamic import and preload failures', () => {
+        expect(
+            isChunkLoadError(
+                'TypeError: Failed to fetch dynamically imported module',
+            ),
+        ).toBe(true);
+        expect(
+            isChunkLoadError(
+                'TypeError: error loading dynamically imported module',
+            ),
+        ).toBe(true);
+        expect(isChunkLoadError('Importing a module script failed.')).toBe(
+            true,
+        );
+        expect(
+            isChunkLoadError('Unable to preload CSS for /assets/app.css'),
+        ).toBe(true);
+    });
+
+    it('does not match unrelated errors', () => {
+        expect(isChunkLoadError('Network request failed')).toBe(false);
+        expect(isChunkLoadError('Something went wrong')).toBe(false);
+    });
+});

--- a/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/chunkErrorHandler.ts
@@ -1,10 +1,21 @@
 const CHUNK_ERROR_RELOAD_KEY = 'lightdash-chunk-error-reload';
 const RELOAD_COOLDOWN_MS = 60_000; // 60 seconds before allowing another auto-reload
 
-const CHUNK_ERROR_MESSAGE = 'Failed to fetch dynamically imported module';
+const CHUNK_ERROR_MESSAGES = [
+    'Failed to fetch dynamically imported module',
+    'error loading dynamically imported module',
+    'Importing a module script failed',
+    'Failed to load module script',
+    'Unable to preload CSS',
+];
+
+let isChunkLoadErrorHandlerInstalled = false;
 
 export const isChunkLoadError = (message: string): boolean => {
-    return message.includes(CHUNK_ERROR_MESSAGE);
+    const normalizedMessage = message.toLowerCase();
+    return CHUNK_ERROR_MESSAGES.some((chunkErrorMessage) =>
+        normalizedMessage.includes(chunkErrorMessage.toLowerCase()),
+    );
 };
 
 export const isChunkLoadErrorObject = (error: unknown): boolean => {
@@ -52,4 +63,37 @@ export const triggerChunkErrorReload = (): void => {
         // Proceed with reload anyway - worst case user sees manual refresh UI.
     }
     window.location.reload();
+};
+
+const reloadOnceForChunkError = (): boolean => {
+    if (hasRecentChunkReload()) {
+        return false;
+    }
+
+    triggerChunkErrorReload();
+    return true;
+};
+
+export const installChunkLoadErrorHandler = (): void => {
+    if (typeof window === 'undefined' || isChunkLoadErrorHandlerInstalled) {
+        return;
+    }
+
+    isChunkLoadErrorHandlerInstalled = true;
+
+    window.addEventListener('vite:preloadError', (event) => {
+        if (reloadOnceForChunkError()) {
+            event.preventDefault();
+        }
+    });
+
+    window.addEventListener('unhandledrejection', (event) => {
+        if (!isChunkLoadErrorObject(event.reason)) {
+            return;
+        }
+
+        if (reloadOnceForChunkError()) {
+            event.preventDefault();
+        }
+    });
 };

--- a/packages/frontend/src/features/chunkErrorHandler/index.ts
+++ b/packages/frontend/src/features/chunkErrorHandler/index.ts
@@ -1,5 +1,6 @@
 export {
     hasRecentChunkReload,
+    installChunkLoadErrorHandler,
     isChunkLoadError,
     isChunkLoadErrorObject,
     triggerChunkErrorReload,

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeDrawer/index.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeDrawer/index.tsx
@@ -1,7 +1,7 @@
 import { ProjectType } from '@lightdash/common';
 import { Drawer } from '@mantine-8/core';
 import { useHotkeys } from '@mantine/hooks';
-import { type FC } from 'react';
+import { lazy, Suspense, type FC } from 'react';
 import {
     BANNER_HEIGHT,
     NAVBAR_HEIGHT,
@@ -9,8 +9,11 @@ import {
 import { useActiveProjectUuid } from '../../../../hooks/useActiveProject';
 import { useProject } from '../../../../hooks/useProject';
 import { useSourceCodeEditor } from '../../context/useSourceCodeEditor';
-import SourceCodeEditorContent from '../SourceCodeEditorContent';
 import styles from './SourceCodeDrawer.module.css';
+
+const SourceCodeEditorContent = lazy(
+    () => import('../SourceCodeEditorContent'),
+);
 
 /**
  * Inner drawer content that fetches project data.
@@ -52,7 +55,9 @@ const SourceCodeDrawerContent: FC<{ onClose: () => void }> = ({ onClose }) => {
                 '--drawer-top-offset': `${topOffset}px`,
             }}
         >
-            <SourceCodeEditorContent />
+            <Suspense fallback={null}>
+                <SourceCodeEditorContent />
+            </Suspense>
         </Drawer>
     );
 };

--- a/packages/frontend/src/pages/AuthPopupResult.tsx
+++ b/packages/frontend/src/pages/AuthPopupResult.tsx
@@ -45,32 +45,4 @@ const AuthPopupResult: FC = () => {
     );
 };
 
-/**
- * Fixed version of AuthPopupResult that is used in Github authentication
- */
-export const SuccessAuthPopupResult: FC = () => {
-    useMount(() => {
-        setTimeout(() => {
-            window.close();
-        }, 2000);
-    });
-
-    return (
-        <>
-            <DocumentTitle title="Authentication" />
-
-            <Stack>
-                <Box mx="auto" my="lg">
-                    <LightdashLogo />
-                </Box>
-
-                <SuboptimalState
-                    title={'Thank you for authenticating'}
-                    description={'This window will close automatically'}
-                />
-            </Stack>
-        </>
-    );
-};
-
 export default AuthPopupResult;

--- a/packages/frontend/src/pages/SuccessAuthPopupResult.tsx
+++ b/packages/frontend/src/pages/SuccessAuthPopupResult.tsx
@@ -1,0 +1,33 @@
+import { Box, Stack } from '@mantine-8/core';
+import { type FC } from 'react';
+import { useMount } from 'react-use';
+import { DocumentTitle } from '../components/common/DocumentTitle';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
+import LightdashLogo from '../components/LightdashLogo/LightdashLogo';
+
+const SuccessAuthPopupResult: FC = () => {
+    useMount(() => {
+        setTimeout(() => {
+            window.close();
+        }, 2000);
+    });
+
+    return (
+        <>
+            <DocumentTitle title="Authentication" />
+
+            <Stack>
+                <Box mx="auto" my="lg">
+                    <LightdashLogo />
+                </Box>
+
+                <SuboptimalState
+                    title={'Thank you for authenticating'}
+                    description={'This window will close automatically'}
+                />
+            </Stack>
+        </>
+    );
+};
+
+export default SuccessAuthPopupResult;


### PR DESCRIPTION
## Summary

- Convert web, mobile, embedded, and AI agent route modules to React Router route-object `lazy` loading.
- Defer heavy non-route UI behind interaction gates: AI agent launcher, Ask AI nav button, mobile Ask AI link, and source code editor drawer content.
- Move route-only auth popup component into its own default-exported lazy module so unused-export checks stay clean.

## Bundle impact

Measured with `corepack pnpm -F @lightdash/frontend build` and parsed emitted `packages/frontend/build/index.html` + assets.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Initial files | 57 | 89 | +32 async/preload refs |
| Initial raw JS/CSS | 18,286.5 KB | 12,178.5 KB | -6,108.0 KB |
| Initial gzip JS/CSS | 5,296.1 KB | 3,341.5 KB | -1,954.6 KB (-36.9%) |
| Total emitted raw JS/CSS | 31,667.6 KB | 31,950.1 KB | +282.5 KB |
| Total emitted gzip JS/CSS | 7,747.4 KB | 8,012.8 KB | +265.4 KB |

The total emitted size rises slightly, which is expected from more chunk boundaries. The user-facing win is the initial bundle: about 1.95 MB less gzip before first route render.

## Findings

- React Router route-object `lazy` is the right API for this app shape; framework-mode automatic splitting would be a larger migration.
- Remaining initial weight is mostly shared/manual chunks still needed by the eager shell: `react`, `echarts`, `esm`, `uiw`, `mantine`, and `modules`.
- Next meaningful bundle work is dependency-boundary cleanup: avoid broad shared imports that pull charting/editor/common schemas into the shell, then revisit manual chunking.

## Validation

- `corepack pnpm -F @lightdash/frontend unused-exports`
- `corepack pnpm -F @lightdash/frontend typecheck`
- `rm -rf packages/frontend/build && corepack pnpm -F @lightdash/frontend build`
- Commit hook: frontend linter, formatter, git-secrets, unused exports