### PR TITLE
feat(coding-agent): security hardening — scoped token, size guard, audit (slice 4)

### DIFF
--- a/packages/backend/src/clients/github/Github.ts
+++ b/packages/backend/src/clients/github/Github.ts
@@ -867,6 +867,70 @@ export const getInstallationToken = async (
     }
 };
 
+/**
+ * Mint a per-repository, **contents:read-only** installation access token for a
+ * just-in-time clone. Far narrower than {@link getInstallationToken} (org-wide,
+ * read+write): scoped to the single repo and the single permission needed to
+ * clone, so a leaked token can't be used to write or to reach other repos.
+ * Pair with {@link revokeInstallationToken} immediately after the clone — the
+ * host commits via the API with the full installation token, so the sandbox
+ * never needs a usable token to outlive the clone. `repo` is the bare repo name
+ * (the endpoint scopes within the installation).
+ */
+export const getScopedRepoCloneToken = async ({
+    installationId,
+    repo,
+}: {
+    installationId: string;
+    repo: string;
+}): Promise<string> => {
+    try {
+        const octokit = getOctokitRestForApp(installationId);
+        const response = await octokit.rest.apps.createInstallationAccessToken({
+            installation_id: parseInt(installationId, 10),
+            repositories: [repo],
+            permissions: { contents: 'read' },
+        });
+        return response.data.token;
+    } catch (error) {
+        throw new UnexpectedGitError(getErrorMessage(error));
+    }
+};
+
+/**
+ * Revoke an installation access token (`DELETE /installation/token`),
+ * authenticated with the token itself. Throws on failure; the caller treats it
+ * as best-effort (the token is GitHub-capped at 1h and the clone is done).
+ */
+export const revokeInstallationToken = async (token: string): Promise<void> => {
+    const octokit = withRateLimitObserver(new OctokitRest({ auth: token }));
+    await octokit.rest.apps.revokeInstallationAccessToken();
+};
+
+/**
+ * Repo metadata for the coding agent's pre-clone checks: the default branch and
+ * the repository size (in KB, as GitHub reports it). One `repos.get` call.
+ */
+export const getRepoMetadata = async ({
+    owner,
+    repo,
+    installationId,
+    token,
+}: {
+    owner: string;
+    repo: string;
+    installationId?: string;
+    token?: string;
+}): Promise<{ defaultBranch: string; sizeKb: number }> => {
+    const { octokit, headers } = getOctokit(installationId, token);
+    try {
+        const { data } = await octokit.rest.repos.get({ owner, repo, headers });
+        return { defaultBranch: data.default_branch, sizeKb: data.size };
+    } catch (e) {
+        throw new UnexpectedGitError(getErrorMessage(e));
+    }
+};
+
 export const updateFile = async ({
     owner,
     repo,

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -315,6 +315,7 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     aiWriteback: {
         anthropicApiKey: null,
+        codingAgentMaxRepoSizeMb: 500,
     },
     mcp: {
         enabled: true,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1386,6 +1386,14 @@ export type LightdashConfig = {
     };
     aiWriteback: {
         anthropicApiKey: string | null;
+        /**
+         * Pre-clone size ceiling (MB) for the general coding agent. A repo whose
+         * GitHub-reported size exceeds this is rejected with an actionable error
+         * before any sandbox/clone (fail closed, never deadline_exceeded). With
+         * --depth 1 --filter=blob:none the API size over-counts the real fetch,
+         * so the guard is conservative by design.
+         */
+        codingAgentMaxRepoSizeMb: number;
     };
 
     initialSetup?: {
@@ -2537,6 +2545,10 @@ export const parseConfig = (): LightdashConfig => {
         },
         aiWriteback: {
             anthropicApiKey: process.env.AI_WRITEBACK_ANTHROPIC_API_KEY || null,
+            codingAgentMaxRepoSizeMb: parseInt(
+                process.env.AI_CODING_AGENT_MAX_REPO_SIZE_MB || '500',
+                10,
+            ),
         },
         initialSetup: getInitialSetupConfig(),
         updateSetup: getUpdateSetupConfig(),

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../clients/github/Github';
 import {
     AiWritebackService,
+    auditReasonForError,
     computeWritableRepoKeys,
     mergeSourceCodeRepoAccess,
     parseOwnerRepo,
@@ -38,6 +39,12 @@ import {
     PR_TITLE_CLOSE,
     PR_TITLE_OPEN,
 } from './constants';
+import { DeniedPathError } from './deniedPaths';
+import {
+    RepoTooLargeError,
+    WritebackGitNotConnectedError,
+    WritebackThreadPrClosedError,
+} from './errors';
 
 // e2b (and the GitHub client → octokit) are ESM-only and break Jest's parser.
 // Stub the modules so the import graph stays CJS; the run() tests drive the
@@ -46,6 +53,7 @@ jest.mock('e2b', () => ({
     Sandbox: { create: jest.fn(), connect: jest.fn() },
     CommandExitError: class CommandExitError extends Error {},
     TimeoutError: class TimeoutError extends Error {},
+    ALL_TRAFFIC: '0.0.0.0/0',
 }));
 jest.mock('../../../clients/github/Github', () => ({
     createBranch: jest.fn().mockResolvedValue(undefined),
@@ -627,6 +635,27 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         expect(wrapperWrite[1]).toContain('-u ANTHROPIC_API_KEY');
     });
 
+    // R13: the sandbox network lockdown is a security invariant. Egress must
+    // stay allowOut=[anthropic,github,gitlab] / denyOut=ALL — never widened to
+    // `*`. A provider/model change must update the allowlist deliberately; this
+    // test fails loudly if the lockdown is ever loosened.
+    it('creates the sandbox with denyOut=ALL and a fixed egress allowlist', async () => {
+        const sandbox = fakeSandbox(0, true);
+        (Sandbox.create as jest.Mock).mockClear();
+        (Sandbox.create as jest.Mock).mockResolvedValue(sandbox);
+
+        await runService(sandbox);
+
+        expect(Sandbox.create).toHaveBeenCalledTimes(1);
+        const [, options] = (Sandbox.create as jest.Mock).mock.calls[0];
+        expect(options.network).toEqual({
+            allowOut: ['api.anthropic.com', 'github.com', 'gitlab.com'],
+            denyOut: ['0.0.0.0/0'], // ALL_TRAFFIC
+        });
+        expect(options.network.allowOut).not.toContain('*');
+        expect(options.lifecycle).toEqual({ onTimeout: 'pause' });
+    });
+
     it('skips the PR when the agent exits non-zero', async () => {
         const sandbox = fakeSandbox(1, true);
         (Sandbox.create as jest.Mock).mockResolvedValue(sandbox);
@@ -1193,5 +1222,54 @@ describe('computeWritableRepoKeys', () => {
             false,
         );
         expect(keys.size).toBe(0);
+    });
+});
+
+describe('auditReasonForError', () => {
+    it('maps each terminal coding-agent error to a stable reason', () => {
+        expect(auditReasonForError(new DeniedPathError(['.env']))).toBe(
+            'denied_path',
+        );
+        expect(
+            auditReasonForError(new RepoTooLargeError('a/b', 900, 500)),
+        ).toBe('repo_too_large');
+        expect(
+            auditReasonForError(
+                new WritebackGitNotConnectedError(PullRequestProvider.GITHUB),
+            ),
+        ).toBe('not_installed');
+        expect(
+            auditReasonForError(new WritebackThreadPrClosedError('merged')),
+        ).toBe('pr_not_open');
+    });
+
+    it('distinguishes the ForbiddenError authz sub-conditions by message', () => {
+        expect(
+            auditReasonForError(
+                new ForbiddenError(
+                    'The repository lightdash/lightdash cannot be edited',
+                ),
+            ),
+        ).toBe('denied_repo');
+        expect(
+            auditReasonForError(
+                new ForbiddenError(
+                    'a/b is not accessible to your linked GitHub account',
+                ),
+            ),
+        ).toBe('user_intersection');
+        expect(
+            auditReasonForError(
+                new ForbiddenError(
+                    "a/b is not accessible to your organization's GitHub App installation",
+                ),
+            ),
+        ).toBe('installation');
+        // A bare ForbiddenError (the manage:SourceCode gate) -> permission.
+        expect(auditReasonForError(new ForbiddenError())).toBe('permission');
+    });
+
+    it('falls back to unknown for unrecognised errors', () => {
+        expect(auditReasonForError(new Error('boom'))).toBe('unknown');
     });
 });

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -29,9 +29,12 @@ import type {
 } from '../../../analytics/LightdashAnalytics';
 import {
     getRepoDefaultBranch,
+    getRepoMetadata,
     getRepoTree,
+    getScopedRepoCloneToken,
     listReposAccessibleToInstallation,
     listReposAccessibleToUser,
+    revokeInstallationToken,
 } from '../../../clients/github/Github';
 import { getGitlabProjects } from '../../../clients/gitlab/Gitlab';
 import type { LightdashConfig } from '../../../config/parseConfig';
@@ -59,6 +62,7 @@ import {
     CWD,
     GATHER_REPO_CONTEXT_SANDBOX_PATH,
     GENERAL_ALLOWED_TOOLS,
+    GENERAL_DISALLOWED_TOOLS,
     GENERAL_SKILLS_DIR,
     GIT_TIMEOUT_MS,
     PR_DESCRIPTION_PATH,
@@ -74,7 +78,9 @@ import {
     TMP_PROFILES_DIR,
     WAREHOUSE_SKILL_PATH,
 } from './constants';
+import { DeniedPathError } from './deniedPaths';
 import {
+    RepoTooLargeError,
     WritebackGitNotConnectedError,
     WritebackThreadPrClosedError,
 } from './errors';
@@ -259,6 +265,29 @@ export const computeWritableRepoKeys = (
             .filter((key) => !DENYLISTED_WRITE_REPOS.has(key.toLowerCase()))
             .filter((key) => !intersectWithUser || userKeys.has(key)),
     );
+};
+
+/**
+ * Classify a coding-agent failure into a stable audit `reason` category that
+ * distinguishes the conditions decision #2 requires (user-intersection /
+ * installation / branch-protection / denied-repo / denied-path / size). Keyword
+ * matching on the ForbiddenError sub-cases is acceptable for an audit log.
+ */
+export const auditReasonForError = (error: unknown): string => {
+    if (error instanceof DeniedPathError) return 'denied_path';
+    if (error instanceof RepoTooLargeError) return 'repo_too_large';
+    if (error instanceof WritebackGitNotConnectedError) return 'not_installed';
+    if (error instanceof WritebackThreadPrClosedError) return 'pr_not_open';
+    if (error instanceof ForbiddenError) {
+        const message = error.message.toLowerCase();
+        if (message.includes('cannot be edited')) return 'denied_repo';
+        if (message.includes('linked github')) return 'user_intersection';
+        if (message.includes('installation')) return 'installation';
+        if (message.includes('organization')) return 'no_org';
+        return 'permission';
+    }
+    if (error instanceof ParameterError) return 'invalid_target';
+    return 'unknown';
 };
 
 export class AiWritebackService extends BaseService {
@@ -1311,17 +1340,43 @@ export class AiWritebackService extends BaseService {
                       })
                     : null;
 
+            // Clone with a scoped, revocable token when the config provides one
+            // (general agent) — keep the full installation for the host-side
+            // commit. Only mint on a fresh clone; a resume reuses the existing
+            // checkout (its clone token was already scrubbed + revoked).
+            let cloneInstallation = installation;
+            let onAfterClone: (() => Promise<void>) | undefined;
+            if (
+                config.resolveCloneToken &&
+                !turn.existingRow &&
+                installation.provider === PullRequestProvider.GITHUB
+            ) {
+                const minted = await config.resolveCloneToken({
+                    gitConnection: turn.gitConnection,
+                    installation,
+                });
+                if (minted) {
+                    cloneInstallation = {
+                        ...installation,
+                        token: minted.token,
+                        userToken: null,
+                    };
+                    onAfterClone = minted.onAfterClone;
+                }
+            }
+
             sandbox = await this.acquireSandbox({
                 projectUuid,
                 cloneTarget: turn.provider.getCloneTarget(
                     turn.gitConnection,
-                    installation,
+                    cloneInstallation,
                 ),
                 existingRow: turn.existingRow,
                 adoptBranch: adoptedPr?.headRef ?? null,
                 setStage,
                 templateRef: config.resolveTemplateRef(),
                 cloneExtraOptions: config.cloneExtraOptions,
+                onAfterClone,
             });
 
             setStage('agent');
@@ -1338,6 +1393,7 @@ export class AiWritebackService extends BaseService {
                 source,
                 recordStep,
                 allowedTools: setup.allowedTools,
+                disallowedTools: setup.disallowedTools,
                 addDirs: setup.addDirs,
                 model: setup.model,
                 warehouseType: turn.warehouseType,
@@ -1715,21 +1771,22 @@ export class AiWritebackService extends BaseService {
             const reason = inInstallation
                 ? `${key} is not accessible to your linked GitHub account`
                 : `${key} is not accessible to your organization's GitHub App installation`;
-            this.logger.info('AI coding agent write denied', {
-                event: 'ai_coding_agent.write.denied',
-                projectUuid: project.projectUuid,
-                target: key,
-                reason,
-                intersectWithUser,
-            });
             throw new ForbiddenError(reason);
         }
 
-        const branch = await getRepoDefaultBranch({
+        // Pre-clone size guard (R9): fail closed BEFORE any sandbox/clone with an
+        // actionable error, never a deadline_exceeded from a giant clone.
+        const { defaultBranch: branch, sizeKb } = await getRepoMetadata({
             owner,
             repo,
             installationId,
         });
+        const limitMb =
+            this.lightdashConfig.aiWriteback.codingAgentMaxRepoSizeMb;
+        const sizeMb = Math.round(sizeKb / 1024);
+        if (sizeMb > limitMb) {
+            throw new RepoTooLargeError(key, sizeMb, limitMb);
+        }
 
         return {
             organizationUuid: user.organizationUuid,
@@ -1822,6 +1879,7 @@ export class AiWritebackService extends BaseService {
         setStage,
         templateRef,
         cloneExtraOptions,
+        onAfterClone,
     }: {
         projectUuid: string;
         cloneTarget: CloneTarget;
@@ -1830,6 +1888,8 @@ export class AiWritebackService extends BaseService {
         setStage: SetStage;
         templateRef: string;
         cloneExtraOptions: Record<string, unknown>;
+        /** Run after a fresh clone + .git scrub (e.g. revoke the scoped token). */
+        onAfterClone?: () => Promise<void>;
     }): Promise<Sandbox> {
         setStage('sandbox');
 
@@ -1895,6 +1955,21 @@ export class AiWritebackService extends BaseService {
                     error,
                 )}`,
             );
+        }
+
+        // Revoke the scoped clone token now the checkout exists (general agent).
+        // Best-effort: a revoke failure is logged, not thrown — the token is
+        // already scrubbed from .git and GitHub caps it at 1h anyway.
+        if (onAfterClone) {
+            try {
+                await onAfterClone();
+            } catch (error) {
+                this.logger.warn(
+                    `AiWriteback: onAfterClone (clone-token revoke) failed (sandboxId=${sandbox.sandboxId}): ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+            }
         }
         return sandbox;
     }
@@ -2020,6 +2095,7 @@ export class AiWritebackService extends BaseService {
         source,
         recordStep,
         allowedTools,
+        disallowedTools,
         addDirs,
         model,
         warehouseType,
@@ -2034,6 +2110,8 @@ export class AiWritebackService extends BaseService {
         recordStep: (step: AiWritebackStep) => void;
         /** Claude Code `--allowedTools` string for this mode. */
         allowedTools: string;
+        /** Claude Code `--disallowedTools` string (paths denied under the allow). */
+        disallowedTools: string | undefined;
         /** Extra `--add-dir` mounts beyond the repo CWD. */
         addDirs: string[];
         /** Anthropic model the CLI runs with. */
@@ -2140,6 +2218,9 @@ export class AiWritebackService extends BaseService {
         };
 
         const continueFlag = isResume ? '--continue ' : '';
+        const disallowedFlag = disallowedTools
+            ? ` --disallowedTools "${disallowedTools}"`
+            : '';
         let result;
         try {
             result = await sandbox.commands.run(
@@ -2156,7 +2237,7 @@ export class AiWritebackService extends BaseService {
                     // metadata, the skills dirs) has to be added explicitly or the
                     // operation is refused. The mounts differ per mode.
                     `${addDirs.map((dir) => `--add-dir ${dir}`).join(' ')} ` +
-                    `--allowedTools "${allowedTools}"`,
+                    `--allowedTools "${allowedTools}"${disallowedFlag}`,
                 {
                     cwd: CWD,
                     timeoutMs: RUN_TIMEOUT_MS,
@@ -2432,7 +2513,65 @@ export class AiWritebackService extends BaseService {
             repoTarget: args.repoTarget ?? null,
             source: args.source,
         });
-        return this.runCodingAgent(args, this.generalCodingAgentConfig());
+        try {
+            const result = await this.runCodingAgent(
+                args,
+                this.generalCodingAgentConfig(),
+            );
+            this.emitWriteAudit({
+                user: args.user,
+                projectUuid: args.projectUuid,
+                targetRepo: result.repository,
+                allowed: true,
+                reason: null,
+            });
+            return result;
+        } catch (error) {
+            // Audit every denied/failed attempt with the condition-specific
+            // reason — the forensic record of the org token mutating a repo.
+            this.emitWriteAudit({
+                user: args.user,
+                projectUuid: args.projectUuid,
+                targetRepo: args.repoTarget ?? null,
+                allowed: false,
+                reason: auditReasonForError(error),
+            });
+            throw error;
+        }
+    }
+
+    /**
+     * The coding-agent write audit (decision #2): one structured line per
+     * attempt — `{ user, project, target_repo, allowed, reason }` — so the org
+     * installation token mutating an arbitrary repo always leaves a trail. Self
+     * contained: an audit failure must never affect the run.
+     */
+    private emitWriteAudit({
+        user,
+        projectUuid,
+        targetRepo,
+        allowed,
+        reason,
+    }: {
+        user: SessionUser;
+        projectUuid: string;
+        targetRepo: string | null;
+        allowed: boolean;
+        reason: string | null;
+    }): void {
+        try {
+            this.logger.info('coding_agent_write', {
+                event: 'coding_agent_write',
+                userUuid: user.userUuid,
+                organizationUuid: user.organizationUuid ?? null,
+                projectUuid,
+                targetRepo,
+                allowed,
+                reason,
+            });
+        } catch {
+            // best-effort audit; never throw back into the run
+        }
     }
 
     /**
@@ -2453,9 +2592,31 @@ export class AiWritebackService extends BaseService {
                     name: e2bCodingAgentTemplateName,
                     tag: e2bCodingAgentTemplateTag,
                 }),
-            // depth:1 is applied in acquireSandbox; blob:none + size guard land
-            // with the security slice. No extra clone options for now.
-            cloneExtraOptions: {},
+            // depth:1 (acquireSandbox) + blob:none keeps the clone minimal; the
+            // pre-clone size guard (resolveWritableRepoTarget) bounds it further.
+            cloneExtraOptions: { filter: 'blob:none' },
+            resolveCloneToken: async ({ gitConnection, installation }) => {
+                // GitHub: mint a per-repo contents:read-only token, revoked once
+                // the checkout exists. GitLab can't revoke OAuth tokens as
+                // cleanly, so it falls back to the .git scrub only (null here).
+                if (installation.provider !== PullRequestProvider.GITHUB) {
+                    return null;
+                }
+                const token = await getScopedRepoCloneToken({
+                    installationId: installation.installationId,
+                    repo: gitConnection.repo,
+                });
+                return {
+                    token,
+                    onAfterClone: async () => {
+                        await revokeInstallationToken(token);
+                        this.logger.info(
+                            'AI coding agent scoped clone token revoked',
+                            { event: 'ai_coding_agent.clone_token.revoked' },
+                        );
+                    },
+                };
+            },
             buildAgentSetup: async ({ sandbox, repository }) => {
                 const repoContext =
                     await this.gatherGeneralRepoContext(sandbox);
@@ -2465,6 +2626,7 @@ export class AiWritebackService extends BaseService {
                         repoContext,
                     }),
                     allowedTools: GENERAL_ALLOWED_TOOLS,
+                    disallowedTools: GENERAL_DISALLOWED_TOOLS,
                     addDirs: ['/tmp', GENERAL_SKILLS_DIR],
                     model: CLAUDE_MODEL,
                 };

--- a/packages/backend/src/ee/services/AiWritebackService/constants.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/constants.ts
@@ -150,6 +150,31 @@ export const CLAUDE_MODEL = 'claude-sonnet-4-6';
 // read-only because the general agent has no Bash — skills can't execute.
 export const GENERAL_SKILLS_DIR = '/home/user/.lightdash-coding-skills';
 
+// Read paths DENIED to the general coding agent even though they fall under the
+// `Read(/CWD/**)` allow — applied via Claude Code `--disallowedTools`. Excludes
+// `.git` (clone remote/creds + git internals) so the agent can't lift a token
+// from `.git/config` and exfiltrate it via the PR (R4), and common secret files
+// so it can't read+leak them (R6). Defense-in-depth: the clone token is already
+// scoped + scrubbed + revoked, and secrets are denied at commit time too.
+export const GENERAL_DISALLOWED_TOOLS = [
+    `Read(/${CWD}/.git/**)`,
+    `Read(/${CWD}/.env)`,
+    `Read(/${CWD}/.env.*)`,
+    `Read(/${CWD}/**/.env)`,
+    `Read(/${CWD}/**/.env.*)`,
+    `Read(/${CWD}/**/*.pem)`,
+    `Read(/${CWD}/**/*.key)`,
+    `Read(/${CWD}/**/*.p12)`,
+    `Read(/${CWD}/**/*.pfx)`,
+    `Read(/${CWD}/**/id_rsa)`,
+    `Read(/${CWD}/**/id_ed25519)`,
+    `Read(/${CWD}/**/.npmrc)`,
+    `Read(/${CWD}/**/.pypirc)`,
+    `Read(/${CWD}/**/credentials)`,
+    `Read(/${CWD}/**/*.keyfile)`,
+    `Read(/${CWD}/**/*.keyfile.json)`,
+].join(',');
+
 // Fine-grained tool permissions for the GENERAL coding agent (editRepo). The
 // security-critical difference from ALLOWED_TOOLS: there are ZERO Bash entries.
 // With no Bash and no per-language toolchain, "no in-sandbox build" is

--- a/packages/backend/src/ee/services/AiWritebackService/errors.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/errors.ts
@@ -44,3 +44,17 @@ export class WritebackThreadPrClosedError extends ParameterError {
         this.reason = reason;
     }
 }
+
+/**
+ * Thrown by the general coding agent's pre-clone size guard when a target repo
+ * exceeds `codingAgentMaxRepoSizeMb`. Fails closed before any sandbox/clone with
+ * an actionable message (never a `deadline_exceeded` from a giant clone). The
+ * `editRepo` tool catches it (via `instanceof`) and tags `repo_too_large`.
+ */
+export class RepoTooLargeError extends ParameterError {
+    constructor(repo: string, sizeMb: number, limitMb: number) {
+        super(
+            `The repository ${repo} is too large to edit (${sizeMb} MB, limit is ${limitMb} MB). Tell the user the coding agent can't clone repositories above this size.`,
+        );
+    }
+}

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -116,6 +116,12 @@ export type CodingAgentSetup = {
     systemPrompt: string;
     /** Claude Code `--allowedTools` string for this mode. */
     allowedTools: string;
+    /**
+     * Claude Code `--disallowedTools` string — paths denied even under the
+     * allowlist (general agent: `.git` + secret files). Empty/undefined omits
+     * the flag.
+     */
+    disallowedTools?: string;
     /** Extra `--add-dir` mounts beyond the repo CWD (e.g. /tmp, skills dirs). */
     addDirs: string[];
     /** Anthropic model the CLI runs with. */
@@ -144,6 +150,18 @@ export type CodingAgentConfig = {
     resolveTemplateRef: () => string;
     /** Extra options merged into `sandbox.git.clone` (e.g. a blob filter). */
     cloneExtraOptions: Record<string, unknown>;
+    /**
+     * Mint a short-lived, narrowly-scoped token for the clone instead of using
+     * the org-wide installation token (general agent). Returns the token plus an
+     * `onAfterClone` to revoke it once the checkout exists — the host commits via
+     * the API with the full installation token, so the sandbox never needs a
+     * usable token to outlive the clone (R2/R4). Returns null (or is undefined)
+     * to clone with the installation token, as dbt writeback does.
+     */
+    resolveCloneToken?: (args: {
+        gitConnection: GitConnection;
+        installation: GitInstallation;
+    }) => Promise<{ token: string; onAfterClone: () => Promise<void> } | null>;
     /**
      * Stage any sandbox prerequisites that inform the prompt (repo context,
      * profiles, tree listing) and build the system prompt + CLI knobs for this

--- a/packages/backend/src/ee/services/ai/tools/editRepo.ts
+++ b/packages/backend/src/ee/services/ai/tools/editRepo.ts
@@ -7,6 +7,7 @@ import {
 import { tool } from 'ai';
 import { DeniedPathError } from '../../AiWritebackService/deniedPaths';
 import {
+    RepoTooLargeError,
     WritebackGitNotConnectedError,
     WritebackThreadPrClosedError,
 } from '../../AiWritebackService/errors';
@@ -34,6 +35,9 @@ type EditRepoErrorCode =
 const classifyEditRepoError = (error: unknown): EditRepoErrorCode => {
     if (error instanceof DeniedPathError) {
         return 'denied_path';
+    }
+    if (error instanceof RepoTooLargeError) {
+        return 'repo_too_large';
     }
     if (error instanceof ForbiddenError) {
         return 'repo_write_forbidden';
@@ -107,6 +111,16 @@ export const getEditRepo = ({ editRepo }: Dependencies) =>
                         metadata: {
                             status: 'error' as const,
                             errorCode: 'pull_request_not_open' as const,
+                        },
+                    };
+                }
+                // Repo too large — terminal, do not retry. Relay verbatim.
+                if (error instanceof RepoTooLargeError) {
+                    return {
+                        result: error.message,
+                        metadata: {
+                            status: 'error' as const,
+                            errorCode: 'repo_too_large' as const,
                         },
                     };
                 }


### PR DESCRIPTION
## 📚 Stack — general-purpose coding agent

The **write** counterpart to repo discovery: the AI agent can make a code change to any repo the org's GitHub/GitLab App installation can write (intersected with the user's own access) and open a pull request, via a new `editRepo` tool. It reuses the AI-writeback E2B → signed-commit → PR engine. Gated by the new `ai-coding-agent` feature flag — **off by default, EE-gated**; the flag is presence-of-feature, the per-repo write authz lives in the service.

Reviewed bottom-up; each PR is self-contained and CI-green on its parent.

| # | Slice | |
|---|---|---|
| #24508 | 1 · lean E2B image + CI publish | **merge first** — builds/publishes the template the agent runs in |
| #24502 | 2 · engine + `editRepo` tool foundation | |
| #24503 | 3 · writable-repo authz chokepoint | |
| #24504 | 4 · security hardening | **🔒 release gate** — flag must not open to any customer until this lands |
| #24505 | 5 · multi-repo threads | |
| #24506 | 6 · rich PR card | |
| #24507 | 7 · GitLab parity | live-verification pending (no GitLab repo in local env) |

---

### This PR — Slice 4: security hardening (RELEASE GATE)

- Per-repo `contents:read` scoped clone token, revoked after clone (+ `.git` scrub) — the sandbox never holds a usable token beyond the clone (R2/R4).
- Pre-clone size guard (fail closed), `.git`/secrets excluded from the agent Read scope, structured `coding_agent_write` audit line per attempt, netlock-invariant regression test (R13).
- **The flag must not open to any customer until this PR lands.**
