### PR TITLE
fix(reviews): exclude remediation build-fix threads from review classifier

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -219,6 +219,18 @@ describe('AiAgentReviewClassifierModel', () => {
             expect(query.sql).toContain('project_type');
             expect(query.bindings).toContain(ProjectType.PREVIEW);
         });
+
+        it('excludes remediation build-fix work threads', async () => {
+            tracker.on.select(AiPromptTableName).responseOnce([]);
+
+            await model.listTurnReviewCandidates({
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain(AiAgentReviewRemediationTableName);
+            expect(query.sql).toContain('work_thread_uuid');
+        });
     });
 
     describe('remediation events', () => {

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -756,6 +756,16 @@ export class AiAgentReviewClassifierModel {
             // Preview projects host writeback verification threads — reviewing
             // them would feed the reviewer's own output back into itself.
             .whereNot('project.project_type', ProjectType.PREVIEW)
+            // Remediation build-fix threads are the reviewer's own output;
+            // reviewing them would open a review item on the fix it just made.
+            .whereNotExists((builder) => {
+                void builder
+                    .select(this.database.raw('1'))
+                    .from(`${AiAgentReviewRemediationTableName} as remediation`)
+                    .whereRaw(
+                        'remediation.work_thread_uuid = thread.ai_thread_uuid',
+                    );
+            })
             .whereIn('thread.created_from', ['web_app', 'slack'])
             .where((builder) => {
                 void builder


### PR DESCRIPTION
## Problem

The AI-review **remediation workspace** opens its PR through a real conversational **Build-fix thread** — a normal `web_app` agent thread created in the *source* project (see #24499). When the review classifier next ran, it picked up that build-fix thread as a reviewable conversation and created a **review item on the agent's own fix** — a feedback loop (review → fix → review of the fix → …).

## Root cause

`fetchBaseCandidateRows` in `AiAgentReviewClassifierModel` selects every `web_app`/`slack` agent turn with a response/error for classification. It already excludes **preview** projects — which is why the *verification* (Test, preview-mode) thread was never reviewed — but the **build-fix** thread lives in the source project, so nothing filtered it out.

## Fix

Add a correlated `NOT EXISTS` guard to the candidate query that drops any thread recorded as an `ai_agent_review_remediation.work_thread_uuid`, mirroring the existing preview-project exclusion. Build-fix threads are the reviewer's own output and must never be re-reviewed.

```sql
not exists (
  select 1 from ai_agent_review_remediation as remediation
  where remediation.work_thread_uuid = thread.ai_thread_uuid
)
```

`work_thread_uuid` is `NULL` for project_context remediations and for prompt remediations before their thread exists, so those rows never match and exclude nothing. The remediation row is written immediately after the work thread — and long before that thread produces a reviewable response — so there's no race window where an unlinked work thread could be classified.

## Regression analysis

- **Normal agent threads** (no remediation): unaffected — `NOT EXISTS` only matches threads that are a remediation's `work_thread_uuid`.
- **Verification / preview threads**: already excluded by the preview-project guard; unchanged.
- **The original failing conversation** that spawned a review: still reviewable — only the synthetic build-fix thread is excluded, not its source thread.
- Read-path query change only; no schema or data migration.

## Test

`AiAgentReviewClassifierModel.test.ts` → `listTurnReviewCandidates › excludes remediation build-fix work threads` asserts the candidate SQL references the remediation table and `work_thread_uuid`. Full model suite: 38/38 green.

---

> ⚠️ **Linear ticket**: none was provided — please add a `Closes: PROD-XXXX` line. This is a follow-up fix to the remediation workspace stack (#24499 / #24500 / #24501).
