### PR TITLE
feat(reviews): build-fix thread + verification backend for remediation workspace

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -346,6 +346,35 @@ export class AiAgentAdminController extends BaseController {
     }
 
     /**
+     * Re-verify a remediation after its PR changed: recompiles the existing
+     * preview and re-runs the Test-fix verification thread.
+     * @summary Retest an AI agent review remediation
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/review-items/{fingerprint}/retest')
+    @OperationId('retestAiAgentReviewRemediation')
+    async retestReviewRemediation(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+    ): Promise<ApiAiAgentReviewItemActivityResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().retestReviewRemediation(
+                    toSessionUser(req.account),
+                    fingerprint,
+                ),
+        };
+    }
+
+    /**
      * Preview the file change a writeback PR would make, without opening it.
      * Only project_context findings have a deterministic diff.
      * @summary Preview AI agent review item writeback diff

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -1058,6 +1058,7 @@ export class AiAgentController extends BaseController {
                               agentUuid,
                               threadUuid,
                               enableSqlMode: body?.enableSqlMode ?? false,
+                              autoApproveSql: body?.autoApproveSql ?? false,
                               toolHints: body?.toolHints ?? [],
                           },
                       );

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -261,6 +261,7 @@ export type DbAiAgentReviewRemediation = {
     source_thread_uuid: string;
     source_project_uuid: string;
     source_agent_uuid: string;
+    work_thread_uuid: string | null;
     pull_request_uuid: string | null;
     preview_project_uuid: string | null;
     preview_agent_uuid: string | null;

--- a/packages/backend/src/ee/database/migrations/20260618130000_add_work_thread_to_ai_agent_review_remediation.ts
+++ b/packages/backend/src/ee/database/migrations/20260618130000_add_work_thread_to_ai_agent_review_remediation.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+const remediationTable = 'ai_agent_review_remediation';
+const aiThreadTable = 'ai_thread';
+const workThreadColumn = 'work_thread_uuid';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table
+            .uuid(workThreadColumn)
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(aiThreadTable)
+            .onDelete('SET NULL');
+        table.index([workThreadColumn]);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table.dropColumn(workThreadColumn);
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -330,12 +330,13 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentService:
+                        repository.getAiAgentService<AiAgentService>(),
                     featureFlagService: repository.getFeatureFlagService(),
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
                     projectModel: models.getProjectModel(),
-                    aiWritebackService:
-                        repository.getAiWritebackService<AiWritebackService>(),
+                    projectService: repository.getProjectService(),
                     projectContextService:
                         repository.getProjectContextService<ProjectContextService>(),
                     pullRequestsModel: models.getPullRequestsModel(),

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -141,6 +141,7 @@ const makeRemediationRow = (
     source_thread_uuid: THREAD_UUID,
     source_project_uuid: PROJECT_UUID,
     source_agent_uuid: AGENT_UUID,
+    work_thread_uuid: null,
     pull_request_uuid: PULL_REQUEST_UUID,
     linked_pr_url: 'https://github.com/acme/dbt/pull/42',
     preview_project_uuid: PREVIEW_PROJECT_UUID,
@@ -865,6 +866,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 sourceThreadUuid: THREAD_UUID,
                 sourceProjectUuid: PROJECT_UUID,
                 sourceAgentUuid: AGENT_UUID,
+                workThreadUuid: null,
                 retryPrompt: 'Show revenue',
                 createdByUserUuid: null,
             });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -126,6 +126,7 @@ const mapReviewRemediation = (
         sourceThreadUuid: row.source_thread_uuid,
         sourceProjectUuid: row.source_project_uuid,
         sourceAgentUuid: row.source_agent_uuid,
+        workThreadUuid: row.work_thread_uuid,
         pullRequestUuid: row.pull_request_uuid,
         linkedPrUrl: row.linked_pr_url,
         previewProjectUuid: row.preview_project_uuid,
@@ -204,6 +205,7 @@ type CreateReviewRemediationArgs = {
     sourceThreadUuid: string;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
+    workThreadUuid: string | null;
     retryPrompt: string | null;
     createdByUserUuid: string | null;
 };
@@ -1308,6 +1310,35 @@ export class AiAgentReviewClassifierModel {
         return row ? mapReviewRemediation(row) : null;
     }
 
+    async findReviewRemediationByWorkThread(args: {
+        organizationUuid: string;
+        workThreadUuid: string;
+    }): Promise<AiAgentReviewRemediation | null> {
+        const row = (await this.database<AiAgentReviewRemediationTable>(
+            `${AiAgentReviewRemediationTableName} as remediation`,
+        )
+            .leftJoin(
+                `${PullRequestsTableName} as pull_request`,
+                'pull_request.pull_request_uuid',
+                'remediation.pull_request_uuid',
+            )
+            .where('remediation.organization_uuid', args.organizationUuid)
+            .where('remediation.work_thread_uuid', args.workThreadUuid)
+            .orderBy('remediation.updated_at', 'desc')
+            .select<ReviewRemediationRow>(
+                'remediation.*',
+                {
+                    linked_pr_url: 'pull_request.pr_url',
+                },
+                this.database.raw(
+                    '(extract(epoch from (now() - remediation.updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )
+            .first()) as ReviewRemediationRow | undefined;
+
+        return row ? mapReviewRemediation(row) : null;
+    }
+
     async createReviewRemediation(
         args: CreateReviewRemediationArgs,
     ): Promise<AiAgentReviewRemediation> {
@@ -1322,6 +1353,7 @@ export class AiAgentReviewClassifierModel {
                 source_thread_uuid: args.sourceThreadUuid,
                 source_project_uuid: args.sourceProjectUuid,
                 source_agent_uuid: args.sourceAgentUuid,
+                work_thread_uuid: args.workThreadUuid,
                 retry_prompt: args.retryPrompt,
                 created_by_user_uuid: args.createdByUserUuid,
             })
@@ -1332,6 +1364,22 @@ export class AiAgentReviewClassifierModel {
             linked_pr_url: null,
             updated_at_age_ms: 0,
         });
+    }
+
+    async setReviewRemediationWorkThread(args: {
+        remediationUuid: string;
+        organizationUuid: string;
+        workThreadUuid: string;
+    }): Promise<void> {
+        await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('ai_agent_review_remediation_uuid', args.remediationUuid)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                work_thread_uuid: args.workThreadUuid,
+                updated_at: this.database.fn.now() as never,
+            });
     }
 
     async updateReviewRemediationStatus(

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -32,6 +32,7 @@ const PREVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000008';
 const PREVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000009';
 const PREVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000010';
 const COMPILE_JOB_UUID = '00000000-0000-0000-0000-000000000011';
+const WORK_THREAD_UUID = '00000000-0000-0000-0000-000000000012';
 const SITE_URL = 'https://app.lightdash.cloud';
 const PR_URL = 'https://github.com/acme/dbt/pull/42';
 
@@ -85,6 +86,7 @@ const makeRemediation = (
     sourceThreadUuid: THREAD_UUID,
     sourceProjectUuid: PROJECT_UUID,
     sourceAgentUuid: AGENT_UUID,
+    workThreadUuid: WORK_THREAD_UUID,
     pullRequestUuid: 'pull-request-1',
     linkedPrUrl: 'https://github.com/acme/dbt/pull/42',
     previewProjectUuid: null,
@@ -130,10 +132,11 @@ const makeService = ({
     featureFlagService = {},
     aiOrganizationSettingsService = {},
     projectModel = {},
+    projectService = {},
     schedulerClient = {},
     githubAppInstallationsModel = {},
     gitlabAppInstallationsModel = {},
-    aiWritebackService = {},
+    aiAgentService = {},
     pullRequestsModel = {},
     writebackPreviewService = {},
     jobModel = {},
@@ -144,10 +147,11 @@ const makeService = ({
     featureFlagService?: Record<string, unknown>;
     aiOrganizationSettingsService?: Record<string, unknown>;
     projectModel?: Record<string, unknown>;
+    projectService?: Record<string, unknown>;
     schedulerClient?: Record<string, unknown>;
     githubAppInstallationsModel?: Record<string, unknown>;
     gitlabAppInstallationsModel?: Record<string, unknown>;
-    aiWritebackService?: Record<string, unknown>;
+    aiAgentService?: Record<string, unknown>;
     pullRequestsModel?: Record<string, unknown>;
     writebackPreviewService?: Record<string, unknown>;
     jobModel?: Record<string, unknown>;
@@ -191,6 +195,17 @@ const makeService = ({
                 .fn()
                 .mockResolvedValue(undefined),
             createRemediationEvent: jest.fn().mockResolvedValue(undefined),
+            listRemediationEvents: jest.fn().mockResolvedValue([]),
+            getThreadWritebackPullRequests: jest
+                .fn()
+                .mockResolvedValue(
+                    new Map([
+                        [WORK_THREAD_UUID, [{ prUrl: PR_URL, createdAt: NOW }]],
+                    ]),
+                ),
+            findReviewRemediationByWorkThread: jest
+                .fn()
+                .mockResolvedValue(null),
             ...aiAgentReviewClassifierModel,
         },
         featureFlagService: {
@@ -209,9 +224,17 @@ const makeService = ({
             findExploresFromCache: jest.fn().mockResolvedValue({}),
             ...projectModel,
         },
-        aiWritebackService: {
-            run: jest.fn().mockResolvedValue({ prUrl: PR_URL }),
-            ...aiWritebackService,
+        aiAgentService: {
+            generateAgentThreadResponse: jest
+                .fn()
+                .mockResolvedValue('Opened a pull request.'),
+            ...aiAgentService,
+        },
+        projectService: {
+            scheduleCompileProject: jest
+                .fn()
+                .mockResolvedValue({ jobUuid: COMPILE_JOB_UUID }),
+            ...projectService,
         },
         projectContextService: {},
         pullRequestsModel: {
@@ -385,6 +408,7 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
                         sourceThreadUuid: 'thread-1',
                         sourceProjectUuid: 'project-1',
                         sourceAgentUuid: 'agent-1',
+                        workThreadUuid: null,
                         pullRequestUuid: null,
                         linkedPrUrl: null,
                         previewProjectUuid: null,
@@ -907,6 +931,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
             events: [],
             liveState: null,
             liveMessage: null,
+            verdictStale: false,
         });
         expect(
             aiAgentReviewClassifierModel.listRemediationEvents,
@@ -966,44 +991,36 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
         ).not.toHaveBeenCalled();
     });
 
-    it('records writeback_completed and pr_opened activity events', async () => {
+    it('runs the build-fix thread and records a pr_opened activity event', async () => {
         const aiAgentReviewClassifierModel = {
             createRemediationEvent: jest.fn().mockResolvedValue(undefined),
         };
-        const aiWritebackService = {
-            run: jest.fn().mockResolvedValue({
-                prUrl: PR_URL,
-                additions: 9,
-                deletions: 1,
-                steps: [
-                    { kind: 'read', label: 'schema.yml' },
-                    { kind: 'edit', label: 'accounts.yml' },
-                ],
-            }),
+        const aiAgentService = {
+            generateAgentThreadResponse: jest
+                .fn()
+                .mockResolvedValue('Opened a pull request.'),
         };
         const service = makeService({
             aiAgentReviewClassifierModel,
-            aiWritebackService,
+            aiAgentService,
         });
 
         await service.runReviewItemWritebackJob(payload);
 
-        expect(
-            aiAgentReviewClassifierModel.createRemediationEvent,
-        ).toHaveBeenCalledWith(
+        // The build-fix thread (not the headless sandbox) opens the PR, pinning
+        // the editDbtProject tool on the opening turn.
+        expect(aiAgentService.generateAgentThreadResponse).toHaveBeenCalledWith(
+            expect.anything(),
             expect.objectContaining({
-                remediationUuid: REMEDIATION_UUID,
-                organizationUuid: ORGANIZATION_UUID,
-                event: {
-                    eventType: 'writeback_completed',
-                    payload: {
-                        files: ['accounts.yml'],
-                        additions: 9,
-                        deletions: 1,
-                    },
-                },
+                threadUuid: WORK_THREAD_UUID,
+                autoApproveSql: true,
+                toolHints: ['editDbtProject'],
+                forceToolHints: true,
+                suppressWritebackPreview: true,
             }),
         );
+        // writeback_completed is emitted by the shared editDbtProject seam, not
+        // the job; the job records pr_opened once it resolves the opened PR.
         expect(
             aiAgentReviewClassifierModel.createRemediationEvent,
         ).toHaveBeenCalledWith(
@@ -1012,6 +1029,58 @@ describe('AiAgentAdminService.runReviewItemWritebackJob', () => {
                     eventType: 'pr_opened',
                     payload: { prUrl: PR_URL, prNumber: 42 },
                 },
+            }),
+        );
+    });
+
+    it('re-verifies a remediation in place on retest', async () => {
+        const schedulerClient = {
+            aiAgentReviewRemediationCompile: jest
+                .fn()
+                .mockResolvedValue({ jobId: 'job-1' }),
+        };
+        const projectService = {
+            scheduleCompileProject: jest
+                .fn()
+                .mockResolvedValue({ jobUuid: COMPILE_JOB_UUID }),
+        };
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest.fn().mockResolvedValue(
+                makeReviewItem({
+                    remediation: makeRemediation({
+                        previewProjectUuid: PREVIEW_PROJECT_UUID,
+                        previewThreadUuid: PREVIEW_THREAD_UUID,
+                    }),
+                }),
+            ),
+            updateReviewRemediationStatus: jest
+                .fn()
+                .mockResolvedValue(undefined),
+        };
+        const service = makeService({
+            schedulerClient,
+            projectService,
+            aiAgentReviewClassifierModel,
+        });
+
+        await service.retestReviewRemediation(makeAdminUser(), 'fingerprint-1');
+
+        // Recompiles the existing preview in place (no new clone) ...
+        expect(projectService.scheduleCompileProject).toHaveBeenCalledWith(
+            expect.anything(),
+            PREVIEW_PROJECT_UUID,
+            expect.anything(),
+            true,
+            true,
+        );
+        // ... then reuses the compile poll to re-run verification.
+        expect(
+            schedulerClient.aiAgentReviewRemediationCompile,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                remediationUuid: REMEDIATION_UUID,
+                previewProjectUuid: PREVIEW_PROJECT_UUID,
+                compileJobUuid: COMPILE_JOB_UUID,
             }),
         );
     });

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -29,6 +29,7 @@ import {
     ParameterError,
     PullRequestProvider,
     PullRequestSource,
+    RequestMethod,
     UpdateAiAgentReviewItemStatus,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackEligibility,
@@ -60,6 +61,7 @@ import { type PullRequestsModel } from '../../models/PullRequestsModel';
 import { type UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
+import { type ProjectService } from '../../services/ProjectService/ProjectService';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
@@ -67,8 +69,8 @@ import {
     buildYmlPathByModel,
     planReviewWriteback,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type AiAgentService } from './AiAgentService/AiAgentService';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
-import { type AiWritebackService } from './AiWritebackService/AiWritebackService';
 import { type WritebackPreviewService } from './AiWritebackService/WritebackPreviewService';
 import { type ProjectContextService } from './ProjectContextService/ProjectContextService';
 
@@ -76,10 +78,11 @@ type AiAgentAdminServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentService: AiAgentService;
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
     projectModel: ProjectModel;
-    aiWritebackService: AiWritebackService;
+    projectService: ProjectService;
     projectContextService: ProjectContextService;
     pullRequestsModel: PullRequestsModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -285,13 +288,15 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
 
+    private readonly aiAgentService: AiAgentService;
+
     private readonly featureFlagService: FeatureFlagService;
 
     private readonly aiOrganizationSettingsService: AiOrganizationSettingsService;
 
     private readonly projectModel: ProjectModel;
 
-    private readonly aiWritebackService: AiWritebackService;
+    private readonly projectService: ProjectService;
 
     private readonly projectContextService: ProjectContextService;
 
@@ -315,11 +320,12 @@ export class AiAgentAdminService extends BaseService {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentService = dependencies.aiAgentService;
         this.featureFlagService = dependencies.featureFlagService;
         this.aiOrganizationSettingsService =
             dependencies.aiOrganizationSettingsService;
         this.projectModel = dependencies.projectModel;
-        this.aiWritebackService = dependencies.aiWritebackService;
+        this.projectService = dependencies.projectService;
         this.projectContextService = dependencies.projectContextService;
         this.pullRequestsModel = dependencies.pullRequestsModel;
         this.githubAppInstallationsModel =
@@ -971,6 +977,19 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
+        // Plan the writeback up front: for semantic_layer we seed a real
+        // Build-fix thread with the writeback prompt so the workspace can show
+        // it the moment Create PR is clicked; project_context stays a
+        // deterministic, threadless writeback.
+        const explores = await this.projectModel.findExploresFromCache(
+            scope.projectUuid,
+            'name',
+        );
+        const plan = planReviewWriteback(
+            reviewItem,
+            buildYmlPathByModel(Object.values(explores)),
+        );
+
         // The model presents a stale remediation as failed, which relaxes the
         // eligibility check above — but the partial unique index still sees
         // the row as active, so it must be persisted as failed (the model
@@ -987,6 +1006,42 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 promptUuid: finding.promptUuid,
             });
+
+        // Create the Build-fix thread before the remediation row so a failed
+        // unique-index insert leaves only a harmless orphan thread, never a
+        // remediation pointing at a thread that doesn't exist. The source
+        // project/agent were validated above (eligibility + scope), so the
+        // auth-bypassing model call is safe.
+        let workThreadUuid: string | null = null;
+        if (plan.strategy === 'prompt') {
+            const created =
+                await this.aiAgentModel.createWebAppThreadWithPrompt({
+                    thread: {
+                        organizationUuid,
+                        projectUuid: scope.projectUuid,
+                        userUuid: user.userUuid,
+                        createdFrom: 'web_app' as const,
+                        agentUuid: scope.agentUuid,
+                    },
+                    prompt: {
+                        createdByUserUuid: user.userUuid,
+                        prompt: plan.promptText,
+                        context: [
+                            {
+                                type: 'thread',
+                                threadUuid: finding.threadUuid,
+                                promptUuid: finding.promptUuid,
+                            },
+                        ],
+                    },
+                });
+            workThreadUuid = created.threadUuid;
+            await this.aiAgentModel.updateThreadTitle({
+                threadUuid: workThreadUuid,
+                title: `Fix review: ${reviewItem.title}`,
+            });
+        }
+
         // The one-active-per-fingerprint index can still reject the insert in
         // a race (concurrent retry, or a worker reviving the row between the
         // read and the stale update) — surface that as a conflict, not a 500.
@@ -1002,6 +1057,7 @@ export class AiAgentAdminService extends BaseService {
                         sourceThreadUuid: finding.threadUuid,
                         sourceProjectUuid: finding.projectUuid,
                         sourceAgentUuid: finding.agentUuid,
+                        workThreadUuid,
                         retryPrompt,
                         createdByUserUuid: user.userUuid,
                     },
@@ -1186,34 +1242,42 @@ export class AiAgentAdminService extends BaseService {
                     prUrl: writeback.prUrl,
                 });
             } else {
-                const result = await this.aiWritebackService.run({
-                    user,
-                    projectUuid,
-                    prompt: plan.promptText,
-                    source: 'admin_review',
-                    onProgress: (message) => {
+                // Run the Build-fix thread: the conversational agent calls
+                // editDbtProject, which opens the PR and links it to this
+                // thread via ai_writeback_thread. The writeback_completed event
+                // is emitted by the shared editDbtProject seam so that
+                // user-driven Continue PR turns record it too.
+                const remediation = remediationUuid
+                    ? await this.aiAgentReviewClassifierModel.getReviewRemediation(
+                          { organizationUuid, remediationUuid },
+                      )
+                    : null;
+                const workThreadUuid = remediation?.workThreadUuid ?? null;
+                if (!workThreadUuid) {
+                    throw new ParameterError(
+                        'Build-fix thread was not created for this remediation',
+                    );
+                }
+                await this.aiAgentService.generateAgentThreadResponse(user, {
+                    agentUuid,
+                    threadUuid: workThreadUuid,
+                    autoApproveSql: true,
+                    // Force the writeback tool on the opening turn so the run
+                    // always opens a PR rather than just discussing the fix.
+                    toolHints: ['editDbtProject'],
+                    forceToolHints: true,
+                    // The review flow owns preview + verification (below), so the
+                    // tool must not also create its own preview project.
+                    suppressWritebackPreview: true,
+                    onStepProgress: (message) => {
                         void setProgress(message);
                     },
                 });
-                prUrl = result.prUrl;
-                if (remediationUuid) {
-                    await this.aiAgentReviewClassifierModel.createRemediationEvent(
-                        {
-                            remediationUuid,
-                            organizationUuid,
-                            event: {
-                                eventType: 'writeback_completed',
-                                payload: {
-                                    files: (result.steps ?? [])
-                                        .filter((step) => step.kind === 'edit')
-                                        .map((step) => step.label),
-                                    additions: result.additions ?? null,
-                                    deletions: result.deletions ?? null,
-                                },
-                            },
-                        },
+                const writebackPrs =
+                    await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                        [workThreadUuid],
                     );
-                }
+                prUrl = writebackPrs.get(workThreadUuid)?.[0]?.prUrl ?? null;
                 pullRequest = prUrl
                     ? await this.pullRequestsModel.findByProjectAndUrl(
                           projectUuid,
@@ -1427,7 +1491,12 @@ export class AiAgentAdminService extends BaseService {
                 fingerprint,
             );
         if (!reviewItem?.remediation) {
-            return { events: [], liveState: null, liveMessage: null };
+            return {
+                events: [],
+                liveState: null,
+                liveMessage: null,
+                verdictStale: false,
+            };
         }
 
         const events =
@@ -1447,7 +1516,97 @@ export class AiAgentAdminService extends BaseService {
                 liveState === 'writeback'
                     ? reviewItem.prWritebackMessage
                     : null,
+            verdictStale: AiAgentAdminService.deriveVerdictStale(events),
         };
+    }
+
+    /**
+     * A verdict is stale when the PR moved on after it was produced: the latest
+     * commit-landing event (pr_opened / pr_updated / writeback_completed)
+     * occurred after the latest verification_completed. No verdict yet → never
+     * stale (the in-flight states cover that).
+     */
+    private static deriveVerdictStale(
+        events: AiAgentReviewRemediationEvent[],
+    ): boolean {
+        const latestOccurredAt = (
+            eventTypes: AiAgentReviewRemediationEventType[],
+        ): number => {
+            const times = events
+                .filter((event) => eventTypes.includes(event.eventType))
+                .map((event) => new Date(event.occurredAt).getTime());
+            return times.length > 0 ? Math.max(...times) : -Infinity;
+        };
+        const latestVerification = latestOccurredAt(['verification_completed']);
+        if (latestVerification === -Infinity) {
+            return false;
+        }
+        const latestCommit = latestOccurredAt([
+            'pr_opened',
+            'pr_updated',
+            'writeback_completed',
+        ]);
+        return latestCommit > latestVerification;
+    }
+
+    /**
+     * Re-verify a remediation after the PR changed (a Continue PR commit). The
+     * preview project tracks the PR head branch, so a fresh compile picks up the
+     * new commits in place — no new clone. Resets the remediation to pr_open so
+     * the existing compile poll runs, which on completion seeds a fresh Test-fix
+     * thread and re-runs verification (clearing the stale verdict).
+     */
+    async retestReviewRemediation(
+        user: SessionUser,
+        fingerprint: string,
+    ): Promise<AiAgentReviewItemActivity> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        const remediation = reviewItem?.remediation ?? null;
+        if (!remediation) {
+            throw new NotFoundError('No remediation to retest');
+        }
+        if (!remediation.previewProjectUuid) {
+            throw new ParameterError(
+                'This remediation has no preview to retest',
+            );
+        }
+
+        await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus({
+            remediationUuid: remediation.uuid,
+            organizationUuid,
+            status: 'pr_open',
+        });
+
+        const { jobUuid } = await this.projectService.scheduleCompileProject(
+            user,
+            remediation.previewProjectUuid,
+            RequestMethod.BACKEND,
+            true,
+            true,
+        );
+
+        await this.schedulerClient.aiAgentReviewRemediationCompile({
+            organizationUuid,
+            projectUuid: remediation.sourceProjectUuid,
+            userUuid: user.userUuid,
+            fingerprint,
+            remediationUuid: remediation.uuid,
+            previewProjectUuid: remediation.previewProjectUuid,
+            compileJobUuid: jobUuid,
+            startedAt: Date.now(),
+        });
+
+        return this.getReviewItemActivity(user, fingerprint);
     }
 
     private static deriveRemediationLiveState(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -381,7 +381,9 @@ type AiAgentServiceDependencies = {
     pullRequestsModel: Pick<PullRequestsModel, 'findByAiThreadUuid' | 'find'>;
     aiAgentReviewClassifierModel: Pick<
         AiAgentReviewClassifierModel,
-        'findReviewRemediationByPreviewThread'
+        | 'findReviewRemediationByPreviewThread'
+        | 'findReviewRemediationByWorkThread'
+        | 'createRemediationEvent'
     >;
     prometheusMetrics?: PrometheusMetrics;
 };
@@ -634,7 +636,9 @@ export class AiAgentService extends BaseService {
 
     private readonly aiAgentReviewClassifierModel: Pick<
         AiAgentReviewClassifierModel,
-        'findReviewRemediationByPreviewThread'
+        | 'findReviewRemediationByPreviewThread'
+        | 'findReviewRemediationByWorkThread'
+        | 'createRemediationEvent'
     >;
 
     private readonly aiAgentMcpRuntimeClient: AiAgentMcpRuntimeClient;
@@ -3983,12 +3987,14 @@ export class AiAgentService extends BaseService {
             agentUuid,
             threadUuid,
             enableSqlMode,
+            autoApproveSql,
             toolHints,
             runtimeOptions,
         }: {
             agentUuid: string;
             threadUuid: string;
             enableSqlMode: boolean;
+            autoApproveSql?: boolean;
             toolHints: string[];
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
         },
@@ -4040,6 +4046,7 @@ export class AiAgentService extends BaseService {
                     stream: true,
                     canManageAgent,
                     enableSqlMode,
+                    autoApproveSql,
                     toolHints,
                     runtimeOptions,
                 },
@@ -4266,10 +4273,23 @@ export class AiAgentService extends BaseService {
             agentUuid,
             threadUuid,
             autoApproveSql = false,
+            toolHints,
+            forceToolHints,
+            onStepProgress,
+            suppressWritebackPreview,
         }: {
             agentUuid: string;
             threadUuid: string;
             autoApproveSql?: boolean;
+            toolHints?: string[];
+            forceToolHints?: boolean;
+            onStepProgress?: (
+                progress: string,
+                toolName?: string,
+                progressId?: string,
+                progressStatus?: 'in_progress' | 'complete' | 'error',
+            ) => void;
+            suppressWritebackPreview?: boolean;
         },
     ): Promise<string> {
         try {
@@ -4307,6 +4327,10 @@ export class AiAgentService extends BaseService {
                     // Non-stream callers (eval, etc.) preserve flag-only gating.
                     enableSqlMode: true,
                     autoApproveSql,
+                    toolHints,
+                    forceToolHints,
+                    onSlackStepProgress: onStepProgress,
+                    suppressWritebackPreview,
                 },
             );
             return response;
@@ -5781,6 +5805,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 progressStatus?: 'in_progress' | 'complete' | 'error',
             ) => void;
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
+            suppressWritebackPreview?: boolean;
         },
     ) {
         const { projectUuid, organizationUuid } = prompt;
@@ -6021,6 +6046,31 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         onProgress: writebackProgressCallback,
                     }),
             );
