### PR TITLE
feat(coding-agent): multi-repo threads — (thread,repo) re-key + concurrency lock (slice 5)

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -108,6 +108,12 @@ export type DbAiWritebackThread = {
     ai_thread_uuid: string;
     sandbox_id: string;
     pull_request_uuid: string | null;
+    /** "owner/repo" this row's sandbox + PR target; null only on legacy rows. */
+    target_repo: string | null;
+    /** Git host for this row's PR ('github' | 'gitlab'); null on legacy rows. */
+    provider: string | null;
+    /** Feature branch pushed by this row's sandbox; null until a branch exists. */
+    branch: string | null;
     created_at: Date;
 };
 
@@ -115,9 +121,16 @@ export type AiWritebackThreadTable = Knex.CompositeTableType<
     DbAiWritebackThread,
     Pick<
         DbAiWritebackThread,
-        'ai_thread_uuid' | 'sandbox_id' | 'pull_request_uuid'
+        | 'ai_thread_uuid'
+        | 'sandbox_id'
+        | 'pull_request_uuid'
+        | 'target_repo'
+        | 'provider'
+        | 'branch'
     >,
-    Pick<DbAiWritebackThread, 'sandbox_id' | 'pull_request_uuid'>
+    Partial<
+        Pick<DbAiWritebackThread, 'sandbox_id' | 'pull_request_uuid' | 'branch'>
+    >
 >;
 
 export const AiPromptTableName = 'ai_prompt';

