### PR TITLE
fix: fail preview compile job on scheduler error

### DIFF
--- a/packages/api-tests/tests/roles.test.ts
+++ b/packages/api-tests/tests/roles.test.ts
@@ -12,6 +12,7 @@ import {
     loginWithEmail,
     loginWithPermissions,
 } from '../helpers/auth';
+import { pollUntil } from '../helpers/polling';
 
 type RoleResult = {
     roleUuid: string;
@@ -819,6 +820,73 @@ describe('Roles API Tests', () => {
                     SEED_PROJECT.project_uuid,
                 );
                 expect(previewProjectAsCreator.status).toBe(200);
+            } finally {
+                if (previewProjectUuid) {
+                    await admin.delete(
+                        `/api/v1/org/projects/${previewProjectUuid}`,
+                        { failOnStatusCode: false },
+                    );
+                }
+            }
+        });
+
+        it('should mark preview compile job as failed when custom role lacks compile scopes', async () => {
+            let previewProjectUuid: string | undefined;
+            const roleResp = await admin.post<Body<RoleResult>>(
+                `${orgRolesApiUrl}/${testOrgUuid}/roles`,
+                {
+                    name: `Preview Missing Compile ${Date.now()}`,
+                    description: 'Preview role without compile scopes',
+                    scopes: ['view:Project', 'create:Project@preview'],
+                },
+            );
+            const { roleUuid } = roleResp.body.results;
+            rolesToCleanup.push(roleUuid);
+
+            const { client: member, email } = await loginWithPermissions(
+                'member',
+                [],
+            );
+            const me = await member.get<Body<{ userUuid: string }>>(
+                `${apiUrl}/user`,
+            );
+
+            await admin.post<Body<AssignmentResult>>(
+                `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${me.body.results.userUuid}`,
+                { roleId: roleUuid },
+            );
+
+            const previewUser = await loginWithEmail(email);
+
+            try {
+                const resp = await previewUser.post<
+                    Body<{ projectUuid: string; compileJobUuid: string }>
+                >(
+                    `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/createPreview`,
+                    {
+                        name: `Missing Compile Preview ${Date.now()}`,
+                        copyContent: true,
+                    },
+                );
+
+                expect(resp.status).toBe(200);
+                previewProjectUuid = resp.body.results.projectUuid;
+
+                const job = await pollUntil<
+                    Body<{
+                        jobStatus: 'STARTED' | 'RUNNING' | 'DONE' | 'ERROR';
+                    }>
+                >(
+                    previewUser,
+                    `${apiUrl}/jobs/${resp.body.results.compileJobUuid}`,
+                    {
+                        timeout: 15_000,
+                        interval: 500,
+                        condition: (body) => body.results.jobStatus === 'ERROR',
+                    },
+                );
+
+                expect(job.results.jobStatus).toBe('ERROR');
             } finally {
                 if (previewProjectUuid) {
                     await admin.delete(

--- a/packages/backend/src/scheduler/SchedulerTask.test.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.test.ts
@@ -7,7 +7,9 @@ import {
     GoogleSheetsTransientError,
     MetricType,
     NotEnoughResults,
+    SchedulerJobStatus,
     ThresholdOperator,
+    type CompileProjectPayload,
     type UploadGsheetPayload,
 } from '@lightdash/common';
 import ExecutionContext from 'node-execution-context';
@@ -693,5 +695,74 @@ describe('uploadGsheetFromQuery — rows branch', () => {
         expect(mockAppendToSheet).toHaveBeenCalledTimes(1);
         expect(mockAppendToSheet.mock.calls[0][2]).toEqual(payload.rows);
         expect(mockExecuteMetricQueryAndGetResults).not.toHaveBeenCalled();
+    });
+});
+
+describe('compileProject', () => {
+    const makeTask = (
+        overrides: Partial<ConstructorParameters<typeof SchedulerTask>[0]> = {},
+    ) => {
+        const stub = {} as ConstructorParameters<typeof SchedulerTask>[0];
+        return new SchedulerTask({
+            ...stub,
+            ...overrides,
+        });
+    };
+
+    it('marks the legacy job as failed when project compile is forbidden', async () => {
+        const error = new ForbiddenError();
+        const mockGetSessionByUserUuid = jest.fn().mockResolvedValue({
+            userUuid: 'user-1',
+        });
+        const mockLogSchedulerJob = jest.fn().mockResolvedValue(undefined);
+        const mockCompileProject = jest.fn().mockRejectedValue(error);
+        const mockMarkJobAsFailed = jest.fn().mockResolvedValue(undefined);
+
+        const task = makeTask({
+            userService: {
+                getSessionByUserUuid: mockGetSessionByUserUuid,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['userService'],
+            schedulerService: {
+                logSchedulerJob: mockLogSchedulerJob,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['schedulerService'],
+            projectService: {
+                compileProject: mockCompileProject,
+                _markJobAsFailed: mockMarkJobAsFailed,
+            } as unknown as ConstructorParameters<
+                typeof SchedulerTask
+            >[0]['projectService'],
+        });
+
+        const payload: CompileProjectPayload = {
+            createdByUserUuid: 'user-1',
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            requestMethod: 'api',
+            jobUuid: 'job-1',
+            isPreview: true,
+            validateAfterCompile: false,
+            userUuid: 'user-1',
+        };
+
+        await expect(
+            (
+                task as unknown as {
+                    compileProject(
+                        jobId: string,
+                        scheduledTime: Date,
+                        payload: CompileProjectPayload,
+                    ): Promise<void>;
+                }
+            ).compileProject('graphile-job-1', new Date(), payload),
+        ).rejects.toBe(error);
+
+        expect(mockLogSchedulerJob).toHaveBeenCalledWith(
+            expect.objectContaining({ status: SchedulerJobStatus.ERROR }),
+        );
+        expect(mockMarkJobAsFailed).toHaveBeenCalledWith('job-1');
     });
 });

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2071,6 +2071,7 @@ export default class SchedulerTask {
                     createdByUserUuid: payload.createdByUserUuid,
                 },
             });
+            await this.projectService._markJobAsFailed(payload.jobUuid);
             throw e;
         }
     }


### PR DESCRIPTION
## Summary

- Mark the legacy compile job as `ERROR` when the scheduler compile task fails before project compile can update job steps
- Add a scheduler unit regression for forbidden preview compiles
- Add a custom-role API regression that verifies preview compile jobs become terminal when compile scopes are missing

## Testing

- `pnpm --filter backend test -- src/scheduler/SchedulerTask.test.ts -t "marks the legacy job as failed when project compile is forbidden"`
- `pnpm test:api tests/roles.test.ts -t "should mark preview compile job as failed when custom role lacks compile scopes"`
- `pnpm test:api tests/roles.test.ts -t "should allow project-scoped custom role to create preview without copying content"`
- `pnpm --filter backend typecheck:fast`
- `pnpm --filter api-tests typecheck`
- `pnpm exec oxfmt packages/api-tests/tests/roles.test.ts packages/backend/src/scheduler/SchedulerTask.test.ts packages/backend/src/scheduler/SchedulerTask.ts --check`
- `git diff --check HEAD`

Relates: PROD-8227
Closes: #24515