### PR TITLE
feat(conditional-formatting): support bold/italic/underline text styling

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5076,11 +5076,25 @@ const models: TsoaRoute.Models = {
         enums: ['cell', 'text', 'row'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ConditionalFormattingTextStyle: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                underline: { dataType: 'boolean' },
+                italic: { dataType: 'boolean' },
+                bold: { dataType: 'boolean' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ConditionalFormattingConfigWithSingleColor: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                textStyle: { ref: 'ConditionalFormattingTextStyle' },
                 applyTo: { ref: 'ConditionalFormattingColorApplyTo' },
                 rules: {
                     dataType: 'array',
@@ -5148,6 +5162,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                textStyle: { ref: 'ConditionalFormattingTextStyle' },
                 applyTo: { ref: 'ConditionalFormattingColorApplyTo' },
                 rule: {
                     ref: 'ConditionalFormattingMinMax_number-or-auto_',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5740,8 +5740,29 @@
                 "enum": ["cell", "text", "row"],
                 "type": "string"
             },
+            "ConditionalFormattingTextStyle": {
+                "properties": {
+                    "underline": {
+                        "type": "boolean",
+                        "description": "Underline matching cell text"
+                    },
+                    "italic": {
+                        "type": "boolean",
+                        "description": "Render matching cell text in italics"
+                    },
+                    "bold": {
+                        "type": "boolean",
+                        "description": "Render matching cell text in bold"
+                    }
+                },
+                "type": "object"
+            },
             "ConditionalFormattingConfigWithSingleColor": {
                 "properties": {
+                    "textStyle": {
+                        "$ref": "#/components/schemas/ConditionalFormattingTextStyle",
+                        "description": "Text styling (bold/italic/underline) applied to matching cell text"
+                    },
                     "applyTo": {
                         "$ref": "#/components/schemas/ConditionalFormattingColorApplyTo",
                         "description": "Apply formatting to cell background or text"
@@ -5822,6 +5843,10 @@
             },
             "ConditionalFormattingConfigWithColorRange": {
                 "properties": {
+                    "textStyle": {
+                        "$ref": "#/components/schemas/ConditionalFormattingTextStyle",
+                        "description": "Text styling (bold/italic/underline) applied to matching cell text"
+                    },
                     "applyTo": {
                         "$ref": "#/components/schemas/ConditionalFormattingColorApplyTo",
                         "description": "Apply formatting to cell background or text"

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -593,6 +593,10 @@
                             "type": "null"
                         }
                     ]
+                },
+                "textStyle": {
+                    "$ref": "#/$defs/ConditionalFormattingTextStyle",
+                    "description": "Text styling (bold/italic/underline) applied to matching cell text"
                 }
             },
             "required": ["rule", "color", "target"],
@@ -633,6 +637,10 @@
                             "type": "null"
                         }
                     ]
+                },
+                "textStyle": {
+                    "$ref": "#/$defs/ConditionalFormattingTextStyle",
+                    "description": "Text styling (bold/italic/underline) applied to matching cell text"
                 }
             },
             "required": ["rules", "color", "target"],
@@ -668,6 +676,23 @@
                 }
             },
             "required": ["max", "min"],