+
+            // Build-fix seam: if this thread is a review remediation's work
+            // thread, every commit it lands (the initial run and each Continue
+            // PR turn) must be reflected on the remediation so the Test-fix
+            // verdict is marked stale (verdict staleness is derived from event
+            // ordering). null for ordinary writeback threads — a no-op.
+            const reviewRemediation = organizationUuid
+                ? await this.aiAgentReviewClassifierModel.findReviewRemediationByWorkThread(
+                      {
+                          organizationUuid,
+                          workThreadUuid: prompt.threadUuid,
+                      },
+                  )
+                : null;
+            if (reviewRemediation && result.prUrl) {
+                await this.aiAgentReviewClassifierModel.createRemediationEvent({
+                    remediationUuid: reviewRemediation.uuid,
+                    organizationUuid: reviewRemediation.organizationUuid,
+                    event: {
+                        eventType: 'pr_updated',
+                        payload: { prUrl: result.prUrl },
+                    },
+                });
+            }
+
             // On a successful PR open/update, add a green-tick reaction to the
             // user's original Slack mention so they see the outcome at a
             // glance without scrolling through the agent's reply. Best-effort
@@ -6080,7 +6130,11 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // CI-posted URL. Returns null for unsupported projects (e.g.
             // CLI-deployed) or on any failure — those surface no preview.
             let previewUrl: string | null = null;
