### PR TITLE
fix: mark forbidden preview compile jobs failed

### DIFF
--- a/packages/api-tests/tests/roles.test.ts
+++ b/packages/api-tests/tests/roles.test.ts
@@ -769,9 +769,10 @@ describe('Roles API Tests', () => {
             const me = await member.get<Body<{ userUuid: string }>>(
                 `${apiUrl}/user`,
             );
+            const memberUserUuid = me.body.results.userUuid;
 
             await admin.post<Body<AssignmentResult>>(
-                `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${me.body.results.userUuid}`,
+                `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${memberUserUuid}`,
                 { roleId: roleUuid },
             );
 
@@ -823,6 +824,12 @@ describe('Roles API Tests', () => {
                 if (previewProjectUuid) {
                     await admin.delete(
                         `/api/v1/org/projects/${previewProjectUuid}`,
+                        { failOnStatusCode: false },
+                    );
+                }
+                if (memberUserUuid) {
+                    await admin.delete(
+                        `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${memberUserUuid}`,
                         { failOnStatusCode: false },
                     );
                 }

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -5,6 +5,8 @@ import {
     FeatureFlags,
     FilterOperator,
     ForbiddenError,
+    JobStatusType,
+    JobStepType,
     MetricType,
     NotFoundError,
     OrganizationMemberRole,
@@ -168,7 +170,13 @@ const projectModel = {
     getTableGroups: jest.fn(async () => ({})),
     getCachedExploreNames: jest.fn(async () => []),
     saveExploresToCache: jest.fn(async () => ({ cachedExploreUuids: [] })),
+    setTableGroups: jest.fn(async () => undefined),
+    updateProjectDefaults: jest.fn(async () => undefined),
     updateDefaultUserSpaces: jest.fn(async () => undefined),
+    tryAcquireProjectLock: jest.fn(
+        async (_projectUuid: string, onLockAcquired: () => Promise<void>) =>
+            onLockAcquired(),
+    ),
 };
 const preAggregateModel = {
     upsertPreAggregateDefinitions: jest.fn(),
@@ -188,6 +196,16 @@ const savedChartModel = {
 };
 const jobModel = {
     get: jest.fn(async () => job),
+    update: jest.fn(async () => undefined),
+    updateJobStep: jest.fn(async () => undefined),
+    setPendingJobsToSkipped: jest.fn(async () => undefined),
+    tryJobStep: jest.fn(
+        async <T>(
+            _jobUuid: string,
+            _stepType: JobStepType,
+            callback: () => Promise<T>,
+        ) => callback(),
+    ),
 };
 const spaceModel = {
     getAllSpaces: jest.fn(async () => spacesWithSavedCharts),
@@ -1484,7 +1502,6 @@ describe('ProjectService', () => {
                 service.getJobStatus('jobUuid', anotherUser),
             ).rejects.toThrowError(NotFoundError);
         });
-
         test('should limit CSV results', async () => {
             const csvCellsLimit = 100000;
             const maxLimit = 5000;
@@ -1553,6 +1570,36 @@ describe('ProjectService', () => {
             ).toEqual(50000);
         });
     });
+
+    describe('compileProject', () => {
+        test('marks the job as failed when the user cannot compile', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            const noCompileUser: SessionUser = {
+                ...user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['view'] },
+                ]),
+            };
+
+            await expect(
+                service.compileProject(
+                    noCompileUser,
+                    projectUuid,
+                    RequestMethod.WEB_APP,
+                    compileJobUuid,
+                ),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(jobModel.setPendingJobsToSkipped).toHaveBeenCalledWith(
+                compileJobUuid,
+            );
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.ERROR,
+            });
+            expect(projectModel.tryAcquireProjectLock).not.toHaveBeenCalled();
+        });
+    });
+
     describe('searchFieldUniqueValues', () => {
         const replaceWhitespace = (str: string) =>
             str.replace(/\s+/g, ' ').trim();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3066,19 +3066,6 @@ export class ProjectService extends BaseService {
         const updatedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot('update', subject('Project', updatedProject))
-        ) {
-            throw new ForbiddenError();
-        }
-
-        if (updatedProject.warehouseConnection === undefined) {
-            throw new Error(
-                `Missing warehouseConnection details on project ${projectUuid}'}`,
-            );
-        }
-
         // This job is the job model we use to compile projects
         // This is not the graphile Job id we use on scheduler
         // TODO: remove this old job method and replace with scheduler log details
@@ -3106,6 +3093,22 @@ export class ProjectService extends BaseService {
         };
 
         try {
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'update',
+                    subject('Project', updatedProject),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
+
+            if (updatedProject.warehouseConnection === undefined) {
+                throw new Error(
+                    `Missing warehouseConnection details on project ${projectUuid}'}`,
+                );
+            }
+
             await this.jobModel.update(job.jobUuid, {
                 jobStatus: JobStatusType.RUNNING,
             });
@@ -6217,6 +6220,13 @@ export class ProjectService extends BaseService {
                 }),
             )
         ) {
+            await this._markJobAsFailed(jobUuid).catch((e) => {
+                this.logger.error(
+                    `Failed to mark compile job as failed: ${
+                        e instanceof Error ? e.stack : e
+                    }`,
+                );
+            });
             throw new ForbiddenError();
         }
 


### PR DESCRIPTION
## Summary

- Mark legacy compile jobs as `ERROR` when a preview compile worker hits missing compile permissions
- Keep preview compile permission cleanup in `ProjectService` so job polling reaches a terminal state
- Add a focused ProjectService regression and clean up the preview role assignment test

## Testing

- `pnpm -F backend test -- ProjectService.test.ts -t "marks the job as failed when the user cannot compile"`
- `pnpm -F backend typecheck:fast`
- `pnpm -F api-tests typecheck`
- `pnpm -F api-tests lint`
- `pnpm -F api-tests format && pnpm -F backend format`
- `git diff --check`

Closes: PROD-8385
Closes: #24515
