### PR TITLE
feat(coding-agent): rich PR card for editRepo tool calls (slice 6)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -5,9 +5,11 @@ import {
     type AiMcpServer,
     isToolProposeChangeResult,
     isToolEditDbtProjectResult,
+    isToolEditRepoResult,
     isToolSetupPreviewDeployResult,
     type ToolProposeChangeArgs,
     type ToolEditDbtProjectOutput,
+    type ToolEditRepoOutput,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -73,6 +75,7 @@ import { ContentLink, type SqlRunnerLinkState } from './ContentLink';
 import { MessageModelIndicator } from './MessageModelIndicator';
 import { rehypeAiAgentContentLinks } from './rehypeContentLinks';
 import { AiEditDbtProjectToolCall } from './ToolCalls/AiEditDbtProjectToolCall';
+import { AiEditRepoToolCall } from './ToolCalls/AiEditRepoToolCall';
 import { AiProposeChangeToolCall } from './ToolCalls/AiProposeChangeToolCall';
 import { ImproveContextToolCall } from './ToolCalls/ImproveContextToolCall';
 import {
@@ -470,6 +473,25 @@ const AssistantBubbleContent: FC<{
             metadata: liveOutput.metadata,
             isPreviewDeploySetup: livePart?.toolName === 'setupPreviewDeploy',
         };
+    })();
+
+    // General coding-agent (editRepo) PR card metadata — resolved the same way
+    // as editDbtProject (persisted result, then live streaming part), but kept
+    // separate since it has no preview / post-merge migration.
+    const editRepoMetadata: ToolEditRepoOutput['metadata'] | null = (() => {
+        const persisted = message.toolResults.find(isToolEditRepoResult);
+        if (persisted) return persisted.metadata;
+        const livePart = streamingState?.parts.find(
+            (p): p is Extract<StreamPart, { type: 'toolCall' }> =>
+                p.type === 'toolCall' &&
+                p.toolName === 'editRepo' &&
+                p.toolResult !== null &&
+                p.isPreliminary !== true,
+        );
+        const liveOutput = livePart?.toolResult as
+            | ToolEditRepoOutput
+            | undefined;
+        return liveOutput?.metadata ?? null;
     })();
 
     const mcpUnavailableNotices = streamingState?.mcpUnavailableNotices ?? [];
@@ -917,6 +939,12 @@ const AssistantBubbleContent: FC<{
                     }
                     agentUuid={agentUuid}
                     threadUuid={message.threadUuid}
+                />
+            )}
+            {editRepoMetadata && (
+                <AiEditRepoToolCall
+                    metadata={editRepoMetadata}
+                    projectUuid={projectUuid}
                 />
             )}
         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
