### PR TITLE
fix(reviews): source review-item assignees from project users-with-roles (ZAP-520)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
+
+const updateMutate = vi.fn();
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useUpdateAiAgentReviewItemAssignee: () => ({
+        mutate: updateMutate,
+        isLoading: false,
+    }),
+}));
+
+// One user with a direct project role, one whose project access is inherited
+// (projectRole === null). The old picker filtered to direct ADMIN/DEVELOPER
+// members and dropped the inherited user — this is the case ZAP-520 fixes.
+const usersWithProjectRole = [
+    {
+        userUuid: 'direct-admin',
+        firstName: 'Dana',
+        lastName: 'Direct',
+        email: 'dana@example.com',
+        projectRole: 'admin',
+    },
+    {
+        userUuid: 'inherited-user',
+        firstName: 'Ingrid',
+        lastName: 'Inherited',
+        email: 'ingrid@example.com',
+        projectRole: null,
+    },
+];
+
+vi.mock('../../../../../hooks/useProjectUsersWithRolesV2', () => ({
+    useProjectUsersWithRoles: () => ({ usersWithProjectRole }),
+}));
+
+describe('ReviewAssigneeMenu', () => {
+    it('lists every project user, including those with inherited access', async () => {
+        renderWithProviders(
+            <ReviewAssigneeMenu
+                projectUuid="p"
+                fingerprint="fp"
+                assignedToUserUuid={null}
+            />,
+        );
+
+        fireEvent.click(screen.getByLabelText('Assign user'));
+
+        expect(await screen.findByText('Dana Direct')).toBeInTheDocument();
+        // Previously excluded: access is inherited, no direct project role.
+        expect(await screen.findByText('Ingrid Inherited')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -1,4 +1,3 @@
-import { ProjectMemberRole } from '@lightdash/common';
 import {
     Box,
     Menu,
@@ -12,7 +11,7 @@ import { IconSearch, IconUserMinus, IconUserPlus } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { useProjectAccess } from '../../../../../hooks/useProjectAccess';
+import { useProjectUsersWithRoles } from '../../../../../hooks/useProjectUsersWithRolesV2';
 import { useUpdateAiAgentReviewItemAssignee } from '../../hooks/useAiAgentAdmin';
 import classes from './ReviewKanbanBoard.module.css';
 
@@ -24,31 +23,26 @@ type Props = {
     className?: string;
 };
 
-const ASSIGNABLE_ROLES = new Set([
-    ProjectMemberRole.ADMIN,
-    ProjectMemberRole.DEVELOPER,
-]);
-
 export const ReviewAssigneeMenu: FC<Props> = ({
     projectUuid,
     fingerprint,
     assignedToUserUuid,
     className,
 }) => {
-    const { data: members } = useProjectAccess(projectUuid ?? '');
+    // Source the candidate list from the same hook the project users & groups
+    // table uses, so anyone who can access the project is assignable — not just
+    // users with a direct project membership (which excluded group- and
+    // org-inherited access).
+    const { usersWithProjectRole } = useProjectUsersWithRoles(
+        projectUuid ?? '',
+    );
     const updateAssignee = useUpdateAiAgentReviewItemAssignee();
     const [search, setSearch] = useState('');
 
     if (!projectUuid) return null;
 
-    const allMembers = members ?? [];
-    const assignable = allMembers
-        .filter((m) => ASSIGNABLE_ROLES.has(m.role))
-        .sort((a, b) =>
-            `${a.firstName} ${a.lastName}`.localeCompare(
-                `${b.firstName} ${b.lastName}`,
-            ),
-        );
+    const allMembers = usersWithProjectRole;
+    const assignable = allMembers;
 
     const query = search.trim().toLowerCase();
     const filtered = query

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -22,8 +22,8 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
     }),
 }));
 
-vi.mock('../../../../../hooks/useProjectAccess', () => ({
-    useProjectAccess: () => ({ data: [] }),
+vi.mock('../../../../../hooks/useProjectUsersWithRolesV2', () => ({
+    useProjectUsersWithRoles: () => ({ usersWithProjectRole: [] }),
 }));
 
 vi.mock('../AgentNamePill', () => ({ AgentNamePill: () => null }));


### PR DESCRIPTION
## Problem

The "Assign to" picker on AI-review board cards/drawer (`ReviewAssigneeMenu`) sourced its candidate list from `useProjectAccess`, which returns only **direct** project members (`project_memberships`). Anyone whose project access is **inherited** — via a group with project access, or via an org-level role (e.g. org admins) — never appeared, so the picker was missing legitimate users.

## Fix

Switch `ReviewAssigneeMenu` to `useProjectUsersWithRoles` — the same hook the project **users & groups** table (`ProjectAccess`) uses. It returns every user who can access the project (direct + group- + org-inherited), so the picker now lists them all, with search unchanged.

## Behaviour change

The old picker also filtered to direct `ADMIN`/`DEVELOPER` members only. That filter is removed: the picker now mirrors the users & groups table and lists all project users (the v2 hook exposes only each user's *direct* role, so a meaningful "can-remediate" filter can't be derived from it without re-deriving inheritance). If we want to re-scope assignees to people who can act on a remediation, that's a follow-up — say the word and I'll add an effective-role filter.

## Regression analysis

- **Read-only change** on the frontend candidate list; no API, schema, or assignment-write behaviour changes.
- Assignment still writes `assignedToUserUuid` exactly as before; only the set of selectable users widened.
- Empty `projectUuid` path is unchanged (component returns `null`; the hook's project query is `enabled: !!projectUuid`).

## Test

`ReviewAssigneeMenu.test.tsx` opens the picker and asserts both a direct-role user **and** a user with inherited access (no direct `projectRole`) are listed — the latter is the case this fixes. Board + menu suites green.

Closes: ZAP-520
