### PR TITLE
feat(reviews): workspace entry points on the board & drawer

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
@@ -1,6 +1,7 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import AiAgentAdminReviewItemsTable from './AiAgentAdminReviewItemsTable';
@@ -169,9 +170,11 @@ describe('AiAgentAdminReviewItemsTable', () => {
         const onReviewItemSelect = vi.fn();
 
         renderWithProviders(
-            <AiAgentAdminReviewItemsTable
-                onReviewItemSelect={onReviewItemSelect}
-            />,
+            <MemoryRouter>
+                <AiAgentAdminReviewItemsTable
+                    onReviewItemSelect={onReviewItemSelect}
+                />
+            </MemoryRouter>,
         );
 
         expect(screen.queryByText('View thread')).not.toBeInTheDocument();

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -3,12 +3,10 @@ import {
     type AiAgentReviewRemediationEvent,
     type AiAgentReviewRemediationLiveState,
 } from '@lightdash/common';
-import { Anchor, Box, Button } from '@mantine-8/core';
-import { IconMessages } from '@tabler/icons-react';
+import { Anchor, Box } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { useMemo, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
-import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiAgentReviewItemActivity } from '../../hooks/useAiAgentAdmin';
 import styles from './RemediationActivityTimeline.module.css';
 
@@ -218,28 +216,7 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
             ? [...eventRows, liveRow(data.liveState, data.liveMessage)]
             : eventRows;
         if (!workThreadUrl) return liveRows;
-        return [
-            ...liveRows,
-            {
-                key: 'test-fix-action',
-                label: 'Test fix',
-                when: '',
-                state: 'done' as const,
-                meta: (
-                    <Button
-                        component="a"
-                        href={workThreadUrl}
-                        size="compact-xs"
-                        variant="default"
-                        leftSection={
-                            <MantineIcon icon={IconMessages} size="xs" />
-                        }
-                    >
-                        Test fix
-                    </Button>
-                ),
-            },
-        ];
+        return liveRows;
     }, [data, reviewItem, workThreadUrl]);
 
     if (rows.length === 0) {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
@@ -1,5 +1,6 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { ReviewItemActions } from './ReviewItemActions';
@@ -76,7 +77,12 @@ const makeReviewItem = (
 describe('ReviewItemActions', () => {
     it('does not render the unsupported root cause blocked reason', () => {
         renderWithProviders(
-            <ReviewItemActions reviewItem={makeReviewItem()} mode="drawer" />,
+            <MemoryRouter>
+                <ReviewItemActions
+                    reviewItem={makeReviewItem()}
+                    mode="drawer"
+                />
+            </MemoryRouter>,
         );
 
         expect(
@@ -86,17 +92,19 @@ describe('ReviewItemActions', () => {
 
     it('still renders other blocked reasons', () => {
         renderWithProviders(
-            <ReviewItemActions
-                reviewItem={makeReviewItem({
-                    writebackEligibility: {
-                        eligible: false,
-                        reason: 'missing_project',
-                        strategy: null,
-                        provider: null,
-                    },
-                })}
-                mode="drawer"
-            />,
+            <MemoryRouter>
+                <ReviewItemActions
+                    reviewItem={makeReviewItem({
+                        writebackEligibility: {
+                            eligible: false,
+                            reason: 'missing_project',
+                            strategy: null,
+                            provider: null,
+                        },
+                    })}
+                    mode="drawer"
+                />
+            </MemoryRouter>,
         );
 
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -11,9 +11,10 @@ import {
 import {
     IconAlertCircle,
     IconInfoCircle,
-    IconMessages,
+    IconLayoutColumns,
 } from '@tabler/icons-react';
 import { type FC, type SyntheticEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
     useAiAgentAdminReviewItem,
@@ -37,7 +38,12 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
 }) => {
     const createWriteback = useCreateAiAgentReviewItemWriteback();
     const updateStatus = useUpdateAiAgentReviewItemStatus();
+    const navigate = useNavigate();
     const [previewOpen, setPreviewOpen] = useState(false);
+
+    const workspaceUrl = `/generalSettings/ai/reviews/${encodeURIComponent(
+        reviewItem.fingerprint,
+    )}`;
 
     const propInFlight =
         reviewItem.prWritebackStatus === 'queued' ||
@@ -63,12 +69,6 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     const previewsDiff = current.primaryRootCause === 'project_context';
 
     const phase = current.prWritebackMessage ?? 'Opening pull request…';
-    const workThreadUrl =
-        current.remediation?.previewProjectUuid &&
-        current.remediation.previewAgentUuid &&
-        current.remediation.previewThreadUuid
-            ? `/projects/${current.remediation.previewProjectUuid}/ai-agents/${current.remediation.previewAgentUuid}/threads/${current.remediation.previewThreadUuid}`
-            : null;
     const remediationError =
         current.remediation?.status === 'failed'
             ? current.remediation.errorMessage
@@ -133,40 +133,44 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
             ) : (
                 <Stack gap={mode === 'drawer' ? 'xs' : 6} align="flex-start">
                     <Group gap={4} wrap="wrap">
-                        {current.linkedPrUrl && (
+                        {/* Once a remediation exists, the workspace is the one
+                            place to view the PR and the verification — collapse
+                            to a single entry point. */}
+                        {current.remediation ? (
                             <Button
-                                component="a"
-                                href={current.linkedPrUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
+                                component={Link}
+                                to={workspaceUrl}
                                 onClick={stopPropagation}
                                 size={buttonSize}
                                 fz="xs"
-                                loading={createWriteback.isLoading}
-                                variant="subtle"
-                                color="gray"
-                            >
-                                View PR
-                            </Button>
-                        )}
-
-                        {workThreadUrl && mode !== 'drawer' && (
-                            <Button
-                                component="a"
-                                href={workThreadUrl}
-                                onClick={stopPropagation}
-                                size={buttonSize}
-                                fz="xs"
-                                variant="default"
+                                variant="light"
+                                color="indigo"
                                 leftSection={
                                     <MantineIcon
-                                        icon={IconMessages}
-                                        size="xs"
+                                        size="sm"
+                                        icon={IconLayoutColumns}
                                     />
                                 }
                             >
-                                Test fix
+                                Open workspace
                             </Button>
+                        ) : (
+                            current.linkedPrUrl && (
+                                <Button
+                                    component="a"
+                                    href={current.linkedPrUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    onClick={stopPropagation}
+                                    size={buttonSize}
+                                    fz="xs"
+                                    loading={createWriteback.isLoading}
+                                    variant="subtle"
+                                    color="gray"
+                                >
+                                    View PR
+                                </Button>
+                            )
                         )}
 
                         {canCreatePr && !current.linkedPrUrl && (
@@ -187,9 +191,13 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                                         if (previewsDiff) {
                                             setPreviewOpen(true);
                                         } else {
-                                            createWriteback.mutate(
-                                                current.fingerprint,
-                                            );
+                                            void createWriteback
+                                                .mutateAsync(
+                                                    current.fingerprint,
+                                                )
+                                                .then(() =>
+                                                    navigate(workspaceUrl),
+                                                );
                                         }
                                     }}
                                 >

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -12,8 +12,10 @@ import {
     IconArrowUpRight,
     IconBox,
     IconGitPullRequest,
+    IconLayoutColumns,
 } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
+import { Link } from 'react-router';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import {
@@ -53,6 +55,10 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
     const startKind = getStartWritebackKind(item);
 
     const remediation = item.remediation;
+    const hasWorkspace = Boolean(remediation);
+    const workspaceHref = `/generalSettings/ai/reviews/${encodeURIComponent(
+        item.fingerprint,
+    )}`;
     const hasPreview = Boolean(remediation?.previewProjectUuid);
 
     const isPreviewBuilding =
@@ -175,23 +181,26 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                 </Stack>
             </Box>
 
-            {hasPreview && !isPreviewBuilding && previewHref && (
-                <Box
-                    component="a"
-                    href={previewHref}
-                    onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
-                        e.stopPropagation()
-                    }
-                    className={styles.cardFooter}
-                >
-                    <Group gap={6} align="center">
-                        <MantineIcon icon={IconBox} size={13} />
-                        <Text fz="xs">Preview project</Text>
-                    </Group>
-                    <MantineIcon icon={IconArrowUpRight} size={14} />
-                </Box>
-            )}
-            {hasPreview && isPreviewBuilding && (
+            {!hasWorkspace &&
+                hasPreview &&
+                !isPreviewBuilding &&
+                previewHref && (
+                    <Box
+                        component="a"
+                        href={previewHref}
+                        onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                            e.stopPropagation()
+                        }
+                        className={styles.cardFooter}
+                    >
+                        <Group gap={6} align="center">
+                            <MantineIcon icon={IconBox} size={13} />
+                            <Text fz="xs">Preview project</Text>
+                        </Group>
+                        <MantineIcon icon={IconArrowUpRight} size={14} />
+                    </Box>
+                )}
+            {!hasWorkspace && hasPreview && isPreviewBuilding && (
                 <Box className={styles.cardFooter}>
                     <Group gap={6} align="center">
                         <MantineIcon icon={IconBox} size={13} />
@@ -210,6 +219,23 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                             Building…
                         </Text>
                     </Group>
+                </Box>
+            )}
+
+            {hasWorkspace && (
+                <Box
+                    component={Link}
+                    to={workspaceHref}
+                    onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                        e.stopPropagation()
+                    }
+                    className={styles.cardFooter}
+                >
+                    <Group gap={6} align="center">
+                        <MantineIcon icon={IconLayoutColumns} size={13} />
+                        <Text fz="xs">Open workspace</Text>
+                    </Group>
+                    <MantineIcon icon={IconArrowUpRight} size={14} />
                 </Box>
             )}
 


### PR DESCRIPTION
Part of the AI-review remediation workspace stack — stacked on #24500.

Wires the board and drawer into the workspace:

- **Open workspace** entry on the kanban card and the review-item actions.
- Once a remediation exists, the actions collapse to a single **Open workspace** button — drops the redundant *View PR* / *Test fix* (the workspace owns both).
- Hides the "Preview project" card footer when a workspace is attached.
- Removes the duplicate *Test fix* row from the remediation activity timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
