### PR TITLE
feat(reviews): paired remediation workspace UI

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
@@ -1,0 +1,38 @@
+.panes {
+    align-items: stretch;
+    min-height: 0;
+}
+
+.pane {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.paneBody {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+/* Build is the primary pane (you act here); Test is the narrower verification rail. */
+.paneBuild {
+    flex: 1.4 1 0;
+}
+
+.paneTest {
+    flex: 1 1 0;
+}
+
+/* Tie the Test pane to the preview environment with the preview-banner blue. */
+.panePreview {
+    border-top: 2px solid var(--mantine-color-blue-6);
+}
+
+.connector {
+    flex: 0 0 auto;
+    align-self: center;
+    color: var(--mantine-color-dimmed);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -1,0 +1,415 @@
+import {
+    Badge,
+    Button,
+    Divider,
+    Flex,
+    Group,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    ThemeIcon,
+} from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
+import {
+    IconArrowRight,
+    IconExternalLink,
+    IconFileDiff,
+    IconGitPullRequest,
+    IconRefresh,
+} from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { useParams } from 'react-router';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import PageBreadcrumbs from '../../../../../components/common/PageBreadcrumbs';
+import { useProjects } from '../../../../../hooks/useProjects';
+import {
+    useAiAgentAdminAgents,
+    useAiAgentAdminReviewItem,
+    useAiAgentReviewItemActivity,
+    useAiAgentReviewItemPrDiff,
+    useRetestAiAgentReviewRemediation,
+} from '../../hooks/useAiAgentAdmin';
+import { AgentNamePill } from '../AgentNamePill';
+import {
+    reviewRootCauseColors,
+    reviewRootCauseLabels,
+} from './reviewItemDetails';
+import { ReviewPrDiffModal } from './ReviewPrDiffModal';
+import classes from './ReviewRemediationWorkspace.module.css';
+import { WorkspaceThreadPane } from './WorkspaceThreadPane';
+
+type PaneBadge = { label: string; color: string; loading: boolean };
+
+const WORKSPACE_HEIGHT = 'calc(100vh - 170px)';
+
+export const ReviewRemediationWorkspace = () => {
+    const { fingerprint } = useParams<{ fingerprint: string }>();
+
+    const { data: reviewItem, isLoading: isItemLoading } =
+        useAiAgentAdminReviewItem(fingerprint ?? '', {
+            enabled: !!fingerprint,
+        });
+    const { data: projects = [] } = useProjects();
+    const { data: agents = [] } = useAiAgentAdminAgents();
+
+    const remediation = reviewItem?.remediation ?? null;
+
+    const isLive =
+        remediation?.status === 'queued' ||
+        remediation?.status === 'running' ||
+        remediation?.status === 'pr_open' ||
+        remediation?.status === 'preview_ready';
+
+    const { data: activity } = useAiAgentReviewItemActivity(fingerprint ?? '', {
+        enabled: !!fingerprint,
+        refetchInterval: isLive ? 2500 : false,
+    });
+
+    const prDiff = useAiAgentReviewItemPrDiff(fingerprint ?? '', {
+        enabled: !!reviewItem?.linkedPrUrl,
+    });
+    const [diffOpen, diffHandlers] = useDisclosure(false);
+
+    const retest = useRetestAiAgentReviewRemediation();
+
+    const projectName = (uuid: string | null | undefined) =>
+        projects.find((p) => p.projectUuid === uuid)?.name ?? null;
+    const agentFor = (uuid: string | null | undefined) =>
+        agents.find((a) => a.uuid === uuid) ?? null;
+
+    const hasVerification =
+        activity?.events.some(
+            (event) => event.eventType === 'verification_completed',
+        ) ?? false;
+
+    const testBadge = useMemo<PaneBadge | null>(() => {
+        if (!activity) return null;
+        if (activity.liveState === 'writeback')
+            return {
+                label: 'Waiting for build',
+                color: 'gray',
+                loading: false,
+            };
+        if (activity.liveState === 'compiling')
+            return { label: 'Building preview', color: 'blue', loading: true };
+        if (activity.liveState === 'verifying')
+            return { label: 'Testing', color: 'blue', loading: true };
+        if (activity.verdictStale)
+            return { label: 'Stale — retest', color: 'yellow', loading: false };
+        if (hasVerification)
+            return { label: 'Verdict ready', color: 'green', loading: false };
+        if (remediation?.status === 'failed')
+            return { label: 'Failed', color: 'red', loading: false };
+        return null;
+    }, [activity, hasVerification, remediation?.status]);
+
+    const buildBadge: PaneBadge | null =
+        activity?.liveState === 'writeback'
+            ? { label: 'Opening PR', color: 'blue', loading: true }
+            : null;
+
+    if (isItemLoading) {
+        return (
+            <Group justify="center" mt="xl">
+                <Loader />
+            </Group>
+        );
+    }
+
+    if (!reviewItem || !remediation) {
+        return (
+            <Stack gap="md">
+                <PageBreadcrumbs
+                    items={[
+                        { title: 'Ask AI', to: '/generalSettings/ai/general' },
+                        { title: 'Reviews', to: '/generalSettings/ai/reviews' },
+                        { title: 'Workspace', active: true },
+                    ]}
+                />
+                <Text c="dimmed">
+                    No remediation workspace for this finding yet. Open a pull
+                    request from the reviews board first.
+                </Text>
+            </Stack>
+        );
+    }
+
+    const hasBuildThread = !!remediation.workThreadUuid;
+    const canRetest =
+        !!remediation.previewProjectUuid && !!remediation.previewThreadUuid;
+    const hasTestThread =
+        !!remediation.previewProjectUuid &&
+        !!remediation.previewAgentUuid &&
+        !!remediation.previewThreadUuid;
+
+    const buildAgent = agentFor(remediation.sourceAgentUuid);
+    const testAgent = agentFor(remediation.previewAgentUuid);
+    const buildProjectName = projectName(remediation.sourceProjectUuid);
+    const previewProjectName =
+        projectName(remediation.previewProjectUuid) ?? 'Preview environment';
+
+    const renderBadge = (badge: PaneBadge) => (
+        <Badge
+            size="sm"
+            variant="light"
+            color={badge.color}
+            leftSection={
+                badge.loading ? (
+                    <Loader size={9} color={badge.color} />
+                ) : undefined
+            }
+        >
+            {badge.label}
+        </Badge>
+    );
+
+    const stepIcon = (n: number, color: string) => (
+        <ThemeIcon size="sm" radius="xl" variant="filled" color={color}>
+            <Text fz="xs" fw={700}>
+                {n}
+            </Text>
+        </ThemeIcon>
+    );
+
+    const testPane = (className: string) => (
+        <Paper withBorder className={className}>
+            <Group justify="space-between" p="sm" wrap="nowrap">
+                <Group gap="xs" wrap="nowrap" miw={0}>
+                    {stepIcon(2, 'blue')}
+                    <Text fw={600} fz="sm">
+                        Test the fix
+                    </Text>
+                    <Text fz="xs" c="dimmed" truncate maw={150}>
+                        · {previewProjectName}
+                    </Text>
+                    {testBadge && renderBadge(testBadge)}
+                </Group>
+                <Group gap="xs" wrap="nowrap">
+                    {hasTestThread && testAgent && (
+                        <AgentNamePill
+                            name={testAgent.name}
+                            imageUrl={testAgent.imageUrl ?? null}
+                            variant="inline"
+                        />
+                    )}
+                    <Button
+                        size="compact-xs"
+                        variant={activity?.verdictStale ? 'filled' : 'light'}
+                        color="yellow"
+                        disabled={!canRetest}
+                        loading={retest.isLoading}
+                        leftSection={
+                            <MantineIcon icon={IconRefresh} size={16} />
+                        }
+                        onClick={() =>
+                            fingerprint && retest.mutate({ fingerprint })
+                        }
+                    >
+                        Retest
+                    </Button>
+                </Group>
+            </Group>
+            <Divider />
+            <div className={classes.paneBody}>
+                {hasTestThread &&
+                remediation.previewProjectUuid &&
+                remediation.previewAgentUuid &&
+                remediation.previewThreadUuid ? (
+                    <WorkspaceThreadPane
+                        projectUuid={remediation.previewProjectUuid}
+                        agentUuid={remediation.previewAgentUuid}
+                        agentName={testAgent?.name ?? 'Verification'}
+                        threadUuid={remediation.previewThreadUuid}
+                        interactive={false}
+                    />
+                ) : (
+                    <Stack align="center" mt="xl" gap="xs">
+                        {isLive && <Loader size="sm" />}
+                        <Text c="dimmed" fz="sm" ta="center" maw={320}>
+                            {activity?.liveState === 'writeback'
+                                ? 'Waiting for the pull request to open…'
+                                : activity?.liveState === 'compiling'
+                                  ? 'Building the preview environment…'
+                                  : activity?.liveState === 'verifying'
+                                    ? 'Running verification in the preview…'
+                                    : 'The verdict appears here once the preview is ready.'}
+                        </Text>
+                    </Stack>
+                )}
+            </div>
+        </Paper>
+    );
+
+    return (
+        <Stack gap="sm" h="100%">
+            <Group justify="space-between" align="center" wrap="nowrap">
+                <Group gap="sm" wrap="nowrap" miw={0}>
+                    <PageBreadcrumbs
+                        items={[
+                            {
+                                title: 'Ask AI',
+                                to: '/generalSettings/ai/general',
+                            },
+                            {
+                                title: 'Reviews',
+                                to: '/generalSettings/ai/reviews',
+                            },
+                            { title: reviewItem.title, active: true },
+                        ]}
+                    />
+                    <CategoryBadge
+                        color={
+                            reviewRootCauseColors[reviewItem.primaryRootCause]
+                        }
+                        label={
+                            reviewRootCauseLabels[reviewItem.primaryRootCause]
+                        }
+                    />
+                </Group>
+                <Group gap="xs" wrap="nowrap">
+                    {reviewItem.linkedPrUrl && (
+                        <Button
+                            variant="default"
+                            size="xs"
+                            leftSection={
+                                <MantineIcon icon={IconFileDiff} size={18} />
+                            }
+                            onClick={diffHandlers.open}
+                        >
+                            View changes
+                            {prDiff.data
+                                ? ` (${prDiff.data.files.length})`
+                                : ''}
+                        </Button>
+                    )}
+                    {reviewItem.linkedPrUrl && (
+                        <Button
+                            component="a"
+                            href={reviewItem.linkedPrUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            variant="default"
+                            size="xs"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconGitPullRequest}
+                                    size={18}
+                                />
+                            }
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconExternalLink}
+                                    size={16}
+                                />
+                            }
+                        >
+                            View PR
+                        </Button>
+                    )}
+                </Group>
+            </Group>
+
+            {hasBuildThread ? (
+                <Flex gap="sm" className={classes.panes} h={WORKSPACE_HEIGHT}>
+                    <Paper
+                        withBorder
+                        className={`${classes.pane} ${classes.paneBuild}`}
+                    >
+                        <Group justify="space-between" p="sm" wrap="nowrap">
+                            <Group gap="xs" wrap="nowrap" miw={0}>
+                                {stepIcon(1, 'indigo')}
+                                <Text fw={600} fz="sm">
+                                    Build the fix
+                                </Text>
+                                {buildProjectName && (
+                                    <Text fz="xs" c="dimmed" truncate maw={150}>
+                                        · {buildProjectName}
+                                    </Text>
+                                )}
+                                {buildBadge && renderBadge(buildBadge)}
+                            </Group>
+                            {buildAgent && (
+                                <AgentNamePill
+                                    name={buildAgent.name}
+                                    imageUrl={buildAgent.imageUrl ?? null}
+                                    variant="inline"
+                                />
+                            )}
+                        </Group>
+                        <Divider />
+                        {buildBadge && activity?.liveMessage && (
+                            <Text fz="xs" c="dimmed" px="sm" py={4} truncate>
+                                {activity.liveMessage}
+                            </Text>
+                        )}
+                        <div className={classes.paneBody}>
+                            <WorkspaceThreadPane
+                                projectUuid={remediation.sourceProjectUuid}
+                                agentUuid={remediation.sourceAgentUuid}
+                                agentName={buildAgent?.name ?? 'Build fix'}
+                                threadUuid={remediation.workThreadUuid!}
+                                interactive
+                            />
+                        </div>
+                    </Paper>
+
+                    <Flex className={classes.connector}>
+                        <MantineIcon icon={IconArrowRight} size={24} />
+                    </Flex>
+
+                    {testPane(
+                        `${classes.pane} ${classes.paneTest} ${classes.panePreview}`,
+                    )}
+                </Flex>
+            ) : (
+                <Flex
+                    direction="column"
+                    gap="sm"
+                    className={classes.panes}
+                    h={WORKSPACE_HEIGHT}
+                >
+                    <Paper withBorder p="sm">
+                        <Group justify="space-between" wrap="nowrap">
+                            <Group gap="xs" wrap="nowrap" miw={0}>
+                                {stepIcon(1, 'indigo')}
+                                <Text fw={600} fz="sm">
+                                    Deterministic fix
+                                </Text>
+                                <Text fz="xs" c="dimmed" truncate>
+                                    · Project context — written without a build
+                                    conversation
+                                </Text>
+                            </Group>
+                            {reviewItem.linkedPrUrl && (
+                                <Button
+                                    variant="subtle"
+                                    color="gray"
+                                    size="compact-xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconFileDiff}
+                                            size={16}
+                                        />
+                                    }
+                                    onClick={diffHandlers.open}
+                                >
+                                    View the change
+                                </Button>
+                            )}
+                        </Group>
+                    </Paper>
+                    {testPane(`${classes.pane} ${classes.panePreview}`)}
+                </Flex>
+            )}
+
+            <ReviewPrDiffModal
+                opened={diffOpen}
+                onClose={diffHandlers.close}
+                diff={prDiff.data}
+                isLoading={prDiff.isLoading}
+            />
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
@@ -1,0 +1,134 @@
+import {
+    type AiPromptContextInput,
+    type AiPromptContextItem,
+} from '@lightdash/common';
+import { Center, Loader } from '@mantine-8/core';
+import { useCallback, useMemo, type FC } from 'react';
+import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
+import {
+    useAiAgentThread,
+    useCreateAgentThreadMessageMutation,
+} from '../../hooks/useProjectAiAgents';
+import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
+import { AgentChatInput } from '../ChatElements/AgentChatInput';
+import { contextItemsToContentMentionSuggestions } from '../ChatElements/contentMentions';
+
+type SubmitArgs = {
+    message: string;
+    toolHints: string[];
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContextItem[];
+};
+
+type Props = {
+    projectUuid: string;
+    agentUuid: string;
+    agentName: string;
+    threadUuid: string;
+    /** Build-fix pane gets a live input; the Test-fix verdict pane is read-only. */
+    interactive: boolean;
+    placeholder?: string;
+};
+
+export const WorkspaceThreadPane: FC<Props> = ({
+    projectUuid,
+    agentUuid,
+    agentName,
+    threadUuid,
+    interactive,
+    placeholder,
+}) => {
+    const {
+        data: thread,
+        isLoading,
+        refetch,
+    } = useAiAgentThread(projectUuid, agentUuid, threadUuid);
+
+    const { isStreaming, isPending } = usePendingThreadRefetch(
+        thread,
+        threadUuid,
+        refetch,
+    );
+
+    const { mutateAsync: createMessage, isLoading: isCreating } =
+        useCreateAgentThreadMessageMutation(
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            {},
+        );
+
+    const contentMentionItems = useMemo(
+        () =>
+            contextItemsToContentMentionSuggestions(
+                thread?.messages.flatMap((message) =>
+                    message.role === 'user' ? message.context : [],
+                ) ?? [],
+                'thread',
+            ),
+        [thread?.messages],
+    );
+
+    const handleSubmit = useCallback(
+        ({ message, toolHints, context, optimisticContext }: SubmitArgs) => {
+            const firstAssistant = thread?.messages?.find(
+                (m) => m.role === 'assistant',
+            );
+            // Continue PR turns are frictionless: SQL runs auto-approved and the
+            // writeback tool is pinned so a follow-up reliably updates the PR.
+            void createMessage({
+                prompt: message,
+                modelConfig: firstAssistant?.modelConfig ?? undefined,
+                context,
+                optimisticContext,
+                enableSqlMode: true,
+                autoApproveSql: true,
+                toolHints: toolHints.includes('editDbtProject')
+                    ? toolHints
+                    : ['editDbtProject', ...toolHints],
+            });
+        },
+        [createMessage, thread?.messages],
+    );
+
+    if (isLoading || !thread) {
+        return (
+            <Center mt="xl">
+                <Loader size="sm" color="gray" />
+            </Center>
+        );
+    }
+
+    return (
+        <AgentChatDisplay
+            thread={thread}
+            agentName={agentName}
+            enableAutoScroll
+            projectUuid={projectUuid}
+            agentUuid={agentUuid}
+            renderArtifactsInline
+        >
+            {interactive ? (
+                <AgentChatInput
+                    loading={isCreating || isStreaming || isPending}
+                    onSubmit={handleSubmit}
+                    placeholder={
+                        placeholder ?? `Ask ${agentName} to refine the PR…`
+                    }
+                    messageCount={thread.messages?.length || 0}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    fullWidth
+                    showSuggestions={false}
+                    threadUuid={threadUuid}
+                    contentMentionPriorityItems={contentMentionItems}
+                    latestAssistantMessageUuid={
+                        [...(thread.messages ?? [])]
+                            .reverse()
+                            .find((m) => m.role === 'assistant')?.uuid
+                    }
+                />
+            ) : undefined}
+        </AgentChatDisplay>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -251,6 +251,43 @@ export const useAiAgentReviewItemActivity = (
     });
 };
 
+const retestAiAgentReviewRemediation = async (fingerprint: string) => {
+    return lightdashApi<ApiAiAgentReviewItemActivityResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(
+            fingerprint,
+        )}/retest`,
+        method: 'POST',
+        body: undefined,
+    });
+};
+
+export const useRetestAiAgentReviewRemediation = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemActivityResponse['results'],
+        ApiError,
+        { fingerprint: string }
+    >({
+        mutationFn: ({ fingerprint }) =>
+            retestAiAgentReviewRemediation(fingerprint),
+        onSuccess: (_data, { fingerprint }) => {
+            showToastSuccess({ title: 'Re-testing the fix…' });
+            void queryClient.invalidateQueries({
+                queryKey: ['ai-agent-admin-review-item-activity', fingerprint],
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['ai-agent-admin-review-item', fingerprint],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({ title: 'Failed to retest', apiError: error });
+        },
+    });
+};
+
 const getAiAgentReviewItemPrDiff = async (fingerprint: string) => {
     return lightdashApi<ApiAiAgentReviewItemPrDiffResponse['results']>({
         version: 'v1',

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -1005,6 +1005,7 @@ export const useCreateAgentThreadMessageMutation = (
         ApiAiAgentThreadMessageCreateRequest & {
             optimisticContext?: AiPromptContext;
             enableSqlMode?: boolean;
+            autoApproveSql?: boolean;
             toolHints?: string[];
         },
         { messageUuid: string }
@@ -1012,6 +1013,7 @@ export const useCreateAgentThreadMessageMutation = (
         mutationFn: ({
             optimisticContext: _optimisticContext,
             enableSqlMode: _enableSqlMode,
+            autoApproveSql: _autoApproveSql,
             toolHints: _toolHints,
             ...data
         }) =>
@@ -1091,6 +1093,7 @@ export const useCreateAgentThreadMessageMutation = (
                 threadUuid: threadUuid!,
                 messageUuid: data.uuid,
                 enableSqlMode: vars.enableSqlMode,
+                autoApproveSql: vars.autoApproveSql,
                 toolHints: vars.toolHints,
                 onFinish: () =>
                     queryClient.invalidateQueries([

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -42,6 +42,7 @@ export interface AiAgentThreadStreamOptions {
     threadUuid: string;
     messageUuid: string;
     enableSqlMode?: boolean;
+    autoApproveSql?: boolean;
     toolHints?: string[];
     onFinish?: () => void;
     onError?: (error: string) => void;
@@ -88,6 +89,7 @@ const getAgentThreadReadableStream = async (
     agentUuid: string,
     threadUuid: string,
     enableSqlMode: boolean,
+    autoApproveSql: boolean,
     toolHints: string[],
     { signal }: { signal: AbortSignal },
 ) => {
@@ -96,7 +98,7 @@ const getAgentThreadReadableStream = async (
             projectUuid,
         )}/${agentUuid}/threads/${threadUuid}/stream`,
         method: 'POST',
-        body: JSON.stringify({ enableSqlMode, toolHints }),
+        body: JSON.stringify({ enableSqlMode, autoApproveSql, toolHints }),
         signal,
     });
 
