### PR TITLE
fix(data-apps): make external-fetch path semantics unambiguous in agent metadata

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -19,6 +19,7 @@ jest.mock('ai', () => ({
 
 type AppExternalConnectionDoc = {
     alias: string;
+    origin: string;
     allowedMethods: string[];
     allowedPathPrefixes: string[];
     samples: ExternalConnectionSample[];
@@ -120,12 +121,14 @@ describe('AppGenerateService.writeExternalConnectionSamples', () => {
         const docs: AppExternalConnectionDoc[] = [
             {
                 alias: 'weather',
+                origin: 'https://api.weather.test',
                 allowedMethods: ['GET'],
                 allowedPathPrefixes: ['/v1/'],
                 samples: [makeSample('weather', 1)],
             },
             {
                 alias: 'crm',
+                origin: 'https://api.crm.test',
                 allowedMethods: ['GET', 'POST'],
                 allowedPathPrefixes: ['/api/'],
                 samples: [makeSample('crm', 1), makeSample('crm', 2)],
@@ -156,6 +159,10 @@ describe('AppGenerateService.writeExternalConnectionSamples', () => {
         const weatherDoc = JSON.parse(weatherCall[1]);
         expect(weatherDoc.howToCall).toContain('weather');
         expect(weatherDoc.howToCall).toContain('externalFetch');
+        // The doc must spell out origin + the full request URL so the agent
+        // never guesses that the path is relative to the prefix.
+        expect(weatherDoc.origin).toBe('https://api.weather.test');
+        expect(weatherDoc.requestUrl).toContain('https://api.weather.test');
         expect(weatherDoc.allowedMethods).toEqual(['GET']);
         expect(weatherDoc.allowedPathPrefixes).toEqual(['/v1/']);
         expect(weatherDoc.samples).toHaveLength(1);
@@ -182,6 +189,7 @@ describe('AppGenerateService.writeExternalConnectionSamples', () => {
         const docs: AppExternalConnectionDoc[] = [
             {
                 alias: 'weather',
+                origin: 'https://api.weather.test',
                 allowedMethods: ['GET'],
                 allowedPathPrefixes: ['/v1/'],
                 samples: [],
@@ -240,6 +248,7 @@ describe('AppGenerateService pipeline external-access flag gate', () => {
             .mockResolvedValue([
                 {
                     alias: 'weather',
+                    origin: 'https://api.weather.test',
                     allowedMethods: ['GET'],
                     allowedPathPrefixes: ['/v1/'],
                     samples: [makeSample('weather', 1)],

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -105,6 +105,7 @@ import { getTemplateInstructions } from './templates';
 
 type AppExternalConnectionDoc = {
     alias: string;
+    origin: string;
     allowedMethods: ExternalConnectionMethod[];
     allowedPathPrefixes: string[];
     samples: ExternalConnectionSample[];
@@ -1204,15 +1205,27 @@ export class AppGenerateService extends BaseService {
 
         const fileEntries: string[] = [];
         for (const doc of docs) {
+            const firstPrefix = doc.allowedPathPrefixes[0];
+            const exampleMethod = doc.allowedMethods[0] ?? 'GET';
+            // Prefer a real saved sample path; otherwise derive one from the first
+            // allowed prefix. Either way it is the COMPLETE path from the origin.
+            const examplePath =
+                doc.samples[0]?.request.path ??
+                `${firstPrefix ?? '/'}<resource>`;
             const fileContent = JSON.stringify(
                 {
                     alias: doc.alias,
                     signature:
                         "externalFetch(alias: string, opts: { method?: 'GET' | 'POST'; path: string; query?: Record<string, string>; body?: unknown }): Promise<{ status: number; contentType: string; body: unknown; truncated: boolean }>",
-                    howToCall: `const result = await client.externalFetch('${doc.alias}', { method: 'GET', path: '<a path under allowedPathPrefixes>', query: { /* string values only */ } });\nconst data = result.body;`,
+                    origin: doc.origin,
+                    // The single most-misread thing: `path` is the COMPLETE path from
+                    // the origin, not relative to the prefix. Spell out origin + path.
+                    requestUrl: `${doc.origin} + path  (your path is appended to the origin verbatim — the origin and path prefix are NEVER auto-prepended). Example full URL: ${doc.origin}${examplePath}`,
+                    howToCall: `const result = await client.externalFetch('${doc.alias}', { method: '${exampleMethod}', path: '${examplePath}', query: { /* string values only */ } });\nconst data = result.body;`,
                     rules: [
                         "query is Record<string, string> — EVERY value must be a string. Write { latitude: '52.52' }, never { latitude: 52.52 }. Numbers and booleans are rejected with a 422.",
-                        'method must be one of allowedMethods; path must start with one of allowedPathPrefixes.',
+                        `path is the COMPLETE path appended to the origin (requestUrl = origin + path). Pass the full path starting from the origin — e.g. "${examplePath}" — and make sure it starts with one of allowedPathPrefixes. Do NOT shorten it to the trailing segment and do NOT assume the origin or prefix is auto-prepended.`,
+                        'method must be one of allowedMethods.',
                         'Read the response from result.body. result.status is the upstream HTTP status; result.truncated is true if the response was capped.',
                         'Auth is injected by Lightdash — never include credentials, API keys, or headers.',
                     ],
@@ -1243,7 +1256,8 @@ export class AppGenerateService extends BaseService {
 
         return (
             `[Linked external connections — the app can call these external APIs via client.externalFetch(alias, opts). ` +
-            `Each /tmp/external-data/{alias}.json documents one connection: its signature, allowedMethods/allowedPathPrefixes, rules, and example request/response pairs. ` +
+            `Each /tmp/external-data/{alias}.json documents one connection: its signature, origin, requestUrl, allowedMethods/allowedPathPrefixes, rules, and example request/response pairs. ` +
+            `IMPORTANT: path is the COMPLETE path appended to the connection's origin (requestUrl = origin + path) — the origin and prefix are NOT auto-prepended. Always pass the full path from the doc's howToCall or a saved sample (e.g. "/repos/owner/repo/issues", never a shortened "/issues"). ` +
             `IMPORTANT: query is Record<string, string> — every query value must be a string (e.g. { latitude: '52.52' }, not 52.52); numbers are rejected with a 422. Read the response from result.body. ` +
             `Auth is handled by Lightdash — never send credentials. Treat sample values as illustrative of shape, not exhaustive.]\n` +
             `${fileEntries.join('\n')}\n\n`
@@ -1261,6 +1275,7 @@ export class AppGenerateService extends BaseService {
         return Promise.all(
             links.map(async (link) => ({
                 alias: link.alias,
+                origin: link.connection.origin,
                 allowedMethods: link.connection.allowedMethods,
                 allowedPathPrefixes: link.connection.allowedPathPrefixes,
                 // Cap at 5 samples — enough to illustrate the API shape without bloating the prompt

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -168,11 +168,12 @@ If the app is linked to one or more **external connections** (third-party HTTP A
 
 Each file documents one connection:
 - `signature` / `howToCall` — the exact typed SDK call. Auth is injected by Lightdash — never include credentials or API keys.
-- `rules` — hard requirements. The big one: **`query` is `Record<string, string>` — every query value MUST be a string** (`{ latitude: '52.52' }`, never `{ latitude: 52.52 }`); numbers and booleans are rejected with a 422. Read the response from `result.body`.
+- `origin` / `requestUrl` — the connection's base origin (host only) and how the URL is formed: **the full request URL is `origin + path`.** Your `path` is appended to the origin verbatim — the origin and the path prefix are NOT auto-prepended.
+- `rules` — hard requirements. The big ones: (1) **`path` is the COMPLETE path from the origin** — pass the whole path (e.g. `/repos/owner/repo/issues`, never a shortened `/issues`) and make sure it starts with one of `allowedPathPrefixes`. (2) **`query` is `Record<string, string>` — every query value MUST be a string** (`{ latitude: '52.52' }`, never `{ latitude: 52.52 }`); numbers and booleans are rejected with a 422. Read the response from `result.body`.
 - `allowedMethods` / `allowedPathPrefixes` — the methods and path prefixes the admin has permitted; only call within these bounds.
-- `samples` — example `{ request, response }` pairs. Copy the request shape (path + query) when building your `externalFetch` calls. Treat response values as illustrative of shape, not exhaustive.
+- `samples` — example `{ request, response }` pairs. Copy the request shape — including the FULL `request.path` — when building your `externalFetch` calls. Treat response values as illustrative of shape, not exhaustive.
 
-A connection with no saved samples still has a file (with an empty `samples` array) — use `allowedMethods` and `allowedPathPrefixes` to infer what the API supports.
+A connection with no saved samples still has a file (with an empty `samples` array) — use `origin`, `allowedMethods`, and `allowedPathPrefixes` to infer what the API supports. The path must still be the complete path from the origin, starting with an allowed prefix.
 
 ## Attached images
 
@@ -935,13 +936,13 @@ const user = await client.auth.getUser();
 
 When an app needs data from an external HTTP API (Stripe, a CRM, a weather
 service, etc.), the workspace admin configures a named **connection** in
-Lightdash that stores the base URL and credentials. The app references it by
+Lightdash that stores the origin (host) and credentials. The app references it by
 **alias** only:
 
 ```tsx
 const res = await lightdash.externalFetch('stripe', {
     method: 'GET',          // 'GET' | 'POST' — defaults to 'GET'
-    path: '/v1/charges',    // relative path appended to the connection's base URL
+    path: '/v1/charges',    // COMPLETE path appended to the connection's origin (host). Full URL = origin + path. Must start with an allowed prefix; it is NOT relative to the prefix.
     query: { limit: '10' }, // Record<string, string> — values MUST be strings
     // body: { ... },       // JSON body (POST only)
 });
@@ -967,6 +968,11 @@ credentials, makes the request server-side, and returns the response.
   the admin to configure the connection — do not work around it.
 - **Never** put a full URL, host, or HTTP header in the call. Only `alias`,
   `path`, `query`, `method`, and `body` are accepted.
+- **`path` is the COMPLETE path appended to the connection's origin** — the full
+  request URL is `origin + path`. The origin and any allowed path prefix are NOT
+  auto-prepended, so pass the whole path (e.g. `/repos/owner/repo/issues`, never a
+  shortened `/issues`). It must start with one of `allowedPathPrefixes`, and when
+  a sample exists, copy its `request.path` structure exactly.
 - **`query` values must be strings.** `query` is `Record<string, string>` —
   stringify every value: `{ latitude: '52.52', limit: '10' }`, never
   `{ latitude: 52.52, limit: 10 }`. Numeric or boolean query values are


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
