### PR TITLE
feat(reviews): allow dismissing a review item past triage (ZAP-519)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
@@ -1,9 +1,13 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { ReviewItemActions } from './ReviewItemActions';
+
+const { updateStatusMutate } = vi.hoisted(() => ({
+    updateStatusMutate: vi.fn(),
+}));
 
 vi.mock('../../hooks/useAiAgentAdmin', () => ({
     useAiAgentAdminReviewItem: () => ({ data: undefined }),
@@ -13,7 +17,7 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
     }),
     useUpdateAiAgentReviewItemStatus: () => ({
         isLoading: false,
-        mutate: vi.fn(),
+        mutate: updateStatusMutate,
     }),
 }));
 
@@ -110,5 +114,37 @@ describe('ReviewItemActions', () => {
         expect(
             screen.getByText('No project is linked to this finding'),
         ).toBeInTheDocument();
+    });
+
+    it('lets you dismiss an item that has moved past triage', () => {
+        updateStatusMutate.mockClear();
+        renderWithProviders(
+            <MemoryRouter>
+                <ReviewItemActions
+                    reviewItem={makeReviewItem({ status: 'open' })}
+                    mode="drawer"
+                />
+            </MemoryRouter>,
+        );
+
+        fireEvent.click(screen.getByText('Dismiss'));
+
+        expect(updateStatusMutate).toHaveBeenCalledWith({
+            fingerprint: 'review-1',
+            body: { status: 'dismissed', dismissedReason: 'not_actionable' },
+        });
+    });
+
+    it('does not offer dismiss on a terminal item', () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <ReviewItemActions
+                    reviewItem={makeReviewItem({ status: 'resolved' })}
+                    mode="drawer"
+                />
+            </MemoryRouter>,
+        );
+
+        expect(screen.queryByText('Dismiss')).not.toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -56,6 +56,13 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     });
     const current = polled ?? reviewItem;
 
+    // Terminal items are already closed; everything before that (To Do, In
+    // Progress, …) can still be dismissed.
+    const isTerminal =
+        current.status === 'resolved' ||
+        current.status === 'dismissed' ||
+        current.status === 'duplicate';
+
     const isWritebackInFlight =
         current.prWritebackStatus === 'queued' ||
         current.prWritebackStatus === 'running';
@@ -228,6 +235,31 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                                     />
                                 </ActionIcon>
                             </Tooltip>
+                        )}
+
+                        {/* Dismiss stays available past triage so an item can be
+                            closed at any stage (the triage lane has its own
+                            Accept/Dismiss pair above). */}
+                        {!isTerminal && (
+                            <Button
+                                size={buttonSize}
+                                radius="md"
+                                variant="subtle"
+                                color="gray"
+                                loading={updateStatus.isLoading}
+                                onClick={(event) => {
+                                    stopPropagation(event);
+                                    updateStatus.mutate({
+                                        fingerprint: current.fingerprint,
+                                        body: {
+                                            status: 'dismissed',
+                                            dismissedReason: 'not_actionable',
+                                        },
+                                    });
+                                }}
+                            >
+                                Dismiss
+                            </Button>
                         )}
                     </Group>
 


### PR DESCRIPTION
## Problem

A review item could only be dismissed while it was in the **triage** lane — `ReviewItemActions` rendered the Accept/Dismiss pair only for `status === 'triage'`. Once an item moved to **To Do** or **In Progress** there was no dismiss affordance anywhere (the kanban card has none either), so it was stuck until resolved.

The backend already allows dismissing from any status (`updateReviewItemStatus` only requires a reason and closes any active remediation) — this was purely a missing UI path.

## Fix

Add a **Dismiss** action to the non-triage branch of `ReviewItemActions`, shown for any **non-terminal** item (i.e. not already `resolved`/`dismissed`/`duplicate`). It reuses the existing status mutation with `dismissedReason: 'not_actionable'`, matching the triage Dismiss. Because the table and the drawer both render `ReviewItemActions`, a To Do / In Progress item can now be dismissed from either surface.

Dismissing an In Progress item with an active remediation is safe: the backend already closes that remediation (as `failed`) when an item goes to a terminal status.

## Scope note

Terminal items (Done lane) intentionally don't show Dismiss — they're already closed. If you want re-dismissing a resolved item too, that's a one-line change; say the word.

## Test

`ReviewItemActions.test.tsx`: an `open` item now shows Dismiss and clicking it calls the status mutation with `dismissed` / `not_actionable`; a `resolved` item shows no Dismiss. Full Admin suite green (34 tests).

Closes: ZAP-519
