### PR TITLE
fix: wrap AiMarkdown in an error boundary

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -68,6 +68,7 @@ import {
 import styles from './AgentChatAssistantBubble.module.css';
 import AgentChatDebugDrawer from './AgentChatDebugDrawer';
 import { AiArtifactInline } from './AiArtifactInline';
+import { AiMarkdownErrorBoundary } from './AiMarkdownErrorBoundary';
 import { AiArtifactButton } from './ArtifactButton/AiArtifactButton';
 import { ContentLink, type SqlRunnerLinkState } from './ContentLink';
 import { MessageModelIndicator } from './MessageModelIndicator';
@@ -643,46 +644,48 @@ const AssistantBubbleContent: FC<{
                             }`}
                             style={mdStyle}
                         >
-                            <Streamdown
-                                parseIncompleteMarkdown
-                                controls={false}
-                                caret="block"
-                                isAnimating={isStreaming}
-                                mode={isStreaming ? 'streaming' : 'static'}
-                                remarkPlugins={[remarkGfm, remarkEmoji]}
-                                rehypePlugins={[rehypeAiAgentContentLinks]}
-                                plugins={markdownPlugins}
-                                components={{
-                                    a: ({ node, children, ...props }) => {
-                                        const contentType =
-                                            'data-content-type' in props &&
-                                            typeof props[
-                                                'data-content-type'
-                                            ] === 'string'
-                                                ? props['data-content-type']
-                                                : undefined;
-                                        return (
-                                            <ContentLink
-                                                contentType={contentType}
-                                                props={props}
-                                                message={message}
-                                                projectUuid={projectUuid}
-                                                agentUuid={agentUuid}
-                                                sqlRunnerLinkState={
-                                                    sqlRunnerLinkState
-                                                }
-                                                onDashboardLinkClick={
-                                                    onDashboardLinkClick
-                                                }
-                                            >
-                                                {children}
-                                            </ContentLink>
-                                        );
-                                    },
-                                }}
-                            >
-                                {latestTextSeg.text}
-                            </Streamdown>
+                            <AiMarkdownErrorBoundary>
+                                <Streamdown
+                                    parseIncompleteMarkdown
+                                    controls={false}
+                                    caret="block"
+                                    isAnimating={isStreaming}
+                                    mode={isStreaming ? 'streaming' : 'static'}
+                                    remarkPlugins={[remarkGfm, remarkEmoji]}
+                                    rehypePlugins={[rehypeAiAgentContentLinks]}
+                                    plugins={markdownPlugins}
+                                    components={{
+                                        a: ({ node, children, ...props }) => {
+                                            const contentType =
+                                                'data-content-type' in props &&
+                                                typeof props[
+                                                    'data-content-type'
+                                                ] === 'string'
+                                                    ? props['data-content-type']
+                                                    : undefined;
+                                            return (
+                                                <ContentLink
+                                                    contentType={contentType}
+                                                    props={props}
+                                                    message={message}
+                                                    projectUuid={projectUuid}
+                                                    agentUuid={agentUuid}
+                                                    sqlRunnerLinkState={
+                                                        sqlRunnerLinkState
+                                                    }
+                                                    onDashboardLinkClick={
+                                                        onDashboardLinkClick
+                                                    }
+                                                >
+                                                    {children}
+                                                </ContentLink>
+                                            );
+                                        },
+                                    }}
+                                >
+                                    {latestTextSeg.text}
+                                </Streamdown>
+                            </AiMarkdownErrorBoundary>
                         </Box>
                     ) : null;
                     const pendingApprovalContent =
@@ -840,46 +843,61 @@ const AssistantBubbleContent: FC<{
                                 className={styles.aiMarkdown}
                                 style={{ ...mdStyle, paddingBlock: '0.5rem' }}
                             >
-                                <Streamdown
-                                    parseIncompleteMarkdown
-                                    controls={false}
-                                    animated
-                                    mode="static"
-                                    remarkPlugins={[remarkGfm, remarkEmoji]}
-                                    rehypePlugins={[rehypeAiAgentContentLinks]}
-                                    plugins={markdownPlugins}
-                                    components={{
-                                        a: ({ node, children, ...props }) => {
-                                            const contentType =
-                                                'data-content-type' in props &&
-                                                typeof props[
-                                                    'data-content-type'
-                                                ] === 'string'
-                                                    ? props['data-content-type']
-                                                    : undefined;
+                                <AiMarkdownErrorBoundary>
+                                    <Streamdown
+                                        parseIncompleteMarkdown
+                                        controls={false}
+                                        animated
+                                        mode="static"
+                                        remarkPlugins={[remarkGfm, remarkEmoji]}
+                                        rehypePlugins={[
+                                            rehypeAiAgentContentLinks,
+                                        ]}
+                                        plugins={markdownPlugins}
+                                        components={{
+                                            a: ({
+                                                node,
+                                                children,
+                                                ...props
+                                            }) => {
+                                                const contentType =
+                                                    'data-content-type' in
+                                                        props &&
+                                                    typeof props[
+                                                        'data-content-type'
+                                                    ] === 'string'
+                                                        ? props[
+                                                              'data-content-type'
+                                                          ]
+                                                        : undefined;
 
-                                            return (
-                                                <ContentLink
-                                                    contentType={contentType}
-                                                    props={props}
-                                                    message={message}
-                                                    projectUuid={projectUuid}
-                                                    agentUuid={agentUuid}
-                                                    sqlRunnerLinkState={
-                                                        sqlRunnerLinkState
-                                                    }
-                                                    onDashboardLinkClick={
-                                                        onDashboardLinkClick
-                                                    }
-                                                >
-                                                    {children}
-                                                </ContentLink>
-                                            );
-                                        },
-                                    }}
-                                >
-                                    {messageContent}
-                                </Streamdown>
+                                                return (
+                                                    <ContentLink
+                                                        contentType={
+                                                            contentType
+                                                        }
+                                                        props={props}
+                                                        message={message}
+                                                        projectUuid={
+                                                            projectUuid
+                                                        }
+                                                        agentUuid={agentUuid}
+                                                        sqlRunnerLinkState={
+                                                            sqlRunnerLinkState
+                                                        }
+                                                        onDashboardLinkClick={
+                                                            onDashboardLinkClick
+                                                        }
+                                                    >
+                                                        {children}
+                                                    </ContentLink>
+                                                );
+                                            },
+                                        }}
+                                    >
+                                        {messageContent}
+                                    </Streamdown>
+                                </AiMarkdownErrorBoundary>
                             </Box>
                         ) : null}
                     </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiMarkdownErrorBoundary.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiMarkdownErrorBoundary.tsx
@@ -1,5 +1,10 @@
 import { Text } from '@mantine-8/core';
-import { Component, type PropsWithChildren, type ReactNode } from 'react';
+import {
+    Component,
+    type ErrorInfo,
+    type PropsWithChildren,
+    type ReactNode,
+} from 'react';
 
 type Props = PropsWithChildren<{
     fallback?: ReactNode;
@@ -14,6 +19,10 @@ export class AiMarkdownErrorBoundary extends Component<Props, State> {
 
     static getDerivedStateFromError() {
         return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        console.error('Failed to render AI markdown', error, errorInfo);
     }
 
     render() {

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiMarkdownErrorBoundary.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiMarkdownErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Text } from '@mantine-8/core';
+import { Component, type PropsWithChildren, type ReactNode } from 'react';
+
+type Props = PropsWithChildren<{
+    fallback?: ReactNode;
+}>;
+
+type State = {
+    hasError: boolean;
+};
+
+export class AiMarkdownErrorBoundary extends Component<Props, State> {
+    state: State = { hasError: false };
+
+    static getDerivedStateFromError() {
+        return { hasError: true };
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                this.props.fallback ?? (
+                    <Text size="xs" c="dimmed">
+                        Couldn&apos;t render this message.
+                    </Text>
+                )
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/LiveActivityCard.tsx
@@ -22,6 +22,7 @@ import { Streamdown } from 'streamdown';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
 import { type StepProgressMessage } from '../../../store/aiAgentThreadStreamSlice';
 import bubbleStyles from '../AgentChatAssistantBubble.module.css';
+import { AiMarkdownErrorBoundary } from '../AiMarkdownErrorBoundary';
 import { AgentStepGroups } from './AgentStepGroups';
 import { ToolCallDescription } from './descriptions/ToolCallDescription';
 import { DiscoverFieldsTrace, type TraceEntry } from './DiscoverFieldsTrace';
@@ -255,14 +256,16 @@ export const ReasoningHistoryRow: FC<{
                         color: 'var(--mantine-color-ldGray-7)',
                     }}
                 >
-                    <Streamdown
-                        parseIncompleteMarkdown
-                        controls={false}
-                        mode="static"
-                        remarkPlugins={[remarkGfm, remarkEmoji]}
-                    >
-                        {combined}
-                    </Streamdown>
+                    <AiMarkdownErrorBoundary>
+                        <Streamdown
+                            parseIncompleteMarkdown
+                            controls={false}
+                            mode="static"
+                            remarkPlugins={[remarkGfm, remarkEmoji]}
+                        >
+                            {combined}
+                        </Streamdown>
+                    </AiMarkdownErrorBoundary>
                 </Box>
             </Collapse>
         </Box>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ --><!-- reference the related issue e.g. #150 -->

### Description:

Sentry showed an error bubbling up to the top of the app and traced it to Streamdown in chat bubbles. This mitigation add an error boundary around the streamdown instances so errors there won't bubble up. 