+            "type": "object"
+        },
+        "ConditionalFormattingTextStyle": {
+            "properties": {
+                "bold": {
+                    "description": "Render matching cell text in bold",
+                    "type": "boolean"
+                },
+                "italic": {
+                    "description": "Render matching cell text in italics",
+                    "type": "boolean"
+                },
+                "underline": {
+                    "description": "Underline matching cell text",
+                    "type": "boolean"
+                }
+            },
             "type": "object"
         },
         "ConditionalFormattingWithCompareTarget_number-or-string_": {

--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -15,6 +15,15 @@ export type ConditionalFormattingColorRange = {
     end: string;
 };
 
+export type ConditionalFormattingTextStyle = {
+    /** Render matching cell text in bold */
+    bold?: boolean;
+    /** Render matching cell text in italics */
+    italic?: boolean;
+    /** Underline matching cell text */
+    underline?: boolean;
+};
+
 export type ConditionalFormattingWithValues<T = number | string> =
     BaseFilterRule<FilterOperator, T> & {
         /** Values to compare against */
@@ -52,6 +61,8 @@ export type ConditionalFormattingConfigWithSingleColor = {
     rules: ConditionalFormattingWithFilterOperator[];
     /** Apply formatting to cell background or text */
     applyTo?: ConditionalFormattingColorApplyTo;
+    /** Text styling (bold/italic/underline) applied to matching cell text */
+    textStyle?: ConditionalFormattingTextStyle;
 };
 
 export const isConditionalFormattingConfigWithSingleColor = (
@@ -68,6 +79,8 @@ export type ConditionalFormattingConfigWithColorRange = {
     rule: ConditionalFormattingMinMax<number | 'auto'>;
     /** Apply formatting to cell background or text */
     applyTo?: ConditionalFormattingColorApplyTo;
+    /** Text styling (bold/italic/underline) applied to matching cell text */
+    textStyle?: ConditionalFormattingTextStyle;
 };
 
 export const isConditionalFormattingConfigWithColorRange = (

--- a/packages/common/src/utils/conditionalFormatting.test.ts
+++ b/packages/common/src/utils/conditionalFormatting.test.ts
@@ -5,6 +5,7 @@ import {
     createConditionalFormattingConfigWithSingleColor,
     createConditionalFormattingRuleWithValues,
     getConditionalFormattingConfig,
+    getConditionalFormattingTextStyle,
     getPivotRowContextKey,
     getRowConditionalFormattingColor,
     hasMatchingConditionalRules,
@@ -350,5 +351,50 @@ describe('getRowConditionalFormattingColor', () => {
             minMaxMap: {},
         });
         expect(result).toBe('#aaaaaa');
+    });
+});
+
+describe('getConditionalFormattingTextStyle', () => {
+    it('returns undefined when no configs have text styling', () => {
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        expect(
+            getConditionalFormattingTextStyle([config, undefined]),
+        ).toBeUndefined();
+    });
+
+    it('returns the text style of a single matching config', () => {
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        config.textStyle = { bold: true };
+        expect(getConditionalFormattingTextStyle([config])).toEqual({
+            bold: true,
+            italic: false,
+            underline: false,
+        });
+    });
+
+    it('unions text styles across multiple matching configs', () => {
+        const boldConfig =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        boldConfig.textStyle = { bold: true };
+        const underlineConfig =
+            createConditionalFormattingConfigWithSingleColor('#00ff00');
+        underlineConfig.textStyle = { underline: true };
+
+        expect(
+            getConditionalFormattingTextStyle([
+                boldConfig,
+                undefined,
+                underlineConfig,
+            ]),
+        ).toEqual({ bold: true, italic: false, underline: true });
+    });
+
+    it('ignores a config whose text style has all toggles off', () => {
+        const config =
+            createConditionalFormattingConfigWithSingleColor('#ff0000');
+        config.textStyle = { bold: false, italic: false, underline: false };
+        expect(getConditionalFormattingTextStyle([config])).toBeUndefined();
     });
 });

--- a/packages/common/src/utils/conditionalFormatting.ts
+++ b/packages/common/src/utils/conditionalFormatting.ts
@@ -18,6 +18,7 @@ import {
     type ConditionalFormattingConfigWithSingleColor,
     type ConditionalFormattingMinMax,
     type ConditionalFormattingMinMaxMap,
+    type ConditionalFormattingTextStyle,
     type ConditionalFormattingWithFilterOperator,
 } from '../types/conditionalFormatting';
 import { LightdashError, NotImplementedError } from '../types/errors';
@@ -752,12 +753,11 @@ export const getConditionalFormattingColor = ({
 };
 
 /**
- * Row-level conditional formatting (PROD-8058): returns the background color to
- * paint across an entire row when a single `applyTo: ROW` rule's trigger field
- * matches. Evaluated once per row, independent of the cell being drawn.
- * Returns null when no ROW rule matches.
+ * Row-level conditional formatting (PROD-8058): returns the matching `applyTo:
+ * ROW` config whose trigger field matches, or undefined. Evaluated once per
+ * row, independent of the cell being drawn.
  */
-export const getRowConditionalFormattingColor = ({
+export const getRowConditionalFormattingConfig = ({
     conditionalFormattings,
     rowFields,
     minMaxMap = {},
@@ -765,10 +765,10 @@ export const getRowConditionalFormattingColor = ({
     conditionalFormattings: ConditionalFormattingConfig[] | undefined;
     rowFields: ConditionalFormattingRowFields;
     minMaxMap: ConditionalFormattingMinMaxMap | undefined;
-}): string | null => {
-    if (!conditionalFormattings) return null;
+}): ConditionalFormattingConfig | undefined => {
+    if (!conditionalFormattings) return undefined;
 
-    const match = conditionalFormattings.find((config) => {
+    return conditionalFormattings.find((config) => {
         if (config.applyTo !== ConditionalFormattingColorApplyTo.ROW) {
             return false;
         }
@@ -784,11 +784,51 @@ export const getRowConditionalFormattingColor = ({
             rowFields,
         );
     });
+};
+
+/**
+ * Row-level conditional formatting (PROD-8058): returns the background color to
+ * paint across an entire row when a single `applyTo: ROW` rule's trigger field
+ * matches. Returns null when no ROW rule matches.
+ */
+export const getRowConditionalFormattingColor = (args: {
+    conditionalFormattings: ConditionalFormattingConfig[] | undefined;
+    rowFields: ConditionalFormattingRowFields;
+    minMaxMap: ConditionalFormattingMinMaxMap | undefined;
+}): string | null => {
+    const match = getRowConditionalFormattingConfig(args);
 
     if (!match) return null;
     return isConditionalFormattingConfigWithSingleColor(match)
         ? match.color
         : null;
+};
+
+/**
+ * Merges the text styling (bold/italic/underline) from every matching config
+ * that applies to a cell — its cell-level, text-level and row-level matches —
+ * into a single style. Returns undefined when no style is set so callers can
+ * skip styling entirely.
+ */
+export const getConditionalFormattingTextStyle = (
+    configs: Array<ConditionalFormattingConfig | undefined>,
+): ConditionalFormattingTextStyle | undefined => {
+    const merged = configs.reduce<ConditionalFormattingTextStyle>(
+        (acc, config) => {
+            const style = config?.textStyle;
+            if (!style) return acc;
+            return {
+                bold: acc.bold || !!style.bold,
+                italic: acc.italic || !!style.italic,
+                underline: acc.underline || !!style.underline,
+            };
+        },
+        { bold: false, italic: false, underline: false },
+    );
+
+    return merged.bold || merged.italic || merged.underline
+        ? merged
+        : undefined;
 };
 
 /**

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingItem.tsx
@@ -20,19 +20,27 @@ import {
     type ConditionalFormattingColorRange,
     type ConditionalFormattingConfig,
     type ConditionalFormattingConfigWithColorRange,
+    type ConditionalFormattingTextStyle,
     type ConditionalFormattingWithFilterOperator,
     type FilterableItem,
     type FilterOperator,
 } from '@lightdash/common';
 import {
     Accordion,
+    ActionIcon,
     Button,
     Flex,
     Group,
     SegmentedControl,
     Stack,
+    Tooltip,
 } from '@mantine-8/core';
-import { IconPlus } from '@tabler/icons-react';
+import {
+    IconBold,
+    IconItalic,
+    IconPlus,
+    IconUnderline,
+} from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import FieldSelect from '../../common/FieldSelect';
@@ -63,6 +71,16 @@ const ConditionalFormattingRuleLabels = {
     [ConditionalFormattingConfigType.Single]: 'Single',
     [ConditionalFormattingConfigType.Range]: 'Range',
 };
+
+const TEXT_STYLE_TOGGLES: {
+    key: keyof ConditionalFormattingTextStyle;
+    label: string;
+    icon: typeof IconBold;
+}[] = [
+    { key: 'bold', label: 'Bold', icon: IconBold },
+    { key: 'italic', label: 'Italic', icon: IconItalic },
+    { key: 'underline', label: 'Underline', icon: IconUnderline },
+];
 
 export const ConditionalFormattingItem: FC<Props> = ({
     colorPalette,
@@ -345,6 +363,18 @@ export const ConditionalFormattingItem: FC<Props> = ({
         [handleChange, config],
     );
 
+    const handleToggleTextStyle = useCallback(
+        (key: keyof ConditionalFormattingTextStyle) => {
+            handleChange(
+                produce(config, (draft) => {
+                    const current = draft.textStyle ?? {};
+                    draft.textStyle = { ...current, [key]: !current[key] };
+                }),
+            );
+        },
+        [handleChange, config],
+    );
+
     const controlLabel = `Rule ${configIndex}`;
     const accordionValue = `${configIndex}`;
 
@@ -499,6 +529,38 @@ export const ConditionalFormattingItem: FC<Props> = ({
                                     )
                                 }
                             />
+                        </Group>
+
+                        <Group gap="xs">
+                            <Config.Label>Text style</Config.Label>
+                            <ActionIcon.Group>
+                                {TEXT_STYLE_TOGGLES.map(
+                                    ({ key, label, icon }) => (
+                                        <Tooltip
+                                            key={key}
+                                            label={label}
+                                            withinPortal
+                                        >
+                                            <ActionIcon
+                                                variant={
+                                                    config.textStyle?.[key]
+                                                        ? 'filled'
+                                                        : 'default'
+                                                }
+                                                aria-label={label}
+                                                onClick={() =>
+                                                    handleToggleTextStyle(key)
+                                                }
+                                            >
+                                                <MantineIcon
+                                                    icon={icon}
+                                                    size="sm"
+                                                />
+                                            </ActionIcon>
+                                        </Tooltip>
+                                    ),
+                                )}
+                            </ActionIcon.Group>
                         </Group>
 
                         {isConditionalFormattingConfigWithSingleColor(

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -1,4 +1,7 @@
-import { assertUnreachable } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type ConditionalFormattingTextStyle,
+} from '@lightdash/common';
 import {
     Box,
     Text,
@@ -58,6 +61,7 @@ type TableCellProps = PolymorphicComponentProps<'th' | 'td', BoxProps> & {
     withInteractions?: boolean;
     withColor?: false | string;
     withBackground?: false | string;
+    withTextStyle?: false | ConditionalFormattingTextStyle;
     withTooltip?: false | string;
     withMenu?:
         | false
@@ -374,6 +378,7 @@ const BaseCell = (
                 withInteractions = false,
                 withColor = false,
                 withBackground = false,
+                withTextStyle = false,
                 withMenu = false,
                 withValue = undefined,
                 ...rest
@@ -413,6 +418,7 @@ const BaseCell = (
                 index,
                 withColor,
                 withBackground,
+                withTextStyle,
             });
 
             const cellHasLargeContent = useMemo(() => {
@@ -453,6 +459,7 @@ const BaseCell = (
                             [classes.withAlignRight]: withAlignRight,
                             [classes.withBoldFont]: withBoldFont,
                             [classes.withColor]: withColor,
+                            [classes.withTextStyle]: !!withTextStyle,
                             [classes.withInteractions]: withInteractions,
                             [classes.withBackground]: withBackground,
                             [classes.withCopying]: clipboard.copied,
@@ -496,6 +503,7 @@ const BaseCell = (
                     classes.withAlignRight,
                     classes.withBoldFont,
                     classes.withColor,
+                    classes.withTextStyle,
                     classes.withInteractions,
                     classes.withBackground,
                     classes.withCopying,
@@ -506,6 +514,7 @@ const BaseCell = (
                     withAlignRight,
                     withBoldFont,
                     withColor,
+                    withTextStyle,
                     withInteractions,
                     withBackground,
                     clipboard.copied,

--- a/packages/frontend/src/components/common/LightTable/styles.ts
+++ b/packages/frontend/src/components/common/LightTable/styles.ts
@@ -1,4 +1,7 @@
-import { assertUnreachable } from '@lightdash/common';
+import {
+    assertUnreachable,
+    type ConditionalFormattingTextStyle,
+} from '@lightdash/common';
 import { createStyles, type MantineTheme } from '@mantine/core';
 import { darken, rgba } from 'polished';
 import { CELL_HEIGHT } from './constants';
@@ -245,6 +248,7 @@ export const useTableCellStyles = createStyles<
         index: number;
         withColor: string | false;
         withBackground: string | false;
+        withTextStyle?: ConditionalFormattingTextStyle | false;
     }
 >(
     (
@@ -255,6 +259,7 @@ export const useTableCellStyles = createStyles<
             index,
             withColor = false,
             withBackground = false,
+            withTextStyle = false,
         },
     ) => {
         const cellHeadBackground = theme.colors.ldGray[0];
@@ -352,6 +357,18 @@ export const useTableCellStyles = createStyles<
             withBoldFont: {
                 fontWeight: 600,
             },
+
+            withTextStyle: withTextStyle
+                ? {
+                      ...(withTextStyle.bold ? { fontWeight: 700 } : {}),
+                      ...(withTextStyle.italic
+                          ? { fontStyle: 'italic' as const }
+                          : {}),
+                      ...(withTextStyle.underline
+                          ? { textDecoration: 'underline' }
+                          : {}),
+                  }
+                : {},
 
             withCopying: {
                 backgroundColor: copyingBackground,

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -5,7 +5,9 @@ import {
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
+    getConditionalFormattingTextStyle,
     getRowConditionalFormattingColor,
+    getRowConditionalFormattingConfig,
     getItemId,
     getPivotRowContextKey,
     isDimension,
@@ -1587,6 +1589,13 @@ const PivotTable: FC<PivotTableProps> = ({
                         },
                     );
 
+                    const rowConditionalFormattingConfig =
+                        getRowConditionalFormattingConfig({
+                            conditionalFormattings,
+                            rowFields: rowLevelFields,
+                            minMaxMap,
+                        });
+
                     return (
                         <Table.Row
                             key={`row-${rowIndex}-${data.pivotConfig.metricsAsRows}`}
@@ -1848,6 +1857,13 @@ const PivotTable: FC<PivotTableProps> = ({
                                 // Font color is set by conditionalFormatting above
                                 const fontColor = conditionalFormatting?.color;
 
+                                const textStyle =
+                                    getConditionalFormattingTextStyle([
+                                        cellConditionalFormattingConfig,
+                                        textConditionalFormattingConfig,
+                                        rowConditionalFormattingConfig,
+                                    ]);
+
                                 // Get field description for label cells (metric labels when metricsAsRows is enabled)
                                 const labelFieldDescription = (() => {
                                     if (meta?.type !== 'label')
@@ -1915,6 +1931,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                         miw={cellWidth}
                                         maw={cellWidth}
                                         withColor={conditionalFormatting?.color}
+                                        withTextStyle={textStyle ?? false}
                                         withBoldFont={meta?.type === 'label'}
                                         withBackground={
                                             conditionalFormatting?.backgroundColor

--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -2,6 +2,7 @@ import {
     isField,
     isRawResultRow,
     isResultValue,
+    type ConditionalFormattingTextStyle,
     type RawResultRow,
     type ResultRow,
 } from '@lightdash/common';
@@ -41,6 +42,7 @@ interface CommonBodyCellProps {
     style?: CSSProperties;
     backgroundColor?: string;
     fontColor?: string;
+    textStyle?: ConditionalFormattingTextStyle;
     isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
@@ -54,6 +56,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     className,
     backgroundColor,
     fontColor,
+    textStyle,
     hasData,
     cellContextMenu,
     isNumericItem,
@@ -163,6 +166,7 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                 $isCopying={isCopying}
                 $backgroundColor={backgroundColor}
                 $fontColor={fontColor}
+                $textStyle={textStyle}
                 $hasData={hasData}
                 $isNaN={!hasData || !isNumericItem}
                 $hasUrls={hasUrls}

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -3,9 +3,11 @@ import {
     getConditionalFormattingColor,
     getConditionalFormattingConfig,
     getConditionalFormattingDescription,
+    getConditionalFormattingTextStyle,
     getItemId,
     getReadableTextColor,
     getRowConditionalFormattingColor,
+    getRowConditionalFormattingConfig,
     isNumericItem,
     type ConditionalFormattingColorRange,
     type ConditionalFormattingMinMax,
@@ -136,6 +138,16 @@ const TableRow: FC<TableRowProps> = ({
         [conditionalFormattings, rowFields, minMaxMap],
     );
 
+    const rowConditionalFormattingConfig = useMemo(
+        () =>
+            getRowConditionalFormattingConfig({
+                conditionalFormattings,
+                rowFields,
+                minMaxMap,
+            }),
+        [conditionalFormattings, rowFields, minMaxMap],
+    );
+
     return (
         <Tr $index={index} ref={measureElement} data-index={virtualIndex}>
             {row.getVisibleCells().map((cell) => {
@@ -233,6 +245,12 @@ const TableRow: FC<TableRowProps> = ({
                     fontColor = getReadableTextColor(rowBackgroundColor);
                 }
 
+                const textStyle = getConditionalFormattingTextStyle([
+                    cellConditionalFormattingConfig,
+                    textConditionalFormattingConfig,
+                    rowConditionalFormattingConfig,
+                ]);
+
                 const suppressContextMenu =
                     cell.getIsPlaceholder() || cell.getIsAggregated();
 
@@ -244,6 +262,7 @@ const TableRow: FC<TableRowProps> = ({
                         style={meta?.style}
                         backgroundColor={backgroundColor}
                         fontColor={fontColor}
+                        textStyle={textStyle}
                         className={meta?.className}
                         index={index}
                         cell={cell}

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -1,3 +1,4 @@
+import { type ConditionalFormattingTextStyle } from '@lightdash/common';
 import { forwardRef, type ComponentPropsWithRef, type ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 import {
@@ -204,6 +205,7 @@ export const Td = styled.td<{
     $isCopying: boolean;
     $backgroundColor?: string;
     $fontColor?: string;
+    $textStyle?: ConditionalFormattingTextStyle;
     $hasData: boolean;
     $isLargeText: boolean;
     $isMinimal: boolean;
@@ -261,6 +263,15 @@ export const Td = styled.td<{
         $fontColor
             ? `
                 color: ${$fontColor} !important;
+            `
+            : ''}
+
+    ${({ $textStyle }) =>
+        $textStyle
+            ? `
+                ${$textStyle.bold ? 'font-weight: 700;' : ''}
+                ${$textStyle.italic ? 'font-style: italic;' : ''}
+                ${$textStyle.underline ? 'text-decoration: underline;' : ''}
             `
             : ''}
 


### PR DESCRIPTION
Extends table conditional formatting so a rule can toggle **bold**, *italic* and underline on matching cell text, in addition to the existing text/background/row colours. Any subset of toggles can be combined with the colour options (e.g. a rule that makes matching cells bold + red).

## Approach
- `ConditionalFormattingTextStyle` (`bold`/`italic`/`underline`) is added as an optional `textStyle` on both the single-colour and colour-range config types.
- `getConditionalFormattingTextStyle()` unions the styles from every config matching a cell (its cell-, text- and row-level matches), so the same toggles apply regardless of the rule's "Apply to" target. `getRowConditionalFormattingColor` is refactored to share a new `getRowConditionalFormattingConfig`.
- The rule editor gains a "Text style" toggle group (bold/italic/underline).
- Styles are applied in both the regular table (`Td` styled component) and the pivot table (`LightTable` cell), including row-level rules.

Generated schemas (`swagger.json`, `routes.ts`, `chart-as-code-1.0.json`) were regenerated.

## Testing
- New unit tests for `getConditionalFormattingTextStyle`; `pnpm -F common test` passes.
- Typecheck + lint pass on touched files; chart-as-code schema check passes.