### PR TITLE
fix(dashboard): polish desktop toolbar icons

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -34,9 +34,8 @@ import {
     type SavedChart,
     type Series,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
+import { ActionIcon, Menu } from '@mantine-8/core';
 import {
-    ActionIcon,
     Badge,
     Box,
     Group,
@@ -1376,7 +1375,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                     </HoverCard.Dropdown>
 
                                     <HoverCard.Target>
-                                        <ActionIcon size="sm">
+                                        <ActionIcon
+                                            size="sm"
+                                            variant="subtle"
+                                            color="gray"
+                                        >
                                             <MantineIcon icon={IconFilter} />
                                         </ActionIcon>
                                     </HoverCard.Target>
@@ -1429,7 +1432,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                         </HoverCard.Dropdown>
 
                                         <HoverCard.Target>
-                                            <ActionIcon size="sm">
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="subtle"
+                                                color="gray"
+                                            >
                                                 <MantineIcon
                                                     icon={IconVariable}
                                                 />

--- a/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
@@ -3,8 +3,8 @@ import {
     type CacheMetadata,
     type QueryResultsPerformance,
 } from '@lightdash/common';
-import { Divider, Stack } from '@mantine-8/core';
-import { ActionIcon, HoverCard } from '@mantine/core';
+import { ActionIcon, Divider, Stack } from '@mantine-8/core';
+import { HoverCard } from '@mantine/core';
 import {
     IconClock,
     IconClockBolt,
@@ -104,7 +104,7 @@ const TileExecutionInfo: FC<TileExecutionInfoProps> = ({
                 </Stack>
             </HoverCard.Dropdown>
             <HoverCard.Target>
-                <ActionIcon size="sm">
+                <ActionIcon size="sm" variant="subtle" color="gray">
                     <MantineIcon
                         icon={
                             cacheMetadata.preAggregate?.hit

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -9,6 +9,7 @@ import {
     Popover,
     Stack,
     Text,
+    Tooltip,
     type PopoverProps,
 } from '@mantine-8/core';
 import { useDisclosure, useScrollIntoView } from '@mantine/hooks';
@@ -136,6 +137,16 @@ export const DashboardTileComments: FC<
 
         return 'gray';
     }, [unreadNotificationsForTile]);
+
+    const handleTargetClick = useCallback(() => {
+        if (openedComments) {
+            onClose?.();
+        } else {
+            onOpen?.();
+        }
+
+        setOpenedComments((prev) => !prev);
+    }, [onClose, onOpen, openedComments]);
 
     const handleOnOpen = useCallback(() => {
         track({
@@ -276,34 +287,36 @@ export const DashboardTileComments: FC<
 
             <Popover.Target ref={targetRefComments}>
                 <Indicator
+                    inline
                     label={comments && comments.length}
                     size={12}
                     disabled={!showIndicator}
-                    offset={4}
+                    offset={3}
                     color={indicatorColor}
                     styles={{
                         indicator: {
-                            fontSize: 11,
+                            fontSize: 10,
                             padding: 0,
                         },
                     }}
                 >
-                    <ActionIcon
-                        size="sm"
-                        variant="light"
-                        color="gray"
-                        onClick={() => {
-                            if (openedComments) {
-                                onClose?.();
-                            } else {
-                                onOpen?.();
-                            }
-
-                            setOpenedComments((prev) => !prev);
-                        }}
+                    <Tooltip
+                        label="Comments"
+                        withArrow
+                        withinPortal
+                        position="top"
+                        disabled={openedComments}
                     >
-                        <MantineIcon icon={IconMessage} />
-                    </ActionIcon>
+                        <ActionIcon
+                            display="block"
+                            size="sm"
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleTargetClick}
+                        >
+                            <MantineIcon icon={IconMessage} />
+                        </ActionIcon>
+                    </Tooltip>
                 </Indicator>
             </Popover.Target>
         </Popover>


### PR DESCRIPTION
### Description
Polishes dashboard tile toolbar actions:
- keeps comments in the toolbar
- shows the AI orb first
- aligns subtle icon styling

<img width="362" height="192" alt="CleanShot 2026-06-22 at 12 44 02@2x" src="https://github.com/user-attachments/assets/7b3168f5-c16b-493f-a26b-06b13111c89c" />