### PR TITLE
fix(reviews): default SQL mode on in workspace build threads (ZAP-517)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/WorkspaceThreadPane.tsx
@@ -4,11 +4,20 @@ import {
 } from '@lightdash/common';
 import { Center, Loader } from '@mantine-8/core';
 import { useCallback, useMemo, type FC } from 'react';
+import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import {
     useAiAgentThread,
     useCreateAgentThreadMessageMutation,
 } from '../../hooks/useProjectAiAgents';
+import {
+    selectThreadSqlModeRaw,
+    setThreadSqlMode,
+} from '../../store/aiAgentThreadModeSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
 import { contextItemsToContentMentionSuggestions } from '../ChatElements/contentMentions';
@@ -50,6 +59,16 @@ export const WorkspaceThreadPane: FC<Props> = ({
         refetch,
     );
 
+    const dispatch = useAiAgentStoreDispatch();
+    const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    // Build-fix threads exist to edit the dbt project with SQL introspection,
+    // so SQL mode defaults on here (unlike normal chat) until the user toggles
+    // it. `raw === undefined` means no stored toggle yet.
+    const rawSqlMode = useAiAgentStoreSelector(
+        selectThreadSqlModeRaw(threadUuid),
+    );
+    const sqlMode = rawSqlMode ?? true;
+
     const { mutateAsync: createMessage, isLoading: isCreating } =
         useCreateAgentThreadMessageMutation(
             projectUuid,
@@ -81,14 +100,14 @@ export const WorkspaceThreadPane: FC<Props> = ({
                 modelConfig: firstAssistant?.modelConfig ?? undefined,
                 context,
                 optimisticContext,
-                enableSqlMode: true,
+                enableSqlMode: sqlMode,
                 autoApproveSql: true,
                 toolHints: toolHints.includes('editDbtProject')
                     ? toolHints
                     : ['editDbtProject', ...toolHints],
             });
         },
-        [createMessage, thread?.messages],
+        [createMessage, thread?.messages, sqlMode],
     );
 
     if (isLoading || !thread) {
@@ -121,6 +140,15 @@ export const WorkspaceThreadPane: FC<Props> = ({
                     fullWidth
                     showSuggestions={false}
                     threadUuid={threadUuid}
+                    sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                    onSqlModeChange={
+                        sqlModeAvailable
+                            ? (enabled) =>
+                                  dispatch(
+                                      setThreadSqlMode({ threadUuid, enabled }),
+                                  )
+                            : undefined
+                    }
                     contentMentionPriorityItems={contentMentionItems}
                     latestAssistantMessageUuid={
                         [...(thread.messages ?? [])]

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+    aiAgentThreadModeSlice,
+    selectThreadSqlMode,
+    selectThreadSqlModeRaw,
+    setThreadSqlMode,
+} from './aiAgentThreadModeSlice';
+
+const { reducer } = aiAgentThreadModeSlice;
+
+const wrap = (aiAgentThreadMode: ReturnType<typeof reducer>) => ({
+    aiAgentThreadMode,
+});
+
+describe('aiAgentThreadModeSlice', () => {
+    it('selectThreadSqlMode defaults to false for an unknown thread', () => {
+        const state = wrap(reducer(undefined, { type: '@@init' }));
+        expect(selectThreadSqlMode('t1')(state)).toBe(false);
+    });
+
+    it('selectThreadSqlModeRaw is undefined until the thread is toggled', () => {
+        // undefined lets callers (e.g. workspace build threads) pick their own
+        // default — `raw ?? true` — without changing the global default.
+        const state = wrap(reducer(undefined, { type: '@@init' }));
+        expect(selectThreadSqlModeRaw('t1')(state)).toBeUndefined();
+        expect(selectThreadSqlModeRaw('t1')(state) ?? true).toBe(true);
+    });
+
+    it('reflects the stored value once set', () => {
+        const next = reducer(
+            undefined,
+            setThreadSqlMode({ threadUuid: 't1', enabled: false }),
+        );
+        const state = wrap(next);
+        expect(selectThreadSqlModeRaw('t1')(state)).toBe(false);
+        expect(selectThreadSqlModeRaw('t1')(state) ?? true).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadModeSlice.ts
@@ -39,3 +39,11 @@ export const selectThreadSqlMode =
     (threadUuid: string) =>
     (state: { aiAgentThreadMode: State }): boolean =>
         state.aiAgentThreadMode[threadUuid]?.sqlMode ?? DEFAULT_SQL_MODE;
+
+// Returns undefined when the thread has no stored toggle yet, so a caller can
+// apply its own default (workspace build threads default SQL mode on) while
+// everywhere else keeps DEFAULT_SQL_MODE.
+export const selectThreadSqlModeRaw =
+    (threadUuid: string) =>
+    (state: { aiAgentThreadMode: State }): boolean | undefined =>
+        state.aiAgentThreadMode[threadUuid]?.sqlMode;


### PR DESCRIPTION
## Problem

In the remediation **workspace**, the Build-fix pane (`WorkspaceThreadPane`) never wired the SQL-mode toggle into `AgentChatInput`. So:

- the toggle didn't render in the build pane at all, and
- the per-thread SQL-mode state fell back to the global default (`false`),

even though the pane's submit handler always sent `enableSqlMode: true`. The control was both **hidden and misleading** — SQL mode was effectively on, but nothing showed it and the user couldn't see or change it.

## Fix

Wire the toggle into `WorkspaceThreadPane`, mirroring the normal chat (`LauncherPanel`):

- Gate visibility on `useAiAgentSqlModeAvailable` (the `manage:SqlRunner` ability), same as everywhere else.
- Default **on** for build threads via a new `selectThreadSqlModeRaw` selector (returns `undefined` when the thread has no stored toggle, so the pane applies `?? true` without changing the global default used by normal chat).
- `handleSubmit` now sends `enableSqlMode: sqlMode` (the toggle value) instead of a hard-coded `true`, so the toggle is meaningful; `autoApproveSql` and the `editDbtProject` tool pin are unchanged.

When the user lacks the SqlRunner ability the toggle stays hidden and `sqlMode` remains its `true` default — i.e. no behaviour change from today for those users.

## Verification

Verified live in the workspace: the Build pane now renders **"SQL mode on"** with the toggle pressed by default.

`aiAgentThreadModeSlice.test.ts`: `selectThreadSqlMode` still defaults `false`; `selectThreadSqlModeRaw` is `undefined` until toggled (so `raw ?? true` → on for build threads) and reflects the stored value once set.

Closes: ZAP-517