-            if (result.prUrl) {
+            if (
+                result.prUrl &&
+                !options?.suppressWritebackPreview &&
+                !reviewRemediation
+            ) {
                 const preview =
                     await this.writebackPreviewService.createPreviewForPullRequest(
                         {
@@ -6423,6 +6477,13 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             canManageAgent: boolean;
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
+            // Set by the review Build-fix flow, which owns preview compilation
+            // and verification itself — the editDbtProject tool must not also
+            // spin up its own preview project.
+            suppressWritebackPreview?: boolean;
+            // Forces the first tool hint on the opening step instead of merely
+            // suggesting it (review Build-fix guarantees editDbtProject runs).
+            forceToolHints?: boolean;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -6460,6 +6521,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             canManageAgent: boolean;
             enableSqlMode?: boolean;
             autoApproveSql?: boolean;
+            suppressWritebackPreview?: boolean;
+            forceToolHints?: boolean;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -6556,6 +6619,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                           })
                     : undefined),
             runtimeOptions: options.runtimeOptions,
+            suppressWritebackPreview: options.suppressWritebackPreview,
         });
 
         const enableSqlMode = options.enableSqlMode ?? false;
@@ -6851,6 +6915,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             siteUrl: this.lightdashConfig.siteUrl,
             canManageAgent: options.canManageAgent,
             toolHints: options.toolHints ?? [],