@@ -264,6 +266,7 @@ export function useAiAgentThreadStreamMutation() {
             threadUuid,
             messageUuid,
             enableSqlMode = false,
+            autoApproveSql = false,
             toolHints = [],
             onFinish,
             onError,
@@ -282,6 +285,7 @@ export function useAiAgentThreadStreamMutation() {
                     agentUuid,
                     threadUuid,
                     enableSqlMode,
+                    autoApproveSql,
                     toolHints,
                     {
                         signal: abortController.signal,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -65,6 +65,7 @@ import SupportImpersonationPanel from '../components/UserSettings/SupportImperso
 import UserAttributesPanel from '../components/UserSettings/UserAttributesPanel';
 import UsersAndGroupsPanel from '../components/UserSettings/UsersAndGroupsPanel';
 import VerifiedDomainsPanel from '../components/UserSettings/VerifiedDomains/VerifiedDomainsPanel';
+import { ReviewRemediationWorkspace } from '../ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace';
 import { AiAgentsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiAgentsSettingsPage';
 import { AiGeneralSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage';
 import { AiReviewsSettingsPage } from '../ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage';
@@ -577,6 +578,14 @@ const Settings: FC = () => {
                         </AiSettingsProviders>
                     ),
                 });
+                allowedRoutes.push({
+                    path: '/ai/reviews/:fingerprint',
+                    element: (
+                        <AiSettingsProviders>
+                            <ReviewRemediationWorkspace />
+                        </AiSettingsProviders>
+                    ),
+                });
             }
         }
 
@@ -713,6 +722,10 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 { path: '/generalSettings/ai/reviews' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/reviews/:fingerprint' },
                 location.pathname,
             )
         );


### PR DESCRIPTION
Part of the AI-review remediation workspace stack — stacked on #24499.

Full-page workspace at `/generalSettings/ai/reviews/:fingerprint`:

- **Numbered ① Build → ② Test** flow with a connector arrow, so two chats read as one directional flow.
- **Build pane** (primary, wider): the live, interactive Build-fix thread — `editDbtProject` follow-ups adopt the same PR; SQL auto-approved; AI suggestions off.
- **Test pane** (verification rail, preview-blue accent): the read-only verification conversation + per-pane status (*Building preview / Testing / Verdict ready / Stale*) + **Retest**.
- Each pane is labelled with its **project + agent**.
- Header: root-cause badge, **View changes** (inline `@pierre/diffs` PR diff) and **View PR**.
- **project_context** collapses to a single verdict-focused column (no empty build chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
