### PR TITLE
fix(ai): improve filter validation errors

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -1484,7 +1484,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                        "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -1519,7 +1524,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                        "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "boolean",
@@ -1568,7 +1579,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                        "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1603,7 +1619,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                        "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "string",
@@ -1654,7 +1676,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                        "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1699,7 +1726,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                        "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1752,7 +1785,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                        "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1809,7 +1848,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                        "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "number",
@@ -1868,7 +1913,12 @@ Example B — "Revenue by month with year-over-year comparison"
                                     "anyOf": [
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                        "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1904,7 +1954,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                        "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -1958,7 +2014,17 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                        "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2032,7 +2098,17 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                        "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2107,7 +2183,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                        "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2165,7 +2247,13 @@ Example B — "Revenue by month with year-over-year comparison"
                                       },
                                       {
                                         "additionalProperties": false,
-                                        "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                        "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                         "properties": {
                                           "fieldFilterType": {
                                             "const": "date",
@@ -2346,7 +2434,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2381,7 +2474,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -2430,7 +2529,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2465,7 +2569,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -2516,7 +2626,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2561,7 +2676,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2614,7 +2735,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2671,7 +2798,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -2730,7 +2863,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2766,7 +2904,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2820,7 +2964,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2894,7 +3048,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -2969,7 +3133,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3027,7 +3197,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3092,7 +3268,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -3127,7 +3308,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "boolean",
@@ -3176,7 +3363,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -3211,7 +3403,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "string",
@@ -3262,7 +3460,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3307,7 +3510,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3360,7 +3569,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3417,7 +3632,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "number",
@@ -3476,7 +3697,12 @@ Example B — "Revenue by month with year-over-year comparison"
                           "anyOf": [
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3512,7 +3738,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3566,7 +3798,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3640,7 +3882,17 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3715,7 +3967,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3773,7 +4031,13 @@ Example B — "Revenue by month with year-over-year comparison"
                             },
                             {
                               "additionalProperties": false,
-                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                               "properties": {
                                 "fieldFilterType": {
                                   "const": "date",
@@ -3836,7 +4100,12 @@ Example B — "Revenue by month with year-over-year comparison"
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3881,7 +4150,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3934,7 +4209,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -3991,7 +4272,13 @@ Example B — "Revenue by month with year-over-year comparison"
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -4849,7 +5136,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4884,7 +5176,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                          "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -4933,7 +5231,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -4968,7 +5271,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5019,7 +5328,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5064,7 +5378,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5117,7 +5437,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5174,7 +5500,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5233,7 +5565,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5269,7 +5606,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5323,7 +5666,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5397,7 +5750,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5472,7 +5835,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5530,7 +5899,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -5595,7 +5970,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                          "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5630,7 +6010,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                          "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "boolean",
@@ -5679,7 +6065,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                          "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5714,7 +6105,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                          "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "string",
@@ -5765,7 +6162,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                          "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5810,7 +6212,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                          "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5863,7 +6271,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                          "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5920,7 +6334,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                          "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "number",
@@ -5979,7 +6399,12 @@ Usage Tips:
                       "anyOf": [
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                          "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6015,7 +6440,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                          "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6069,7 +6500,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                          "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6143,7 +6584,17 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                          "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6218,7 +6669,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                          "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6276,7 +6733,13 @@ Usage Tips:
                         },
                         {
                           "additionalProperties": false,
-                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                          "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                           "properties": {
                             "fieldFilterType": {
                               "const": "date",
@@ -6339,7 +6802,12 @@ Usage Tips:
                   "anyOf": [
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                      "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6384,7 +6852,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                      "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6437,7 +6911,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                      "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",
@@ -6494,7 +6974,13 @@ Usage Tips:
                     },
                     {
                       "additionalProperties": false,
-                      "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                      "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                       "properties": {
                         "fieldFilterType": {
                           "const": "number",

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -1483,7 +1483,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                                    "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "boolean",
@@ -1518,7 +1523,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                                    "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -1562,7 +1573,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                                    "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "string",
@@ -1597,7 +1613,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                                    "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -1643,7 +1665,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                                    "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "number",
@@ -1688,7 +1715,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                                    "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1726,7 +1759,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                                    "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1768,7 +1807,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                                    "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -1812,7 +1857,12 @@ Recommended Dashboard Structure:
                                                 "anyOf": [
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                                    "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "const": "date",
@@ -1848,7 +1898,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                                    "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1896,7 +1952,17 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                                    "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -1964,7 +2030,17 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                                    "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2033,7 +2109,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                                    "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -2075,7 +2157,13 @@ Recommended Dashboard Structure:
                                                   },
                                                   {
                                                     "additionalProperties": false,
-                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                                    "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                                     "properties": {
                                                       "fieldFilterType": {
                                                         "$ref": "#/properties/visualizations/items/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -4589,7 +4677,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                              "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "boolean",
@@ -4624,7 +4717,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                              "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -4668,7 +4767,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                              "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "string",
@@ -4703,7 +4807,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                              "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -4749,7 +4859,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                              "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "number",
@@ -4794,7 +4909,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                              "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4832,7 +4953,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                              "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4874,7 +5001,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                              "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -4918,7 +5051,12 @@ Notes:
                                           "anyOf": [
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                              "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "const": "date",
@@ -4954,7 +5092,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                              "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5002,7 +5146,17 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                              "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5070,7 +5224,17 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                              "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5139,7 +5303,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                              "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -5181,7 +5351,13 @@ Notes:
                                             },
                                             {
                                               "additionalProperties": false,
-                                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                              "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                               "properties": {
                                                 "fieldFilterType": {
                                                   "$ref": "#/properties/queryConfig/properties/customMetrics/anyOf/0/items/anyOf/0/properties/filters/anyOf/0/items/properties/filter/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6224,7 +6400,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"isNull"}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notNull"}",
+                                "description": "Use for boolean fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "boolean",
@@ -6259,7 +6440,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for boolean fields when matching or excluding true/false values. Examples: {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}; {"fieldId":"users_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"notEquals","values":[false]}",
+                                "description": "Use for boolean fields when matching or excluding true/false values. Type shape: {
+  fieldId: "users_is_active"; // use the actual field id
+  fieldType: "boolean"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "boolean"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: [boolean]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/0/anyOf/0/properties/fieldFilterType",
@@ -6303,7 +6490,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"isNull"}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notNull"}",
+                                "description": "Use for string fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "string",
@@ -6338,7 +6530,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Examples: {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"equals","values":["complete","paid"]}; {"fieldId":"customers_email","fieldType":"string","fieldFilterType":"string","operator":"include","values":["@lightdash.com"]}; {"fieldId":"products_sku","fieldType":"string","fieldFilterType":"string","operator":"startsWith","values":["SKU-"]}; {"fieldId":"orders_status","fieldType":"string","fieldFilterType":"string","operator":"notEquals","values":["cancelled"]}",
+                                "description": "Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. Type shape: {
+  fieldId: "orders_status"; // use the actual field id
+  fieldType: "string"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "string"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals" | "startsWith" | "endsWith" | "include" | "doesNotInclude"; // | means or
+  values: string[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/1/anyOf/0/properties/fieldFilterType",
@@ -6384,7 +6582,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"isNull"}; {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"notNull"}",
+                                "description": "Use for numeric fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "number",
@@ -6429,7 +6632,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields that equal or exclude specific values. Examples: {"fieldId":"orders_item_count","fieldType":"count","fieldFilterType":"number","operator":"equals","values":[1,2]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"notEquals","values":[0]}",
+                                "description": "Use for numeric fields that equal or exclude specific values. Type shape: {
+  fieldId: "orders_item_count"; // use the actual field id
+  fieldType: "count"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: number[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6467,7 +6676,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields with a single comparison threshold. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"greaterThan","values":[1000]}; {"fieldId":"orders_discount_percent","fieldType":"number","fieldFilterType":"number","operator":"lessThanOrEqual","values":[0.15]}",
+                                "description": "Use for numeric fields with a single comparison threshold. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [number]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6509,7 +6724,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for numeric fields inside or outside a two-value range. Examples: {"fieldId":"orders_total_revenue","fieldType":"sum","fieldFilterType":"number","operator":"inBetween","values":[100,500]}; {"fieldId":"orders_margin_percent","fieldType":"number","fieldFilterType":"number","operator":"notInBetween","values":[0.2,0.4]}",
+                                "description": "Use for numeric fields inside or outside a two-value range. Type shape: {
+  fieldId: "orders_total_revenue"; // use the actual field id
+  fieldType: "sum"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "number"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween" | "notInBetween"; // | means or
+  values: [number, number]; // exactly two array values; lower and upper bounds
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/2/anyOf/0/properties/fieldFilterType",
@@ -6553,7 +6774,12 @@ Usage Tips:
                             "anyOf": [
                               {
                                 "additionalProperties": false,
-                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"isNull"}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notNull"}",
+                                "description": "Use for date/timestamp fields when checking if a value is missing or present. Do not include values. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "isNull" | "notNull"; // | means or
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "const": "date",
@@ -6589,7 +6815,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"equals","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"notEquals","values":["2024-01-01T00:00:00Z"]}",
+                                "description": "Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use inThePast. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "equals" | "notEquals"; // | means or
+  values: string[];
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6637,7 +6869,17 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[3],"settings":{"completed":true,"unitOfTime":"months"}}; {"fieldId":"orders_ship_date","fieldType":"date","fieldFilterType":"date","operator":"inTheNext","values":[14],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInThePast","values":[7],"settings":{"completed":false,"unitOfTime":"days"}}",
+                                "description": "Use for relative date requests such as "last 2 weeks" or "next 3 months". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inThePast" | "notInThePast" | "inTheNext"; // | means or
+  values: [number]; // exactly one array value; number of periods
+  settings: {
+  completed: false | true; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6705,7 +6947,17 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"days"}}; {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"notInTheCurrent","values":[1],"settings":{"completed":false,"unitOfTime":"months"}}",
+                                "description": "Use for current date requests such as "today", "this week", "this month", or "this year". Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inTheCurrent" | "notInTheCurrent"; // | means or
+  values: [1]; // exactly one array value; always [1] for current-period filters
+  settings: {
+  completed: false; // false includes current partial period; true means completed periods only
+  unitOfTime: "days" | "weeks" | "months" | "quarters" | "years";
+};
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6774,7 +7026,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"greaterThanOrEqual","values":["2024-01-01"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"lessThan","values":["2024-02-01T00:00:00Z"]}",
+                                "description": "Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "lessThan" | "lessThanOrEqual" | "greaterThan" | "greaterThanOrEqual"; // | means or
+  values: [string]; // exactly one array value
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",
@@ -6816,7 +7074,13 @@ Usage Tips:
                               },
                               {
                                 "additionalProperties": false,
-                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Examples: {"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01","2024-01-31"]}; {"fieldId":"orders_created_at","fieldType":"timestamp","fieldFilterType":"date","operator":"inBetween","values":["2024-01-01T00:00:00Z","2024-01-31T23:59:59Z"]}",
+                                "description": "Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. Type shape: {
+  fieldId: "orders_order_date"; // use the actual field id
+  fieldType: "date"; // one of: string, number, timestamp, date, boolean, percentile, average, count, count_distinct, sum, sum_distinct, average_distinct, min, max, percent_of_previous, percent_of_total, running_total, median
+  fieldFilterType: "date"; // one of: string, number, date, boolean; used to choose valid operators
+  operator: "inBetween"; // | means or
+  values: [string, string]; // exactly two array values; lower and upper bounds
+}",
                                 "properties": {
                                   "fieldFilterType": {
                                     "$ref": "#/properties/filters/anyOf/0/properties/dimensions/anyOf/0/items/anyOf/3/anyOf/0/properties/fieldFilterType",

--- a/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateFilterRuleErrors.test.ts
@@ -1,0 +1,215 @@
+import { FilterOperator, type FilterRule } from '@lightdash/common';
+import { vi } from 'vitest';
+import Logger from '../../../../logging/logger';
+import { mockOrdersExplore } from './validationExplore.mock';
+import { validateFilterRules } from './validators';
+
+const rule = (args: {
+    id: string;
+    fieldId: string;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: unknown;
+}): FilterRule => ({
+    id: args.id,
+    target: { fieldId: args.fieldId },
+    operator: args.operator,
+    ...(args.values !== undefined ? { values: args.values } : {}),
+    ...(args.settings !== undefined
+        ? { settings: args.settings as FilterRule['settings'] }
+        : {}),
+});
+
+const getValidationMessage = (filterRule: FilterRule): string => {
+    try {
+        validateFilterRules(mockOrdersExplore, [filterRule]);
+    } catch (error) {
+        if (error instanceof Error) {
+            return error.message;
+        }
+        return String(error);
+    }
+
+    throw new Error('Expected filter validation to fail');
+};
+
+describe('validateFilterRules error messages', () => {
+    beforeEach(() => {
+        vi.spyOn(Logger, 'error').mockImplementation(() => Logger);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('explains invalid boolean filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-boolean',
+                fieldId: 'orders_is_active',
+                operator: FilterOperator.GREATER_THAN,
+                values: [true],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_is_active" (Is Active).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is not available for boolean fields.',
+        );
+        expect(message).toContain(
+            'For boolean fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_is_active","fieldType":"boolean","fieldFilterType":"boolean","operator":"equals","values":[true]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains invalid string filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-string',
+                fieldId: 'orders_customer_name',
+                operator: FilterOperator.GREATER_THAN,
+                values: ['Alice'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_customer_name" (Customer Name).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is not available for string fields.',
+        );
+        expect(message).toContain(
+            'For string fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_customer_name","fieldType":"string","fieldFilterType":"string","operator":"include","values":["contains"]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains presence filters that include values', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-presence',
+                fieldId: 'orders_is_active',
+                operator: FilterOperator.NULL,
+                values: [true],
+            }),
+        );
+
+        expect(message).toContain(
+            '"isNull" is a presence operator and must not include values or settings. Received values=[true] settings=undefined.',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains settings on non-date filters', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-settings',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: [100],
+                settings: { completed: false, unitOfTime: 'weeks' },
+            }),
+        );
+
+        expect(message).toContain(
+            '"settings" is only valid for relative or current date filters. Remove settings from this number filter.',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains settings on explicit date filters', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-date-settings',
+                fieldId: 'orders_order_date',
+                operator: FilterOperator.EQUALS,
+                values: ['2024-01-01'],
+                settings: { completed: false, unitOfTime: 'weeks' },
+            }),
+        );
+
+        expect(message).toContain(
+            '"settings" is only valid for relative or current date filters. Remove settings when using "equals".',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('preserves explicit null values in the problem description', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-null-value',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: null as unknown as unknown[],
+            }),
+        );
+
+        expect(message).toContain('Received null.');
+        expect(message).not.toContain('Received [].');
+    });
+
+    it('explains invalid number filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-number',
+                fieldId: 'orders_amount',
+                operator: FilterOperator.GREATER_THAN,
+                values: ['100'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_amount" (Amount).',
+        );
+        expect(message).toContain(
+            '"greaterThan" is a valid number operator, but values must be an array with exactly one number. Received ["100"].',
+        );
+        expect(message).toContain(
+            'For number fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_amount","fieldType":"number","fieldFilterType":"number","operator":"greaterThan","values":[100]}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+
+    it('explains invalid date filters with available combinations', () => {
+        const message = getValidationMessage(
+            rule({
+                id: 'filter-date',
+                fieldId: 'orders_order_date',
+                operator: FilterOperator.EQUALS,
+                values: ['last 2 weeks'],
+            }),
+        );
+
+        expect(message).toContain(
+            'Invalid filter for field "orders_order_date" (Order Date).',
+        );
+        expect(message).toContain(
+            '"equals" is a valid date operator, but values must be ISO date/datetime strings. Received ["last 2 weeks"].',
+        );
+        expect(message).toContain(
+            'For date fields, these are all available filter combinations:',
+        );
+        expect(message).toContain(
+            '{"fieldId":"orders_order_date","fieldType":"date","fieldFilterType":"date","operator":"inThePast","values":[2],"settings":{"completed":false,"unitOfTime":"weeks"}}',
+        );
+        expect(message).not.toContain('invalid_union');
+        expect(message).not.toContain('ZodError');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -12,12 +12,15 @@ import {
     DependencyNode,
     detectCircularDependencies,
     Explore,
+    FilterOperator,
     FilterRule,
     Filters,
     FilterType,
+    formatFilterExamplesAsJsonLines,
     getCustomMetricType,
     getErrorMessage,
     getFields,
+    getFilterExamples,
     getFilterRulesFromGroup,
     getFilterTypeFromItemType,
     getItemId,
@@ -40,9 +43,11 @@ import {
     ToolRunQueryArgsTransformed,
     ToolSortField,
     TransformedCustomMetric,
+    UnitOfTime,
     WeekDay,
     WindowFunctionType,
 } from '@lightdash/common';
+import { z } from 'zod';
 import Logger from '../../../../logging/logger';
 import { populateCustomMetricsSQL } from './populateCustomMetricsSQL';
 import { serializeData } from './serializeData';
@@ -162,6 +167,293 @@ export function validateCustomMetricsDefinition(
     }
 }
 
+const getAvailableFilterOperators = (
+    filterType: FilterType,
+): FilterOperator[] =>
+    Array.from(
+        new Set(
+            getFilterExamples({
+                fieldId: 'field_id',
+                fieldType: filterType,
+                fieldFilterType: filterType,
+            }).map((example) => example.operator),
+        ),
+    );
+
+const stringifyReceivedValue = (value: unknown): string => {
+    try {
+        return JSON.stringify(value) ?? String(value);
+    } catch {
+        return String(value);
+    }
+};
+
+const getFieldLabel = (
+    field: CompiledField | AdditionalMetric | TableCalculation,
+): string => {
+    if ('label' in field && field.label) {
+        return field.label;
+    }
+
+    if ('displayName' in field && field.displayName) {
+        return field.displayName;
+    }
+
+    return getItemId(field);
+};
+
+const valuesDescription = (values: unknown): string =>
+    values === undefined ? '[]' : stringifyReceivedValue(values);
+
+const settingsDescription = (settings: unknown): string =>
+    settings === undefined ? 'undefined' : stringifyReceivedValue(settings);
+
+const hasOnlyValuesOfType = (
+    values: unknown,
+    valueType: 'boolean' | 'number' | 'string',
+): boolean =>
+    Array.isArray(values) &&
+    values.every((value) => typeof value === valueType);
+
+const hasLength = (values: unknown, length: number): boolean =>
+    Array.isArray(values) && values.length === length;
+
+const relativeDateUnitSchema = z.union([
+    z.literal(UnitOfTime.days),
+    z.literal(UnitOfTime.weeks),
+    z.literal(UnitOfTime.months),
+    z.literal(UnitOfTime.quarters),
+    z.literal(UnitOfTime.years),
+]);
+
+const dateSettingsSchema = z
+    .object({
+        completed: z.boolean(),
+        unitOfTime: relativeDateUnitSchema,
+    })
+    .strict();
+
+const currentDateSettingsSchema = z
+    .object({
+        completed: z.literal(false),
+        unitOfTime: relativeDateUnitSchema,
+    })
+    .strict();
+
+const dateOrDateTimeSchema = z.union([
+    z.string().date(),
+    z.string().datetime(),
+]);
+
+const hasDateSettings = (settings: unknown): boolean =>
+    dateSettingsSchema.safeParse(settings).success;
+
+const hasCurrentDateSettings = (settings: unknown): boolean =>
+    currentDateSettingsSchema.safeParse(settings).success;
+
+const isIsoDateOrDateTime = (value: unknown): value is string =>
+    dateOrDateTimeSchema.safeParse(value).success;
+
+const hasOnlyIsoDateValues = (values: unknown): boolean =>
+    Array.isArray(values) && values.every(isIsoDateOrDateTime);
+
+const hasCurrentDateValue = (values: unknown): boolean =>
+    Array.isArray(values) && values.length === 1 && values[0] === 1;
+
+const getFilterRuleProblem = (
+    filterRule: FilterRule,
+    filterType: FilterType,
+): string => {
+    const availableOperators = getAvailableFilterOperators(filterType);
+
+    if (!availableOperators.includes(filterRule.operator)) {
+        return `"${filterRule.operator}" is not available for ${filterType} fields. Available operators: ${availableOperators.join(', ')}.`;
+    }
+
+    if (
+        [FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
+            filterRule.operator,
+        ) &&
+        (filterRule.values !== undefined || filterRule.settings !== undefined)
+    ) {
+        return `"${filterRule.operator}" is a presence operator and must not include values or settings. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    if (filterType !== FilterType.DATE && filterRule.settings !== undefined) {
+        return `"settings" is only valid for relative or current date filters. Remove settings from this ${filterType} filter. Received settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    if (
+        filterType === FilterType.DATE &&
+        ![
+            FilterOperator.IN_THE_PAST,
+            FilterOperator.NOT_IN_THE_PAST,
+            FilterOperator.IN_THE_NEXT,
+            FilterOperator.IN_THE_CURRENT,
+            FilterOperator.NOT_IN_THE_CURRENT,
+        ].includes(filterRule.operator) &&
+        filterRule.settings !== undefined
+    ) {
+        return `"settings" is only valid for relative or current date filters. Remove settings when using "${filterRule.operator}". Received settings=${settingsDescription(filterRule.settings)}.`;
+    }
+
+    switch (filterType) {
+        case FilterType.BOOLEAN:
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'boolean'))
+            ) {
+                return `"${filterRule.operator}" is a valid boolean operator, but values must be an array with exactly one boolean. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.STRING:
+            if (
+                ![FilterOperator.NULL, FilterOperator.NOT_NULL].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyValuesOfType(filterRule.values, 'string')
+            ) {
+                return `"${filterRule.operator}" is a valid string operator, but values must be an array of strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.NUMBER:
+            if (
+                [
+                    FilterOperator.LESS_THAN,
+                    FilterOperator.LESS_THAN_OR_EQUAL,
+                    FilterOperator.GREATER_THAN,
+                    FilterOperator.GREATER_THAN_OR_EQUAL,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number'))
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array with exactly one number. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_BETWEEN,
+                    FilterOperator.NOT_IN_BETWEEN,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 2) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number'))
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array with exactly two numbers. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyValuesOfType(filterRule.values, 'number')
+            ) {
+                return `"${filterRule.operator}" is a valid number operator, but values must be an array of numbers. Received ${valuesDescription(filterRule.values)}.`;
+            }
+            break;
+        case FilterType.DATE:
+            if (
+                [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS].includes(
+                    filterRule.operator,
+                ) &&
+                !hasOnlyIsoDateValues(filterRule.values)
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be ISO date/datetime strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.LESS_THAN,
+                    FilterOperator.LESS_THAN_OR_EQUAL,
+                    FilterOperator.GREATER_THAN,
+                    FilterOperator.GREATER_THAN_OR_EQUAL,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyIsoDateValues(filterRule.values))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be an array with exactly one ISO date/datetime string. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                filterRule.operator === FilterOperator.IN_BETWEEN &&
+                (!hasLength(filterRule.values, 2) ||
+                    !hasOnlyIsoDateValues(filterRule.values))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be an array with exactly two ISO date/datetime strings. Received ${valuesDescription(filterRule.values)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_THE_CURRENT,
+                    FilterOperator.NOT_IN_THE_CURRENT,
+                ].includes(filterRule.operator) &&
+                (!hasCurrentDateValue(filterRule.values) ||
+                    !hasCurrentDateSettings(filterRule.settings))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be [1] and settings must include completed=false and unitOfTime. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+            }
+
+            if (
+                [
+                    FilterOperator.IN_THE_PAST,
+                    FilterOperator.NOT_IN_THE_PAST,
+                    FilterOperator.IN_THE_NEXT,
+                ].includes(filterRule.operator) &&
+                (!hasLength(filterRule.values, 1) ||
+                    !hasOnlyValuesOfType(filterRule.values, 'number') ||
+                    !hasDateSettings(filterRule.settings))
+            ) {
+                return `"${filterRule.operator}" is a valid date operator, but values must be one number and settings must include completed and unitOfTime. Received values=${valuesDescription(filterRule.values)} settings=${settingsDescription(filterRule.settings)}.`;
+            }
+            break;
+        default:
+            return assertUnreachable(
+                filterType,
+                `Invalid field type: ${filterType}`,
+            );
+    }
+
+    return `The filter JSON does not match any supported ${filterType} filter combination.`;
+};
+
+const formatFilterRuleValidationError = (
+    filterRule: FilterRule,
+    field: CompiledField | AdditionalMetric | TableCalculation,
+    filterType: FilterType,
+): string => {
+    const examples = formatFilterExamplesAsJsonLines(
+        getFilterExamples({
+            fieldId: filterRule.target.fieldId,
+            fieldType: field.type ?? filterType,
+            fieldFilterType: filterType,
+        }),
+    );
+
+    return `Invalid filter for field "${filterRule.target.fieldId}" (${getFieldLabel(field)}).
+
+Problem: ${getFilterRuleProblem(filterRule, filterType)}
+
+For ${filterType} fields, these are all available filter combinations:
+${examples}`;
+};
+
+const getFilterSchemaInput = (
+    filterRule: FilterRule,
+    field: CompiledField | AdditionalMetric | TableCalculation,
+    fieldFilterType: FilterType,
+) => ({
+    fieldId: filterRule.target.fieldId,
+    fieldType: field.type,
+    fieldFilterType,
+    operator: filterRule.operator,
+    ...(filterRule.values !== undefined ? { values: filterRule.values } : {}),
+    ...(filterRule.settings !== undefined
+        ? { settings: filterRule.settings }
+        : {}),
+});
+
 function validateFilterRule(
     filterRule: FilterRule,
     field: CompiledField | AdditionalMetric | TableCalculation,
@@ -174,66 +466,65 @@ function validateFilterRule(
 
     switch (filterType) {
         case FilterType.BOOLEAN:
-            const parsedBooleanFilterRule = booleanFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'boolean',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedBooleanFilterRule = booleanFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.BOOLEAN),
+            );
 
             if (!parsedBooleanFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected boolean filter rule for field ${filterRule.target.fieldId}. Error: ${parsedBooleanFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.BOOLEAN,
+                    ),
                 );
             }
 
             break;
         case FilterType.DATE:
-            const parsedDateFilterRule = dateFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'date',
-                operator: filterRule.operator,
-                values: filterRule.values,
-                settings: filterRule.settings,
-            });
+            const parsedDateFilterRule = dateFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.DATE),
+            );
 
             if (!parsedDateFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected date filter rule for field ${filterRule.target.fieldId}. Error: ${parsedDateFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.DATE,
+                    ),
                 );
             }
 
             break;
         case FilterType.NUMBER:
-            const parsedNumberFilterRule = numberFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'number',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedNumberFilterRule = numberFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.NUMBER),
+            );
 
             if (!parsedNumberFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected number filter rule for field ${filterRule.target.fieldId}. Error: ${parsedNumberFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.NUMBER,
+                    ),
                 );
             }
 
             break;
         case FilterType.STRING:
-            const parsedStringFilterRule = stringFilterSchema.safeParse({
-                fieldId: filterRule.target.fieldId,
-                fieldType: field.type,
-                fieldFilterType: 'string',
-                operator: filterRule.operator,
-                values: filterRule.values,
-            });
+            const parsedStringFilterRule = stringFilterSchema.safeParse(
+                getFilterSchemaInput(filterRule, field, FilterType.STRING),
+            );
 
             if (!parsedStringFilterRule.success) {
                 throw new AiAgentValidatorError(
-                    `Expected string filter rule for field ${filterRule.target.fieldId}. Error: ${parsedStringFilterRule.error.message}`,
+                    formatFilterRuleValidationError(
+                        filterRule,
+                        field,
+                        FilterType.STRING,
+                    ),
                 );
             }
 

--- a/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/booleanFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonBooleanFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -17,6 +17,7 @@ const commonBooleanFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.BOOLEAN),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const booleanFilterSchema = z.union([
     commonBooleanFilterRuleSchema
         .extend({
@@ -27,19 +28,14 @@ const booleanFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for boolean fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for boolean fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'users_is_active',
                     fieldType: DimensionType.BOOLEAN,
                     fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'users_is_active',
-                    fieldType: DimensionType.BOOLEAN,
-                    fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -58,21 +54,17 @@ const booleanFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one boolean value, e.g. [true] or [false].'),
         })
+        .strict()
         .describe(
-            `Use for boolean fields when matching or excluding true/false values. ${filterJsonExamples(
+            `Use for boolean fields when matching or excluding true/false values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'users_is_active',
                     fieldType: DimensionType.BOOLEAN,
                     fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.EQUALS,
-                    values: [true],
-                },
-                {
-                    fieldId: 'users_is_active',
-                    fieldType: DimensionType.BOOLEAN,
-                    fieldFilterType: FilterType.BOOLEAN,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: [false],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/dateFilters.ts
@@ -8,9 +8,9 @@ import {
 import { getFieldIdSchema } from '../fieldId';
 import {
     datePresenceOperatorDescription,
-    filterJsonExamples,
     filterOperatorList,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const dateOrDateTimeSchema = z
     .union([z.string().date(), z.string().datetime()])
@@ -29,6 +29,7 @@ const commonDateFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.DATE),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const dateFilterSchema = z.union([
     commonDateFilterRuleSchema
         .extend({
@@ -39,19 +40,14 @@ const dateFilterSchema = z.union([
                 ])
                 .describe(datePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for date/timestamp fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for date/timestamp fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -69,21 +65,17 @@ const dateFilterSchema = z.union([
                 .array(dateOrDateTimeSchema)
                 .describe('One or more explicit ISO dates/datetimes.'),
         })
+        .strict()
         .describe(
-            `Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use ${FilterOperator.IN_THE_PAST}. ${filterJsonExamples(
+            `Use for specific dates like 2024-01-01. For relative periods like "last 2 weeks", use ${FilterOperator.IN_THE_PAST}. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.EQUALS,
-                    values: ['2024-01-01'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: ['2024-01-01T00:00:00Z'],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),
@@ -120,53 +112,21 @@ const dateFilterSchema = z.union([
                         ])
                         .describe('Period unit for the relative date filter.'),
                 })
+                .strict()
                 .describe('Relative period settings.'),
         })
+        .strict()
         .describe(
-            `Use for relative date requests such as "last 2 weeks" or "next 3 months". ${filterJsonExamples(
+            `Use for relative date requests such as "last 2 weeks" or "next 3 months". ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_PAST,
-                    values: [2],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.weeks,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_PAST,
-                    values: [3],
-                    settings: {
-                        completed: true,
-                        unitOfTime: UnitOfTime.months,
-                    },
-                },
-                {
-                    fieldId: 'orders_ship_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_NEXT,
-                    values: [14],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_IN_THE_PAST,
-                    values: [7],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
+                    operators: [
+                        FilterOperator.IN_THE_PAST,
+                        FilterOperator.NOT_IN_THE_PAST,
+                        FilterOperator.IN_THE_NEXT,
+                    ],
                 },
             )}`,
         ),
@@ -201,31 +161,20 @@ const dateFilterSchema = z.union([
                             'Current period unit, e.g. weeks for this week.',
                         ),
                 })
+                .strict()
                 .describe('Current-period settings.'),
         })
+        .strict()
         .describe(
-            `Use for current date requests such as "today", "this week", "this month", or "this year". ${filterJsonExamples(
+            `Use for current date requests such as "today", "this week", "this month", or "this year". ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_THE_CURRENT,
-                    values: [1],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.days,
-                    },
-                },
-                {
-                    fieldId: 'orders_order_date',
-                    fieldType: DimensionType.DATE,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.NOT_IN_THE_CURRENT,
-                    values: [1],
-                    settings: {
-                        completed: false,
-                        unitOfTime: UnitOfTime.months,
-                    },
+                    operators: [
+                        FilterOperator.IN_THE_CURRENT,
+                        FilterOperator.NOT_IN_THE_CURRENT,
+                    ],
                 },
             )}`,
         ),
@@ -246,21 +195,19 @@ const dateFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one explicit ISO date/datetime threshold.'),
         })
+        .strict()
         .describe(
-            `Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. ${filterJsonExamples(
+            `Use for date/timestamp fields before, on-or-before, after, or on-or-after a specific date. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.GREATER_THAN_OR_EQUAL,
-                    values: ['2024-01-01'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.LESS_THAN,
-                    values: ['2024-02-01T00:00:00Z'],
+                    operators: [
+                        FilterOperator.LESS_THAN,
+                        FilterOperator.LESS_THAN_OR_EQUAL,
+                        FilterOperator.GREATER_THAN,
+                        FilterOperator.GREATER_THAN_OR_EQUAL,
+                    ],
                 },
             )}`,
         ),
@@ -278,21 +225,14 @@ const dateFilterSchema = z.union([
                     'Exactly two explicit ISO dates/datetimes: [start, end].',
                 ),
         })
+        .strict()
         .describe(
-            `Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. ${filterJsonExamples(
+            `Use for explicit date ranges such as from 2024-01-01 to 2024-01-31. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_order_date',
                     fieldType: DimensionType.DATE,
                     fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: ['2024-01-01', '2024-01-31'],
-                },
-                {
-                    fieldId: 'orders_created_at',
-                    fieldType: DimensionType.TIMESTAMP,
-                    fieldFilterType: FilterType.DATE,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: ['2024-01-01T00:00:00Z', '2024-01-31T23:59:59Z'],
+                    operators: [FilterOperator.IN_BETWEEN],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/filterDescriptionUtils.ts
@@ -6,8 +6,3 @@ export const filterOperatorList = (...operators: FilterOperator[]): string =>
 export const valuePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing values, ${FilterOperator.NOT_NULL} for present values.`;
 
 export const datePresenceOperatorDescription = `Use ${FilterOperator.NULL} for missing dates, ${FilterOperator.NOT_NULL} for present dates.`;
-
-export const filterJsonExamples = (
-    ...examples: Record<string, unknown>[]
-): string =>
-    `Examples: ${examples.map((example) => JSON.stringify(example)).join('; ')}`;

--- a/packages/common/src/ee/AiAgent/schemas/filters/filterExamples.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/filterExamples.ts
@@ -1,0 +1,384 @@
+import { DimensionType, MetricType } from '../../../../types/field';
+import {
+    FilterOperator,
+    FilterType,
+    UnitOfTime,
+} from '../../../../types/filter';
+import assertUnreachable from '../../../../utils/assertUnreachable';
+
+export type AiFilterExample = {
+    fieldId: string;
+    fieldType: string;
+    fieldFilterType: FilterType;
+    operator: FilterOperator;
+    values?: unknown[];
+    settings?: {
+        completed: boolean;
+        unitOfTime: UnitOfTime;
+    };
+};
+
+type FilterExampleTemplate = Omit<
+    AiFilterExample,
+    'fieldId' | 'fieldType' | 'fieldFilterType'
+>;
+
+type GetFilterExamplesArgs = {
+    fieldId: string;
+    fieldType: string;
+    fieldFilterType: FilterType;
+    operators?: FilterOperator[];
+};
+
+const booleanFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: [true] },
+    { operator: FilterOperator.NOT_EQUALS, values: [false] },
+];
+
+const stringFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: ['example'] },
+    { operator: FilterOperator.NOT_EQUALS, values: ['excluded'] },
+    { operator: FilterOperator.STARTS_WITH, values: ['prefix'] },
+    { operator: FilterOperator.ENDS_WITH, values: ['suffix'] },
+    { operator: FilterOperator.INCLUDE, values: ['contains'] },
+    { operator: FilterOperator.NOT_INCLUDE, values: ['exclude'] },
+];
+
+const numberFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: [100] },
+    { operator: FilterOperator.NOT_EQUALS, values: [100] },
+    { operator: FilterOperator.LESS_THAN, values: [100] },
+    { operator: FilterOperator.LESS_THAN_OR_EQUAL, values: [100] },
+    { operator: FilterOperator.GREATER_THAN, values: [100] },
+    { operator: FilterOperator.GREATER_THAN_OR_EQUAL, values: [100] },
+    { operator: FilterOperator.IN_BETWEEN, values: [100, 500] },
+    { operator: FilterOperator.NOT_IN_BETWEEN, values: [100, 500] },
+];
+
+const dateRelativeUnits = [
+    UnitOfTime.days,
+    UnitOfTime.weeks,
+    UnitOfTime.months,
+    UnitOfTime.quarters,
+    UnitOfTime.years,
+] as const;
+
+const dateRelativeFilterExampleTemplates: FilterExampleTemplate[] = [
+    FilterOperator.IN_THE_PAST,
+    FilterOperator.NOT_IN_THE_PAST,
+    FilterOperator.IN_THE_NEXT,
+].flatMap((operator) =>
+    dateRelativeUnits.flatMap((unitOfTime) =>
+        [false, true].map((completed) => ({
+            operator,
+            values: [2],
+            settings: { completed, unitOfTime },
+        })),
+    ),
+);
+
+const dateCurrentFilterExampleTemplates: FilterExampleTemplate[] = [
+    FilterOperator.IN_THE_CURRENT,
+    FilterOperator.NOT_IN_THE_CURRENT,
+].flatMap((operator) =>
+    dateRelativeUnits.map((unitOfTime) => ({
+        operator,
+        values: [1],
+        settings: { completed: false, unitOfTime },
+    })),
+);
+
+const dateFilterExampleTemplates: FilterExampleTemplate[] = [
+    { operator: FilterOperator.NULL },
+    { operator: FilterOperator.NOT_NULL },
+    { operator: FilterOperator.EQUALS, values: ['2024-01-01'] },
+    {
+        operator: FilterOperator.NOT_EQUALS,
+        values: ['2024-01-01T00:00:00Z'],
+    },
+    ...dateRelativeFilterExampleTemplates,
+    ...dateCurrentFilterExampleTemplates,
+    { operator: FilterOperator.LESS_THAN, values: ['2024-02-01T00:00:00Z'] },
+    {
+        operator: FilterOperator.LESS_THAN_OR_EQUAL,
+        values: ['2024-02-01'],
+    },
+    { operator: FilterOperator.GREATER_THAN, values: ['2024-01-01'] },
+    {
+        operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+        values: ['2024-01-01'],
+    },
+    {
+        operator: FilterOperator.IN_BETWEEN,
+        values: ['2024-01-01', '2024-01-31'],
+    },
+];
+
+const getFilterExampleTemplates = (
+    fieldFilterType: FilterType,
+): FilterExampleTemplate[] => {
+    switch (fieldFilterType) {
+        case FilterType.BOOLEAN:
+            return booleanFilterExampleTemplates;
+        case FilterType.STRING:
+            return stringFilterExampleTemplates;
+        case FilterType.NUMBER:
+            return numberFilterExampleTemplates;
+        case FilterType.DATE:
+            return dateFilterExampleTemplates;
+        default:
+            return assertUnreachable(
+                fieldFilterType,
+                `Unknown filter type ${fieldFilterType}`,
+            );
+    }
+};
+
+export const getFilterExamples = ({
+    fieldId,
+    fieldType,
+    fieldFilterType,
+    operators,
+}: GetFilterExamplesArgs): AiFilterExample[] => {
+    const allowedOperators = operators ? new Set(operators) : null;
+
+    return getFilterExampleTemplates(fieldFilterType)
+        .filter(
+            (template) =>
+                allowedOperators === null ||
+                allowedOperators.has(template.operator),
+        )
+        .map((template) => ({
+            fieldId,
+            fieldType,
+            fieldFilterType,
+            ...template,
+        }));
+};
+
+export const formatFilterExamplesInline = (
+    examples: AiFilterExample[],
+): string => examples.map((example) => JSON.stringify(example)).join('; ');
+
+export const formatFilterExamplesAsJsonLines = (
+    examples: AiFilterExample[],
+): string => examples.map((example) => JSON.stringify(example)).join('\n');
+
+const literalUnion = (values: unknown[]): string =>
+    Array.from(new Set(values.map((value) => JSON.stringify(value)))).join(
+        ' | ',
+    );
+
+const enumValuesList = (...enumValues: object[]): string =>
+    Array.from(
+        new Set(
+            enumValues.flatMap((values) =>
+                Object.values(values).filter(
+                    (value): value is string => typeof value === 'string',
+                ),
+            ),
+        ),
+    ).join(', ');
+
+const validFieldTypes = enumValuesList(DimensionType, MetricType);
+const validFieldFilterTypes = enumValuesList(FilterType);
+
+type SupportedExamplePrimitive = boolean | number | string;
+
+type SupportedExamplePrimitiveName = 'boolean' | 'number' | 'string';
+
+const isSupportedExamplePrimitive = (
+    value: unknown,
+): value is SupportedExamplePrimitive =>
+    ['boolean', 'number', 'string'].includes(typeof value);
+
+const primitiveName = (
+    value: SupportedExamplePrimitive,
+): SupportedExamplePrimitiveName => {
+    switch (typeof value) {
+        case 'boolean':
+            return 'boolean';
+        case 'number':
+            return 'number';
+        case 'string':
+            return 'string';
+        default:
+            return assertUnreachable(
+                value,
+                `Unsupported example value type: ${typeof value}`,
+            );
+    }
+};
+
+const valuesTypeForOperator = (
+    operator: FilterOperator,
+    primitive: SupportedExamplePrimitiveName | 'unknown',
+): string | null => {
+    switch (operator) {
+        case FilterOperator.NULL:
+        case FilterOperator.NOT_NULL:
+            return null;
+        case FilterOperator.EQUALS:
+        case FilterOperator.NOT_EQUALS:
+            return primitive === 'boolean' ? '[boolean]' : `${primitive}[]`;
+        case FilterOperator.STARTS_WITH:
+        case FilterOperator.ENDS_WITH:
+        case FilterOperator.INCLUDE:
+        case FilterOperator.NOT_INCLUDE:
+            return 'string[]';
+        case FilterOperator.LESS_THAN:
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+        case FilterOperator.GREATER_THAN:
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+        case FilterOperator.IN_THE_PAST:
+        case FilterOperator.NOT_IN_THE_PAST:
+        case FilterOperator.IN_THE_NEXT:
+            return `[${primitive}]`;
+        case FilterOperator.IN_BETWEEN:
+        case FilterOperator.NOT_IN_BETWEEN:
+            return `[${primitive}, ${primitive}]`;
+        case FilterOperator.IN_THE_CURRENT:
+        case FilterOperator.NOT_IN_THE_CURRENT:
+            return '[1]';
+        case FilterOperator.IN_PERIOD_TO_DATE:
+            return null;
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported filter operator: ${operator}`,
+            );
+    }
+};
+
+const valuesTypeForExamples = (examples: AiFilterExample[]): string | null => {
+    const valuesExample = examples.find((example) => example.values)?.values;
+    if (!valuesExample) return null;
+
+    const firstValue = valuesExample[0];
+    const primitive = isSupportedExamplePrimitive(firstValue)
+        ? primitiveName(firstValue)
+        : 'unknown';
+    const valueTypes = new Set(
+        examples
+            .map((example) =>
+                valuesTypeForOperator(example.operator, primitive),
+            )
+            .filter((valueType) => valueType !== null),
+    );
+
+    return Array.from(valueTypes).join(' | ');
+};
+
+const valuesCommentForOperator = (
+    operator: FilterOperator,
+    primitive: SupportedExamplePrimitiveName | 'unknown',
+): string => {
+    switch (operator) {
+        case FilterOperator.NULL:
+        case FilterOperator.NOT_NULL:
+        case FilterOperator.IN_PERIOD_TO_DATE:
+            return '';
+        case FilterOperator.EQUALS:
+        case FilterOperator.NOT_EQUALS:
+            return primitive === 'boolean' ? ' // exactly one array value' : '';
+        case FilterOperator.IN_THE_CURRENT:
+        case FilterOperator.NOT_IN_THE_CURRENT:
+            return ' // exactly one array value; always [1] for current-period filters';
+        case FilterOperator.IN_THE_PAST:
+        case FilterOperator.NOT_IN_THE_PAST:
+        case FilterOperator.IN_THE_NEXT:
+            return ' // exactly one array value; number of periods';
+        case FilterOperator.IN_BETWEEN:
+        case FilterOperator.NOT_IN_BETWEEN:
+            return ' // exactly two array values; lower and upper bounds';
+        case FilterOperator.LESS_THAN:
+        case FilterOperator.LESS_THAN_OR_EQUAL:
+        case FilterOperator.GREATER_THAN:
+        case FilterOperator.GREATER_THAN_OR_EQUAL:
+            return ' // exactly one array value';
+        case FilterOperator.STARTS_WITH:
+        case FilterOperator.ENDS_WITH:
+        case FilterOperator.INCLUDE:
+        case FilterOperator.NOT_INCLUDE:
+            return '';
+        default:
+            return assertUnreachable(
+                operator,
+                `Unsupported filter operator: ${operator}`,
+            );
+    }
+};
+
+const valuesCommentForExamples = (examples: AiFilterExample[]): string => {
+    const valuesExample = examples.find((example) => example.values)?.values;
+    if (!valuesExample) return '';
+
+    const firstValue = valuesExample[0];
+    const primitive = isSupportedExamplePrimitive(firstValue)
+        ? primitiveName(firstValue)
+        : 'unknown';
+    const comments = new Set(
+        examples
+            .map((example) =>
+                valuesCommentForOperator(example.operator, primitive),
+            )
+            .filter((comment) => comment !== ''),
+    );
+
+    return Array.from(comments).join(' | ');
+};
+
+const settingsTypeForExamples = (
+    examples: AiFilterExample[],
+): string | null => {
+    const settingsExamples = examples
+        .map((example) => example.settings)
+        .filter((settings) => settings !== undefined);
+
+    if (settingsExamples.length === 0) return null;
+
+    return `{
+  completed: ${literalUnion(settingsExamples.map((settings) => settings.completed))}; // false includes current partial period; true means completed periods only
+  unitOfTime: ${literalUnion(settingsExamples.map((settings) => settings.unitOfTime))};
+}`;
+};
+
+export const formatFilterExamplesAsTypeDeclaration = (
+    examples: AiFilterExample[],
+): string => {
+    const firstExample = examples[0];
+    if (!firstExample) return '{}';
+
+    const valuesType = valuesTypeForExamples(examples);
+    const settingsType = settingsTypeForExamples(examples);
+
+    return `{
+  fieldId: "${firstExample.fieldId}"; // use the actual field id
+  fieldType: "${firstExample.fieldType}"; // one of: ${validFieldTypes}
+  fieldFilterType: "${firstExample.fieldFilterType}"; // one of: ${validFieldFilterTypes}; used to choose valid operators
+  operator: ${literalUnion(examples.map((example) => example.operator))}; // | means or${
+      valuesType
+          ? `
+  values: ${valuesType};${valuesCommentForExamples(examples)}`
+          : ''
+  }${
+      settingsType
+          ? `
+  settings: ${settingsType};`
+          : ''
+  }
+}`;
+};
+
+export const filterJsonExamplesForOperators = (
+    args: GetFilterExamplesArgs & { operators: FilterOperator[] },
+): string =>
+    `Type shape: ${formatFilterExamplesAsTypeDeclaration(
+        getFilterExamples(args),
+    )}`;

--- a/packages/common/src/ee/AiAgent/schemas/filters/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/index.ts
@@ -18,6 +18,7 @@ export {
     numberFilterSchema,
     stringFilterSchema,
 };
+export * from './filterExamples';
 
 const filterAndOrSchema = z
     .union([z.literal('and'), z.literal('or')])

--- a/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/numberFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonNumberFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -27,6 +27,7 @@ const commonNumberFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.NUMBER),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const numberFilterSchema = z.union([
     commonNumberFilterRuleSchema
         .extend({
@@ -37,19 +38,14 @@ const numberFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for numeric fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for numeric fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_total_revenue',
-                    fieldType: MetricType.SUM,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -67,21 +63,17 @@ const numberFilterSchema = z.union([
                 .array(z.number())
                 .describe('One or more exact numeric values to match.'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields that equal or exclude specific values. ${filterJsonExamples(
+            `Use for numeric fields that equal or exclude specific values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_item_count',
                     fieldType: MetricType.COUNT,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.EQUALS,
-                    values: [1, 2],
-                },
-                {
-                    fieldId: 'orders_discount_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: [0],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                    ],
                 },
             )}`,
         ),
@@ -102,21 +94,19 @@ const numberFilterSchema = z.union([
                 .length(1)
                 .describe('Exactly one numeric threshold value.'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields with a single comparison threshold. ${filterJsonExamples(
+            `Use for numeric fields with a single comparison threshold. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.GREATER_THAN,
-                    values: [1000],
-                },
-                {
-                    fieldId: 'orders_discount_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.LESS_THAN_OR_EQUAL,
-                    values: [0.15],
+                    operators: [
+                        FilterOperator.LESS_THAN,
+                        FilterOperator.LESS_THAN_OR_EQUAL,
+                        FilterOperator.GREATER_THAN,
+                        FilterOperator.GREATER_THAN_OR_EQUAL,
+                    ],
                 },
             )}`,
         ),
@@ -133,21 +123,17 @@ const numberFilterSchema = z.union([
                 .length(2)
                 .describe('Exactly two numeric bounds: [lower, upper].'),
         })
+        .strict()
         .describe(
-            `Use for numeric fields inside or outside a two-value range. ${filterJsonExamples(
+            `Use for numeric fields inside or outside a two-value range. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_total_revenue',
                     fieldType: MetricType.SUM,
                     fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.IN_BETWEEN,
-                    values: [100, 500],
-                },
-                {
-                    fieldId: 'orders_margin_percent',
-                    fieldType: DimensionType.NUMBER,
-                    fieldFilterType: FilterType.NUMBER,
-                    operator: FilterOperator.NOT_IN_BETWEEN,
-                    values: [0.2, 0.4],
+                    operators: [
+                        FilterOperator.IN_BETWEEN,
+                        FilterOperator.NOT_IN_BETWEEN,
+                    ],
                 },
             )}`,
         ),

--- a/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
+++ b/packages/common/src/ee/AiAgent/schemas/filters/stringFilters.ts
@@ -3,10 +3,10 @@ import { DimensionType, MetricType } from '../../../../types/field';
 import { FilterOperator, FilterType } from '../../../../types/filter';
 import { getFieldIdSchema } from '../fieldId';
 import {
-    filterJsonExamples,
     filterOperatorList,
     valuePresenceOperatorDescription,
 } from './filterDescriptionUtils';
+import { filterJsonExamplesForOperators } from './filterExamples';
 
 const commonStringFilterRuleSchema = z.object({
     fieldId: getFieldIdSchema({ additionalDescription: null }),
@@ -17,6 +17,7 @@ const commonStringFilterRuleSchema = z.object({
     fieldFilterType: z.literal(FilterType.STRING),
 });
 
+// Strict variants prevent Zod from silently stripping invalid AI keys like values/settings.
 const stringFilterSchema = z.union([
     commonStringFilterRuleSchema
         .extend({
@@ -27,19 +28,14 @@ const stringFilterSchema = z.union([
                 ])
                 .describe(valuePresenceOperatorDescription),
         })
+        .strict()
         .describe(
-            `Use for string fields when checking if a value is missing or present. Do not include values. ${filterJsonExamples(
+            `Use for string fields when checking if a value is missing or present. Do not include values. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_status',
                     fieldType: DimensionType.STRING,
                     fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NULL,
-                },
-                {
-                    fieldId: 'orders_status',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NOT_NULL,
+                    operators: [FilterOperator.NULL, FilterOperator.NOT_NULL],
                 },
             )}`,
         ),
@@ -63,35 +59,21 @@ const stringFilterSchema = z.union([
                     'String values to match. Do not put natural-language date ranges here.',
                 ),
         })
+        .strict()
         .describe(
-            `Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. ${filterJsonExamples(
+            `Use for text matching on string fields. For dates like "last 2 weeks", use a date filter instead. ${filterJsonExamplesForOperators(
                 {
                     fieldId: 'orders_status',
                     fieldType: DimensionType.STRING,
                     fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.EQUALS,
-                    values: ['complete', 'paid'],
-                },
-                {
-                    fieldId: 'customers_email',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.INCLUDE,
-                    values: ['@lightdash.com'],
-                },
-                {
-                    fieldId: 'products_sku',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.STARTS_WITH,
-                    values: ['SKU-'],
-                },
-                {
-                    fieldId: 'orders_status',
-                    fieldType: DimensionType.STRING,
-                    fieldFilterType: FilterType.STRING,
-                    operator: FilterOperator.NOT_EQUALS,
-                    values: ['cancelled'],
+                    operators: [
+                        FilterOperator.EQUALS,
+                        FilterOperator.NOT_EQUALS,
+                        FilterOperator.STARTS_WITH,
+                        FilterOperator.ENDS_WITH,
+                        FilterOperator.INCLUDE,
+                        FilterOperator.NOT_INCLUDE,
+                    ],
                 },
             )}`,
         ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:
- Replaces raw Zod union dumps for invalid AI filters with concise, repair-oriented errors.
- Adds shared filter example templates used by both schema descriptions and validation errors.
- Shows compact TypeScript-like filter shapes in schema descriptions, with `|` documented as “or”, to avoid huge inline example lists.
- Keeps exhaustive one-line JSON filter combinations in validation errors where they are useful for repair.
- Preserves the actual `fieldType` in examples/errors (for example `count`) while using `fieldFilterType` for the filter family (for example `number`).
- Makes AI filter schemas strict so presence operators reject stray `values`/`settings` instead of silently stripping them.
- Tightens validation messages for presence filters, explicit `null`, date settings, current-period values, and ISO date parsing.
- Uses neutral string examples and expands date repair examples across relative/current unit + `completed` combinations.
- Adds focused backend coverage and updates agent/MCP tool contract snapshots.

### Testing:
- `pnpm -F common build:fast`
- `pnpm -F backend exec jest --config jest.config.js src/ee/services/ai/utils/validateFilterRuleErrors.test.ts`
- `pnpm -F backend exec jest --config jest.config.js src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts src/ee/services/McpService/mcpToolContracts.snapshot.test.ts`
- `pnpm -F backend typecheck:fast`
- `pnpm -F common typecheck:fast`