+            forceToolHints: options.forceToolHints ?? false,
         };
 
         const mcpToolSetup: AgentMcpToolSetup =

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -139,6 +139,22 @@ export const defaultAgentOptions = {
     maxRetries: 6, // Increased for Bedrock rate limits
 };
 
+/**
+ * When forceToolHints is set, force the first hinted tool on the opening step
+ * (toolChoice) and release to auto afterwards. Used by the review Build-fix run
+ * to guarantee the agent opens a PR via editDbtProject rather than just
+ * discussing the fix. No-op if the forced tool isn't in the registered set.
+ */
+const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
+    if (!args.forceToolHints) return undefined;
+    const forcedTool = args.toolHints[0];
+    if (!forcedTool || !(forcedTool in tools)) return undefined;
+    return ({ stepNumber }: { stepNumber: number }) =>
+        stepNumber === 0
+            ? { toolChoice: { type: 'tool' as const, toolName: forcedTool } }
+            : {};
+};
+
 const getAgentTools = (
     args: AiAgentArgs,
     dependencies: AiAgentDependencies,
@@ -560,9 +576,11 @@ export const generateAgentResponse = async ({
             'Generate Agent Response',
             `Calling generateText with model: ${modelName}`,
         );
+        const forcedFirstStep = buildForcedFirstStep(args, tools);
         const result = await generateText({
             ...defaultAgentOptions,
             ...args.callOptions,
+            ...(forcedFirstStep ? { prepareStep: forcedFirstStep } : {}),
             providerOptions: args.providerOptions,
             model: args.model,
             tools,
@@ -790,9 +808,11 @@ export const streamAgentResponse = async ({
             'Stream Agent Response',
             `Calling streamText with model: ${modelName}`,
         );
+        const forcedFirstStep = buildForcedFirstStep(args, tools);
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
+            ...(forcedFirstStep ? { prepareStep: forcedFirstStep } : {}),
             providerOptions: args.providerOptions,
             model: args.model,
             tools,

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -97,6 +97,7 @@ const buildSemanticLayerWritebackPrompt = (
 
     const sections = [
         'You are improving the dbt/Lightdash semantic layer YAML to fix a recurring issue surfaced by AI agent review. Make the smallest change that resolves it.',
+        'The original conversation where the agent gave a wrong or insufficient answer is attached to this thread as pinned context. Read it first to understand exactly what was missing, then open a pull request that closes that gap.',
         `Issue: ${item.title}`,
         item.description ? item.description : null,
         recommendation

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -125,6 +125,12 @@ export type AiAgentArgs = AnyAiModel & {
     siteUrl: string;
     canManageAgent: boolean;
     toolHints: string[];
+    /**
+     * When true, the first tool hint is *forced* on the opening step
+     * (toolChoice), not just suggested — used by the review Build-fix run to
+     * guarantee the agent opens a PR via editDbtProject.
+     */
+    forceToolHints?: boolean;
 };
 
 export type PerformanceMetrics = {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13147,11 +13147,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14499,11 +14499,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14564,11 +14564,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14764,11 +14764,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14783,11 +14783,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14802,11 +14802,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15486,6 +15486,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 toolHints: { dataType: 'array', array: { dataType: 'string' } },
+                autoApproveSql: { dataType: 'boolean' },
                 enableSqlMode: { dataType: 'boolean' },
             },
             validators: {},
@@ -21172,6 +21173,14 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                workThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 sourceAgentUuid: { dataType: 'string', required: true },
                 sourceProjectUuid: { dataType: 'string', required: true },
                 sourceThreadUuid: { dataType: 'string', required: true },
@@ -21788,6 +21797,30 @@ const models: TsoaRoute.Models = {
                         payload: {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                prUrl: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['pr_updated'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
                                 previewProjectUuid: {
                                     dataType: 'string',
                                     required: true,
@@ -21944,6 +21977,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                verdictStale: { dataType: 'boolean', required: true },
                 liveMessage: {
                     dataType: 'union',
                     subSchemas: [
@@ -29783,7 +29817,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29793,7 +29827,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29803,7 +29837,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -29816,7 +29850,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30471,7 +30505,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30481,7 +30515,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30491,7 +30525,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30504,7 +30538,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -53880,6 +53914,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'createReviewItemWriteback',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_retestReviewRemediation: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/retest',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.retestReviewRemediation,
+        ),
+
+        async function AiAgentAdminController_retestReviewRemediation(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_retestReviewRemediation,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'retestReviewRemediation',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14730,6 +14730,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -15353,8 +15366,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16079,6 +16092,10 @@
                         },
                         "type": "array",
                         "description": "Tool names hinted by the user when they composed the message (via\nsuggestion chips that carry a tool id). agentV2 appends a soft hint\nto the user message before sending it to the LLM. Transient — never\npersisted."
+                    },
+                    "autoApproveSql": {
+                        "type": "boolean",
+                        "description": "Skips the SQL human-approval gate for this stream. Used by the review\nremediation workspace so Continue PR turns run frictionlessly. Defaults\nto false — normal chat still asks the user to approve SQL."
                     },
                     "enableSqlMode": {
                         "type": "boolean",
@@ -21549,6 +21566,10 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "workThreadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "sourceAgentUuid": {
                         "type": "string"
                     },
@@ -21588,6 +21609,7 @@
                     "previewProjectUuid",
                     "linkedPrUrl",
                     "pullRequestUuid",
+                    "workThreadUuid",
                     "sourceAgentUuid",
                     "sourceProjectUuid",
                     "sourceThreadUuid",
@@ -22198,6 +22220,27 @@
                         "properties": {
                             "payload": {
                                 "properties": {
+                                    "prUrl": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["prUrl"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["pr_updated"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
                                     "previewProjectUuid": {
                                         "type": "string"
                                     }
@@ -22350,6 +22393,10 @@
             },
             "AiAgentReviewItemActivity": {
                 "properties": {
+                    "verdictStale": {
+                        "type": "boolean",
+                        "description": "True when the PR changed after the latest verdict — derived from event\nordering (latest pr_opened/pr_updated/writeback_completed occurred after\nthe latest verification_completed). Drives the \"Retest\" prompt."
+                    },
                     "liveMessage": {
                         "type": "string",
                         "nullable": true,
@@ -22370,7 +22417,12 @@
                         "type": "array"
                     }
                 },
-                "required": ["liveMessage", "liveState", "events"],
+                "required": [
+                    "verdictStale",
+                    "liveMessage",
+                    "liveState",
+                    "events"
+                ],
                 "type": "object"
             },
             "ApiSuccess_AiAgentReviewItemActivity_": {
@@ -30515,22 +30567,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31090,22 +31142,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -40196,7 +40248,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3198.0",
+        "version": "0.3200.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -47345,6 +47397,46 @@
                 },
                 "description": "Open a writeback pull request for a review item (semantic-layer or\nproject-context root cause)",
                 "summary": "Create AI agent review item writeback PR",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/retest": {
+            "post": {
+                "operationId": "retestAiAgentReviewRemediation",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Re-verify a remediation after its PR changed: recompiles the existing\npreview and re-runs the Test-fix verification thread.",
+                "summary": "Retest an AI agent review remediation",
                 "security": [],
                 "parameters": [
                     {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -370,6 +370,7 @@ export type AiAgentReviewRemediation = {
     sourceThreadUuid: string;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
+    workThreadUuid: string | null;
     pullRequestUuid: string | null;
     linkedPrUrl: string | null;
     previewProjectUuid: string | null;
@@ -714,6 +715,10 @@ export type AiAgentReviewRemediationEventDetail =
           eventType: 'pr_opened';
           payload: { prUrl: string; prNumber: number | null };
       }
+    | {
+          eventType: 'pr_updated';
+          payload: { prUrl: string | null };
+      }
     | { eventType: 'preview_compiled'; payload: { previewProjectUuid: string } }
     | {
           eventType: 'verification_completed';
@@ -748,6 +753,12 @@ export type AiAgentReviewItemActivity = {
     liveState: AiAgentReviewRemediationLiveState | null;
     /** Streaming progress text for the live row (writeback step messages). */
     liveMessage: string | null;
+    /**
+     * True when the PR changed after the latest verdict — derived from event
+     * ordering (latest pr_opened/pr_updated/writeback_completed occurred after
+     * the latest verification_completed). Drives the "Retest" prompt.
+     */
+    verdictStale: boolean;
 };
 
 export type ApiAiAgentReviewItemActivityResponse =

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -510,6 +510,12 @@ export type ApiAiAgentThreadStreamRequest = {
      */
     enableSqlMode?: boolean;
     /**
+     * Skips the SQL human-approval gate for this stream. Used by the review
+     * remediation workspace so Continue PR turns run frictionlessly. Defaults
+     * to false — normal chat still asks the user to approve SQL.
+     */
+    autoApproveSql?: boolean;
+    /**
      * Tool names hinted by the user when they composed the message (via
      * suggestion chips that carry a tool id). agentV2 appends a soft hint
      * to the user message before sending it to the LLM. Transient — never


### PR DESCRIPTION
Part of a 3-PR stack for the AI-review **remediation workspace** (paired Build → Test flow):

1. **this PR** — backend + types
2. #24500 — paired workspace UI
3. #24501 — board/drawer entry points

### What this PR does

Semantic-layer review remediation now opens its PR through a **real conversational agent thread** (the *Build-fix thread*) instead of the headless sandbox:

- `createReviewItemWriteback` seeds a `web_app` thread in the source project, pinned with the original failing conversation as context, and stores it on the remediation via a new nullable `work_thread_uuid` column.
- `runReviewItemWritebackJob` runs that thread via `generateAgentThreadResponse` with `editDbtProject` **force-pinned on the opening turn** (`prepareStep` toolChoice) and SQL **auto-approved**, then resolves the opened PR from `ai_writeback_thread` and continues the existing preview → compile → verification flow. It no longer creates a second preview (the tool's own preview is suppressed in this context).
- A shared `editDbtProject` **seam** emits a `pr_updated` event whenever a commit lands in a remediation's work thread (so user-driven Continue PR turns are reflected too).
- **Verdict staleness** is derived from event ordering — latest commit event newer than the latest `verification_completed` — with no PR head SHA stored (see ADR-0002).
- New **Retest** endpoint recompiles the existing preview in place and re-runs verification.
- `autoApproveSql` added to the web-app stream so workspace Continue-PR turns are frictionless.

Design decisions recorded in `docs/adr/0001` (conversational build thread) and `docs/adr/0002` (event-ordering staleness); domain glossary in `CONTEXT.md`.

### Regression analysis

- **semantic_layer remediation** now depends on the `AiWriteback` feature flag (the `editDbtProject` tool is gated on it) and a GitHub/GitLab-connected project. This is acceptable: the flag already gates all agent writeback, and `aiWritebackService.run()` itself already threw `ForbiddenError` without it — so no previously-working path regresses.
- **project_context remediation** is unchanged (still the deterministic writeback).
- **Normal agent chat is unaffected**: force-calling `editDbtProject` is gated behind a new `forceToolHints` flag set only by the review job, and `autoApproveSql` defaults to `false` everywhere else.
- Additive only: one nullable column + one new event-union member (`pr_updated`). No data migration; the activity-timeline switch has a `default` case so no exhaustiveness break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