--- a/packages/backend/src/ee/database/migrations/20260619120000_rekey_ai_writeback_thread_by_repo.ts
+++ b/packages/backend/src/ee/database/migrations/20260619120000_rekey_ai_writeback_thread_by_repo.ts
@@ -1,0 +1,78 @@
+import { Knex } from 'knex';
+
+// Re-key ai_writeback_thread from one row per thread to one row per
+// (thread, target_repo) so a single chat thread can drive edits to more than one
+// repo (the general coding agent), each with its own sandbox + PR. dbt writeback
+// is just the special case with a single row.
+//
+// Adds nullable target_repo ("owner/repo") + provider + branch, backfills the
+// first two from the linked pull_requests row, then swaps the old
+// UNIQUE(ai_thread_uuid) for a composite UNIQUE(ai_thread_uuid, target_repo).
+// The table is small and the feature is pre-release, so this is done in one
+// migration rather than a phased expand/contract; the down() restores the
+// single-key shape.
+const TableName = 'ai_writeback_thread';
+const PullRequestsTableName = 'pull_requests';
+const OldUniqueConstraint = 'ai_writeback_thread_ai_thread_uuid_unique';
+const CompositeUniqueConstraint = 'ai_writeback_thread_thread_repo_unique';
+
+export async function up(knex: Knex): Promise<void> {
+    const hasTargetRepo = await knex.schema.hasColumn(TableName, 'target_repo');
+    if (!hasTargetRepo) {
+        await knex.schema.alterTable(TableName, (table) => {
+            // "owner/repo" the row's sandbox/PR target; null only transiently
+            // before backfill (existing rows) — new rows always set it.
+            table.text('target_repo').nullable();
+            // 'github' | 'gitlab' — the host for this row's PR.
+            table.text('provider').nullable();
+            // The feature branch this row's sandbox pushed to. Lets a later turn
+            // adopt a "branch created, PR pending" row (PR-open failed) and open
+            // the PR without re-committing. Null until a branch is created.
+            table.text('branch').nullable();
+        });
+    }
+
+    // Backfill target_repo + provider from the linked pull request.
+    await knex.raw(
+        `UPDATE ?? AS t
+            SET target_repo = pr.owner || '/' || pr.repo,
+                provider = pr.provider
+            FROM ?? AS pr
+            WHERE t.pull_request_uuid = pr.pull_request_uuid
+              AND t.target_repo IS NULL`,
+        [TableName, PullRequestsTableName],
+    );
+
+    // Swap the single-key unique for the composite. Drop old first so a thread
+    // can hold multiple repo rows. Guard both so the migration is re-runnable.
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        TableName,
+        OldUniqueConstraint,
+    ]);
+    await knex.raw(
+        `ALTER TABLE ?? ADD CONSTRAINT ?? UNIQUE (ai_thread_uuid, target_repo)`,
+        [TableName, CompositeUniqueConstraint],
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??`, [
+        TableName,
+        CompositeUniqueConstraint,
+    ]);
+    // Restore the single-key unique. Safe only because every pre-rekey row was
+    // 1:1 with its thread; new multi-repo rows must be cleared first if present.
+    await knex.raw(`ALTER TABLE ?? ADD CONSTRAINT ?? UNIQUE (ai_thread_uuid)`, [
+        TableName,
+        OldUniqueConstraint,
+    ]);
+
+    const hasTargetRepo = await knex.schema.hasColumn(TableName, 'target_repo');
+    if (hasTargetRepo) {
+        await knex.schema.alterTable(TableName, (table) => {
+            table.dropColumn('target_repo');
+            table.dropColumn('provider');
+            table.dropColumn('branch');
+        });
+    }
+}

--- a/packages/backend/src/ee/models/AiWritebackThreadModel.ts
+++ b/packages/backend/src/ee/models/AiWritebackThreadModel.ts
@@ -26,16 +26,35 @@ export class AiWritebackThreadModel {
         this.database = dependencies.database;
     }
 
-    async findByAiThreadUuid(
+    /**
+     * Resolve the resume row for a `(thread, repo)` pair — the unit a sandbox +
+     * PR is keyed on since the re-key. `targetRepo` is "owner/repo". Legacy rows
+     * (pre-backfill) carry a null `target_repo`; pass null to match those so the
+     * dbt single-row path keeps resuming after upgrade.
+     */
+    async findByAiThreadUuidAndRepo(
         aiThreadUuid: string,
+        targetRepo: string | null,
     ): Promise<AiWritebackThreadWithPrUrl | null> {
-        const row = await this.database(AiWritebackThreadTableName)
+        const query = this.database(AiWritebackThreadTableName)
             .leftJoin(
                 PullRequestsTableName,
                 `${PullRequestsTableName}.pull_request_uuid`,
                 `${AiWritebackThreadTableName}.pull_request_uuid`,
             )
-            .where(`${AiWritebackThreadTableName}.ai_thread_uuid`, aiThreadUuid)
+            .where(
+                `${AiWritebackThreadTableName}.ai_thread_uuid`,
+                aiThreadUuid,
+            );
+        if (targetRepo === null) {
+            void query.whereNull(`${AiWritebackThreadTableName}.target_repo`);
+        } else {
+            void query.where(
+                `${AiWritebackThreadTableName}.target_repo`,
+                targetRepo,
+            );
+        }
+        const row = await query
             .select<AiWritebackThreadWithPrUrl>(
                 `${AiWritebackThreadTableName}.*`,
                 `${PullRequestsTableName}.pr_url`,
@@ -47,7 +66,10 @@ export class AiWritebackThreadModel {
     async create(data: {
         aiThreadUuid: string;
         sandboxId: string;
-        pullRequestUuid: string;
+        pullRequestUuid: string | null;
+        targetRepo: string | null;
+        provider: string | null;
+        branch: string | null;
     }): Promise<DbAiWritebackThread> {
         const [row] = await this.database<AiWritebackThreadTable>(
             AiWritebackThreadTableName,
@@ -56,14 +78,33 @@ export class AiWritebackThreadModel {
                 ai_thread_uuid: data.aiThreadUuid,
                 sandbox_id: data.sandboxId,
                 pull_request_uuid: data.pullRequestUuid,
+                target_repo: data.targetRepo,
+                provider: data.provider,
+                branch: data.branch,
             })
             .returning('*');
         return row;
     }
 
+    /** Link a (now-opened) PR onto an existing row + clear its pending branch. */
+    async setPullRequest(
+        aiWritebackThreadUuid: string,
+        pullRequestUuid: string,
+    ): Promise<void> {
+        await this.database<AiWritebackThreadTable>(AiWritebackThreadTableName)
+            .where('ai_writeback_thread_uuid', aiWritebackThreadUuid)
+            .update({ pull_request_uuid: pullRequestUuid, branch: null });
+    }
+
     async deleteByAiThreadUuid(aiThreadUuid: string): Promise<void> {
         await this.database<AiWritebackThreadTable>(AiWritebackThreadTableName)
             .where('ai_thread_uuid', aiThreadUuid)
+            .delete();
+    }
+
+    async deleteByUuid(aiWritebackThreadUuid: string): Promise<void> {
+        await this.database<AiWritebackThreadTable>(AiWritebackThreadTableName)
+            .where('ai_writeback_thread_uuid', aiWritebackThreadUuid)
             .delete();
     }
 }

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -301,6 +301,13 @@ export class AiWritebackService extends BaseService {
 
     private readonly aiWritebackThreadModel: AiWritebackThreadModel;
 
+    // In-flight (thread, repo) keys, so a second concurrent turn on the same
+    // repo in the same conversation is rejected rather than racing the first
+    // (decision #3). Single-instance only: a horizontally-scaled backend relies
+    // on the chat UI serializing turns per thread; the composite unique still
+    // prevents duplicate rows across instances. Cleared in the run's finally.
+    private readonly inFlightTurns = new Set<string>();
+
     private readonly pullRequestsModel: PullRequestsModel;
 
     private readonly prometheusMetrics?: PrometheusMetrics;
@@ -1288,6 +1295,18 @@ export class AiWritebackService extends BaseService {
 
         const repository = `${turn.gitConnection.owner}/${turn.gitConnection.repo}`;
 
+        // Reject a second concurrent turn on the same (thread, repo) — both
+        // would resume/race the same sandbox or open duplicate PRs (decision #3).
+        // Only tracked conversations have a stable key; one-shots are independent.
+        // Checked before acquiring so a rejection never enters the finally that
+        // would clear the winner's lock.
+        const lockKey = aiThreadUuid ? `${aiThreadUuid}::${repository}` : null;
+        if (lockKey && this.inFlightTurns.has(lockKey)) {
+            throw new ParameterError(
+                'An edit is already in progress for this repository in this conversation. Please wait for it to finish before making another change.',
+            );
+        }
+
         const tracker = this.startTracking({ user, projectUuid, turn });
 
         let failureStage: AiWritebackFailureStage = 'install';
@@ -1325,6 +1344,11 @@ export class AiWritebackService extends BaseService {
         // it would poison the row for every future turn. Fresh turns have no
         // such row, so the default kill is fine.
         let pauseOnExit = turn.isResume;
+        // Acquire the in-flight lock last, right before the work — only plain
+        // declarations sit between here and the finally that releases it.
+        if (lockKey) {
+            this.inFlightTurns.add(lockKey);
+        }
         try {
             const installation = await turn.provider.resolveInstallation(
                 turn.organizationUuid,
@@ -1547,6 +1571,9 @@ export class AiWritebackService extends BaseService {
             tracker.failed(failureStage, error);
             throw error;
         } finally {
+            if (lockKey) {
+                this.inFlightTurns.delete(lockKey);
+            }
             if (sandbox) {
                 await this.releaseSandbox(sandbox, pauseOnExit, projectUuid);
             }

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -1597,10 +1597,16 @@ export class AiWritebackService extends BaseService {
                   })
                 : this.resolveDbtTurnTarget({ user, project });
 
-        // Resume only when both the caller supplied a thread uuid AND we
-        // have a stored sandbox for it. Otherwise we start fresh.
+        // Resume only when the caller supplied a thread uuid AND we have a
+        // stored sandbox for THIS repo. Keyed on (thread, repo) since the
+        // re-key, so a thread can drive edits to several repos, each resuming
+        // its own sandbox + PR.
+        const targetRepo = `${target.gitConnection.owner}/${target.gitConnection.repo}`;
         const existingRow = aiThreadUuid
-            ? await this.aiWritebackThreadModel.findByAiThreadUuid(aiThreadUuid)
+            ? await this.aiWritebackThreadModel.findByAiThreadUuidAndRepo(
+                  aiThreadUuid,
+                  targetRepo,
+              )
             : null;
 
         // A thread is bound to its first PR. If that PR has since been merged or
@@ -1902,13 +1908,15 @@ export class AiWritebackService extends BaseService {
                 return sandbox;
             } catch (error) {
                 // The persisted sandbox is gone (reaped by E2B, or some other
-                // permanent failure). Clear the row so the next turn starts
-                // fresh instead of looping on the same dead reference.
+                // permanent failure). Clear THIS (thread, repo) row only — other
+                // repos' rows on the same thread keep their sandboxes — so the
+                // next turn for this repo starts fresh instead of looping on the
+                // dead reference.
                 this.logger.warn(
-                    `AiWriteback: failed to resume sandbox ${existingRow.sandbox_id} — clearing conversation row (ai_thread_uuid=${existingRow.ai_thread_uuid}): ${getErrorMessage(error)}`,
+                    `AiWriteback: failed to resume sandbox ${existingRow.sandbox_id} — clearing conversation row (ai_thread_uuid=${existingRow.ai_thread_uuid}, repo=${existingRow.target_repo}): ${getErrorMessage(error)}`,
                 );
-                await this.aiWritebackThreadModel.deleteByAiThreadUuid(
-                    existingRow.ai_thread_uuid,
+                await this.aiWritebackThreadModel.deleteByUuid(
+                    existingRow.ai_writeback_thread_uuid,
                 );
                 throw new ParameterError(
                     'This writeback conversation has expired. Please start a new one.',
@@ -2891,6 +2899,10 @@ export class AiWritebackService extends BaseService {
                 aiThreadUuid,
                 sandboxId: sandbox.sandboxId,
                 pullRequestUuid: pullRequest.pullRequestUuid,
+                // Key the row on its repo so a thread can hold several.
+                targetRepo: `${turn.gitConnection.owner}/${turn.gitConnection.repo}`,
+                provider: turn.provider.provider,
+                branch: null,
             });
         }
     }


### PR DESCRIPTION
## 📚 Stack — general-purpose coding agent

The **write** counterpart to repo discovery: the AI agent can make a code change to any repo the org's GitHub/GitLab App installation can write (intersected with the user's own access) and open a pull request, via a new `editRepo` tool. It reuses the AI-writeback E2B → signed-commit → PR engine. Gated by the new `ai-coding-agent` feature flag — **off by default, EE-gated**; the flag is presence-of-feature, the per-repo write authz lives in the service.

Reviewed bottom-up; each PR is self-contained and CI-green on its parent.

| # | Slice | |
|---|---|---|
| #24508 | 1 · lean E2B image + CI publish | **merge first** — builds/publishes the template the agent runs in |
| #24502 | 2 · engine + `editRepo` tool foundation | |
| #24503 | 3 · writable-repo authz chokepoint | |
| #24504 | 4 · security hardening | **🔒 release gate** — flag must not open to any customer until this lands |
| #24505 | 5 · multi-repo threads | |
| #24506 | 6 · rich PR card | |
| #24507 | 7 · GitLab parity | live-verification pending (no GitLab repo in local env) |

---

### This PR — Slice 5: multi-repo threads (2 commits)

- Migration: re-key `ai_writeback_thread` to `(thread, repo)` — one sandbox + PR per repo, so a thread can edit several repos; backfill from `pull_requests`.
- In-memory concurrency lock rejecting a second in-flight turn on the same `(thread, repo)`.
- Orphan-branch adopt-on-resume deferred (groundwork laid).
