### PR TITLE
fix: handle malformed URI errors

### DIFF
--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -43,6 +43,14 @@ export const errorHandler = (error: Error): LightdashError => {
     ) {
         return new PayloadTooLargeError();
     }
+    if (error instanceof URIError || error.name === 'URIError') {
+        return new LightdashError({
+            statusCode: 400,
+            name: 'URIError',
+            message: 'Invalid URI encoding',
+            data: {},
+        });
+    }
     if (error instanceof LightdashError) {
         return error;
     }


### PR DESCRIPTION
## Summary
- Return `400 Bad Request` for malformed URI decoding errors instead of `500 UnexpectedServerError`.

## Testing
- `pnpm -F backend typecheck:fast`
- Replayed malformed percent-encoded path with `curl --path-as-is` and confirmed `400 Bad Request`.

Closes: #24524