### PR TITLE
docs(query-builder): add investigation notes and lessons

### DIFF
--- a/INVESTIGATION.md
+++ b/INVESTIGATION.md
@@ -1,0 +1,259 @@
+# Investigation — PROD-8117: Duplicate `_distinct` metric in pivot/fanout SQL
+
+> Internal working note. Not for commit (contains customer + Pylon references).
+
+## TL;DR
+
+When a `type: number` metric references a `sum_distinct` / `average_distinct` metric on a
+**fanned-out** explore, the metric query builder emits that derived metric **twice under the
+same SQL alias** — once correctly (from the outer `dd` SELECT, using the `dd_*` dedup CTE) and
+once as a raw fallback aggregate inside the per-table fanout-protection CTE
+(`cte_metrics_<table>`). Same alias twice = broken output.
+
+- **Snowflake**: hard SQL error (duplicate output column).
+- **BigQuery**: silently renames one column to `*_1` → viz layer gets unexpected columns / wrong values.
+- **Postgres**: tolerates duplicate output aliases, so the SQL "runs" but the visualization breaks.
+
+Fix = skip these derived (`nonAggReferencingDd`) metrics when building the fanout metrics CTE,
+so they are only projected once, from the outer SELECT.
+
+---
+
+## Identifiers / cross-references
+
+| System | Ref |
+|---|---|
+| Linear | **PROD-8117** — "[Pivot Table] Duplicate SQL field generated for _distinct measures when pivot is enabled" |
+| GitHub issue | **#23861** (mirror of PROD-8117), filed by Tori Whaley, 2026-06-03. Labels: 🐛 bug, ⚙️ backend, 📓 table visualization |
+| GitHub PR | **#24017** — "fix(pivot): duplicate distinct metric projection in pivot queries" (OPEN). `Closes #23861` |
+| Slack (origin) | Customer thread led by Oliver Ramsay, 2026-06-02 (channel `C0ATLBUDDV0`) |
+| Slack (DM) | DM with Tori Whaley re: the PR (Jun 8–9) |
+
+### People
+- **Kostas Spyrlidis** (+ Andreas Potel-Stüber) — customer who reported & self-diagnosed it (building a Looker-style P&L). Found the extra measure on line 36 of their generated SQL.
+- **Oliver Ramsay** — Lightdash SE/CS on the call; turned on the pivot-improvements feature flag, asked for the explore YAML.
+- **Tori Whaley** — filed #23861 / PROD-8117; gave the PR an informal 👍 over DM but flagged PoP.
+- **Jess Hitchcock** (`@jess`, Analytics Engineering Advocate) — the go-to for fanout/PoP speccing; the person to verify PoP permutations with before merge.
+- **Irakli Janiashvili** (me, `IrakliJani`) — author of PR #24017.
+
+---
+
+## The bug
+
+### Symptom
+Customer chart: pivot table with a `_distinct` metric (e.g. `count_distinct` / `sum_distinct`)
+alongside ≥1 other measure produces SQL containing **two fields with the same alias** for the
+distinct-derived measure — one respecting the distinct config, one ignoring it.
+
+### Root cause (where it lives)
+`packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` — the **fanout-protection** path
+(NOT `PivotQueryBuilder.ts`; the pivot wrapper is downstream and unrelated to this duplication).
+
+Two relevant CTE mechanisms in `MetricQueryBuilder`:
+1. **`dd_*` CTEs** — deduplication for distinct metrics (`sum_distinct`/`average_distinct`),
+   using `ROW_NUMBER() OVER (PARTITION BY <distinctKeys> ...)` then aggregating where `__dd_rn = 1`.
+2. **Fanout-protection CTEs** — `cte_keys_<table>` (SELECT DISTINCT primary keys) +
+   `cte_metrics_<table>` (aggregates joined 1:1 on those keys). Built when a **plain,
+   fanout-prone aggregate** on the "one" side of a one-to-many join would be inflated.
+
+The derived `type: number` metric (e.g. `total / NULLIF(distinct_metric, 0)`) was being added to
+`cte_metrics_<table>`, where its `compiledSql` expands the distinct metric down to its **raw
+fallback aggregate** (the `dd_*` alias isn't in scope there). It was *also* emitted correctly in
+the outer `dd` SELECT. → duplicate alias.
+
+Key precondition: the duplicate only appears when a `cte_metrics_<table>` CTE actually exists,
+i.e. there is at least one genuinely fanout-protected plain aggregate (`SUM`/`AVG` over a
+column on the "one" side). `count_distinct` and `MIN`/`MAX` are inflation-proof and do **not**
+trigger it; a derived metric alone does **not** trigger it.
+
+### Before / after SQL (from the PR diff comment)
+Before (duplicate — note the same alias appears in `cte_metrics_customers` AND the final SELECT):
+```diff
+ WITH
+   cte_metrics_customers AS (
+     SELECT
+-      (SUM("customers".lifetime_value)) / NULLIF((SUM("customers".lifetime_value)), 0) AS "customers_average_customer_value_deduped",
+       SUM("customers".lifetime_value) AS "customers_total_customer_value"
+     FROM cte_keys_customers
+     LEFT JOIN customers AS "customers" ON cte_keys_customers."pk_customer_id" = "customers".customer_id
+   ),
+   dd_base AS (
+     SELECT
+       cte_unaffected.*,
+-      cte_metrics_customers."customers_average_customer_value_deduped" AS "customers_average_customer_value_deduped",
+       cte_metrics_customers."customers_total_customer_value" AS "customers_total_customer_value"
+     FROM cte_unaffected
+     CROSS JOIN cte_metrics_customers
+   )
+ SELECT
+   dd_base.*,
+   dd_customers_total_customer_value_deduped."customers_total_customer_value_deduped" AS "customers_total_customer_value_deduped",
+   dd_base."customers_total_customer_value" / NULLIF(dd_customers_total_customer_value_deduped."customers_total_customer_value_deduped", 0) AS "customers_average_customer_value_deduped"
+ FROM dd_base
+ CROSS JOIN dd_customers_total_customer_value_deduped
+```
+
+---
+
+## The fix (PR #24017)
+
+### Code change — `MetricQueryBuilder.ts` (~line 2234)
+Inside the loop that builds the fanout metrics CTE, skip non-aggregate metrics that reference a
+distinct metric so they are only emitted from the outer `dd` SELECT:
+
+```ts
+// Non-aggregate metrics referencing sum_distinct/average_distinct
+// must be emitted from the outer dd SELECT where dd_* aliases
+// are available. Emitting compiledSql here expands the distinct
+// metric to its raw fallback aggregate and can duplicate the
+// outer alias.
+if (nonAggReferencingDd.has(getItemId(metric))) {
+    return;
+}
+```
+
+### Files changed
+- `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` — the guard above.
+- `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts` — extended
+  `EXPLORE_WITH_FANOUT_AND_DD_REFERENCE` with metrics: `total_customer_value` (SUM),
+  `total_customer_value_deduped` (SUM_DISTINCT), `average_customer_value_distinct`
+  (AVERAGE_DISTINCT), `average_customer_value_deduped` (NUMBER → references the sum_distinct),
+  `customer_value_vs_distinct_average` (NUMBER → references the average_distinct). Added two
+  `CompiledMetricQuery` fixtures: `METRIC_QUERY_FANOUT_AND_SAME_TABLE_DD_REFERENCE` and
+  `METRIC_QUERY_FANOUT_AND_SAME_TABLE_AVERAGE_DD_REFERENCE`.
+- `packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts`
+  — two new tests.
+- `packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap`
+  — new snapshots.
+
+### Test approach (what the snapshot test uses)
+- **Vitest** snapshot test (`toMatchSnapshot()`), no DB.
+- `buildQuery()` helper (`metricQueryBuilderSnapshots/helpers.ts`) instantiates `MetricQueryBuilder`
+  with `SNAPSHOT_DEFAULTS` (mock `warehouseClientMock`, UTC tz, intrinsic user attrs) and returns
+  `formatSql(query)`.
+- Inputs are the inline mocks from `MetricQueryBuilder.mock.ts`.
+- Beyond the snapshot, each test pins the regression explicitly:
+  - `expect(query).toContain('cte_metrics_customers')`
+  - `expect(query).not.toContain('<raw fallback projection>')`
+  - `expect(query.match(/AS "<alias>"/g)).toHaveLength(1)` — alias appears exactly once.
+
+Run / update:
+```bash
+pnpm -F backend test:dev:nowatch         # runs tests for modified files
+# or invoke vitest on fanoutQueries and pass -u to refresh snapshots
+```
+
+---
+
+## Reproduction notes (gotchas)
+
+To reproduce you need **all** of:
+1. A fanned-out explore (one-to-many join).
+2. A derived `type: number` metric referencing a `sum_distinct` / `average_distinct` metric.
+3. **A plain fanout-prone aggregate** (`SUM`/`AVG` over a column on the "one" side) so that
+   `cte_metrics_<table>` actually gets built. Without this, the derived metric is emitted only
+   once and the bug does NOT appear (the SQL is correct).
+
+### Jaffle shop availability
+`examples/full-jaffle-shop-demo/dbt/models/customers.yml`:
+- `total_order_amount_deduped` — **sum_distinct** (line 63), `distinct_keys: [orders.order_id]`.
+- `avg_order_amount_deduped` — **average_distinct** (line 70). **Nothing references it.**
+- `average_customer_lifetime_value` — **number** (line 84):
+  `${total_order_amount_deduped} / NULLIF(${unique_customer_count}, 0)` → references the sum_distinct. ✅
+- `orders.deduped_revenue_per_order` (orders.yml:103) — number → `${customers.total_order_amount_deduped} / NULLIF(...)` (cross-model sum_distinct). ✅
+
+| PR test case | Existing jaffle metric? |
+|---|---|
+| number → **sum_distinct** | ✅ `average_customer_lifetime_value` |
+| number → **average_distinct** | ❌ none (`avg_order_amount_deduped` is unreferenced) |
+
+Catch: jaffle has **no ungated plain `SUM` over a customers column**. The only fanout-prone
+customers aggregate is `customers_average_age`, and `age` is gated behind
+`required_attributes: is_admin: "true"` (customers.yml:172). So in the live app you must either
+run as a user with `is_admin=true`, or add a one-line metric:
+```yaml
+total_lifetime_value:
+  type: sum
+  sql: ${customer_lifetime_value}
+```
+
+### Metric query that reproduces (sum_distinct, customers explore)
+```json
+{
+  "exploreName": "customers",
+  "dimensions": [],
+  "metrics": [
+    "customers_average_customer_lifetime_value",
+    "customers_average_age",
+    "orders_total_order_amount"
+  ],
+  "filters": {},
+  "sorts": [{ "fieldId": "customers_average_customer_lifetime_value", "descending": true }],
+  "limit": 500,
+  "tableCalculations": []
+}
+```
+(Replace `customers_average_age` with `customers_total_lifetime_value` if you add the metric above,
+to avoid the `is_admin` gate.)
+
+The "did it reproduce?" tell: a `cte_metrics_customers` CTE appears, and pre-fix
+`customers_average_customer_lifetime_value` appears **twice** (once inside `cte_metrics_customers`,
+once in the final SELECT).
+
+> Note: an earlier candidate query using `customers_total_order_amount_inflated` +
+> `orders_total_order_amount` did NOT reproduce — both are orders-grain `SUM(orders.amount)`, so no
+> `cte_metrics_customers` was built and the derived metric was correctly emitted once.
+
+---
+
+## Open items / review concerns
+- **PoP permutations** — Tori flagged (DM) that this should be checked against period-over-period.
+  To verify with **Jess Hitchcock**. Not yet done.
+- There's a separate **"PoP fix" PR** that was "blindcoded" (mentioned to Tori) — unresolved / not pinned down.
+- PR #24017 has **no formal GitHub review** yet (Tori's 👍 was DM-only).
+- average_distinct case has **no jaffle coverage** outside the unit-test mock.
+
+---
+
+## Git / branch state (as of this investigation)
+
+- **Branch**: `fix(pivot)/distinct-duplicate-metric` (checked out via `gh pr checkout 24017`).
+- **Tracked in Graphite** with parent `main` (`gt track --parent main`).
+- **Restacked** onto latest main via `gt sync` + `gt restack`.
+  - main fast-forwarded to `1597a9a063` (release `0.3190.1`).
+  - Restack was clean (no conflicts).
+- Local branch vs main: **0 behind / 2 ahead**.
+  - `9a49d4f6f0` fix(pivot): distinct duplicate metric
+  - `2a90713a95` test(query-builder): cover average distinct fanout
+- ⚠️ Local branch has **diverged from `origin/fix(pivot)/distinct-duplicate-metric`**
+  (`ahead 462, behind 2`) because the rebase rewrote the two commits onto new main.
+  Updating PR #24017 requires a **force-push** (`gt submit` or `git push --force-with-lease`).
+  Not yet pushed.
+
+Commands used:
+```bash
+gh pr checkout 24017
+gt sync --no-interactive          # ff main, restacked tracked branches, deleted nothing
+gt track --parent main            # PR branch was untracked (gh checkout)
+gt restack                        # clean
+```
+
+---
+
+## Related but SEPARATE issue — PROD-8338 (Trino stage-count blowup)
+
+Not the same bug; same general area (pivot SQL). Tracked here only to avoid confusion.
+
+- **Pylon #13802** (assignee: me) / **GitHub #24388** / **Linear PROD-8338**.
+- Reporter: **Tony Orciuoli (Workday)**, self-hosted **Trino**. GH handle `agha4to`.
+- Symptom: after upgrade `0.3004.1 → 0.3123.0`, pivot charts fail with
+  *"Number of stages in the query (156) exceeds the allowed maximum (150)"* — specifically when
+  **sorting** a pivoted column (sort adds metric-ranking CTEs).
+- Root cause: `PivotQueryBuilder.ts` builds a CTE chain; Trino/Athena/Spark inline (don't
+  materialize) CTEs, re-expanding the heavy base each reference; `pivot_query` referenced twice.
+- Tony attached a Cursor-assisted 5-point refactor proposal for `PivotQueryBuilder.ts`
+  (rankings from anchor CTEs not `group_by_query`; drop redundant DISTINCT; linearize final
+  assembly so `pivot_query` referenced once; shared `getPivotBaseOutputColumnNames` helper;
+  `_order` carry-through fixes). Engine-agnostic, neutral on materializing warehouses.
+- Workaround floated internally: raise Trino `query.max-stage-count` (e.g. 300).
+- Status: P2/High, no fix PR yet. Giorgi Bagdavadze tagged to look.

--- a/MISSION.md
+++ b/MISSION.md
@@ -1,0 +1,22 @@
+# Mission: Understand Lightdash Backend Query Generation
+
+## Why
+Irakli needs a durable mental model of Lightdash backend SQL/query-builder systems so he can safely reason about changes involving fanouts, period-over-period, pivot queries, distinct metrics, and CTE composition.
+
+## Success looks like
+- Explain the boundary between `MetricQueryBuilder`, `PivotQueryBuilder`, and `AsyncQueryService.runQueryAndTransformRows`.
+- Predict when joins cause metric inflation and how Lightdash fanout protection responds.
+- Trace one generated output alias through CTE scopes back to base SQL.
+- Explain period-over-period as shifted metric computation joined back to current rows.
+- Explain why pivot SQL stays long and how row/column indexes become wide pivot output.
+
+## Constraints
+- Teach from repository code and Lightdash documentation, not generic BI lore.
+- Use small concrete datasets before abstract code.
+- Keep each lesson printable, visual, and reviewable.
+- Do not read `packages/formula-tests/`.
+
+## Out of scope
+- The current bug/PR except as motivation.
+- Full frontend pivot rendering internals beyond backend query transformation.
+- Warehouse optimizer deep dives unless required for conceptual correctness.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,7 @@
+# Teaching Notes
+
+- User wants deep concept-first lessons generated from scratch.
+- Avoid centering on the current investigation/bug.
+- User prefers Mermaid diagrams in HTML lessons with:
+  `<script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'; mermaid.initialize({ startOnLoad: true, theme: 'neutral' });</script>`
+- Assume comfort with TypeScript and SQL, but not BI query-builder internals.

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,0 +1,29 @@
+# Lightdash Backend Query Generation Resources
+
+## Knowledge
+
+- [Lightdash docs: Joins reference — fanouts and relationships](https://docs.lightdash.com/references/joins)
+  Defines join relationships, primary keys, directionality, and fanout handling. Use for: user-facing semantics of fanout protection.
+- [Lightdash docs: Period-over-period guide](https://docs.lightdash.com/guides/period-over-period)
+  Explains period comparison workflows and examples. Use for: user-facing intent before backend SQL mechanics.
+- [`packages/backend/src/utils/QueryBuilder/CLAUDE.md`](packages/backend/src/utils/QueryBuilder/CLAUDE.md)
+  Local map of query builders and pivot CTE modes. Use for: high-level architecture and pivot boundaries.
+- [`packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts`](packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts)
+  Main semantic SQL builder. Use for: joins, metric SELECTs, fanout CTEs, distinct metric CTEs, PoP CTEs, alias rewriting.
+- [`packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts`](packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts)
+  Pivot SQL wrapper. Use for: `original_query`, `group_by_query`, `pivot_query`, row/column ranks, sort anchor CTEs.
+- [`packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts`](packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts)
+  Query execution and streaming pivot row transformation. Use for: how long pivot SQL rows become wide result rows.
+- [`packages/common/src/types/pivot.ts`](packages/common/src/types/pivot.ts)
+  `PivotConfig` and `PivotConfiguration` types. Use for: vocabulary and fields passed to `PivotQueryBuilder`.
+- [`packages/common/src/pivot/derivePivotConfigFromChart.ts`](packages/common/src/pivot/derivePivotConfigFromChart.ts)
+  Derives `PivotConfiguration` from saved chart config and metric query. Use for: how table/cartesian chart settings become backend pivot instructions.
+- [`packages/common/src/types/periodOverPeriodComparison.ts`](packages/common/src/types/periodOverPeriodComparison.ts)
+  PoP helper metadata and generated additional metric construction. Use for: generated metric IDs, labels, and comparison keys.
+
+## Wisdom (Communities)
+
+- Lightdash backend/query-builder PR review
+  Best place to test edge-case assumptions against maintainers.
+- Jess Hitchcock / Analytics Engineering Advocate review
+  Internal high-context reviewer for fanout and period-over-period semantics.

--- a/assets/lesson.css
+++ b/assets/lesson.css
@@ -1,0 +1,83 @@
+:root {
+  --bg: #fffdf8;
+  --paper: #ffffff;
+  --ink: #1f2933;
+  --muted: #64748b;
+  --line: #e7decf;
+  --accent: #5b3cc4;
+  --accent-2: #0f766e;
+  --accent-soft: #f2edff;
+  --warn-soft: #fff7df;
+  --good-soft: #ecfdf5;
+  --bad-soft: #fef2f2;
+  --code-bg: #f7f2ea;
+  --shadow: 0 1px 0 rgba(31, 41, 51, 0.04), 0 12px 35px rgba(31, 41, 51, 0.06);
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(91,60,196,0.08), transparent 34rem),
+    var(--bg);
+  color: var(--ink);
+  font: 16px/1.58 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+main {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 48px 24px 88px;
+}
+h1, h2, h3 { line-height: 1.15; letter-spacing: -0.026em; }
+h1 { font-size: clamp(2.3rem, 5.4vw, 4.8rem); margin: 0 0 0.32em; }
+h2 { font-size: clamp(1.55rem, 2.2vw, 2.1rem); margin: 2.4em 0 0.7em; padding-top: 1em; border-top: 1px solid var(--line); }
+h3 { font-size: 1.18rem; margin: 1.35em 0 0.4em; }
+p, li { max-width: 78ch; }
+a { color: var(--accent); text-decoration-thickness: 0.08em; text-underline-offset: 0.18em; }
+.kicker { color: var(--accent); font-weight: 800; letter-spacing: 0.09em; text-transform: uppercase; font-size: 0.82rem; }
+.subtitle { color: var(--muted); font-size: 1.13rem; max-width: 76ch; }
+.nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 26px 0 34px; }
+.nav a, .badge { display: inline-block; border: 1px solid var(--line); border-radius: 999px; padding: 5px 12px; background: rgba(255,255,255,0.74); color: var(--muted); font-size: 0.9rem; text-decoration: none; }
+.nav a:hover { color: var(--accent); border-color: #cbbcff; }
+.card, .checkpoint, .warning, .win, .aside, .danger {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  padding: 18px 20px;
+  margin: 20px 0;
+  background: rgba(255,255,255,0.72);
+  box-shadow: var(--shadow);
+}
+.checkpoint { background: var(--accent-soft); border-color: #d7c9ff; }
+.warning { background: var(--warn-soft); border-color: #efd28a; }
+.win { background: var(--good-soft); border-color: #9ee7d4; }
+.danger { background: var(--bad-soft); border-color: #fecaca; }
+.aside { background: #f8fafc; }
+.grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+.two-col { display: grid; gap: 18px; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+.three-col { display: grid; gap: 16px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+@media (max-width: 800px) { .two-col, .three-col { grid-template-columns: 1fr; } }
+pre, code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+code { background: var(--code-bg); padding: 0.12em 0.34em; border-radius: 6px; font-size: 0.92em; }
+pre { overflow-x: auto; background: var(--code-bg); border: 1px solid var(--line); border-radius: 16px; padding: 16px 18px; line-height: 1.45; }
+pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.88rem; }
+.mermaid { background: #fbf7f0; border: 1px solid var(--line); border-radius: 16px; padding: 18px; margin: 22px 0; overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; margin: 18px 0; font-size: 0.95rem; }
+th, td { border-bottom: 1px solid var(--line); padding: 10px 9px; text-align: left; vertical-align: top; }
+th { color: var(--muted); font-weight: 800; background: rgba(255,255,255,0.52); }
+caption { text-align: left; color: var(--muted); font-size: 0.9rem; margin-bottom: 7px; }
+details { border-top: 1px solid var(--line); padding: 14px 0; }
+summary { cursor: pointer; font-weight: 800; }
+details p { margin-bottom: 0; }
+.small { color: var(--muted); font-size: 0.92rem; }
+.term { color: var(--accent); font-weight: 800; }
+.file { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.92em; }
+.flowline { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; white-space: pre-wrap; background: #fbf7f0; border: 1px solid var(--line); border-radius: 16px; padding: 16px; }
+.callout-title { font-weight: 900; display: block; margin-bottom: 5px; }
+hr { border: 0; border-top: 1px solid var(--line); margin: 32px 0; }
+@media print {
+  body { background: white; }
+  main { max-width: none; padding: 24px; }
+  .card, .checkpoint, .warning, .win, .aside, .danger, pre, .mermaid { break-inside: avoid; box-shadow: none; }
+  .nav { display: none; }
+  a::after { content: " (" attr(href) ")"; font-size: 0.82em; color: var(--muted); }
+}

--- a/lessons/0000-intro-lightdash-query-systems.html
+++ b/lessons/0000-intro-lightdash-query-systems.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Intro: Lightdash Backend Query Systems</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Lesson 0000 · System map</p>
+  <h1>Lightdash query generation is a pipeline, not one query builder</h1>
+  <p class="subtitle">The backend SQL that reaches a warehouse is assembled by several systems. Each system has one job: semantic metrics, fanout protection, distinct deduplication, period comparison, pivot indexing, or result transformation.</p>
+
+  <nav class="nav">
+    <a href="./0001-fanouts-deep-dive.html">1 Fanouts</a>
+    <a href="./0002-ctes-deep-dive.html">2 CTEs</a>
+    <a href="./0003-period-over-period-deep-dive.html">3 PoP</a>
+    <a href="./0004-pivot-queries-deep-dive.html">4 Pivot queries</a>
+    <a href="../reference/lightdash-query-builder-reference.html">Reference</a>
+  </nav>
+
+  <section class="win">
+    <span class="callout-title">What you should be able to do after this lesson</span>
+    Look at a generated query and name the subsystem responsible for each major CTE family: semantic metric SQL, fanout protection, distinct metrics, period-over-period, and pivot indexing.
+  </section>
+
+  <h2>1. The big architecture map</h2>
+  <p>The local query-builder guide says there are three main builders: <code>MetricQueryBuilder</code>, <code>PivotQueryBuilder</code>, and <code>SqlQueryBuilder</code>. For Explore/Chart metric queries, the important path is usually <code>MetricQueryBuilder → optional PivotQueryBuilder → AsyncQueryService</code>.</p>
+
+  <div class="mermaid">
+flowchart TD
+  UI[Saved chart / Explorer request] --> MQ[MetricQuery<br/>dimensions, metrics, filters, sorts]
+  MQ --> Compile[compileMetricQuery<br/>additional metrics, table calcs, custom dims]
+  Compile --> MQB[MetricQueryBuilder]
+
+  subgraph MQBSystems[MetricQueryBuilder systems]
+    Sem[Semantic SELECT<br/>dimensions + metric SQL + joins]
+    Fan[Fanout protection<br/>cte_keys_* + cte_metrics_*]
+    DD[Distinct metric dedup<br/>dd_* + dd_base]
+    POP[Period-over-period<br/>base_metrics / pop_* or cte_pop_*]
+  end
+
+  MQB --> Sem
+  Sem --> Fan
+  Fan --> DD
+  DD --> POP
+  POP --> FlatSQL[Flat semantic SQL result]
+
+  FlatSQL --> MaybePivot{PivotConfiguration?}
+  MaybePivot -- no --> Run[warehouse execute]
+  MaybePivot -- yes --> PQB[PivotQueryBuilder]
+  PQB --> OQ[original_query]
+  OQ --> GB[group_by_query]
+  GB --> PQ[pivot_query<br/>row_index + column_index]
+  PQ --> Run
+  Run --> Transform[AsyncQueryService.runQueryAndTransformRows]
+  Transform --> Result[Rows + columns + pivotDetails]
+  </div>
+
+  <section class="checkpoint">
+    <span class="callout-title">Boundary rule</span>
+    <code>MetricQueryBuilder</code> decides what metrics mean. <code>PivotQueryBuilder</code> decides how pivot rows and columns are indexed. <code>AsyncQueryService.runQueryAndTransformRows</code> turns long pivot rows into the wide shape returned/stored for results.
+  </section>
+
+  <h2>2. Start with a concrete chart</h2>
+  <p>Imagine a user asks for a pivot table:</p>
+
+  <ul>
+    <li>Rows: <code>orders_order_date_month</code></li>
+    <li>Pivot columns: <code>orders_status</code></li>
+    <li>Metric: <code>orders_revenue</code></li>
+    <li>Period comparison: previous month revenue</li>
+    <li>Explore has joins that may fan out some metrics</li>
+  </ul>
+
+  <p>This sounds like “one query”. In Lightdash it becomes a chain of responsibilities:</p>
+
+  <table>
+    <thead><tr><th>Question</th><th>Responsible system</th><th>Typical files</th></tr></thead>
+    <tbody>
+      <tr><td>What does <code>orders_revenue</code> mean?</td><td>Semantic compiler + <code>MetricQueryBuilder</code></td><td><a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts">MetricQueryBuilder.ts</a></td></tr>
+      <tr><td>Which joins are needed?</td><td><code>MetricQueryBuilder.getJoinSQL</code></td><td><a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts">MetricQueryBuilder.ts</a></td></tr>
+      <tr><td>Could the join multiply rows and inflate an aggregate?</td><td>Fanout detection/protection</td><td><a href="../packages/backend/src/utils/QueryBuilder/utils.ts">QueryBuilder utils</a>, <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts">MetricQueryBuilder.ts</a></td></tr>
+      <tr><td>Is a metric <code>sum_distinct</code> / <code>average_distinct</code>?</td><td>Distinct metric CTE builder</td><td><a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts">buildDistinctMetricCtes</a></td></tr>
+      <tr><td>Is there a generated previous-period metric?</td><td>PoP config and CTE builder</td><td><a href="../packages/common/src/types/periodOverPeriodComparison.ts">periodOverPeriodComparison.ts</a>, <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts">MetricQueryBuilder.ts</a></td></tr>
+      <tr><td>How do rows become pivot columns?</td><td>Pivot SQL wrapper + streaming transform</td><td><a href="../packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts">PivotQueryBuilder.ts</a>, <a href="../packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts">AsyncQueryService.ts</a></td></tr>
+    </tbody>
+  </table>
+
+  <h2>3. Minimum vocabulary</h2>
+  <div class="grid">
+    <section class="card"><h3>Metric query</h3><p>The request shape: explore name, dimensions, metrics, filters, sorts, limit, table calculations, optional additional metrics, and optional pivot dimensions.</p></section>
+    <section class="card"><h3>Compiled metric query</h3><p>The query after custom metrics, custom dimensions, and table calculations are compiled. PoP generated metrics appear in <code>additionalMetrics</code> and compiled metric maps.</p></section>
+    <section class="card"><h3>Explore</h3><p>The semantic model: base table, joined tables, dimensions, metrics, primary keys, and join relationships.</p></section>
+    <section class="card"><h3>Grain</h3><p>What one row represents. Fanout bugs are usually grain mismatch bugs.</p></section>
+    <section class="card"><h3>Fanout</h3><p>A join that multiplies rows from some table. Multiplication can inflate <code>SUM</code> and <code>AVG</code>.</p></section>
+    <section class="card"><h3>CTE</h3><p>A named SQL subquery in a <code>WITH</code> clause. In Lightdash, CTEs are the boundaries between query-builder systems.</p></section>
+    <section class="card"><h3>PoP</h3><p>Period-over-period: a generated metric that reruns a base metric over a shifted time window and joins it back to current rows.</p></section>
+    <section class="card"><h3>Pivot long rows</h3><p>Rows that still have a pivot header value column plus <code>row_index</code> and <code>column_index</code>. They are not yet final wide pivot rows.</p></section>
+  </div>
+
+  <h2>4. The simplest non-pivot query path</h2>
+  <p>If there are no fanouts, no distinct metrics, no PoP, and no pivoting, <code>MetricQueryBuilder</code> can produce familiar SQL:</p>
+
+  <pre><code>SELECT
+  DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
+  SUM("orders".amount) AS "orders_revenue"
+FROM "analytics"."orders" AS "orders"
+WHERE "orders".is_completed = true
+GROUP BY 1
+ORDER BY "orders_order_date_month" ASC
+LIMIT 500</code></pre>
+
+  <p>Most complexity is conditional. Lightdash adds layers only when the query asks for semantics that cannot be expressed safely in that simple shape.</p>
+
+  <h2>5. Why CTE layers appear</h2>
+  <table>
+    <thead><tr><th>If the query needs…</th><th>Lightdash may add…</th><th>Why</th></tr></thead>
+    <tbody>
+      <tr><td>Aggregate on a table duplicated by joins</td><td><code>cte_keys_*</code>, <code>cte_metrics_*</code>, <code>cte_unaffected</code></td><td>Aggregate at the table's safe primary-key grain.</td></tr>
+      <tr><td><code>sum_distinct</code> or <code>average_distinct</code></td><td><code>dd_*</code>, <code>dd_base</code></td><td>Deduplicate by configured distinct keys using <code>ROW_NUMBER()</code>.</td></tr>
+      <tr><td>Generated previous-period metric</td><td><code>base_metrics</code>, <code>pop_min_max_*</code>, <code>pop_metrics_*</code>, or fanout-aware <code>cte_pop_*</code></td><td>Compute current rows and shifted comparison rows separately.</td></tr>
+      <tr><td>Pivot visualization</td><td><code>original_query</code>, <code>group_by_query</code>, <code>pivot_query</code>, ranking/anchor CTEs</td><td>Add row/column indexes and preserve order/limits for streaming transform.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>6. The four deep dives</h2>
+  <p>The rest of this sequence isolates one concept at a time. This matters because bugs often look like “pivot broke”, but the broken SQL alias may have been emitted by fanout protection or distinct-metric handling before pivoting even starts.</p>
+
+  <div class="mermaid">
+flowchart LR
+  F[1 Fanouts<br/>why rows multiply] --> C[2 CTEs<br/>how scopes compose]
+  C --> P[3 PoP<br/>shifted self-join]
+  P --> V[4 Pivot<br/>long rows to wide output]
+  </div>
+
+  <section class="aside">
+    <span class="callout-title">Primary sources used</span>
+    Repo files: <a href="../packages/backend/src/utils/QueryBuilder/CLAUDE.md"><code>QueryBuilder/CLAUDE.md</code></a>, <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts"><code>MetricQueryBuilder.ts</code></a>, <a href="../packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts"><code>PivotQueryBuilder.ts</code></a>, <a href="../packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts"><code>AsyncQueryService.ts</code></a>, <a href="../packages/common/src/types/pivot.ts"><code>types/pivot.ts</code></a>, <a href="../packages/common/src/pivot/derivePivotConfigFromChart.ts"><code>derivePivotConfigFromChart.ts</code></a>, and <a href="../packages/common/src/types/periodOverPeriodComparison.ts"><code>periodOverPeriodComparison.ts</code></a>. Docs: <a href="https://docs.lightdash.com/references/joins">joins/fanouts</a> and <a href="https://docs.lightdash.com/guides/period-over-period">period-over-period</a>.
+  </section>
+
+  <h2>7. Recall checkpoints</h2>
+  <details><summary>Which class owns semantic metric SQL?</summary><p><code>MetricQueryBuilder</code>. It builds dimensions, metric aggregates, joins, filters, and semantic CTEs like fanout, distinct, and PoP CTEs.</p></details>
+  <details><summary>Which class adds <code>row_index</code> and <code>column_index</code>?</summary><p><code>PivotQueryBuilder</code>, specifically through <code>pivot_query</code> and related ranking CTEs.</p></details>
+  <details><summary>Which function widens long pivot rows into output rows?</summary><p><code>AsyncQueryService.runQueryAndTransformRows</code>. It groups streamed rows by <code>row_index</code> and writes pivot-value-suffixed columns.</p></details>
+  <details><summary>What is the best first question when SQL looks scary?</summary><p>“Which subsystem owns this CTE or alias?” Then inspect the nearby scope and only then move outward.</p></details>
+
+  <p class="small">Next lesson: <a href="./0001-fanouts-deep-dive.html">Fanouts Deep Dive</a>. Keep the reference open: <a href="../reference/lightdash-query-builder-reference.html">Lightdash query-builder reference</a>. Ask the agent follow-up questions whenever a CTE or alias boundary feels unclear.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>

--- a/lessons/0001-fanouts-deep-dive.html
+++ b/lessons/0001-fanouts-deep-dive.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fanouts Deep Dive</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Lesson 0001 · Fanouts</p>
+  <h1>Fanouts are aggregate bugs caused by changing row grain</h1>
+  <p class="subtitle">A fanout is not mysterious. It is a join that makes rows from one table appear multiple times. If you aggregate those repeated rows, some metrics lie.</p>
+
+  <nav class="nav">
+    <a href="./0000-intro-lightdash-query-systems.html">Intro</a>
+    <a href="./0002-ctes-deep-dive.html">Next: CTEs</a>
+    <a href="../reference/lightdash-query-builder-reference.html">Reference</a>
+  </nav>
+
+  <section class="win">
+    <span class="callout-title">What you should be able to do after this lesson</span>
+    Given a base table, a join relationship, and a metric, predict whether the metric can inflate and explain why Lightdash may build <code>cte_keys_*</code> and <code>cte_metrics_*</code>.
+  </section>
+
+  <h2>1. Grain: the unit of one row</h2>
+  <p><span class="term">Grain</span> means what one row represents. A table can have customer grain, order grain, line-item grain, account grain, session grain, and so on. A join changes the result grain when one row on one side matches multiple rows on the other side.</p>
+
+  <div class="two-col">
+    <section class="card">
+      <h3>customers</h3>
+      <table><thead><tr><th>customer_id</th><th>lifetime_value</th><th>plan</th></tr></thead><tbody><tr><td>1</td><td>100</td><td>Pro</td></tr><tr><td>2</td><td>70</td><td>Free</td></tr></tbody></table>
+      <p class="small">Grain: one row per customer.</p>
+    </section>
+    <section class="card">
+      <h3>orders</h3>
+      <table><thead><tr><th>order_id</th><th>customer_id</th><th>amount</th></tr></thead><tbody><tr><td>10</td><td>1</td><td>20</td></tr><tr><td>11</td><td>1</td><td>30</td></tr><tr><td>12</td><td>2</td><td>15</td></tr></tbody></table>
+      <p class="small">Grain: one row per order.</p>
+    </section>
+  </div>
+
+  <p>If the Explore starts from <code>customers</code> and left-joins <code>orders</code>, customer <code>1</code> appears twice:</p>
+
+  <pre><code>SELECT
+  customers.customer_id,
+  customers.lifetime_value,
+  orders.order_id,
+  orders.amount
+FROM customers
+LEFT JOIN orders ON customers.customer_id = orders.customer_id;
+
+-- joined result
+-- customer_id | lifetime_value | order_id | amount
+-- 1           | 100            | 10       | 20
+-- 1           | 100            | 11       | 30
+-- 2           | 70             | 12       | 15</code></pre>
+
+  <p>The joined result is no longer one row per customer. It is closer to order grain, with customer fields repeated.</p>
+
+  <h2>2. Metric inflation: repeated rows enter the aggregate</h2>
+  <p>Now compare two metrics:</p>
+
+  <table>
+    <thead><tr><th>Metric</th><th>SQL after join</th><th>Result</th><th>Correct?</th></tr></thead>
+    <tbody>
+      <tr><td>Total order amount</td><td><code>SUM(orders.amount)</code></td><td><code>20 + 30 + 15 = 65</code></td><td>Yes</td></tr>
+      <tr><td>Total customer LTV</td><td><code>SUM(customers.lifetime_value)</code></td><td><code>100 + 100 + 70 = 270</code></td><td>No; true total is <code>170</code></td></tr>
+    </tbody>
+  </table>
+
+  <p>The customer metric inflates because the join duplicated customer rows. The order metric did not inflate because the join result still has one row per order.</p>
+
+  <div class="mermaid">
+flowchart LR
+  C1[customer 1<br/>ltv 100] --> O10[order 10]
+  C1 --> O11[order 11]
+  C2[customer 2<br/>ltv 70] --> O12[order 12]
+  O10 --> Joined1[customer 1 ltv 100]
+  O11 --> Joined2[customer 1 ltv 100 again]
+  O12 --> Joined3[customer 2 ltv 70]
+  Joined1 --> Sum[SUM ltv = 270]
+  Joined2 --> Sum
+  Joined3 --> Sum
+  </div>
+
+  <h2>3. Relationship names are directional</h2>
+  <p>The Lightdash joins docs emphasize direction: “Accounts joining to Users (one-to-many) is completely different from Users joining to Accounts (many-to-one).” The relationship is from the current/starting table toward the joined table.</p>
+
+  <table>
+    <thead><tr><th>Relationship</th><th>Question to ask</th><th>Fanout intuition</th></tr></thead>
+    <tbody>
+      <tr><td><code>one-to-many</code></td><td>For one starting row, can I find many joined rows?</td><td>Starting-table fields can repeat.</td></tr>
+      <tr><td><code>many-to-one</code></td><td>For many starting rows, do they each find one joined row?</td><td>Joined-table fields can repeat across starting rows; starting rows usually do not multiply.</td></tr>
+      <tr><td><code>one-to-one</code></td><td>Does each side match at most one row?</td><td>No multiplication expected.</td></tr>
+      <tr><td><code>many-to-many</code></td><td>Can multiple rows on each side match multiple rows?</td><td>Assume broad fanout risk.</td></tr>
+    </tbody>
+  </table>
+
+  <p>Lightdash docs recommend defining <code>relationship</code> and <code>primary_key</code> in YAML so Lightdash can understand the intended row-level granularity and prevent metric inflation (<a href="https://docs.lightdash.com/references/joins#handling-fanouts">Handling fanouts</a>).</p>
+
+  <pre><code>type: model
+name: customers
+primary_key: customer_id
+
+joins:
+  - join: orders
+    sql_on: ${customers.customer_id} = ${orders.customer_id}
+    relationship: one-to-many</code></pre>
+
+  <h2>4. Which metric types are vulnerable?</h2>
+  <p>In <a href="../packages/backend/src/utils/QueryBuilder/utils.ts"><code>QueryBuilder/utils.ts</code></a>, Lightdash marks these as inflation-proof: <code>COUNT_DISTINCT</code>, <code>SUM_DISTINCT</code>, <code>AVERAGE_DISTINCT</code>, <code>MIN</code>, and <code>MAX</code>. That does not mean every query is magically easy; it means repeated rows do not affect those metrics the same way plain <code>SUM</code>/<code>AVG</code> are affected.</p>
+
+  <table>
+    <thead><tr><th>Metric type</th><th>Repeated rows effect</th><th>Example</th></tr></thead>
+    <tbody>
+      <tr><td><code>SUM</code></td><td>Usually unsafe if summing repeated one-side rows.</td><td><code>SUM(customers.lifetime_value)</code> becomes <code>270</code>.</td></tr>
+      <tr><td><code>AVG</code></td><td>Can be unsafe because repeated entities get extra weight.</td><td>Customer 1's LTV is counted twice in the average.</td></tr>
+      <tr><td><code>COUNT</code></td><td>Counts joined rows, so may or may not match intent.</td><td><code>COUNT(customers.customer_id)</code> after order join counts order rows with customer IDs.</td></tr>
+      <tr><td><code>COUNT_DISTINCT</code></td><td>Repeated IDs collapse.</td><td><code>COUNT_DISTINCT(customers.customer_id)</code> remains <code>2</code>.</td></tr>
+      <tr><td><code>MIN</code>/<code>MAX</code></td><td>Repeating a value does not change min/max.</td><td><code>MAX(customers.lifetime_value)</code> remains <code>100</code>.</td></tr>
+      <tr><td><code>SUM_DISTINCT</code>/<code>AVERAGE_DISTINCT</code></td><td>Handled by explicit distinct-key deduplication.</td><td>Uses <code>dd_*</code> CTEs, covered in the CTE lesson.</td></tr>
+    </tbody>
+  </table>
+
+  <section class="warning">
+    <span class="callout-title">Important nuance</span>
+    “Inflation-proof” is about repeated identical source rows under join fanout. It does not prove the metric matches business intent. For example, <code>COUNT_DISTINCT(order_id)</code> is mathematically stable under repeated joins, but it may still answer the wrong question if the distinct key is wrong.
+  </section>
+
+  <h2>5. How Lightdash detects tables with possible metric inflation</h2>
+  <p><code>MetricQueryBuilder.getExperimentalMetricsCteSQL</code> calls <code>findTablesWithMetricInflation</code> with tables, joins, base table, and joined tables. That function uses join relationships to identify tables whose metrics may inflate in the current query. If a join lacks a relationship, Lightdash warns because it cannot safely infer the fanout risk.</p>
+
+  <div class="mermaid">
+flowchart TD
+  A[Selected dimensions/metrics/filters] --> B[Which tables are required?]
+  B --> C[Which joins are needed?]
+  C --> D[findTablesWithMetricInflation]
+  D --> E{Table has primary key?}
+  E -- no --> W[Warn: cannot deduplicate safely]
+  E -- yes --> F[Build fanout protection CTEs]
+  </div>
+
+  <h2>6. The Lightdash fanout protection pattern</h2>
+  <p>For each table whose metrics can inflate, Lightdash builds two CTEs:</p>
+
+  <ol>
+    <li><code>cte_keys_&lt;table&gt;</code>: from the full joined query, select distinct output dimensions plus the protected table's primary key.</li>
+    <li><code>cte_metrics_&lt;table&gt;</code>: join those keys back to only the protected table by primary key and aggregate the table's vulnerable metrics.</li>
+  </ol>
+
+  <div class="mermaid">
+flowchart TD
+  J[Full joined world<br/>dimensions, filters, all joins] --> K[cte_keys_customers<br/>DISTINCT dimensions + customers.pk]
+  K --> M[cte_metrics_customers<br/>join keys back to customers by pk]
+  M --> Safe[Safe customer SUM/AVG/etc]
+  J --> U[cte_unaffected<br/>dimensions + safe or unaffected metrics]
+  Safe --> Final[final SELECT]
+  U --> Final
+  </div>
+
+  <pre><code>WITH cte_keys_customers AS (
+  SELECT DISTINCT
+    "orders".status AS "orders_status",
+    "customers".customer_id AS "pk_customer_id"
+  FROM "customers" AS "customers"
+  LEFT JOIN "orders" AS "orders"
+    ON "customers".customer_id = "orders".customer_id
+),
+
+cte_metrics_customers AS (
+  SELECT
+    cte_keys_customers."orders_status",
+    SUM("customers".lifetime_value) AS "customers_total_ltv"
+  FROM cte_keys_customers
+  LEFT JOIN "customers" AS "customers"
+    ON cte_keys_customers."pk_customer_id" = "customers".customer_id
+  GROUP BY 1
+),
+
+cte_unaffected AS (
+  SELECT
+    "orders".status AS "orders_status",
+    SUM("orders".amount) AS "orders_total_amount"
+  FROM "customers" AS "customers"
+  LEFT JOIN "orders" AS "orders"
+    ON "customers".customer_id = "orders".customer_id
+  GROUP BY 1
+)
+
+SELECT
+  cte_unaffected.*,
+  cte_metrics_customers."customers_total_ltv"
+FROM cte_unaffected
+INNER JOIN cte_metrics_customers
+  ON cte_unaffected."orders_status" = cte_metrics_customers."orders_status";</code></pre>
+
+  <h2>7. Why not just <code>SUM(DISTINCT lifetime_value)</code>?</h2>
+  <p>Because distinct values are not distinct entities. If two different customers both have LTV <code>100</code>, <code>SUM(DISTINCT lifetime_value)</code> counts <code>100</code> once, not twice. Fanout protection must deduplicate by entity key, not by metric value.</p>
+
+  <div class="two-col">
+    <section class="danger">
+      <h3>Wrong dedup key: value</h3>
+      <pre><code>SUM(DISTINCT lifetime_value)
+-- customer A = 100
+-- customer B = 100
+-- result: 100 (wrong)</code></pre>
+    </section>
+    <section class="win">
+      <h3>Right dedup key: primary key</h3>
+      <pre><code>SELECT DISTINCT customer_id
+-- A, B
+SUM(lifetime_value)
+-- result: 200</code></pre>
+    </section>
+  </div>
+
+  <h2>8. How dimensions affect the safe grain</h2>
+  <p>If you group by an order dimension like <code>orders.status</code>, <code>cte_keys_customers</code> may contain the same customer primary key under multiple statuses. That is not necessarily wrong: the output question is now “customer LTV by order status”, and the metric is repeated across statuses because each status group has relevant customer keys. Fanout protection prevents duplicate keys within a group; it does not decide whether the analysis itself makes business sense.</p>
+
+  <section class="checkpoint">
+    <span class="callout-title">Mental model</span>
+    Fanout protection deduplicates protected table primary keys <em>within each output dimension group</em>. It does not globally force a customer to appear in only one result row if your selected dimensions intentionally split the result into multiple groups.
+  </section>
+
+  <h2>9. Prediction exercises</h2>
+  <details><summary>Base: customers. Join: customers → orders one-to-many. Metric: <code>SUM(customers.lifetime_value)</code>. Inflates?</summary><p>Yes. Customer rows are repeated by orders; plain sum sees the repeated customer values.</p></details>
+  <details><summary>Base: customers. Join: customers → orders one-to-many. Metric: <code>SUM(orders.amount)</code>. Inflates?</summary><p>Usually no from this join alone. The joined result is at order grain for orders, so each order amount appears once.</p></details>
+  <details><summary>Base: orders. Join: orders → customers many-to-one. Metric: <code>SUM(orders.amount)</code>. Inflates?</summary><p>No from the many-to-one join. Each order finds one customer; order rows are not multiplied.</p></details>
+  <details><summary>Base: orders. Join: orders → order_items one-to-many. Metric: <code>AVG(orders.total_amount)</code>. Inflates?</summary><p>Yes. Orders with more items appear more times and get extra weight in the average.</p></details>
+  <details><summary>Base: orders. Join: orders → order_items one-to-many. Metric: <code>COUNT_DISTINCT(orders.order_id)</code>. Inflates?</summary><p>No. Repeated order IDs collapse under <code>COUNT_DISTINCT</code>.</p></details>
+  <details><summary>Why does Lightdash need <code>primary_key</code> for fanout protection?</summary><p>Because <code>cte_keys_*</code> must select a distinct entity key and then rejoin to the protected table by that key. Without a primary key, Lightdash cannot know which rows represent one entity.</p></details>
+
+  <section class="aside">
+    <span class="callout-title">Primary source to review</span>
+    Lightdash docs: <a href="https://docs.lightdash.com/references/joins#handling-fanouts">Handling fanouts</a>. Code: fanout path in <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts"><code>MetricQueryBuilder.getExperimentalMetricsCteSQL</code></a> and inflation-proof metric list in <a href="../packages/backend/src/utils/QueryBuilder/utils.ts"><code>isInflationProofMetric</code></a>.
+  </section>
+
+  <p class="small">Next lesson: <a href="./0002-ctes-deep-dive.html">CTEs Deep Dive</a>. Ask the agent to give you five more fanout scenarios and quiz your predictions.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>

--- a/lessons/0002-ctes-deep-dive.html
+++ b/lessons/0002-ctes-deep-dive.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CTEs Deep Dive</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Lesson 0002 · CTE composition</p>
+  <h1>CTEs are named scopes: Lightdash query magic is scope management</h1>
+  <p class="subtitle">Generated Lightdash SQL looks scary because it stacks many CTEs. The way through is to track each CTE's input, output columns, and alias scope.</p>
+
+  <nav class="nav">
+    <a href="./0001-fanouts-deep-dive.html">Previous: Fanouts</a>
+    <a href="./0003-period-over-period-deep-dive.html">Next: PoP</a>
+    <a href="../reference/lightdash-query-builder-reference.html">Reference</a>
+  </nav>
+
+  <section class="win">
+    <span class="callout-title">What you should be able to do after this lesson</span>
+    Trace one output alias through a generated Lightdash query and identify which CTE created it, which CTEs can reference it, and why sibling CTEs cannot see it unless they join or select from it.
+  </section>
+
+  <h2>1. Plain SQL CTEs: the only rule you need</h2>
+  <p>A CTE is a named subquery. Later CTEs can read earlier CTEs. Sibling CTEs do not share columns by magic. A column alias exists only in the result of the CTE that selected it, and in later queries that read from that CTE.</p>
+
+  <pre><code>WITH revenue_by_month AS (
+  SELECT month, SUM(amount) AS revenue
+  FROM orders
+  GROUP BY month
+),
+
+large_months AS (
+  SELECT month
+  FROM revenue_by_month
+  WHERE revenue > 1000
+)
+
+SELECT * FROM large_months;</code></pre>
+
+  <div class="mermaid">
+flowchart TD
+  A[revenue_by_month<br/>columns: month, revenue] --> B[large_months<br/>reads revenue_by_month<br/>columns: month]
+  B --> C[final SELECT]
+  D[Some sibling CTE] -. cannot see revenue unless it FROM/JOINs A .-> A
+  </div>
+
+  <section class="checkpoint">
+    <span class="callout-title">Scope rule</span>
+    If you see <code>some_alias</code> used inside a CTE, ask: “Is the CTE selecting from a source that exposes <code>some_alias</code>?” If not, the alias is out of scope.
+  </section>
+
+  <h2>2. Why Lightdash uses so many CTEs</h2>
+  <p>Lightdash has to take semantic-layer definitions and produce one warehouse query. Each semantic feature wants a different intermediate shape:</p>
+
+  <ul>
+    <li>Fanout protection needs entity keys and safe aggregates.</li>
+    <li>Distinct metrics need row-numbered deduplication by distinct keys.</li>
+    <li>Period-over-period needs current rows and shifted comparison rows.</li>
+    <li>Pivoting needs long rows ranked by row and column order.</li>
+    <li>Table calculations and post-aggregation metrics may need outer selects.</li>
+  </ul>
+
+  <p>CTEs make those shapes explicit and composable.</p>
+
+  <h2>3. The Lightdash CTE families</h2>
+  <table>
+    <thead><tr><th>CTE family</th><th>Owner</th><th>What it outputs</th><th>Core idea</th></tr></thead>
+    <tbody>
+      <tr><td><code>cte_keys_*</code></td><td>Fanout protection</td><td>Dimension aliases + protected table primary keys</td><td>Find relevant entity keys per output group in the full joined world.</td></tr>
+      <tr><td><code>cte_metrics_*</code></td><td>Fanout protection</td><td>Fanout-safe metrics for one protected table</td><td>Join keys back to the protected table and aggregate there.</td></tr>
+      <tr><td><code>cte_unaffected</code></td><td>Fanout protection</td><td>Dimensions + metrics not emitted from protected metric CTEs</td><td>Keep the rest of the query at the regular grouped grain.</td></tr>
+      <tr><td><code>dd_*</code></td><td>Distinct metrics</td><td>One deduplicated <code>sum_distinct</code> or <code>average_distinct</code></td><td>Use <code>ROW_NUMBER()</code> over distinct keys, aggregate only row one.</td></tr>
+      <tr><td><code>dd_base</code></td><td>Distinct metrics</td><td>The query result before distinct metric values are stitched in</td><td>Provide a stable source for outer distinct metric joins/selects.</td></tr>
+      <tr><td><code>base_metrics</code></td><td>Non-fanout PoP</td><td>Current-period result rows</td><td>Freeze the current query so previous-period rows can join back to it.</td></tr>
+      <tr><td><code>pop_min_max_*</code></td><td>PoP</td><td>Min and max selected comparison time dimension</td><td>Derive shifted previous-period bounds from current rows.</td></tr>
+      <tr><td><code>pop_metrics_*</code></td><td>PoP</td><td>Previous-period metric values</td><td>Rerun base metric SQL over shifted dates.</td></tr>
+      <tr><td><code>cte_pop_keys_*</code></td><td>Fanout-aware PoP</td><td>Shifted-period keys for protected table</td><td>Previous-period version of <code>cte_keys_*</code>.</td></tr>
+      <tr><td><code>cte_pop_metrics_*</code></td><td>Fanout-aware PoP</td><td>Previous-period protected metrics</td><td>Previous-period version of <code>cte_metrics_*</code>.</td></tr>
+      <tr><td><code>original_query</code></td><td>Pivot</td><td>Flat SQL from <code>MetricQueryBuilder</code></td><td>Wrap the semantic query before pivot-specific aggregation.</td></tr>
+      <tr><td><code>group_by_query</code></td><td>Pivot</td><td>Rows at pivot grain</td><td>Group by index + pivot columns, aggregate values.</td></tr>
+      <tr><td><code>pivot_query</code></td><td>Pivot</td><td>Pivot grain + <code>row_index</code> + <code>column_index</code></td><td>Make long rows streamable as a pivot table.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>4. Fanout CTEs as scopes</h2>
+  <p>From the fanout lesson, a protected table produces <code>cte_keys_customers</code> and <code>cte_metrics_customers</code>. The important scope point: <code>cte_metrics_customers</code> can read columns from <code>cte_keys_customers</code> because it explicitly has <code>FROM cte_keys_customers</code>.</p>
+
+  <pre><code>cte_keys_customers AS (
+  SELECT DISTINCT
+    orders.status AS "orders_status",
+    customers.customer_id AS "pk_customer_id"
+  FROM customers
+  LEFT JOIN orders ON ...
+),
+
+cte_metrics_customers AS (
+  SELECT
+    cte_keys_customers."orders_status",
+    SUM(customers.lifetime_value) AS "customers_total_ltv"
+  FROM cte_keys_customers
+  LEFT JOIN customers
+    ON cte_keys_customers."pk_customer_id" = customers.customer_id
+  GROUP BY 1
+)</code></pre>
+
+  <p>But <code>cte_metrics_customers</code> cannot read aliases from <code>cte_unaffected</code> unless it joins <code>cte_unaffected</code>. Sibling CTEs are independent.</p>
+
+  <div class="mermaid">
+flowchart TD
+  K[cte_keys_customers<br/>orders_status, pk_customer_id] --> M[cte_metrics_customers<br/>orders_status, customers_total_ltv]
+  U[cte_unaffected<br/>orders_status, orders_total_amount] --> F[final SELECT]
+  M --> F
+  U -. sibling, not visible inside .-> M
+  </div>
+
+  <h2>5. Distinct metric CTEs as scopes</h2>
+  <p><code>sum_distinct</code> and <code>average_distinct</code> get <code>dd_*</code> CTEs through <code>buildDistinctMetricCtes</code>. The code comments describe the semantics:</p>
+  <ol>
+    <li>Inner subquery picks one row per <code>distinct_keys</code> combination with <code>ROW_NUMBER()</code>.</li>
+    <li>Outer CTE aggregates up to the grain of selected dimensions that overlap distinct keys.</li>
+    <li>The result joins back to <code>dd_base</code> by overlapping keys, or cross joins if scalar.</li>
+  </ol>
+
+  <pre><code>dd_orders_deduped_revenue AS (
+  SELECT
+    SUM(CASE WHEN __dd_rn = 1 THEN __dd_val ELSE NULL END)
+      AS "orders_deduped_revenue"
+  FROM (
+    SELECT
+      orders.amount AS __dd_val,
+      ROW_NUMBER() OVER (
+        PARTITION BY orders.order_id
+        ORDER BY orders.amount
+      ) AS __dd_rn
+    FROM ...joined query...
+  ) __dd_sub
+),
+
+dd_base AS (
+  -- whatever the query had before distinct metrics were stitched in
+),
+
+SELECT
+  dd_base.*,
+  dd_orders_deduped_revenue."orders_deduped_revenue"
+FROM dd_base
+CROSS JOIN dd_orders_deduped_revenue</code></pre>
+
+  <section class="checkpoint">
+    <span class="callout-title">Alias lesson</span>
+    A <code>dd_*</code> metric alias is available only after the query reads from the <code>dd_*</code> CTE. If some earlier sibling CTE emits a derived metric that expects the <code>dd_*</code> alias, the alias is not in scope there.
+  </section>
+
+  <h2>6. PoP CTEs as scopes</h2>
+  <p>PoP creates a current scope and a previous-period scope. In the non-fanout path, <code>base_metrics</code> freezes current rows. <code>pop_min_max_*</code> reads <code>base_metrics</code>. <code>pop_metrics_*</code> reads the base tables again, constrained by shifted bounds. The final select reads both <code>base_metrics</code> and <code>pop_metrics_*</code>.</p>
+
+  <div class="mermaid">
+flowchart TD
+  Current[normal current SELECT] --> Base[base_metrics]
+  Base --> MinMax[pop_min_max_*]
+  MinMax --> Pop[pop_metrics_*]
+  Base --> Final[final SELECT]
+  Pop --> Final
+  </div>
+
+  <p>In the fanout path, the same idea appears as <code>cte_pop_min_max_*</code>, <code>cte_pop_keys_*</code>, and <code>cte_pop_metrics_*</code>. The prefix changes because it must respect the fanout-protected key/metric split.</p>
+
+  <h2>7. Pivot CTEs as scopes</h2>
+  <p>Pivot CTEs are added after the semantic SQL is built. <code>original_query</code> exposes the flat result from <code>MetricQueryBuilder</code>. <code>group_by_query</code> groups that output to pivot grain and gives value aliases suffixes like <code>_any</code>. <code>pivot_query</code> reads <code>group_by_query</code> and adds ranks.</p>
+
+  <pre><code>WITH original_query AS (
+  -- MetricQueryBuilder output
+),
+
+group_by_query AS (
+  SELECT
+    "month",
+    "status",
+    ANY_VALUE("revenue") AS "revenue_any"
+  FROM original_query
+  GROUP BY "month", "status"
+),
+
+pivot_query AS (
+  SELECT
+    g."month",
+    g."status",
+    g."revenue_any",
+    DENSE_RANK() OVER (ORDER BY g."month") AS "row_index",
+    DENSE_RANK() OVER (ORDER BY g."status") AS "column_index"
+  FROM group_by_query g
+)</code></pre>
+
+  <h2>8. How to read a generated query top-down</h2>
+  <p>Top-down reading answers: “What intermediate tables are being created?”</p>
+
+  <ol>
+    <li>Scan the CTE names in order.</li>
+    <li>Classify each CTE family: fanout, distinct, PoP, pivot, table calc/post-agg.</li>
+    <li>For each CTE, list its output aliases from the <code>SELECT</code> clause.</li>
+    <li>Note which later CTEs read it with <code>FROM</code> or <code>JOIN</code>.</li>
+  </ol>
+
+  <div class="flowline">Top-down cheat:
+cte_keys_*       → exposes dimension aliases + pk_*
+cte_metrics_*    → exposes dimension aliases + protected metrics
+dd_*             → exposes joinable dimension aliases + one distinct metric
+dd_base          → exposes everything before dd stitching
+base_metrics     → exposes current-period rows
+pop_metrics_*    → exposes previous-period metric aliases
+original_query   → exposes flat semantic result to pivot
+group_by_query   → exposes pivot grain + value aliases
+pivot_query      → exposes pivot grain + row_index + column_index</div>
+
+  <h2>9. How to read a generated query bottom-up</h2>
+  <p>Bottom-up reading answers: “Where did this final output alias come from?” This is usually better for debugging.</p>
+
+  <section class="checkpoint">
+    <span class="callout-title">Alias tracing algorithm</span>
+    <ol>
+      <li>Pick one final output alias, e.g. <code>"orders_revenue__pop__month_1"</code>.</li>
+      <li>Search the SQL for <code>AS "orders_revenue__pop__month_1"</code>.</li>
+      <li>If multiple places emit it, you found a duplication risk.</li>
+      <li>For the intended emission, identify the CTE or final select that owns it.</li>
+      <li>List every source alias used in its expression.</li>
+      <li>For each source alias, ask: is it in scope via <code>FROM</code>/<code>JOIN</code>?</li>
+      <li>Repeat until you reach base table columns or metric compiled SQL.</li>
+    </ol>
+  </section>
+
+  <h2>10. A miniature alias trace</h2>
+  <pre><code>WITH cte_unaffected AS (
+  SELECT
+    "orders".status AS "orders_status",
+    SUM("orders".amount) AS "orders_total_amount"
+  FROM ...
+  GROUP BY 1
+),
+
+cte_metrics_customers AS (
+  SELECT
+    cte_keys_customers."orders_status",
+    SUM("customers".lifetime_value) AS "customers_total_ltv"
+  FROM cte_keys_customers
+  LEFT JOIN "customers" ON ...
+  GROUP BY 1
+)
+
+SELECT
+  cte_unaffected."orders_status",
+  cte_unaffected."orders_total_amount",
+  cte_metrics_customers."customers_total_ltv"
+FROM cte_unaffected
+INNER JOIN cte_metrics_customers
+  ON cte_unaffected."orders_status" = cte_metrics_customers."orders_status"</code></pre>
+
+  <p>Trace <code>customers_total_ltv</code>:</p>
+  <ol>
+    <li>Final select emits <code>cte_metrics_customers."customers_total_ltv"</code>.</li>
+    <li><code>cte_metrics_customers</code> created that alias with <code>SUM(customers.lifetime_value)</code>.</li>
+    <li>It was safe because it read from <code>cte_keys_customers</code> and joined back to customers by primary key.</li>
+  </ol>
+
+  <h2>11. Why Lightdash rewrites metric references</h2>
+  <p>Semantic metrics can reference other metrics, e.g. <code>${orders.profit} / NULLIF(${orders.revenue}, 0)</code>. Once metrics live in CTEs, the raw semantic reference must become a CTE-qualified SQL reference. <code>replaceMetricReferencesWithCteReferences</code> handles this in <code>MetricQueryBuilder</code>.</p>
+
+  <div class="two-col">
+    <section class="danger">
+      <h3>Raw semantic reference</h3>
+      <pre><code>${orders.revenue}</code></pre>
+      <p class="small">Not valid SQL inside an outer CTE unless compiled/replaced.</p>
+    </section>
+    <section class="win">
+      <h3>CTE-qualified reference</h3>
+      <pre><code>cte_unaffected."orders_revenue"</code></pre>
+      <p class="small">Valid if the current scope reads <code>cte_unaffected</code>.</p>
+    </section>
+  </div>
+
+  <h2>12. Practice</h2>
+  <details><summary>Can <code>cte_metrics_customers</code> use an alias created in <code>cte_unaffected</code>?</summary><p>No, unless <code>cte_metrics_customers</code> explicitly selects from or joins <code>cte_unaffected</code>. They are siblings.</p></details>
+  <details><summary>Why does <code>dd_base</code> exist?</summary><p>It freezes the query result before distinct metrics are stitched in, so <code>dd_*</code> outputs can be joined to a stable base scope.</p></details>
+  <details><summary>What does <code>group_by_query</code> read from?</summary><p><code>original_query</code>, which is the flat semantic result from <code>MetricQueryBuilder</code>.</p></details>
+  <details><summary>If an alias appears as <code>AS "x"</code> in two CTEs, what should you ask?</summary><p>Which CTE is supposed to own <code>x</code>? If both are later selected, the final result may have duplicate or ambiguous columns.</p></details>
+  <details><summary>Why do CTE joins often use dimension aliases?</summary><p>Fanout/PoP/metric CTEs produce metric values at the result grain. Dimension aliases are the keys for stitching those metric values back together.</p></details>
+
+  <section class="aside">
+    <span class="callout-title">Primary source to review</span>
+    Code: <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts"><code>MetricQueryBuilder.ts</code></a>, especially <code>getExperimentalMetricsCteSQL</code>, <code>buildDistinctMetricCtes</code>, the non-fanout PoP block around <code>base_metrics</code>, and <code>replaceMetricReferencesWithCteReferences</code>. Pivot CTEs are in <a href="../packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts"><code>PivotQueryBuilder.ts</code></a>.
+  </section>
+
+  <p class="small">Next lesson: <a href="./0003-period-over-period-deep-dive.html">Period-over-period Deep Dive</a>. Ask the agent to trace a real query alias if you want a live walkthrough.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>

--- a/lessons/0003-period-over-period-deep-dive.html
+++ b/lessons/0003-period-over-period-deep-dive.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Period-over-period Deep Dive</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Lesson 0003 · Period-over-period</p>
+  <h1>Period-over-period is a shifted self-join of metric results</h1>
+  <p class="subtitle">A PoP metric is not just a label or a table calculation. Backend PoP reruns the base metric over a shifted time window and joins previous-period rows back to current-period rows.</p>
+
+  <nav class="nav">
+    <a href="./0002-ctes-deep-dive.html">Previous: CTEs</a>
+    <a href="./0004-pivot-queries-deep-dive.html">Next: Pivot</a>
+    <a href="../reference/lightdash-query-builder-reference.html">Reference</a>
+  </nav>
+
+  <section class="win">
+    <span class="callout-title">What you should be able to do after this lesson</span>
+    Explain why PoP requires a selected comparison time dimension, why it uses min/max CTEs, why date filters are shifted, and why previous-period rows are left-joined back to current rows.
+  </section>
+
+  <h2>1. User-facing idea</h2>
+  <p>The Lightdash guide describes period-over-period as comparing a metric to a previous time period, like month-over-month or year-over-year (<a href="https://docs.lightdash.com/guides/period-over-period">PoP guide</a>). The beta period comparison flow asks the user to select:</p>
+
+  <ul>
+    <li>a time/date dimension,</li>
+    <li>a metric,</li>
+    <li>an offset such as previous month or previous year,</li>
+    <li>then adds a generated metric to the chart.</li>
+  </ul>
+
+  <p>The backend representation is an <code>AdditionalMetric</code> with PoP metadata, built in <a href="../packages/common/src/types/periodOverPeriodComparison.ts"><code>periodOverPeriodComparison.ts</code></a>.</p>
+
+  <pre><code>{
+  table: 'orders',
+  name: 'revenue__pop__month_1__abc123',
+  label: 'Revenue (Previous month)',
+  type: MetricType.SUM,
+  sql: '${TABLE}.amount',
+  hidden: true,
+  generationType: 'periodOverPeriod',
+  baseMetricId: 'orders_revenue',
+  timeDimensionId: 'orders_order_date_month',
+  granularity: TimeFrames.MONTH,
+  periodOffset: 1
+}</code></pre>
+
+  <h2>2. What the metadata means</h2>
+  <table>
+    <thead><tr><th>Field</th><th>Meaning</th><th>Example</th></tr></thead>
+    <tbody>
+      <tr><td><code>generationType</code></td><td>Marks this additional metric as system-generated PoP.</td><td><code>'periodOverPeriod'</code></td></tr>
+      <tr><td><code>baseMetricId</code></td><td>The current-period metric this compares against.</td><td><code>orders_revenue</code></td></tr>
+      <tr><td><code>timeDimensionId</code></td><td>The selected time dimension used to align current and previous rows.</td><td><code>orders_order_date_month</code></td></tr>
+      <tr><td><code>granularity</code></td><td>The interval unit of comparison.</td><td><code>MONTH</code></td></tr>
+      <tr><td><code>periodOffset</code></td><td>How many granularity units backward.</td><td><code>1</code> for previous month, <code>12</code> for same month last year if granularity is month.</td></tr>
+    </tbody>
+  </table>
+
+  <section class="checkpoint">
+    <span class="callout-title">Compile-time guard</span>
+    <code>MetricQueryBuilder</code> requires the PoP comparison time dimension to be selected in the query. Without it, the final join cannot align current and previous rows.
+  </section>
+
+  <h2>3. A tiny month-over-month example</h2>
+  <p>Suppose the current query asks for monthly revenue from March through May 2026.</p>
+
+  <table>
+    <caption>Current-period metric rows</caption>
+    <thead><tr><th>month</th><th>revenue</th></tr></thead>
+    <tbody><tr><td>2026-03-01</td><td>120</td></tr><tr><td>2026-04-01</td><td>150</td></tr><tr><td>2026-05-01</td><td>90</td></tr></tbody>
+  </table>
+
+  <p>For previous month comparison, the backend needs revenue from February through April:</p>
+
+  <table>
+    <caption>Previous-period metric rows</caption>
+    <thead><tr><th>previous month</th><th>previous revenue</th><th>joins to current month</th></tr></thead>
+    <tbody><tr><td>2026-02-01</td><td>100</td><td>2026-03-01</td></tr><tr><td>2026-03-01</td><td>120</td><td>2026-04-01</td></tr><tr><td>2026-04-01</td><td>150</td><td>2026-05-01</td></tr></tbody>
+  </table>
+
+  <p>The final output is current rows plus matched previous rows:</p>
+
+  <table>
+    <thead><tr><th>current month</th><th>revenue</th><th>revenue previous month</th></tr></thead>
+    <tbody><tr><td>2026-03-01</td><td>120</td><td>100</td></tr><tr><td>2026-04-01</td><td>150</td><td>120</td></tr><tr><td>2026-05-01</td><td>90</td><td>150</td></tr></tbody>
+  </table>
+
+  <div class="mermaid">
+flowchart LR
+  P1[Feb revenue 100] -- +1 month --> C1[Mar current row]
+  P2[Mar revenue 120] -- +1 month --> C2[Apr current row]
+  P3[Apr revenue 150] -- +1 month --> C3[May current row]
+  </div>
+
+  <h2>4. Non-fanout PoP SQL shape</h2>
+  <p>When fanout protection does not take over the metric path, <code>MetricQueryBuilder</code> wraps the normal current query as <code>base_metrics</code>, computes current min/max dates, reruns the base metric over shifted bounds, and left-joins the previous rows back.</p>
+
+  <div class="mermaid">
+flowchart TD
+  A[Current metric SELECT] --> B[base_metrics]
+  B --> C[pop_min_max_month_1<br/>MIN/MAX base month]
+  C --> D[pop_metrics_month_1<br/>same metric SQL, shifted date filter]
+  B --> E[final SELECT]
+  D --> E
+  E --> F[current + previous metric columns]
+  </div>
+
+  <pre><code>WITH base_metrics AS (
+  SELECT
+    DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
+    SUM("orders".amount) AS "orders_revenue"
+  FROM "orders" AS "orders"
+  WHERE DATE_TRUNC('MONTH', "orders".order_date)
+    BETWEEN '2026-03-01' AND '2026-05-01'
+  GROUP BY 1
+),
+
+pop_min_max_month_1 AS (
+  SELECT
+    MIN(base_metrics."orders_order_date_month") AS min_date,
+    MAX(base_metrics."orders_order_date_month") AS max_date
+  FROM base_metrics
+),
+
+pop_metrics_month_1 AS (
+  SELECT
+    DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
+    SUM("orders".amount) AS "orders_revenue__pop__month_1"
+  FROM "orders" AS "orders"
+  LEFT JOIN pop_min_max_month_1 ON TRUE
+  WHERE DATE_TRUNC('MONTH', "orders".order_date) >= pop_min_max_month_1.min_date - INTERVAL '1 MONTH'
+    AND DATE_TRUNC('MONTH', "orders".order_date) <= pop_min_max_month_1.max_date - INTERVAL '1 MONTH'
+  GROUP BY 1
+)
+
+SELECT
+  base_metrics.*,
+  pop_metrics_month_1."orders_revenue__pop__month_1"
+FROM base_metrics
+LEFT JOIN pop_metrics_month_1
+  ON base_metrics."orders_order_date_month"
+   = pop_metrics_month_1."orders_order_date_month" + INTERVAL '1 MONTH';</code></pre>
+
+  <h2>5. Why the min/max CTE exists</h2>
+  <p>PoP compares the currently visible time window to a shifted window. Instead of hard-coding the request filter, Lightdash derives the current time bounds from <code>base_metrics</code>:</p>
+
+  <pre><code>SELECT MIN(base.month), MAX(base.month) FROM base_metrics</code></pre>
+
+  <p>Then it computes the comparison window by shifting those bounds. If current months are March–May and offset is one month, previous months are February–April.</p>
+
+  <div class="mermaid">
+timeline
+  title Month-over-month windows
+  2026-02 : previous window begins
+  2026-03 : current window begins; previous rows join to March/April/May
+  2026-04 : overlap month
+  2026-05 : current window ends
+  </div>
+
+  <h2>6. Filter semantics: reuse non-time filters, shift time filters</h2>
+  <p>The previous-period query should answer the same business question in a different time window. So non-time filters are reused; the comparison time dimension's current date condition is replaced by shifted bounds.</p>
+
+  <table>
+    <thead><tr><th>Filter</th><th>Current query</th><th>Previous-period query</th></tr></thead>
+    <tbody>
+      <tr><td><code>orders_status = 'completed'</code></td><td>Keep</td><td>Keep</td></tr>
+      <tr><td><code>country = 'US'</code></td><td>Keep</td><td>Keep</td></tr>
+      <tr><td><code>month between Mar and May</code></td><td>Keep</td><td>Replace with shifted Feb to Apr bounds</td></tr>
+    </tbody>
+  </table>
+
+  <p>In code, this appears as <code>getPopDimensionsFilterSQL(popFieldId)</code> plus interval syntax built from <code>cfg.periodOffset</code> and <code>cfg.granularity</code>.</p>
+
+  <h2>7. The final join condition</h2>
+  <p>For non-time dimensions, current and previous rows match by null-safe equality. For the comparison time dimension, the previous row is shifted forward to equal the current row.</p>
+
+  <pre><code>LEFT JOIN pop_metrics_month_1 ON
+  base_metrics."orders_status" = pop_metrics_month_1."orders_status"
+  AND base_metrics."orders_order_date_month"
+      = pop_metrics_month_1."orders_order_date_month" + INTERVAL '1 MONTH'</code></pre>
+
+  <section class="checkpoint">
+    <span class="callout-title">PoP invariant</span>
+    The previous-period CTE should produce the same grouping dimensions as the current rows. All dimensions join by equality, except the comparison time dimension joins by interval-shifted equality.
+  </section>
+
+  <h2>8. Why <code>LEFT JOIN</code>?</h2>
+  <p>A current row should not disappear just because the previous period has no matching row. If May has revenue but April has none, the output should show May with <code>NULL</code> previous revenue. That requires <code>LEFT JOIN</code>.</p>
+
+  <div class="two-col">
+    <section class="danger">
+      <h3>Inner join behavior</h3>
+      <p>Current rows without previous rows vanish. That hides real current-period data.</p>
+    </section>
+    <section class="win">
+      <h3>Left join behavior</h3>
+      <p>Current rows remain. Previous metric is null when the shifted row is missing.</p>
+    </section>
+  </div>
+
+  <h2>9. Multiple PoP configs</h2>
+  <p><code>MetricQueryBuilder</code> groups selected/filtered PoP metrics by comparison config: <code>timeDimensionId</code>, <code>granularity</code>, and <code>periodOffset</code>. The config gets a short hashed CTE suffix so multiple comparisons can exist in one query, e.g. previous month and same month last year.</p>
+
+  <pre><code>getPopComparisonConfigKey({
+  timeDimensionId: 'orders_order_date_month',
+  granularity: TimeFrames.MONTH,
+  periodOffset: 1
+})
+
+cte suffix: month_1__00abc123</code></pre>
+
+  <p>Metrics with the same config can share min/max and shifted-date CTEs; metrics with different configs need separate shifted windows.</p>
+
+  <h2>10. Fanout-aware PoP: same shifted idea, safer metric path</h2>
+  <p>If the base metric is in a table that needs fanout protection, Lightdash cannot simply rerun a flat previous-period aggregate. It must use the same protected-key pattern in the shifted period.</p>
+
+  <div class="mermaid">
+flowchart TD
+  K[cte_keys_table<br/>current distinct dimensions + pk] --> M[cte_metrics_table<br/>current protected metric]
+  K --> MM[cte_pop_min_max_table<br/>current min/max comparison time]
+  MM --> PK[cte_pop_keys_table<br/>previous-period distinct dimensions + pk]
+  PK --> PM[cte_pop_metrics_table<br/>previous protected metric]
+  M --> Final[final fanout SELECT]
+  PM --> Final
+  Final --> Out[current metric + previous protected metric]
+  </div>
+
+  <p>The crucial difference is that <code>cte_pop_keys_*</code> is not just a copy of <code>cte_keys_*</code>. It selects keys from the shifted previous-period window, because the relevant primary keys may differ between current and previous periods.</p>
+
+  <h2>11. Month-over-month vs year-over-year examples</h2>
+  <table>
+    <thead><tr><th>User intent</th><th>timeDimensionId</th><th>granularity</th><th>periodOffset</th><th>Join intuition</th></tr></thead>
+    <tbody>
+      <tr><td>Previous day</td><td><code>orders_order_date_day</code></td><td><code>DAY</code></td><td><code>1</code></td><td>previous day + 1 day = current day</td></tr>
+      <tr><td>Previous month</td><td><code>orders_order_date_month</code></td><td><code>MONTH</code></td><td><code>1</code></td><td>previous month + 1 month = current month</td></tr>
+      <tr><td>Same month last year</td><td><code>orders_order_date_month</code></td><td><code>MONTH</code></td><td><code>12</code></td><td>previous month + 12 months = current month</td></tr>
+      <tr><td>Previous year</td><td><code>orders_order_date_year</code></td><td><code>YEAR</code></td><td><code>1</code></td><td>previous year + 1 year = current year</td></tr>
+    </tbody>
+  </table>
+
+  <h2>12. Why not just use <code>LAG()</code>?</h2>
+  <p><code>LAG()</code> is row-position based. It compares to “the previous row in the visible ordered result”. Backend PoP is time-window based. It computes the metric over actual shifted dates, with the same non-time filters and grouping dimensions. That is more robust when rows are missing, filters change, or the offset is not simply one visible row.</p>
+
+  <div class="two-col">
+    <section class="card">
+      <h3><code>LAG()</code></h3>
+      <p>Depends on result row order and presence of rows. Good for some table calculations.</p>
+    </section>
+    <section class="card">
+      <h3>Backend PoP</h3>
+      <p>Reruns metric over shifted time bounds and joins by interval. Better semantic comparison.</p>
+    </section>
+  </div>
+
+  <h2>13. Exercises</h2>
+  <details><summary>Current window: March–May. Granularity: month. Offset: 1. What previous window is queried?</summary><p>February–April. Those previous rows join forward to March–May.</p></details>
+  <details><summary>Current month row is May 2026. Granularity month, offset 12. Which previous row joins?</summary><p>May 2025, because May 2025 + 12 months = May 2026.</p></details>
+  <details><summary>Why must <code>orders_order_date_month</code> be selected for a monthly PoP metric?</summary><p>The final join needs the current row's month to match it to the shifted previous row.</p></details>
+  <details><summary>Why do previous-period CTEs reuse country/status filters?</summary><p>The comparison should answer the same business question in a different time window, not a different segment.</p></details>
+  <details><summary>Why does fanout-aware PoP create <code>cte_pop_keys_*</code>?</summary><p>Previous-period primary keys can differ from current-period primary keys, and protected metrics must be aggregated at a safe key grain in the shifted window.</p></details>
+
+  <section class="aside">
+    <span class="callout-title">Primary source to review</span>
+    User-facing docs: <a href="https://docs.lightdash.com/guides/period-over-period">Period-over-period guide</a>. Code: <a href="../packages/common/src/types/periodOverPeriodComparison.ts"><code>periodOverPeriodComparison.ts</code></a> for generated metric metadata, and <a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts"><code>MetricQueryBuilder.ts</code></a> for <code>base_metrics</code>, <code>pop_min_max_*</code>, <code>pop_metrics_*</code>, and fanout-aware <code>cte_pop_*</code> CTEs.
+  </section>
+
+  <p class="small">Next lesson: <a href="./0004-pivot-queries-deep-dive.html">Pivot Queries Deep Dive</a>. Ask the agent to generate a concrete MoM SQL sketch for a metric you care about.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>

--- a/lessons/0004-pivot-queries-deep-dive.html
+++ b/lessons/0004-pivot-queries-deep-dive.html
@@ -1,0 +1,321 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Pivot Queries Deep Dive</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Lesson 0004 · Pivot queries</p>
+  <h1>Lightdash pivot SQL stays long; the backend transform makes it wide</h1>
+  <p class="subtitle">The pivot query builder usually does not create one SQL column per pivot value. It wraps semantic SQL, assigns row and column indexes, and lets streaming backend code widen the result.</p>
+
+  <nav class="nav">
+    <a href="./0003-period-over-period-deep-dive.html">Previous: PoP</a>
+    <a href="./0000-intro-lightdash-query-systems.html">Intro</a>
+    <a href="../reference/lightdash-query-builder-reference.html">Reference</a>
+  </nav>
+
+  <section class="win">
+    <span class="callout-title">What you should be able to do after this lesson</span>
+    Explain how <code>PivotConfiguration</code> becomes <code>original_query → group_by_query → pivot_query</code>, why <code>row_index</code>/<code>column_index</code> exist, and how <code>AsyncQueryService.runQueryAndTransformRows</code> widens rows.
+  </section>
+
+  <h2>1. Two different meanings of “pivot”</h2>
+  <p>Classic SQL pivot means dynamic values become physical SQL columns:</p>
+
+  <pre><code>-- conceptual warehouse pivot
+status values: completed, pending
+columns: revenue_completed, revenue_pending</code></pre>
+
+  <p>Lightdash's backend pivot path is different. <a href="../packages/backend/src/utils/QueryBuilder/CLAUDE.md"><code>QueryBuilder/CLAUDE.md</code></a> states that <code>PivotQueryBuilder</code> does not perform the final pivot. It generates SQL that tags each row with <code>row_index</code> and <code>column_index</code>; the actual spreading happens downstream in <code>AsyncQueryService.runQueryAndTransformRows</code>.</p>
+
+  <div class="mermaid">
+flowchart LR
+  Flat[Flat semantic SQL] --> PivotSQL[PivotQueryBuilder<br/>long rows + row_index + column_index]
+  PivotSQL --> Warehouse[Warehouse returns ordered long rows]
+  Warehouse --> Transform[AsyncQueryService.runQueryAndTransformRows]
+  Transform --> Wide[Wide pivot result rows]
+  </div>
+
+  <h2>2. The source of truth: <code>PivotConfiguration</code></h2>
+  <p><code>PivotConfiguration</code> lives in <a href="../packages/common/src/types/pivot.ts"><code>packages/common/src/types/pivot.ts</code></a>. It is derived from chart config and metric query in <a href="../packages/common/src/pivot/derivePivotConfigFromChart.ts"><code>derivePivotConfigFromChart.ts</code></a>.</p>
+
+  <pre><code>type PivotConfiguration = {
+  indexColumn: PivotIndexColum | PivotIndexColum[] | undefined;
+  valuesColumns: ValuesColumn[];
+  groupByColumns: GroupByColumn[] | undefined;
+  sortBy: SortBy | undefined;
+  metricsAsRows?: boolean;
+  sortOnlyColumns?: ValuesColumn[];
+  sortOnlyDimensions?: GroupByColumn[];
+  passthroughDimensions?: GroupByColumn[];
+  pivotColumnsOrder?: GroupByColumn[];
+}</code></pre>
+
+  <table>
+    <thead><tr><th>Property</th><th>Backend meaning</th><th>Visual intuition</th></tr></thead>
+    <tbody>
+      <tr><td><code>indexColumn</code></td><td>Fields that identify output rows and drive <code>row_index</code>.</td><td>Rows down the left, e.g. month.</td></tr>
+      <tr><td><code>valuesColumns</code></td><td>Metrics/table calculations that become pivot cell values. Each gets an aggregation suffix such as <code>_any</code>.</td><td>Revenue, orders, margin.</td></tr>
+      <tr><td><code>groupByColumns</code></td><td>Fields whose values become pivot header combinations and drive <code>column_index</code>.</td><td>Status across the top.</td></tr>
+      <tr><td><code>sortBy</code></td><td>Fields and directions used to rank rows/columns. May include pinned pivot values.</td><td>Month asc, revenue desc.</td></tr>
+      <tr><td><code>metricsAsRows</code></td><td>Affects column-limit calculation because metrics render as rows, not separate columns.</td><td>Metric names down the row axis.</td></tr>
+      <tr><td><code>sortOnlyColumns</code></td><td>Values needed for sorting but not displayed.</td><td>Hidden metric sort helper.</td></tr>
+      <tr><td><code>sortOnlyDimensions</code></td><td>Hidden pivot dimensions that drive column order but do not render as headers.</td><td>Sort by month number while showing month name.</td></tr>
+      <tr><td><code>passthroughDimensions</code></td><td>Hidden fields carried through so rich text/image templates can read raw values.</td><td>Hidden image URL used by a visible cell.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>3. Tiny input data</h2>
+  <p>Suppose <code>MetricQueryBuilder</code> already returned correct semantic rows:</p>
+
+  <table>
+    <caption>Flat result from MetricQueryBuilder</caption>
+    <thead><tr><th>month</th><th>status</th><th>revenue</th></tr></thead>
+    <tbody>
+      <tr><td>Jan</td><td>completed</td><td>100</td></tr>
+      <tr><td>Jan</td><td>pending</td><td>30</td></tr>
+      <tr><td>Feb</td><td>completed</td><td>120</td></tr>
+      <tr><td>Feb</td><td>pending</td><td>40</td></tr>
+    </tbody>
+  </table>
+
+  <p>The desired rendered pivot is:</p>
+
+  <table>
+    <caption>Final wide pivot shape</caption>
+    <thead><tr><th>month</th><th>revenue_completed</th><th>revenue_pending</th></tr></thead>
+    <tbody>
+      <tr><td>Jan</td><td>100</td><td>30</td></tr>
+      <tr><td>Feb</td><td>120</td><td>40</td></tr>
+    </tbody>
+  </table>
+
+  <p>Lightdash SQL returns an intermediate long shape instead:</p>
+
+  <table>
+    <caption>SQL-shaped long pivot rows</caption>
+    <thead><tr><th>month</th><th>status</th><th>revenue_any</th><th>row_index</th><th>column_index</th><th>total_columns</th></tr></thead>
+    <tbody>
+      <tr><td>Jan</td><td>completed</td><td>100</td><td>1</td><td>1</td><td>2</td></tr>
+      <tr><td>Jan</td><td>pending</td><td>30</td><td>1</td><td>2</td><td>2</td></tr>
+      <tr><td>Feb</td><td>completed</td><td>120</td><td>2</td><td>1</td><td>2</td></tr>
+      <tr><td>Feb</td><td>pending</td><td>40</td><td>2</td><td>2</td><td>2</td></tr>
+    </tbody>
+  </table>
+
+  <h2>4. The normal full-pivot pipeline</h2>
+  <p><code>PivotQueryBuilder.toSql</code> removes the base query limit, builds <code>group_by_query</code>, then chooses simple or full pivot mode depending on whether <code>groupByColumns</code> exist.</p>
+
+  <div class="mermaid">
+flowchart TD
+  A[Base SQL from MetricQueryBuilder] --> B[original_query]
+  B --> C[group_by_query<br/>group by index + groupBy + hidden helpers<br/>aggregate values]
+  C --> D[pivot_query<br/>select fields + row_index + column_index]
+  D --> E[filtered_rows<br/>row_index <= row limit]
+  E --> F[distinct_groups<br/>distinct pivot header combinations]
+  F --> G[total_columns]
+  D --> H[final SELECT p.*, total_columns<br/>ordered by row_index, column_index]
+  G --> H
+  H --> I[AsyncQueryService transform]
+  </div>
+
+  <pre><code>WITH original_query AS (
+  -- MetricQueryBuilder SQL
+),
+
+group_by_query AS (
+  SELECT
+    "month",
+    "status",
+    ANY_VALUE("revenue") AS "revenue_any"
+  FROM original_query
+  GROUP BY "month", "status"
+),
+
+pivot_query AS (
+  SELECT
+    g."month" AS "month",
+    g."status" AS "status",
+    g."revenue_any" AS "revenue_any",
+    DENSE_RANK() OVER (ORDER BY g."month" ASC) AS "row_index",
+    DENSE_RANK() OVER (ORDER BY g."status" ASC) AS "column_index"
+  FROM group_by_query g
+),
+
+filtered_rows AS (
+  SELECT * FROM pivot_query WHERE "row_index" <= 500
+),
+
+distinct_groups AS (
+  SELECT DISTINCT "status" FROM filtered_rows
+),
+
+total_columns AS (
+  SELECT COUNT(*) AS total_columns FROM distinct_groups
+)
+
+SELECT p.*, t.total_columns
+FROM pivot_query p
+CROSS JOIN total_columns t
+WHERE p."row_index" <= 500
+ORDER BY p."row_index", p."column_index";</code></pre>
+
+  <h2>5. <code>group_by_query</code>: pivot grain</h2>
+  <p><code>group_by_query</code> is where rows are collapsed to the pivot grain:</p>
+
+  <pre><code>one row per (index columns + pivot header columns + needed hidden helper dims)</code></pre>
+
+  <p>For table charts, value columns often use <code>ANY_VALUE</code> because the metric was already semantically aggregated by <code>MetricQueryBuilder</code>. The pivot layer is not redefining revenue; it is regrouping the already-produced result for display.</p>
+
+  <section class="checkpoint">
+    <span class="callout-title">Boundary reminder</span>
+    If revenue is semantically wrong before pivoting, <code>group_by_query</code> will preserve or aggregate a wrong value. Pivot code is not responsible for fanout-safe metric semantics.
+  </section>
+
+  <h2>6. <code>row_index</code> and <code>column_index</code></h2>
+  <p>The final streaming transform needs rows ordered so it can accumulate one output object per rendered row. <code>row_index</code> identifies the rendered row. <code>column_index</code> identifies the pivot header order.</p>
+
+  <div class="two-col">
+    <section class="card">
+      <h3><code>row_index</code></h3>
+      <p>Dense rank over index-column order. Example: Jan = 1, Feb = 2.</p>
+    </section>
+    <section class="card">
+      <h3><code>column_index</code></h3>
+      <p>Dense rank over pivot-column order. Example: completed = 1, pending = 2.</p>
+    </section>
+  </div>
+
+  <p>When there are no index columns, all rows can have <code>row_index = 1</code>; when there are no <code>groupByColumns</code>, PivotQueryBuilder takes a simpler path and does not need the full row/column index machinery.</p>
+
+  <h2>7. Streaming transform: long rows become wide rows</h2>
+  <p><code>AsyncQueryService.runQueryAndTransformRows</code> receives warehouse rows in <code>row_index</code>, <code>column_index</code> order. It holds a current output row. When <code>row_index</code> changes, it flushes the previous output row and starts a new one.</p>
+
+  <div class="mermaid">
+sequenceDiagram
+  participant DB as Warehouse rows
+  participant S as AsyncQueryService
+  participant Out as Output stream/file
+  DB->>S: row_index=1, status=completed, revenue_any=100
+  S->>S: start row { month: Jan }
+  S->>S: set revenue_any_completed = 100
+  DB->>S: row_index=1, status=pending, revenue_any=30
+  S->>S: set revenue_any_pending = 30
+  DB->>S: row_index=2, status=completed, revenue_any=120
+  S->>Out: flush Jan row
+  S->>S: start row { month: Feb }
+  </div>
+
+  <p>The pivoted value column name is built from:</p>
+
+  <pre><code>value column field name + '_' + joined raw pivot values
+
+orders_revenue_any + '_' + completed
+= orders_revenue_any_completed</code></pre>
+
+  <p><code>valuesColumnData</code> records metadata for each generated pivot column, including the original reference field, aggregation, pivot values, and <code>columnIndex</code>.</p>
+
+  <h2>8. What <code>total_columns</code> means</h2>
+  <p>The SQL returns <code>total_columns</code> so the frontend/backend can know how many pivot columns exist before column limiting. <code>distinct_groups</code> counts distinct pivot header combinations after row filtering. If there are multiple value columns and metrics are not displayed as rows, the count is multiplied by value count.</p>
+
+  <pre><code>distinct pivot statuses = completed, pending = 2
+valuesColumns = revenue, order_count = 2
+metricsAsRows = false
+
+total_columns = 2 * 2 = 4</code></pre>
+
+  <h2>9. Sorting by dimensions: relatively simple</h2>
+  <p>If sorting only uses index or group-by dimensions, <code>pivot_query</code> can compute <code>DENSE_RANK()</code> inline:</p>
+
+  <pre><code>DENSE_RANK() OVER (ORDER BY g."month" ASC) AS "row_index",
+DENSE_RANK() OVER (ORDER BY g."status" ASC) AS "column_index"</code></pre>
+
+  <p>Custom bin dimensions may carry an <code>_order</code> helper column through the pipeline when actively sorted.</p>
+
+  <h2>10. Sorting by metrics: the anchor problem</h2>
+  <p>Metric sorting in a pivot is harder because each rendered row has many metric cells. If you sort rows by revenue, which pivot column's revenue should decide the row order?</p>
+
+  <table>
+    <thead><tr><th>month</th><th>revenue_completed</th><th>revenue_pending</th></tr></thead>
+    <tbody><tr><td>Jan</td><td>100</td><td>300</td></tr><tr><td>Feb</td><td>200</td><td>20</td></tr></tbody>
+  </table>
+
+  <p>If sorting descending by revenue, Jan wins if pending is the anchor, but Feb wins if completed is the anchor. Lightdash needs a deterministic anchor column.</p>
+
+  <section class="checkpoint">
+    <span class="callout-title">Anchor column</span>
+    When sorting rows by a value column, Lightdash sorts rows by that metric's value in one selected pivot column. By default this is the first pivot column after column ordering. A pinned sort can specify a particular pivot value.</section>
+
+  <h2>11. Metric sorting CTE pipeline</h2>
+  <p><code>PivotQueryBuilder</code> builds extra CTEs for metric sorting:</p>
+
+  <table>
+    <thead><tr><th>CTE</th><th>Role</th></tr></thead>
+    <tbody>
+      <tr><td>Column anchors <code>*_ca</code></td><td>Compute first metric values per pivot-column group to support column ordering.</td></tr>
+      <tr><td><code>column_ranking</code></td><td>Assign <code>col_idx</code> to distinct pivot header combinations.</td></tr>
+      <tr><td><code>anchor_column</code></td><td>Pick the pivot header used as row-sort anchor, usually <code>col_idx = 1</code>.</td></tr>
+      <tr><td>Row anchors <code>*_ra</code></td><td>For each rendered row, get the metric value at the anchor column.</td></tr>
+      <tr><td><code>row_ranking</code></td><td>Assign <code>row_index</code> using row anchor values.</td></tr>
+    </tbody>
+  </table>
+
+  <div class="mermaid">
+flowchart TD
+  GB[group_by_query] --> CA[metric column anchors<br/>*_ca]
+  CA --> CR[column_ranking<br/>DENSE_RANK pivot headers]
+  CR --> AC[anchor_column<br/>pick col_idx=1 or pinned value]
+  GB --> RA[row anchors<br/>*_ra metric value at anchor]
+  AC --> RA
+  RA --> RR[row_ranking<br/>DENSE_RANK rows]
+  CR --> PQ[pivot_query]
+  RR --> PQ
+  </div>
+
+  <p>The local <code>QueryBuilder/CLAUDE.md</code> notes that this precomputed ranking path also helps warehouses like Databricks/Spark where inline CTE expansion can make window-function aliases hard to resolve.</p>
+
+  <h2>12. Three pivot modes to recognize</h2>
+  <table>
+    <thead><tr><th>Mode</th><th>Trigger</th><th>CTE shape</th></tr></thead>
+    <tbody>
+      <tr><td>Simple aggregation</td><td>No <code>groupByColumns</code></td><td><code>original_query → group_by_query → SELECT</code>. No row/column indexes.</td></tr>
+      <tr><td>Full pivot, dimension sort</td><td><code>groupByColumns</code> present; no value-column sort requiring anchors</td><td><code>original_query → group_by_query → pivot_query → filtered_rows → distinct_groups → total_columns</code>.</td></tr>
+      <tr><td>Full pivot, metric sort</td><td>Sort by a value column</td><td>Add <code>*_ca</code>, <code>column_ranking</code>, <code>anchor_column</code>, <code>*_ra</code>, and maybe <code>row_ranking</code>.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>13. Hidden sort-only and passthrough fields</h2>
+  <p><code>derivePivotConfigFromChart</code> routes hidden fields carefully:</p>
+
+  <ul>
+    <li><code>sortOnlyColumns</code>: hidden metrics/table calculations needed for sorting but not display.</li>
+    <li><code>sortOnlyDimensions</code>: hidden pivot dimensions that affect column order but do not become visible headers.</li>
+    <li><code>passthroughDimensions</code>: hidden dimensions that do not sort but must flow through for rich text or image templates.</li>
+  </ul>
+
+  <p>These fields explain some “why is this hidden field in the SQL?” surprises. It may be there to preserve sorting or templates, not to render as a pivot header.</p>
+
+  <h2>14. Exercises</h2>
+  <details><summary>Does <code>PivotQueryBuilder</code> usually emit <code>revenue_completed</code> as a SQL column?</summary><p>No. It emits long rows with <code>status = completed</code>, <code>revenue_any</code>, <code>row_index</code>, and <code>column_index</code>. The backend transform creates the wide column name.</p></details>
+  <details><summary>What does <code>group_by_query</code> group by?</summary><p>Visible pivot group-by columns, sort-only dimensions, passthrough dimensions, and index columns. It aggregates values with the configured aggregation.</p></details>
+  <details><summary>Why is <code>row_index</code> needed?</summary><p>It lets the streaming transform know which warehouse rows belong to the same rendered pivot row.</p></details>
+  <details><summary>Why is metric sorting ambiguous in a pivot?</summary><p>A row has multiple metric values across pivot columns. Lightdash must choose an anchor pivot column whose value controls row order.</p></details>
+  <details><summary>What file turns long pivot rows into wide rows?</summary><p><code>packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts</code>, in <code>runQueryAndTransformRows</code>.</p></details>
+
+  <section class="aside">
+    <span class="callout-title">Primary source to review</span>
+    Code: <a href="../packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts"><code>PivotQueryBuilder.ts</code></a> for SQL CTEs and anchor logic; <a href="../packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts"><code>AsyncQueryService.ts</code></a> for streaming transformation; <a href="../packages/common/src/types/pivot.ts"><code>types/pivot.ts</code></a> and <a href="../packages/common/src/pivot/derivePivotConfigFromChart.ts"><code>derivePivotConfigFromChart.ts</code></a> for configuration derivation.
+  </section>
+
+  <p class="small">You now have the four core concepts. Review the compact sheet: <a href="../reference/lightdash-query-builder-reference.html">Lightdash query-builder reference</a>. Ask the agent to trace a real chart from <code>MetricQuery</code> to pivoted output when ready.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>

--- a/reference/lightdash-query-builder-reference.html
+++ b/reference/lightdash-query-builder-reference.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Lightdash Query Builder Reference</title>
+  <link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<main>
+  <p class="kicker">Reference</p>
+  <h1>Lightdash backend query-builder cheat sheet</h1>
+  <p class="subtitle">A compact glossary and pipeline map for fanouts, CTEs, period-over-period, and pivot queries.</p>
+
+  <nav class="nav">
+    <a href="../lessons/0000-intro-lightdash-query-systems.html">Intro</a>
+    <a href="../lessons/0001-fanouts-deep-dive.html">Fanouts</a>
+    <a href="../lessons/0002-ctes-deep-dive.html">CTEs</a>
+    <a href="../lessons/0003-period-over-period-deep-dive.html">PoP</a>
+    <a href="../lessons/0004-pivot-queries-deep-dive.html">Pivot</a>
+  </nav>
+
+  <h2>One-screen architecture</h2>
+  <div class="mermaid">
+flowchart TD
+  MQ[MetricQuery] --> Compile[compileMetricQuery]
+  Compile --> MQB[MetricQueryBuilder]
+  MQB --> Fan[optional fanout CTEs<br/>cte_keys_* / cte_metrics_* / cte_unaffected]
+  Fan --> DD[optional distinct CTEs<br/>dd_* / dd_base]
+  DD --> POP[optional PoP CTEs<br/>base_metrics + pop_* or cte_pop_*]
+  POP --> Flat[Flat semantic SQL]
+  Flat --> Pivot{pivotConfiguration?}
+  Pivot -- no --> Execute[warehouse execute]
+  Pivot -- yes --> PQB[PivotQueryBuilder<br/>original_query → group_by_query → pivot_query]
+  PQB --> Execute
+  Execute --> Transform[AsyncQueryService.runQueryAndTransformRows]
+  Transform --> Results[rows, columns, pivotDetails]
+  </div>
+
+  <h2>Glossary</h2>
+  <div class="grid">
+    <section class="card"><h3>Grain</h3><p>What one row represents. Example: one customer, one order, one order item.</p></section>
+    <section class="card"><h3>Fanout</h3><p>A join that makes rows from a table repeat, usually one-to-many or many-to-many.</p></section>
+    <section class="card"><h3>Metric inflation</h3><p>An aggregate changes because repeated rows enter the aggregate. Commonly affects <code>SUM</code> and <code>AVG</code>.</p></section>
+    <section class="card"><h3>Inflation-proof metric</h3><p>Metric type stable under repeated rows in Lightdash's fanout logic: <code>COUNT_DISTINCT</code>, <code>SUM_DISTINCT</code>, <code>AVERAGE_DISTINCT</code>, <code>MIN</code>, <code>MAX</code>.</p></section>
+    <section class="card"><h3>CTE</h3><p>A named SQL scope in a <code>WITH</code> clause. Later scopes can read earlier scopes if they <code>FROM</code>/<code>JOIN</code> them.</p></section>
+    <section class="card"><h3>PoP</h3><p>Period-over-period. A generated comparison metric computed over a shifted time window.</p></section>
+    <section class="card"><h3>Pivot long row</h3><p>A row with pivot header values plus <code>row_index</code> and <code>column_index</code>. Not the final wide pivot row.</p></section>
+    <section class="card"><h3>Anchor column</h3><p>The pivot column whose value controls row ordering when sorting pivot rows by a metric.</p></section>
+  </div>
+
+  <h2>CTE family table</h2>
+  <table>
+    <thead><tr><th>Family</th><th>Subsystem</th><th>Reads from</th><th>Outputs</th><th>Purpose</th></tr></thead>
+    <tbody>
+      <tr><td><code>cte_keys_*</code></td><td>Fanout</td><td>Full joined query</td><td>Dimension aliases + <code>pk_*</code></td><td>Find distinct protected table keys per group.</td></tr>
+      <tr><td><code>cte_metrics_*</code></td><td>Fanout</td><td><code>cte_keys_*</code> + protected table</td><td>Dimension aliases + safe metrics</td><td>Aggregate protected metrics without row multiplication.</td></tr>
+      <tr><td><code>cte_unaffected</code></td><td>Fanout</td><td>Full joined query</td><td>Dimensions + unaffected metrics</td><td>Carry the rest of the result grain.</td></tr>
+      <tr><td><code>dd_*</code></td><td>Distinct metrics</td><td>Base tables/joins</td><td>One deduped distinct metric, optional join keys</td><td>Deduplicate by configured distinct keys.</td></tr>
+      <tr><td><code>dd_base</code></td><td>Distinct metrics</td><td>Current final select before dd stitching</td><td>Pre-dd result</td><td>Stable base for joining distinct metrics.</td></tr>
+      <tr><td><code>base_metrics</code></td><td>Non-fanout PoP</td><td>Current metric SELECT</td><td>Current rows</td><td>Freeze current results before comparison.</td></tr>
+      <tr><td><code>pop_min_max_*</code></td><td>PoP</td><td><code>base_metrics</code></td><td><code>min_date</code>, <code>max_date</code></td><td>Derive current window bounds.</td></tr>
+      <tr><td><code>pop_metrics_*</code></td><td>PoP</td><td>Base tables + shifted min/max</td><td>Previous-period metric aliases</td><td>Compute shifted comparison rows.</td></tr>
+      <tr><td><code>cte_pop_keys_*</code></td><td>Fanout PoP</td><td>Full joined query + shifted min/max</td><td>Previous-period dimension aliases + pk</td><td>Fanout-safe shifted keys.</td></tr>
+      <tr><td><code>cte_pop_metrics_*</code></td><td>Fanout PoP</td><td><code>cte_pop_keys_*</code> + protected table</td><td>Previous-period protected metrics</td><td>Fanout-safe shifted metrics.</td></tr>
+      <tr><td><code>original_query</code></td><td>Pivot</td><td>Flat semantic SQL</td><td>Original result fields</td><td>Wrap metric query for pivot pipeline.</td></tr>
+      <tr><td><code>group_by_query</code></td><td>Pivot</td><td><code>original_query</code></td><td>Pivot-grain rows + value aliases</td><td>Group to index + pivot-column grain.</td></tr>
+      <tr><td><code>pivot_query</code></td><td>Pivot</td><td><code>group_by_query</code> + rankings</td><td><code>row_index</code>, <code>column_index</code></td><td>Make long rows streamable as a pivot.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Fanout decision checklist</h2>
+  <ol>
+    <li>What is the starting/base table?</li>
+    <li>What is the join relationship direction?</li>
+    <li>Which table's rows can repeat in the joined result?</li>
+    <li>Is the metric from a repeated table?</li>
+    <li>Is the metric type vulnerable (<code>SUM</code>, <code>AVG</code>, plain <code>COUNT</code>) or inflation-proof/special?</li>
+    <li>Does the repeated table have a primary key so Lightdash can build <code>cte_keys_*</code>?</li>
+  </ol>
+
+  <h2>Alias tracing algorithm</h2>
+  <ol>
+    <li>Pick the final output alias.</li>
+    <li>Search for <code>AS "alias"</code>.</li>
+    <li>If it appears more than once, identify which subsystem emitted each one.</li>
+    <li>For the intended owner, list the source aliases in the expression.</li>
+    <li>Verify the current scope reads from CTEs exposing those source aliases.</li>
+    <li>Repeat until reaching base table columns or compiled metric SQL.</li>
+  </ol>
+
+  <h2>PoP invariant</h2>
+  <pre><code>current rows = base metric over current time window
+previous rows = same base metric over shifted time window
+
+join current to previous:
+  non-time dimensions: null-safe equality
+  comparison time dimension: current_time = previous_time + offset interval
+  join type: LEFT JOIN, so current rows survive missing previous rows</code></pre>
+
+  <h2>Pivot pipeline cheat</h2>
+  <pre><code>original_query
+  = MetricQueryBuilder output, with semantic metrics already decided
+
+group_by_query
+  = SELECT index cols + pivot header cols + aggregated value cols
+    FROM original_query
+    GROUP BY index cols + pivot header cols + helper dims
+
+pivot_query
+  = SELECT group_by_query fields
+    + DENSE_RANK(...) AS row_index
+    + DENSE_RANK(...) AS column_index
+
+AsyncQueryService.runQueryAndTransformRows
+  = stream ordered long rows
+  = when row_index changes, flush current transformed row
+  = value column name = valueField_aggregation + pivot value suffix</code></pre>
+
+  <h2>Metric sort anchor cheat</h2>
+  <div class="mermaid">
+flowchart TD
+  GB[group_by_query] --> CA[*_ca column anchors]
+  CA --> CR[column_ranking]
+  CR --> AC[anchor_column]
+  AC --> RA[*_ra row anchors]
+  GB --> RA
+  RA --> RR[row_ranking]
+  RR --> PQ[pivot_query]
+  CR --> PQ
+  </div>
+
+  <h2>Primary file map</h2>
+  <table>
+    <thead><tr><th>Question</th><th>File/function</th></tr></thead>
+    <tbody>
+      <tr><td>How is high-level query builder architecture described?</td><td><a href="../packages/backend/src/utils/QueryBuilder/CLAUDE.md"><code>packages/backend/src/utils/QueryBuilder/CLAUDE.md</code></a></td></tr>
+      <tr><td>Where are semantic metric SQL, fanouts, distinct metrics, and PoP built?</td><td><a href="../packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts"><code>MetricQueryBuilder.ts</code></a></td></tr>
+      <tr><td>Where is pivot SQL built?</td><td><a href="../packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts"><code>PivotQueryBuilder.ts</code></a></td></tr>
+      <tr><td>Where are pivot rows widened?</td><td><a href="../packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts"><code>AsyncQueryService.runQueryAndTransformRows</code></a></td></tr>
+      <tr><td>What is <code>PivotConfiguration</code>?</td><td><a href="../packages/common/src/types/pivot.ts"><code>packages/common/src/types/pivot.ts</code></a></td></tr>
+      <tr><td>How is pivot config derived from charts?</td><td><a href="../packages/common/src/pivot/derivePivotConfigFromChart.ts"><code>derivePivotConfigFromChart.ts</code></a></td></tr>
+      <tr><td>How are PoP additional metrics named/built?</td><td><a href="../packages/common/src/types/periodOverPeriodComparison.ts"><code>periodOverPeriodComparison.ts</code></a></td></tr>
+    </tbody>
+  </table>
+
+  <p class="small">Print this page or keep it open while reading generated SQL. For deeper explanations, use the lesson links above.</p>
+</main>
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:

### Description:
- Adds query-builder investigation notes and reference material.
- Adds lesson pages covering fanouts, CTEs, period-over-period, and pivot query behavior.
- Includes shared lesson styling and a query-builder reference page.

### Testing:
- Docs-only change; not run.
