### PR TITLE
fix(ai-agents): deliver long Slack agent answers without `msg_too_long`

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7539,10 +7539,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         };
     }
 
-    // Delivers a finished answer across one or more Slack messages: the first
-    // finalizes the live stream, the rest post as replies. Falls back to a
-    // Lightdash link if the answer is too large or still rejected — it's already
-    // persisted, so a delivery failure must never read as a generation failure.
+    // Delivers a finished answer across one or more Slack messages (first
+    // finalizes the stream, rest post as replies), falling back to a Lightdash
+    // link if too large — the answer is already persisted, so this never fails.
     private async deliverModernSlackAnswer({
         slackPrompt,
         threadTs,
@@ -7586,7 +7585,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 threadUrl,
             ),
         ];
-        // `text` is just the notification/fallback; keep it small.
+        // Notification fallback only; keep it small.
         const notificationText = slackifiedMarkdown.slice(0, 3000);
         const isLast = (index: number) => index === messages.length - 1;
 
@@ -7596,7 +7595,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 channelId: slackPrompt.slackChannelId,
                 threadTs,
                 messageTs: streamTs,
-                text: notificationText,
                 chunks: [
                     {
                         type: 'blocks',
@@ -7615,7 +7613,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     channelId: slackPrompt.slackChannelId,
                     threadTs,
                     messageTs: streamTs,
-                    text: 'Your answer is ready in Lightdash.',
                     chunks: [{ type: 'blocks', blocks: linkFallbackBlocks }],
                 })
                 .catch((e) =>
@@ -7991,8 +7988,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         let taskUpdateChain: Promise<void> = Promise.resolve();
         let pendingTaskUpdateCount = 0;
-        // Keyed by tool type (not per call) so repeated calls collapse into one
-        // counted task block, staying under Slack's 50-block message cap.
+        // Keyed by tool type so repeated calls collapse into one counted block.
         const taskStates = new Map<
             string,
             {
@@ -8000,8 +7996,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 calls: Map<string, 'in_progress' | 'complete' | 'error'>;
                 details?: string;
                 output?: string;
-                // Lines already streamed. Slack appends details/output deltas on
-                // each same-id update, so each line must be sent at most once.
+                // Lines already streamed; Slack appends deltas, so send each once.
                 sent: Set<string>;
             }
         >();
@@ -8417,7 +8412,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         channelId: slackPrompt.slackChannelId,
                         threadTs,
                         messageTs: streamTs,
-                        text: 'Your answer is ready in Lightdash.',
                         chunks: [
                             {
                                 type: 'blocks',

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -65,6 +65,7 @@ import {
     GITHUB_MCP_SERVER_NAME,
     GITHUB_MCP_SERVER_URL,
     isGitProjectType,
+    isSlackMessageTooLongError,
     isSlackPrompt,
     isToolProposeChangeSuccessResult,
     KnexPaginateArgs,
@@ -278,6 +279,7 @@ import {
     getReferencedArtifactsBlocks,
     getTextBlocks,
     getThinkingBlocks,
+    splitMarkdownIntoMessages,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
 import {
@@ -7512,6 +7514,158 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         ];
     }
 
+    private getAgentThreadUrl(
+        slackPrompt: SlackPrompt,
+        agentUuid: string | undefined,
+    ): string {
+        return agentUuid
+            ? `${this.lightdashConfig.siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}`
+            : this.lightdashConfig.siteUrl;
+    }
+
+    private static agentFailedMessage(agentName: string | undefined): string {
+        return `${
+            agentName ?? 'Agent'
+        } failed to generate a response. Please try again.`;
+    }
+
+    private static slackLinkSection(text: string, url: string): KnownBlock {
+        return {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `${text} <${url}|View it in Lightdash>.`,
+            },
+        };
+    }
+
+    // Delivers a finished answer across one or more Slack messages: the first
+    // finalizes the live stream, the rest post as replies. Falls back to a
+    // Lightdash link if the answer is too large or still rejected — it's already
+    // persisted, so a delivery failure must never read as a generation failure.
+    private async deliverModernSlackAnswer({
+        slackPrompt,
+        threadTs,
+        streamTs,
+        agentUuid,
+        agentName,
+        slackResponse,
+        slackifiedMarkdown,
+        trailingBlocks,
+    }: {
+        slackPrompt: SlackPrompt;
+        threadTs: string;
+        streamTs: string;
+        agentUuid: string | undefined;
+        agentName: string | undefined;
+        slackResponse: string;
+        slackifiedMarkdown: string;
+        trailingBlocks: (Block | KnownBlock)[];
+    }): Promise<void> {
+        const { messages: answerMessages, truncated } =
+            splitMarkdownIntoMessages(slackResponse);
+        // Always ≥1 message so the stream closes and trailing cards attach.
+        const messages = answerMessages.length > 0 ? answerMessages : [[]];
+        const threadUrl = this.getAgentThreadUrl(slackPrompt, agentUuid);
+
+        // Cards + feedback + any truncation notice ride on the last message only.
+        const lastExtraBlocks: (Block | KnownBlock)[] = [
+            ...trailingBlocks,
+            ...(truncated
+                ? [
+                      AiAgentService.slackLinkSection(
+                          ':scroll: This answer was too long to show in full here.',
+                          threadUrl,
+                      ),
+                  ]
+                : []),
+        ];
+        const linkFallbackBlocks: (Block | KnownBlock)[] = [
+            AiAgentService.slackLinkSection(
+                ':scroll: This answer was too long to show in Slack.',
+                threadUrl,
+            ),
+        ];
+        // `text` is just the notification/fallback; keep it small.
+        const notificationText = slackifiedMarkdown.slice(0, 3000);
+        const isLast = (index: number) => index === messages.length - 1;
+
+        try {
+            await this.slackClient.stopAgentStream({
+                organizationUuid: slackPrompt.organizationUuid,
+                channelId: slackPrompt.slackChannelId,
+                threadTs,
+                messageTs: streamTs,
+                text: notificationText,
+                chunks: [
+                    {
+                        type: 'blocks',
+                        blocks: [
+                            ...messages[0],
+                            ...(isLast(0) ? lastExtraBlocks : []),
+                        ],
+                    },
+                ],
+            });
+        } catch (error) {
+            if (!isSlackMessageTooLongError(error)) throw error;
+            await this.slackClient
+                .stopAgentStream({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channelId: slackPrompt.slackChannelId,
+                    threadTs,
+                    messageTs: streamTs,
+                    text: 'Your answer is ready in Lightdash.',
+                    chunks: [{ type: 'blocks', blocks: linkFallbackBlocks }],
+                })
+                .catch((e) =>
+                    Logger.error(
+                        'Failed to post Slack answer link fallback',
+                        e,
+                    ),
+                );
+            return;
+        }
+
+        for (let index = 1; index < messages.length; index += 1) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await this.slackClient.postMessage({
+                    organizationUuid: slackPrompt.organizationUuid,
+                    channel: slackPrompt.slackChannelId,
+                    thread_ts: threadTs,
+                    text: notificationText,
+                    blocks: [
+                        ...messages[index],
+                        ...(isLast(index) ? lastExtraBlocks : []),
+                    ],
+                    unfurl_links: false,
+                    ...(agentName ? { username: agentName } : {}),
+                });
+            } catch (error) {
+                if (!isSlackMessageTooLongError(error)) throw error;
+                // eslint-disable-next-line no-await-in-loop
+                await this.slackClient
+                    .postMessage({
+                        organizationUuid: slackPrompt.organizationUuid,
+                        channel: slackPrompt.slackChannelId,
+                        thread_ts: threadTs,
+                        text: 'The rest of your answer is in Lightdash.',
+                        blocks: linkFallbackBlocks,
+                        unfurl_links: false,
+                        ...(agentName ? { username: agentName } : {}),
+                    })
+                    .catch((e) =>
+                        Logger.error(
+                            'Failed to post Slack answer link fallback',
+                            e,
+                        ),
+                    );
+                break;
+            }
+        }
+    }
+
     // Share URL for the latest successful runSql, used to resolve the model's
     // [..](#sql-runner-link) anchor into a real link for Slack.
     private async getSqlRunnerShareUrl(
@@ -7837,15 +7991,33 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         let taskUpdateChain: Promise<void> = Promise.resolve();
         let pendingTaskUpdateCount = 0;
+        // Keyed by tool type (not per call) so repeated calls collapse into one
+        // counted task block, staying under Slack's 50-block message cap.
         const taskStates = new Map<
             string,
             {
                 toolName: string;
-                status: 'pending' | 'in_progress' | 'complete' | 'error';
+                calls: Map<string, 'in_progress' | 'complete' | 'error'>;
                 details?: string;
                 output?: string;
+                // Lines already streamed. Slack appends details/output deltas on
+                // each same-id update, so each line must be sent at most once.
+                sent: Set<string>;
             }
         >();
+        const computeTaskAggregate = (
+            calls: Map<string, 'in_progress' | 'complete' | 'error'>,
+        ): { status: 'in_progress' | 'complete' | 'error'; count: number } => {
+            const statuses = [...calls.values()];
+            const count = statuses.length;
+            if (statuses.some((s) => s === 'in_progress')) {
+                return { status: 'in_progress', count };
+            }
+            if (statuses.some((s) => s === 'complete')) {
+                return { status: 'complete', count };
+            }
+            return { status: 'error', count };
+        };
         let currentReasoningStatus:
             | 'pending'
             | 'in_progress'
@@ -7944,40 +8116,48 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
         const finalizeToolTasksForSuccess = () => {
             if (!streamTs) return;
-            const unfinished = [...taskStates.entries()].filter(
-                ([, taskState]) => taskState.status !== 'complete',
-            );
-            for (const [taskId, taskState] of unfinished) {
-                const previousStatus = taskState.status;
-                taskState.status = 'complete';
-                enqueueTaskUpdate(() =>
-                    this.slackClient
-                        .appendAgentStream({
-                            organizationUuid: slackPrompt.organizationUuid,
-                            channelId: slackPrompt.slackChannelId,
-                            threadTs,
-                            messageTs: streamTs,
-                            chunks: [
-                                buildSlackTaskUpdate({
-                                    toolName: taskState.toolName,
-                                    taskId,
-                                    status: 'complete',
-                                    output:
-                                        taskState.output ??
-                                        (previousStatus === 'error'
-                                            ? 'Continued with another approach'
-                                            : (taskState.details ??
-                                              'Step finished')),
-                                }),
-                            ],
-                        })
-                        .catch((error) => {
-                            Logger.debug(
-                                'Failed to finalize Slack AI tool task:',
-                                error,
-                            );
-                        }),
-                );
+            for (const [taskId, taskState] of taskStates.entries()) {
+                const aggregate = computeTaskAggregate(taskState.calls);
+                if (aggregate.status !== 'complete') {
+                    const hadError = aggregate.status === 'error';
+                    for (const callId of taskState.calls.keys()) {
+                        taskState.calls.set(callId, 'complete');
+                    }
+                    const finalOutput =
+                        taskState.output ??
+                        (hadError
+                            ? 'Continued with another approach'
+                            : (taskState.details ?? 'Step finished'));
+                    // Skip if already streamed, else Slack appends a duplicate.
+                    const includeOutput = !taskState.sent.has(finalOutput);
+                    if (includeOutput) taskState.sent.add(finalOutput);
+                    enqueueTaskUpdate(() =>
+                        this.slackClient
+                            .appendAgentStream({
+                                organizationUuid: slackPrompt.organizationUuid,
+                                channelId: slackPrompt.slackChannelId,
+                                threadTs,
+                                messageTs: streamTs,
+                                chunks: [
+                                    buildSlackTaskUpdate({
+                                        toolName: taskState.toolName,
+                                        taskId,
+                                        status: 'complete',
+                                        count: aggregate.count,
+                                        ...(includeOutput
+                                            ? { output: finalOutput }
+                                            : {}),
+                                    }),
+                                ],
+                            })
+                            .catch((error) => {
+                                Logger.debug(
+                                    'Failed to finalize Slack AI tool task:',
+                                    error,
+                                );
+                            }),
+                    );
+                }
             }
         };
 
@@ -8022,13 +8202,25 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             ) {
                 resolvedStatus = 'complete';
             }
-            taskStates.set(progressId, {
+            const taskState = taskStates.get(resolvedToolName) ?? {
                 toolName: resolvedToolName,
-                status: resolvedStatus,
-                ...(resolvedStatus === 'complete' || resolvedStatus === 'error'
-                    ? { output: progress }
-                    : { details: progress }),
-            });
+                calls: new Map<string, 'in_progress' | 'complete' | 'error'>(),
+                sent: new Set<string>(),
+            };
+            taskState.calls.set(progressId, resolvedStatus);
+            const isDone =
+                resolvedStatus === 'complete' || resolvedStatus === 'error';
+            if (isDone) {
+                taskState.output = progress;
+            } else {
+                taskState.details = progress;
+            }
+            // Stream each distinct line at most once (Slack appends deltas).
+            const isNewLine =
+                progress.length > 0 && !taskState.sent.has(progress);
+            if (isNewLine) taskState.sent.add(progress);
+            taskStates.set(resolvedToolName, taskState);
+            const aggregate = computeTaskAggregate(taskState.calls);
             enqueueTaskUpdate(() =>
                 this.slackClient
                     .appendAgentStream({
@@ -8039,12 +8231,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                         chunks: [
                             buildSlackTaskUpdate({
                                 toolName: resolvedToolName,
-                                taskId: progressId,
-                                status: resolvedStatus,
-                                ...(resolvedStatus === 'complete' ||
-                                resolvedStatus === 'error'
+                                taskId: resolvedToolName,
+                                status: aggregate.status,
+                                count: aggregate.count,
+                                ...(isNewLine && isDone
                                     ? { output: progress }
-                                    : { details: progress }),
+                                    : {}),
+                                ...(isNewLine && !isDone
+                                    ? { details: progress }
+                                    : {}),
                             }),
                         ],
                     })
@@ -8188,22 +8383,15 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             queueReasoningTaskUpdate({ status: 'complete' });
             await flushTaskUpdates();
             await updatePlanTitle('Answered');
-            await this.slackClient.stopAgentStream({
-                organizationUuid: slackPrompt.organizationUuid,
-                channelId: slackPrompt.slackChannelId,
+            await this.deliverModernSlackAnswer({
+                slackPrompt,
                 threadTs,
-                messageTs: streamTs,
-                text: slackifiedMarkdown,
-                chunks: [
-                    ...getMarkdownBlocks(slackResponse).map((block) => ({
-                        type: 'blocks' as const,
-                        blocks: [block],
-                    })),
-                    {
-                        type: 'blocks',
-                        blocks,
-                    },
-                ],
+                streamTs,
+                agentUuid: agent?.uuid,
+                agentName: agent?.name,
+                slackResponse,
+                slackifiedMarkdown,
+                trailingBlocks: blocks,
             });
 
             await persistStreamResponseTsAndDeletePlaceholder();
@@ -8219,9 +8407,48 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             );
             return true;
         } catch (error) {
+            // Delivery failure on an already-persisted answer: link, don't fail.
+            if (isSlackMessageTooLongError(error)) {
+                await flushTaskUpdates();
+                await updatePlanTitle('Answered');
+                await this.slackClient
+                    .stopAgentStream({
+                        organizationUuid: slackPrompt.organizationUuid,
+                        channelId: slackPrompt.slackChannelId,
+                        threadTs,
+                        messageTs: streamTs,
+                        text: 'Your answer is ready in Lightdash.',
+                        chunks: [
+                            {
+                                type: 'blocks',
+                                blocks: [
+                                    AiAgentService.slackLinkSection(
+                                        ':scroll: This answer was too long to show in Slack.',
+                                        this.getAgentThreadUrl(
+                                            slackPrompt,
+                                            agent?.uuid,
+                                        ),
+                                    ),
+                                ],
+                            },
+                        ],
+                    })
+                    .catch((e) =>
+                        Logger.error(
+                            'Failed to finalize Slack stream after msg_too_long',
+                            e,
+                        ),
+                    );
+                await persistStreamResponseTsAndDeletePlaceholder();
+                Logger.warn(
+                    'Slack agent answer too long to deliver; linked to Lightdash instead',
+                    error,
+                );
+                return true;
+            }
             const userFacingMessage = getUserFacingErrorMessage(
                 error,
-                'Co-pilot failed to generate a response. Please try again.',
+                AiAgentService.agentFailedMessage(agent?.name),
             );
             queueReasoningTaskUpdate({
                 status: 'error',
@@ -8409,7 +8636,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         } catch (e) {
             const userFacingMessage = getUserFacingErrorMessage(
                 e,
-                'Co-pilot failed to generate a response. Please try again.',
+                AiAgentService.agentFailedMessage(agent?.name),
             );
             await this.slackClient.postMessage({
                 organizationUuid: slackPrompt.organizationUuid,

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -97,6 +97,62 @@ export const getMarkdownBlocks = (text: string): (Block | KnownBlock)[] =>
             }) as unknown as Block,
     );
 
+// Slack rejects a whole message when its blocks are collectively too large
+// (msg_too_long); the threshold is undocumented but answers ~25k chars failed,
+// so we budget well below that and split across messages.
+const SLACK_MESSAGE_TEXT_BUDGET = 11000;
+// Under Slack's 50-block message cap, leaving headroom for trailing cards.
+const SLACK_MESSAGE_BLOCK_LIMIT = 45;
+export const SLACK_MAX_ANSWER_MESSAGES = 4;
+
+export type SlackMarkdownMessages = {
+    messages: (Block | KnownBlock)[][];
+    truncated: boolean;
+};
+
+const getBlockTextLength = (block: Block | KnownBlock): number => {
+    const { text } = block as unknown as { text?: string };
+    return typeof text === 'string' ? text.length : 0;
+};
+
+/**
+ * Splits a long markdown answer into multiple Slack messages, each within a
+ * single message's size budget. Returns `truncated: true` (and only the first
+ * `maxMessages` messages) when the answer is too large to deliver in full.
+ */
+export const splitMarkdownIntoMessages = (
+    text: string,
+    maxMessages: number = SLACK_MAX_ANSWER_MESSAGES,
+): SlackMarkdownMessages => {
+    const blocks = getMarkdownBlocks(text);
+    const messages: (Block | KnownBlock)[][] = [];
+    let current: (Block | KnownBlock)[] = [];
+    let currentChars = 0;
+
+    for (const block of blocks) {
+        const blockChars = getBlockTextLength(block);
+        const exceedsBudget =
+            current.length > 0 &&
+            (currentChars + blockChars > SLACK_MESSAGE_TEXT_BUDGET ||
+                current.length >= SLACK_MESSAGE_BLOCK_LIMIT);
+        if (exceedsBudget) {
+            messages.push(current);
+            current = [];
+            currentChars = 0;
+        }
+        current.push(block);
+        currentChars += blockChars;
+    }
+    if (current.length > 0) {
+        messages.push(current);
+    }
+
+    if (messages.length <= maxMessages) {
+        return { messages, truncated: false };
+    }
+    return { messages: messages.slice(0, maxMessages), truncated: true };
+};
+
 const TOOL_TASK_TITLES: Record<string, string> = {
     agent_reasoning: 'Working through the answer',
     loadProjectContext: 'Reading project context',
@@ -163,12 +219,16 @@ export const buildSlackTaskUpdate = ({
     status,
     details,
     output,
+    count,
 }: {
     toolName: string;
     taskId?: string;
     status: 'pending' | 'in_progress' | 'complete' | 'error';
     details?: string;
     output?: string;
+    // Times this tool type ran; when >1 the title shows "×N" so repeated calls
+    // collapse into one task instead of one block each.
+    count?: number;
 }): SlackStreamChunk => {
     const title = getSlackToolTitle(toolName);
     const resolvedDetails =
@@ -183,7 +243,7 @@ export const buildSlackTaskUpdate = ({
     return {
         type: 'task_update',
         id: getSlackTaskId(taskId ?? toolName),
-        title,
+        title: count && count > 1 ? `${title} ×${count}` : title,
         status,
         ...(resolvedDetails
             ? { details: truncateTaskText(resolvedDetails) }

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -108,8 +108,10 @@ export type SlackMarkdownMessages = {
     truncated: boolean;
 };
 
+// Markdown blocks carry their content as a top-level string `text`, which isn't
+// in the Slack block union — read it loosely and verify the type at runtime.
 const getBlockTextLength = (block: Block | KnownBlock): number => {
-    const { text } = block as unknown as { text?: string };
+    const { text } = block as { text?: unknown };
     return typeof text === 'string' ? text.length : 0;
 };
 

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -97,9 +97,7 @@ export const getMarkdownBlocks = (text: string): (Block | KnownBlock)[] =>
             }) as unknown as Block,
     );
 
-// Slack rejects a whole message when its blocks are collectively too large
-// (msg_too_long); the threshold is undocumented but answers ~25k chars failed,
-// so we budget well below that and split across messages.
+// Well below the (undocumented) size that triggers msg_too_long; ~25k chars failed.
 const SLACK_MESSAGE_TEXT_BUDGET = 11000;
 // Under Slack's 50-block message cap, leaving headroom for trailing cards.
 const SLACK_MESSAGE_BLOCK_LIMIT = 45;
@@ -116,9 +114,8 @@ const getBlockTextLength = (block: Block | KnownBlock): number => {
 };
 
 /**
- * Splits a long markdown answer into multiple Slack messages, each within a
- * single message's size budget. Returns `truncated: true` (and only the first
- * `maxMessages` messages) when the answer is too large to deliver in full.
+ * Splits a long markdown answer into Slack messages within the size budget.
+ * Returns `truncated: true` (and only the first `maxMessages`) when it doesn't fit.
  */
 export const splitMarkdownIntoMessages = (
     text: string,
@@ -226,8 +223,7 @@ export const buildSlackTaskUpdate = ({
     status: 'pending' | 'in_progress' | 'complete' | 'error';
     details?: string;
     output?: string;
-    // Times this tool type ran; when >1 the title shows "×N" so repeated calls
-    // collapse into one task instead of one block each.
+    // Times this tool type ran; >1 renders "×N" instead of one block per call.
     count?: number;
 }): SlackStreamChunk => {
     const title = getSlackToolTitle(toolName);

--- a/packages/common/src/utils/slack.test.ts
+++ b/packages/common/src/utils/slack.test.ts
@@ -1,5 +1,6 @@
 import {
     getSlackErrorCode,
+    isSlackMessageTooLongError,
     isSlackRateLimitedError,
     isUnrecoverableSlackError,
     SLACK_USER_FACING_ERROR_MESSAGES,
@@ -37,6 +38,27 @@ describe('isUnrecoverableSlackError', () => {
             isUnrecoverableSlackError({ data: { error: 'invalid_blocks' } }),
         ).toBe(false);
         expect(isUnrecoverableSlackError(new Error('boom'))).toBe(false);
+    });
+});
+
+describe('isSlackMessageTooLongError', () => {
+    it('returns true for oversized-message codes', () => {
+        expect(
+            isSlackMessageTooLongError({ data: { error: 'msg_too_long' } }),
+        ).toBe(true);
+        expect(
+            isSlackMessageTooLongError({
+                data: { error: 'msg_blocks_too_long' },
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false for other Slack errors and non-Slack errors', () => {
+        expect(
+            isSlackMessageTooLongError({ data: { error: 'invalid_blocks' } }),
+        ).toBe(false);
+        expect(isSlackMessageTooLongError(new Error('boom'))).toBe(false);
+        expect(isSlackMessageTooLongError(undefined)).toBe(false);
     });
 });
 

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -54,9 +54,8 @@ export const isUnrecoverableSlackError = (error: unknown): boolean => {
 };
 
 /**
- * Whether a Slack error is the whole message being too large to deliver
- * (`msg_too_long` / `msg_blocks_too_long`) — a delivery failure, not a
- * generation failure.
+ * Whether a Slack error is the message being too large to deliver — a delivery
+ * failure, not a generation failure.
  */
 export const isSlackMessageTooLongError = (error: unknown): boolean => {
     const errorCode = getSlackErrorCode(error);

--- a/packages/common/src/utils/slack.ts
+++ b/packages/common/src/utils/slack.ts
@@ -54,6 +54,16 @@ export const isUnrecoverableSlackError = (error: unknown): boolean => {
 };
 
 /**
+ * Whether a Slack error is the whole message being too large to deliver
+ * (`msg_too_long` / `msg_blocks_too_long`) — a delivery failure, not a
+ * generation failure.
+ */
+export const isSlackMessageTooLongError = (error: unknown): boolean => {
+    const errorCode = getSlackErrorCode(error);
+    return errorCode === 'msg_too_long' || errorCode === 'msg_blocks_too_long';
+};
+
+/**
  * Checks if a Slack error is a rate limit error.
  * These errors have a special code from the @slack/web-api package.
  */


### PR DESCRIPTION
Closes: PROD-8382
Closes: #24512

### Description

When the Slack AI agent produced a long response, the modern streaming reply finalized the whole answer in a single `chat.stopStream` message. Long answers — and tool-heavy runs — exceeded Slack's per-message size/block limits, so Slack returned `msg_too_long`. The error was caught generically and shown as **"Co-pilot failed to generate a response"**, even though the answer was generated and persisted (visible in the web app). This is a delivery failure, not a generation failure.

There were two independent causes, both fixed:

**1. Oversized answer text**
The answer is now split into multiple thread messages (`splitMarkdownIntoMessages`), each within a per-message size/block budget. The first message finalizes the live stream, the rest post as thread replies, and the trailing artifact/feedback cards ride on the last message. If the answer is still too large for the message cap, we link to the full answer in Lightdash.

**2. Oversized task card**
Repeated same-type tool calls each appended a task block, overflowing Slack's 50-block-per-message cap. Task updates are now aggregated by tool type with a running count (e.g. **`Building chart ×11`**), and each detail/output line is streamed at most once (Slack appends deltas), keeping the card small.

A `msg_too_long` is now treated as a delivery failure — the user gets the answer (across messages, or a link to Lightdash) instead of a false "Co-pilot failed".
