### PR TITLE
feat(reviews): mark a review item resolved from the workspace (ZAP-522)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { MarkResolvedModal } from './MarkResolvedModal';
+
+const { mergeMutate, updateStatusMutate } = vi.hoisted(() => ({
+    mergeMutate: vi.fn(),
+    updateStatusMutate: vi.fn(),
+}));
+
+vi.mock('../../hooks/useMergePullRequest', () => ({
+    useMergePullRequest: () => ({ mutate: mergeMutate, isLoading: false }),
+}));
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useUpdateAiAgentReviewItemStatus: () => ({
+        mutate: updateStatusMutate,
+        isLoading: false,
+    }),
+}));
+
+const baseProps = {
+    opened: true,
+    onClose: vi.fn(),
+    fingerprint: 'fp-1',
+    projectUuid: 'project-1',
+};
+
+describe('MarkResolvedModal', () => {
+    it('offers merge-and-resolve plus resolve-only when a PR is open', () => {
+        updateStatusMutate.mockClear();
+        renderWithProviders(
+            <MarkResolvedModal
+                {...baseProps}
+                prUrl="https://github.com/acme/repo/pull/1"
+            />,
+        );
+
+        expect(
+            screen.getByText('Merge PR & mark resolved'),
+        ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Mark resolved without merging'));
+        expect(updateStatusMutate).toHaveBeenCalledWith(
+            {
+                fingerprint: 'fp-1',
+                body: { status: 'resolved', dismissedReason: null },
+            },
+            expect.anything(),
+        );
+    });
+
+    it('only offers resolve when there is no PR', () => {
+        renderWithProviders(<MarkResolvedModal {...baseProps} prUrl={null} />);
+
+        expect(
+            screen.queryByText('Merge PR & mark resolved'),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Mark resolved')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
@@ -1,0 +1,92 @@
+import { Button, Stack, Text } from '@mantine-8/core';
+import { IconCircleCheck, IconGitMerge } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { useUpdateAiAgentReviewItemStatus } from '../../hooks/useAiAgentAdmin';
+import { useMergePullRequest } from '../../hooks/useMergePullRequest';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    fingerprint: string;
+    /** Project that owns the PR (the remediation's source project). */
+    projectUuid: string;
+    prUrl: string | null;
+};
+
+/**
+ * Resolves a review item from the workspace: optionally merge the open PR, then
+ * mark the item resolved (which also closes its remediation server-side).
+ */
+export const MarkResolvedModal: FC<Props> = ({
+    opened,
+    onClose,
+    fingerprint,
+    projectUuid,
+    prUrl,
+}) => {
+    const merge = useMergePullRequest(projectUuid);
+    const updateStatus = useUpdateAiAgentReviewItemStatus();
+
+    const markResolved = () =>
+        updateStatus.mutate(
+            {
+                fingerprint,
+                body: { status: 'resolved', dismissedReason: null },
+            },
+            { onSuccess: () => onClose() },
+        );
+
+    const mergeAndResolve = () => {
+        if (!prUrl) return;
+        merge.mutate({ prUrl, sha: null }, { onSuccess: markResolved });
+    };
+
+    const isMerging = merge.isLoading;
+    const isResolving = updateStatus.isLoading;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Resolve review item"
+            icon={IconCircleCheck}
+            size="md"
+        >
+            <Stack gap="md">
+                <Text size="sm" c="dimmed">
+                    Resolving marks this review item as done and closes its
+                    remediation.
+                    {prUrl
+                        ? ' Merge the pull request first, or resolve without merging.'
+                        : ''}
+                </Text>
+                <Stack gap="xs">
+                    {prUrl && (
+                        <Button
+                            color="green"
+                            leftSection={<MantineIcon icon={IconGitMerge} />}
+                            loading={isMerging}
+                            disabled={isResolving}
+                            onClick={mergeAndResolve}
+                        >
+                            Merge PR & mark resolved
+                        </Button>
+                    )}
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconCircleCheck} />}
+                        loading={isResolving}
+                        disabled={isMerging}
+                        onClick={markResolved}
+                    >
+                        {prUrl
+                            ? 'Mark resolved without merging'
+                            : 'Mark resolved'}
+                    </Button>
+                </Stack>
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -13,6 +13,7 @@ import {
 import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconArrowRight,
+    IconCircleCheck,
     IconExternalLink,
     IconFileDiff,
     IconGitPullRequest,
@@ -32,6 +33,7 @@ import {
     useRetestAiAgentReviewRemediation,
 } from '../../hooks/useAiAgentAdmin';
 import { AgentNamePill } from '../AgentNamePill';
+import { MarkResolvedModal } from './MarkResolvedModal';
 import {
     reviewRootCauseColors,
     reviewRootCauseLabels,
@@ -71,6 +73,7 @@ export const ReviewRemediationWorkspace = () => {
         enabled: !!reviewItem?.linkedPrUrl,
     });
     const [diffOpen, diffHandlers] = useDisclosure(false);
+    const [resolveOpen, resolveHandlers] = useDisclosure(false);
 
     const retest = useRetestAiAgentReviewRemediation();
 
@@ -308,6 +311,18 @@ export const ReviewRemediationWorkspace = () => {
                             View PR
                         </Button>
                     )}
+                    {reviewItem.status !== 'resolved' && (
+                        <Button
+                            color="green"
+                            size="xs"
+                            leftSection={
+                                <MantineIcon icon={IconCircleCheck} size={18} />
+                            }
+                            onClick={resolveHandlers.open}
+                        >
+                            Resolve
+                        </Button>
+                    )}
                 </Group>
             </Group>
 
@@ -409,6 +424,14 @@ export const ReviewRemediationWorkspace = () => {
                 onClose={diffHandlers.close}
                 diff={prDiff.data}
                 isLoading={prDiff.isLoading}
+            />
+
+            <MarkResolvedModal
+                opened={resolveOpen}
+                onClose={resolveHandlers.close}
+                fingerprint={reviewItem.fingerprint}
+                projectUuid={remediation.sourceProjectUuid}
+                prUrl={reviewItem.linkedPrUrl}
             />
         </Stack>
     );


### PR DESCRIPTION
## Problem

After the remediation moved to the build-thread flow, there was no longer a way to mark a review item **resolved** from the workspace (or the review item) — the capability that used to exist via the text-fix → chat-thread → remediation path was lost.

## Fix

Add a **Resolve** button to the workspace header (shown unless the item is already resolved). It opens a modal with the two actions from the ticket:

- **Merge PR & mark resolved** — merges the open PR, then marks the item resolved (shown only when there's a linked PR).
- **Mark resolved without merging** — marks the item resolved directly.

Marking resolved reuses the existing `updateReviewItemStatus` mutation, which already closes the item's active remediation server-side. Merge reuses `useMergePullRequest`.

## Verification

Verified live: the **Resolve** button renders in the workspace header, and the modal opens with both actions (screenshotted during development).

`MarkResolvedModal.test.tsx`: with a PR, both buttons render and "Mark resolved without merging" calls the status mutation with `resolved`; with no PR, only the resolve button shows.

## Note

This surfaces resolve in the **workspace**. If you also want it on the review-item drawer/card directly (the ticket says "or from a review item"), I can add the same modal trigger there in a follow-up — say the word.

Closes: ZAP-522