@@ -13,8 +13,6 @@ import {
     ThemeIcon,
 } from '@mantine-8/core';
 import {
-    IconBrandGithub,
-    IconBrandGitlab,
     IconCheck,
     IconChevronDown,
     IconEye,
@@ -23,7 +21,6 @@ import {
     IconGitPullRequest,
     IconGitPullRequestClosed,
     IconSettings,
-    type Icon as TablerIcon,
 } from '@tabler/icons-react';
 import confetti from 'canvas-confetti';
 import { useEffect, useRef, useState, type FC } from 'react';
@@ -39,6 +36,7 @@ import { usePullRequestCiChecks } from '../../../hooks/usePullRequestCiChecks';
 import { POST_MERGE_MIGRATION_PROMPT } from '../../../postMergeMigrationPrompt';
 import styles from './AiEditDbtProjectToolCall.module.css';
 import { isMergeable } from './pullRequestActions';
+import { INSTALL_ACTIONS, summarisePrUrl } from './pullRequestCardUtils';
 import { PullRequestCiChecks } from './PullRequestCiChecks';
 import { WritebackDiffModal } from './WritebackDiffModal';
 
@@ -62,49 +60,8 @@ type Props = {
     threadUuid?: string;
 };
 
-// Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle"
-// so the user can verify which repo the PR landed in at a glance. The PR number
-// itself lives on the link button. Best-effort — any non-GitHub host or
-// malformed path falls back to the raw hostname.
-const summarisePrUrl = (prUrl: string): string | null => {
-    try {
-        const url = new URL(prUrl);
-        const segments = url.pathname.split('/').filter(Boolean);
-        if (
-            url.hostname === 'github.com' &&
-            segments.length >= 4 &&
-            segments[2] === 'pull'
-        ) {
-            const [owner, repo] = segments;
-            return `${owner}/${repo}`;
-        }
-        return url.hostname;
-    } catch {
-        return null;
-    }
-};
-
-// A writeback can't open a PR until the org installs the matching git app.
-// The agent's prose already explains the problem, so we surface only the
-// one-click action — each `installUrl` is the same install entry point as the
-// Integrations settings page, opened in a new tab so the user keeps their thread.
-const INSTALL_ACTIONS: Record<
-    'github_not_installed' | 'gitlab_not_installed',
-    { icon: TablerIcon; installUrl: string; cta: string }
-> = {
-    github_not_installed: {
-        icon: IconBrandGithub,
-        installUrl: '/api/v1/github/install',
-        cta: 'Install GitHub App',
-    },
-    gitlab_not_installed: {
-        icon: IconBrandGitlab,
-        installUrl: '/api/v1/gitlab/install',
-        cta: 'Connect GitLab',
-    },
-};
-
-const InstallAppButton: FC<{
+// ts-unused-exports:disable-next-line
+export const InstallAppButton: FC<{
     action: (typeof INSTALL_ACTIONS)[keyof typeof INSTALL_ACTIONS];
 }> = ({ action }) => (
     <Group gap={0}>
@@ -128,7 +85,8 @@ const InstallAppButton: FC<{
  * preview entry is omitted when there's no preview (non-GitHub run, failed
  * preview, or a setup PR). Owns the diff modal it launches.
  */
-const PullRequestViewMenu: FC<{
+// ts-unused-exports:disable-next-line
+export const PullRequestViewMenu: FC<{
     projectUuid: string;
     prUrl: string;
     previewUrl: string | null;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditRepoToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditRepoToolCall.tsx
@@ -1,0 +1,204 @@
+import { type ToolEditRepoOutput } from '@lightdash/common';
+import { Box, Group, Paper, Stack, Text, ThemeIcon } from '@mantine-8/core';
+import { IconGitPullRequest } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { useClosePullRequest } from '../../../hooks/useClosePullRequest';
+import { useMergePullRequest } from '../../../hooks/useMergePullRequest';
+import { usePullRequestCiChecks } from '../../../hooks/usePullRequestCiChecks';
+import {
+    InstallAppButton,
+    PullRequestActionButtons,
+    PullRequestViewMenu,
+} from './AiEditDbtProjectToolCall';
+import styles from './AiEditDbtProjectToolCall.module.css';
+import { INSTALL_ACTIONS, summarisePrUrl } from './pullRequestCardUtils';
+import { PullRequestCiChecks } from './PullRequestCiChecks';
+
+type Props = {
+    metadata: ToolEditRepoOutput['metadata'];
+    projectUuid: string;
+};
+
+/**
+ * Inline card for a general `editRepo` tool call — the counterpart to
+ * {@link AiEditDbtProjectToolCall} for non-dbt repos. Reuses its PR/CI/merge
+ * building blocks (View menu, action buttons, CI checks) but drops the dbt-only
+ * bits: there's no Lightdash preview for an arbitrary repo (previewUrl is always
+ * null) and merging does NOT inject the post-merge semantic-layer migration
+ * prompt. Errors render the install action where actionable and otherwise
+ * nothing — the agent's own reply carries the explanation.
+ */
+export const AiEditRepoToolCall: FC<Props> = ({ metadata, projectUuid }) => {
+    const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
+    const ciCommitSha =
+        metadata.status === 'success' ? (metadata.commitSha ?? null) : null;
+    const { data: ciChecks } = usePullRequestCiChecks(
+        projectUuid,
+        prUrl,
+        ciCommitSha,
+    );
+    const { mutate: merge, isLoading: isMerging } =
+        useMergePullRequest(projectUuid);
+    const { mutate: close, isLoading: isClosing } =
+        useClosePullRequest(projectUuid);
+
+    if (metadata.status === 'error') {
+        // The org just needs the matching git app installed — surface the
+        // one-click action; the agent's reply already explains the rest.
+        if (
+            metadata.errorCode === 'github_not_installed' ||
+            metadata.errorCode === 'gitlab_not_installed'
+        ) {
+            return (
+                <InstallAppButton
+                    action={INSTALL_ACTIONS[metadata.errorCode]}
+                />
+            );
+        }
+        // Forbidden repo, denied path, repo too large, closed PR, etc.: the
+        // agent's prose already explains what happened and why, so a separate
+        // red card would only duplicate it. Render nothing.
+        return null;
+    }
+
+    if (!metadata.prUrl) {
+        return (
+            <Paper withBorder p="sm" radius="md">
+                <Group gap="xs" align="center" wrap="nowrap">
+                    <ThemeIcon
+                        variant="light"
+                        color="ldGray"
+                        radius="md"
+                        size="md"
+                    >
+                        <MantineIcon icon={IconGitPullRequest} size={16} />
+                    </ThemeIcon>
+                    <Text size="sm" c="ldGray.7">
+                        No file changes were needed — no pull request was
+                        opened.
+                    </Text>
+                </Group>
+            </Paper>
+        );
+    }
+
+    // Prefer the explicit repository, falling back to parsing the PR URL.
+    const summary = metadata.repository ?? summarisePrUrl(metadata.prUrl);
+    const shortCommitSha = metadata.commitSha
+        ? metadata.commitSha.slice(0, 7)
+        : null;
+    const additions = metadata.additions ?? null;
+    const deletions = metadata.deletions ?? null;
+    const hasDiffStat = additions !== null || deletions !== null;
+    const resolvedPrUrl = metadata.prUrl;
+
+    return (
+        <Paper
+            withBorder
+            p="sm"
+            radius="md"
+            className={
+                ciChecks?.merged
+                    ? `${styles.card} ${styles.cardMerged}`
+                    : ciChecks?.state === 'closed'
+                      ? `${styles.card} ${styles.cardClosed}`
+                      : styles.card
+            }
+        >
+            <Stack gap="xs">
+                <Box className={styles.header}>
+                    <Group
+                        className={styles.titleBlock}
+                        gap="xs"
+                        align="center"
+                        wrap="nowrap"
+                    >
+                        <MantineIcon
+                            icon={IconGitPullRequest}
+                            size={18}
+                            color="ldGray.7"
+                        />
+                        <Stack gap={0}>
+                            <Text size="sm" fw={500}>
+                                Edited repository
+                            </Text>
+                            {summary && (
+                                <Group gap={6} wrap="nowrap">
+                                    <Text size="xs" c="ldGray.6">
+                                        {summary}
+                                    </Text>
+                                    {shortCommitSha && (
+                                        <>
+                                            <Text size="xs" c="ldGray.4">
+                                                ·
+                                            </Text>
+                                            <Text
+                                                size="xs"
+                                                c="ldGray.6"
+                                                ff="monospace"
+                                                title={
+                                                    metadata.commitSha ??
+                                                    undefined
+                                                }
+                                            >
+                                                {shortCommitSha}
+                                            </Text>
+                                        </>
+                                    )}
+                                    {hasDiffStat && (
+                                        <Group gap={4} wrap="nowrap">
+                                            {additions !== null && (
+                                                <Text
+                                                    size="xs"
+                                                    c="green"
+                                                    ff="monospace"
+                                                >
+                                                    +{additions}
+                                                </Text>
+                                            )}
+                                            {deletions !== null && (
+                                                <Text
+                                                    size="xs"
+                                                    c="red"
+                                                    ff="monospace"
+                                                >
+                                                    −{deletions}
+                                                </Text>
+                                            )}
+                                        </Group>
+                                    )}
+                                </Group>
+                            )}
+                        </Stack>
+                    </Group>
+                    <Box className={styles.actions}>
+                        <PullRequestViewMenu
+                            projectUuid={projectUuid}
+                            prUrl={metadata.prUrl}
+                            previewUrl={null}
+                            commitSha={metadata.commitSha ?? null}
+                        />
+                        <PullRequestActionButtons
+                            ciChecks={ciChecks ?? null}
+                            isMerging={isMerging}
+                            isClosing={isClosing}
+                            onMerge={() =>
+                                merge({
+                                    prUrl: resolvedPrUrl,
+                                    sha: metadata.commitSha ?? null,
+                                })
+                            }
+                            onClose={() => close({ prUrl: resolvedPrUrl })}
+                        />
+                    </Box>
+                </Box>
+                <PullRequestCiChecks
+                    prUrl={metadata.prUrl}
+                    ciChecks={ciChecks ?? null}
+                    hasMergeAction
+                />
+            </Stack>
+        </Paper>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.ts
@@ -1,0 +1,54 @@
+import {
+    IconBrandGithub,
+    IconBrandGitlab,
+    type Icon as TablerIcon,
+} from '@tabler/icons-react';
+
+// Shared helpers/constants for the writeback PR cards (dbt + general coding
+// agent). Kept in a non-component module so both card files can import them
+// without tripping react-refresh's only-export-components rule.
+
+/**
+ * Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle"
+ * so the user can verify which repo the PR landed in at a glance. Best-effort —
+ * any non-GitHub host or malformed path falls back to the raw hostname.
+ */
+export const summarisePrUrl = (prUrl: string): string | null => {
+    try {
+        const url = new URL(prUrl);
+        const segments = url.pathname.split('/').filter(Boolean);
+        if (
+            url.hostname === 'github.com' &&
+            segments.length >= 4 &&
+            segments[2] === 'pull'
+        ) {
+            const [owner, repo] = segments;
+            return `${owner}/${repo}`;
+        }
+        return url.hostname;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * A writeback can't open a PR until the org installs the matching git app. The
+ * agent's prose already explains the problem, so the card surfaces only the
+ * one-click action — each `installUrl` is the same install entry point as the
+ * Integrations settings page.
+ */
+export const INSTALL_ACTIONS: Record<
+    'github_not_installed' | 'gitlab_not_installed',
+    { icon: TablerIcon; installUrl: string; cta: string }
+> = {
+    github_not_installed: {
+        icon: IconBrandGithub,
+        installUrl: '/api/v1/github/install',
+        cta: 'Install GitHub App',
+    },
+    gitlab_not_installed: {
+        icon: IconBrandGitlab,
+        installUrl: '/api/v1/gitlab/install',
+        cta: 'Connect GitLab',
+    },
+};


### PR DESCRIPTION
## 📚 Stack — general-purpose coding agent

The **write** counterpart to repo discovery: the AI agent can make a code change to any repo the org's GitHub/GitLab App installation can write (intersected with the user's own access) and open a pull request, via a new `editRepo` tool. It reuses the AI-writeback E2B → signed-commit → PR engine. Gated by the new `ai-coding-agent` feature flag — **off by default, EE-gated**; the flag is presence-of-feature, the per-repo write authz lives in the service.

Reviewed bottom-up; each PR is self-contained and CI-green on its parent.

| # | Slice | |
|---|---|---|
| #24508 | 1 · lean E2B image + CI publish | **merge first** — builds/publishes the template the agent runs in |
| #24502 | 2 · engine + `editRepo` tool foundation | |
| #24503 | 3 · writable-repo authz chokepoint | |
| #24504 | 4 · security hardening | **🔒 release gate** — flag must not open to any customer until this lands |
| #24505 | 5 · multi-repo threads | |
| #24506 | 6 · rich PR card | |
| #24507 | 7 · GitLab parity | live-verification pending (no GitLab repo in local env) |

---

### This PR — Slice 6: rich PR card

- `AiEditRepoToolCall` renders a full PR card (View / diff / CI checks / merge / close), reusing the dbt card's components; no preview / no post-merge migration prompt.
- Resolves the result via `isToolEditRepoResult` without re-widening the AgentToolOutput union.
