### PR TITLE
feat(reviews): filter review items by assignee (ZAP-524)

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../../../../../hooks/useOnboardingMock', () => ({
 
 vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
     useOrganizationUsers: () => ({ data: [] }),
+    useOrgUsersByUuid: () => new Map(),
 }));
 
 // Stable so the async health/user queries behind useApp don't re-render the

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.test.tsx
@@ -19,6 +19,20 @@ vi.mock('../../../../../hooks/useOnboardingMock', () => ({
     useOnboardingMock: (_examples: unknown, _enabled: boolean) => undefined,
 }));
 
+vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
+    useOrganizationUsers: () => ({ data: [] }),
+}));
+
+// Stable so the async health/user queries behind useApp don't re-render the
+// table mid-interaction and detach the row node under test. `health.data`
+// undefined exercises the provider's own not-loaded fallback path.
+vi.mock('../../../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: { data: undefined },
+        user: { data: { userUuid: 'user-1' } },
+    }),
+}));
+
 vi.mock('../../hooks/useAiAgentAdmin', () => ({
     useAiAgentAdminAgents: () => ({ data: [] }),
     useAiAgentAdminReviewItems: (...args: unknown[]) =>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -31,6 +31,7 @@ import {
     IconRobotFace,
     IconTag,
     IconTriangle,
+    IconUser,
     IconX,
 } from '@tabler/icons-react';
 import { type RowSelectionState } from '@tanstack/react-table';
@@ -53,7 +54,9 @@ import FilterFacet, {
 } from '../../../../../components/common/FilterFacet';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useOnboardingMock } from '../../../../../hooks/useOnboardingMock';
+import { useOrganizationUsers } from '../../../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../../../hooks/useProjects';
+import useApp from '../../../../../providers/App/useApp';
 import {
     useAiAgentAdminAgents,
     useAiAgentAdminReviewItems,
@@ -63,6 +66,10 @@ import {
 import { AgentNamePill } from '../AgentNamePill';
 import styles from './AiAgentAdminReviewItemsTable.module.css';
 import { EXAMPLE_REVIEW_ITEMS, isExampleReviewItem } from './onboarding';
+import {
+    buildAssigneeFacetOptions,
+    matchesAssigneeFilter,
+} from './reviewAssigneeFacet';
 import { ReviewItemActions } from './ReviewItemActions';
 import {
     DEFAULT_VISIBLE_ROOT_CAUSES,
@@ -381,9 +388,18 @@ const AiAgentAdminReviewItemsTable = ({
     const [selectedSignals, setSelectedSignals] = useState<AiAgentTurnSignal[]>(
         [],
     );
+    const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     const deferredSearch = useDeferredValue(search);
     const updateStatus = useUpdateAiAgentReviewItemStatus();
+
+    const { user } = useApp();
+    const currentUserUuid = user.data?.userUuid ?? null;
+    const { data: orgUsers = [] } = useOrganizationUsers();
+    const orgUsersByUuid = useMemo(
+        () => new Map(orgUsers.map((orgUser) => [orgUser.userUuid, orgUser])),
+        [orgUsers],
+    );
 
     // While the tour is running the table always shows the sample rows so the
     // tour is deterministic; otherwise it passes real data straight through
@@ -511,14 +527,20 @@ const AiAgentAdminReviewItemsTable = ({
     }, [searchFilteredReviewSignals, selectedProjectUuids]);
 
     const filteredReviewItems = useMemo(() => {
-        if (selectedRootCauses.length === 0) {
-            return projectFilteredReviewItems;
+        let items = projectFilteredReviewItems;
+        if (selectedRootCauses.length > 0) {
+            const rootCauseSet = new Set(selectedRootCauses);
+            items = items.filter((item) =>
+                rootCauseSet.has(item.primaryRootCause),
+            );
         }
-        const rootCauseSet = new Set(selectedRootCauses);
-        return projectFilteredReviewItems.filter((item) =>
-            rootCauseSet.has(item.primaryRootCause),
-        );
-    }, [projectFilteredReviewItems, selectedRootCauses]);
+        if (selectedAssignees.length > 0) {
+            items = items.filter((item) =>
+                matchesAssigneeFilter(item, selectedAssignees),
+            );
+        }
+        return items;
+    }, [projectFilteredReviewItems, selectedRootCauses, selectedAssignees]);
 
     const filteredReviewSignals = useMemo(() => {
         if (selectedSignals.length === 0) {
@@ -591,6 +613,16 @@ const AiAgentAdminReviewItemsTable = ({
             );
     }, [projectFilteredReviewItems]);
 
+    const assigneeFacetOptions = useMemo(
+        (): FilterFacetOption[] =>
+            buildAssigneeFacetOptions({
+                items: projectFilteredReviewItems,
+                usersByUuid: orgUsersByUuid,
+                currentUserUuid,
+            }),
+        [projectFilteredReviewItems, orgUsersByUuid, currentUserUuid],
+    );
+
     const _signalFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<AiAgentTurnSignal, number>();
         for (const signal of projectFilteredReviewSignals) {
@@ -616,12 +648,14 @@ const AiAgentAdminReviewItemsTable = ({
     const hasActiveFilters =
         selectedProjectUuids.length > 0 ||
         !hasDefaultRootCauseSelection ||
-        selectedSignals.length > 0;
+        selectedSignals.length > 0 ||
+        selectedAssignees.length > 0;
 
     const clearAllFilters = useCallback(() => {
         setSelectedProjectUuids([]);
         setSelectedRootCauses(DEFAULT_VISIBLE_ROOT_CAUSES);
         setSelectedSignals([]);
+        setSelectedAssignees([]);
     }, []);
 
     const handleRowSelectionChange = useCallback(
@@ -710,6 +744,15 @@ const AiAgentAdminReviewItemsTable = ({
                             }
                             emptyLabel="No root causes in current view"
                             tooltipLabel="Filter by root cause"
+                        />
+                        <FilterFacet
+                            label="Assignee"
+                            icon={IconUser}
+                            options={assigneeFacetOptions}
+                            selected={selectedAssignees}
+                            onChange={setSelectedAssignees}
+                            emptyLabel="No assignees in current view"
+                            tooltipLabel="Filter by assignee"
                         />
                         {hasActiveFilters && (
                             <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -54,7 +54,7 @@ import FilterFacet, {
 } from '../../../../../components/common/FilterFacet';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useOnboardingMock } from '../../../../../hooks/useOnboardingMock';
-import { useOrganizationUsers } from '../../../../../hooks/useOrganizationUsers';
+import { useOrgUsersByUuid } from '../../../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../../../hooks/useProjects';
 import useApp from '../../../../../providers/App/useApp';
 import {
@@ -395,11 +395,7 @@ const AiAgentAdminReviewItemsTable = ({
 
     const { user } = useApp();
     const currentUserUuid = user.data?.userUuid ?? null;
-    const { data: orgUsers = [] } = useOrganizationUsers();
-    const orgUsersByUuid = useMemo(
-        () => new Map(orgUsers.map((orgUser) => [orgUser.userUuid, orgUser])),
-        [orgUsers],
-    );
+    const orgUsersByUuid = useOrgUsersByUuid();
 
     // While the tour is running the table always shows the sample rows so the
     // tour is deterministic; otherwise it passes real data straight through

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../../../../hooks/useProjectAccess', () => ({
 
 vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
     useOrganizationUsers: () => ({ data: [] }),
+    useOrgUsersByUuid: () => new Map(),
 }));
 
 vi.mock('../AgentNamePill', () => ({ AgentNamePill: () => null }));

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -26,6 +26,10 @@ vi.mock('../../../../../hooks/useProjectAccess', () => ({
     useProjectAccess: () => ({ data: [] }),
 }));
 
+vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
+    useOrganizationUsers: () => ({ data: [] }),
+}));
+
 vi.mock('../AgentNamePill', () => ({ AgentNamePill: () => null }));
 
 const items = [

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -24,12 +24,14 @@ import {
     Stack,
     Text,
 } from '@mantine-8/core';
-import { IconBox, IconTag } from '@tabler/icons-react';
+import { IconBox, IconTag, IconUser } from '@tabler/icons-react';
 import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
     type FilterFacetOption,
 } from '../../../../../components/common/FilterFacet';
+import { useOrganizationUsers } from '../../../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../../../hooks/useProjects';
+import useApp from '../../../../../providers/App/useApp';
 import {
     useAiAgentAdminReviewItems,
     useCreateAiAgentReviewItemWriteback,
@@ -37,6 +39,10 @@ import {
 } from '../../hooks/useAiAgentAdmin';
 import { type AiAgentAdminReviewItemPreviewTarget } from './AiAgentAdminReviewItemsTable';
 import { EXAMPLE_REVIEW_ITEMS } from './onboarding';
+import {
+    buildAssigneeFacetOptions,
+    matchesAssigneeFilter,
+} from './reviewAssigneeFacet';
 import {
     DEFAULT_VISIBLE_ROOT_CAUSES,
     getIssueTitle,
@@ -150,10 +156,18 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]
     >(DEFAULT_VISIBLE_ROOT_CAUSES);
+    const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
     const { data, isLoading } = useAiAgentAdminReviewItems({
         statuses: BOARD_STATUSES,
     });
     const { data: projects } = useProjects();
+    const { user } = useApp();
+    const currentUserUuid = user.data?.userUuid ?? null;
+    const { data: orgUsers = [] } = useOrganizationUsers();
+    const orgUsersByUuid = useMemo(
+        () => new Map(orgUsers.map((orgUser) => [orgUser.userUuid, orgUser])),
+        [orgUsers],
+    );
     const [expandedLanes, setExpandedLanes] = useState<
         Partial<Record<ReviewLane, boolean>>
     >({});
@@ -204,12 +218,20 @@ export const ReviewKanbanBoard: FC<Props> = ({
     }, [searchFilteredItems, selectedProjectUuids]);
 
     const items = useMemo<AiAgentReviewItemSummary[]>(() => {
-        if (selectedRootCauses.length === 0) return projectFilteredItems;
-        const rootCauseSet = new Set(selectedRootCauses);
-        return projectFilteredItems.filter((item) =>
-            rootCauseSet.has(item.primaryRootCause),
-        );
-    }, [projectFilteredItems, selectedRootCauses]);
+        let next = projectFilteredItems;
+        if (selectedRootCauses.length > 0) {
+            const rootCauseSet = new Set(selectedRootCauses);
+            next = next.filter((item) =>
+                rootCauseSet.has(item.primaryRootCause),
+            );
+        }
+        if (selectedAssignees.length > 0) {
+            next = next.filter((item) =>
+                matchesAssigneeFilter(item, selectedAssignees),
+            );
+        }
+        return next;
+    }, [projectFilteredItems, selectedRootCauses, selectedAssignees]);
 
     const projectFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<string, number>();
@@ -255,6 +277,16 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     String(a.label).localeCompare(String(b.label)),
             );
     }, [projectFilteredItems]);
+
+    const assigneeFacetOptions = useMemo(
+        (): FilterFacetOption[] =>
+            buildAssigneeFacetOptions({
+                items: projectFilteredItems,
+                usersByUuid: orgUsersByUuid,
+                currentUserUuid,
+            }),
+        [projectFilteredItems, orgUsersByUuid, currentUserUuid],
+    );
 
     const lanes = useMemo(() => {
         const byLane: Record<ReviewLane, AiAgentReviewItemSummary[]> = {
@@ -345,6 +377,15 @@ export const ReviewKanbanBoard: FC<Props> = ({
                     }
                     emptyLabel="No root causes in current view"
                     tooltipLabel="Filter by root cause"
+                />
+                <FilterFacet
+                    label="Assignee"
+                    icon={IconUser}
+                    options={assigneeFacetOptions}
+                    selected={selectedAssignees}
+                    onChange={setSelectedAssignees}
+                    emptyLabel="No assignees in current view"
+                    tooltipLabel="Filter by assignee"
                 />
             </Group>
             <Box className={styles.boardWrapper}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -29,7 +29,7 @@ import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
     type FilterFacetOption,
 } from '../../../../../components/common/FilterFacet';
-import { useOrganizationUsers } from '../../../../../hooks/useOrganizationUsers';
+import { useOrgUsersByUuid } from '../../../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../../../hooks/useProjects';
 import useApp from '../../../../../providers/App/useApp';
 import {
@@ -163,11 +163,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const { data: projects } = useProjects();
     const { user } = useApp();
     const currentUserUuid = user.data?.userUuid ?? null;
-    const { data: orgUsers = [] } = useOrganizationUsers();
-    const orgUsersByUuid = useMemo(
-        () => new Map(orgUsers.map((orgUser) => [orgUser.userUuid, orgUser])),
-        [orgUsers],
-    );
+    const orgUsersByUuid = useOrgUsersByUuid();
     const [expandedLanes, setExpandedLanes] = useState<
         Partial<Record<ReviewLane, boolean>>
     >({});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewAssigneeFacet.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewAssigneeFacet.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+    type AssigneeFacetUser,
+    buildAssigneeFacetOptions,
+    matchesAssigneeFilter,
+    UNASSIGNED_FILTER_VALUE,
+} from './reviewAssigneeFacet';
+
+const users = new Map<string, AssigneeFacetUser>([
+    ['u-alice', { firstName: 'Alice', lastName: 'Ack', email: 'a@x.com' }],
+    ['u-bob', { firstName: 'Bob', lastName: 'Bee', email: 'b@x.com' }],
+    ['u-me', { firstName: 'Me', lastName: 'Myself', email: 'me@x.com' }],
+]);
+
+const item = (assignedToUserUuid: string | null) => ({ assignedToUserUuid });
+
+describe('buildAssigneeFacetOptions', () => {
+    it('puts the current user first regardless of count', () => {
+        const options = buildAssigneeFacetOptions({
+            items: [
+                item('u-alice'),
+                item('u-alice'),
+                item('u-alice'),
+                item('u-me'),
+            ],
+            usersByUuid: users,
+            currentUserUuid: 'u-me',
+        });
+        expect(options.map((o) => o.value)).toEqual(['u-me', 'u-alice']);
+        expect(options[0].label).toBe('Me Myself (you)');
+    });
+
+    it('sorts the rest by count desc then name asc', () => {
+        const options = buildAssigneeFacetOptions({
+            items: [item('u-bob'), item('u-alice'), item('u-alice')],
+            usersByUuid: users,
+            currentUserUuid: null,
+        });
+        expect(options.map((o) => o.value)).toEqual(['u-alice', 'u-bob']);
+        expect(options.map((o) => o.count)).toEqual([2, 1]);
+    });
+
+    it('appends an Unassigned bucket only when present', () => {
+        const withUnassigned = buildAssigneeFacetOptions({
+            items: [item('u-alice'), item(null), item(null)],
+            usersByUuid: users,
+            currentUserUuid: null,
+        });
+        expect(withUnassigned.at(-1)).toEqual({
+            value: UNASSIGNED_FILTER_VALUE,
+            label: 'Unassigned',
+            count: 2,
+        });
+
+        const withoutUnassigned = buildAssigneeFacetOptions({
+            items: [item('u-alice')],
+            usersByUuid: users,
+            currentUserUuid: null,
+        });
+        expect(
+            withoutUnassigned.some((o) => o.value === UNASSIGNED_FILTER_VALUE),
+        ).toBe(false);
+    });
+
+    it('falls back to "Unknown user" for unresolved uuids', () => {
+        const options = buildAssigneeFacetOptions({
+            items: [item('u-ghost')],
+            usersByUuid: users,
+            currentUserUuid: null,
+        });
+        expect(options[0].label).toBe('Unknown user');
+    });
+});
+
+describe('matchesAssigneeFilter', () => {
+    it('matches everything when no assignees are selected', () => {
+        expect(matchesAssigneeFilter(item('u-alice'), [])).toBe(true);
+        expect(matchesAssigneeFilter(item(null), [])).toBe(true);
+    });
+
+    it('matches the unassigned sentinel against null assignees', () => {
+        expect(
+            matchesAssigneeFilter(item(null), [UNASSIGNED_FILTER_VALUE]),
+        ).toBe(true);
+        expect(
+            matchesAssigneeFilter(item('u-alice'), [UNASSIGNED_FILTER_VALUE]),
+        ).toBe(false);
+    });
+
+    it('matches a specific assignee uuid', () => {
+        expect(matchesAssigneeFilter(item('u-alice'), ['u-alice'])).toBe(true);
+        expect(matchesAssigneeFilter(item('u-bob'), ['u-alice'])).toBe(false);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewAssigneeFacet.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewAssigneeFacet.ts
@@ -1,0 +1,88 @@
+import { type FilterFacetOption } from '../../../../../components/common/FilterFacet';
+
+// Sentinel facet value for items with no assignee.
+export const UNASSIGNED_FILTER_VALUE = '__unassigned__';
+
+export type AssigneeFacetUser = {
+    firstName: string;
+    lastName: string;
+    email: string;
+};
+
+export type AssigneeFacetItem = {
+    assignedToUserUuid: string | null;
+};
+
+const displayName = (user: AssigneeFacetUser): string =>
+    `${user.firstName} ${user.lastName}`.trim() || user.email;
+
+/**
+ * Builds assignee filter options, current user first then by count, with a
+ * trailing "Unassigned" bucket. Names resolve from the org-user superset so a
+ * cross-project board still labels every assignee.
+ */
+export const buildAssigneeFacetOptions = ({
+    items,
+    usersByUuid,
+    currentUserUuid,
+}: {
+    items: ReadonlyArray<AssigneeFacetItem>;
+    usersByUuid: ReadonlyMap<string, AssigneeFacetUser>;
+    currentUserUuid: string | null;
+}): FilterFacetOption[] => {
+    const counts = new Map<string, number>();
+    let unassigned = 0;
+    for (const item of items) {
+        if (item.assignedToUserUuid) {
+            counts.set(
+                item.assignedToUserUuid,
+                (counts.get(item.assignedToUserUuid) ?? 0) + 1,
+            );
+        } else {
+            unassigned += 1;
+        }
+    }
+
+    const nameFor = (uuid: string): string => {
+        const user = usersByUuid.get(uuid);
+        return user ? displayName(user) : 'Unknown user';
+    };
+
+    const options: FilterFacetOption[] = Array.from(counts.entries())
+        .map(([uuid, count]) => ({
+            uuid,
+            count,
+            name: nameFor(uuid),
+            isCurrentUser: uuid === currentUserUuid,
+        }))
+        .sort((a, b) => {
+            if (a.isCurrentUser) return -1;
+            if (b.isCurrentUser) return 1;
+            return b.count - a.count || a.name.localeCompare(b.name);
+        })
+        .map(({ uuid, count, name, isCurrentUser }) => ({
+            value: uuid,
+            label: isCurrentUser ? `${name} (you)` : name,
+            count,
+        }));
+
+    if (unassigned > 0) {
+        options.push({
+            value: UNASSIGNED_FILTER_VALUE,
+            label: 'Unassigned',
+            count: unassigned,
+        });
+    }
+
+    return options;
+};
+
+export const matchesAssigneeFilter = (
+    item: AssigneeFacetItem,
+    selectedAssignees: ReadonlyArray<string>,
+): boolean => {
+    if (selectedAssignees.length === 0) return true;
+    return selectedAssignees.includes(
+        item.assignedToUserUuid ?? UNASSIGNED_FILTER_VALUE,
+    );
+};

--- a/packages/frontend/src/hooks/useOrganizationUsers.ts
+++ b/packages/frontend/src/hooks/useOrganizationUsers.ts
@@ -13,9 +13,13 @@ import {
     type UseInfiniteQueryOptions,
 } from '@tanstack/react-query';
 import Fuse from 'fuse.js';
+import { useMemo } from 'react';
 import { lightdashApi } from '../api';
 import useToaster from './toaster/useToaster';
 import useQueryError from './useQueryError';
+
+type OrganizationUser =
+    ApiOrganizationMemberProfiles['results']['data'][number];
 
 const getOrganizationUsersQuery = async (params?: {
     includeGroups?: number;
@@ -95,6 +99,18 @@ export const useOrganizationUsers = (params?: {
                 return data;
             },
         },
+    );
+};
+
+export const useOrgUsersByUuid = () => {
+    const { data: orgUsers = [] } = useOrganizationUsers();
+
+    return useMemo(
+        () =>
+            new Map<string, OrganizationUser>(
+                orgUsers.map((orgUser) => [orgUser.userUuid, orgUser]),
+            ),
+        [orgUsers],
     );
 };
 


### PR DESCRIPTION
## Problem

The AI-review board and findings table could be filtered by **Project** and **Cause**, but not by who a finding is assigned to. With assignees now first-class (board cards show them; you can assign from the card/drawer), there was no way to narrow the queue to "my findings" or to a specific teammate's.

## Fix

Add an **Assignee** `FilterFacet` to both the board (`ReviewKanbanBoard`) and the findings table (`AiAgentAdminReviewItemsTable`), next to the existing Project and Cause facets. Options are ordered **current user first**, then by count, then alphabetically, with a trailing **Unassigned** bucket. The shared facet logic (option building + filter predicate + the unassigned sentinel) lives in a new `reviewAssigneeFacet.ts` so the two surfaces stay in sync.

## Name resolution

Assignee display names resolve from `useOrganizationUsers` (the org-wide superset) rather than per-project members, because the board and table span multiple projects in a single view — a project-scoped hook can't label an assignee who belongs to a different project. Unresolved uuids fall back to "Unknown user".

## Regression analysis

- **Additive, read-only filter.** No API, schema, or assignment-write changes; `assignedToUserUuid` is read, never written.
- When no assignee is selected the facet is a no-op (`matchesAssigneeFilter` returns `true` for an empty selection), so default board/table contents are unchanged.
- The Unassigned bucket only renders when at least one unassigned item is in view; the current-user `(you)` suffix only when the current user has assigned items.
- Counts are computed off the same partially-filtered set the sibling facets use (post project/search), matching existing facet behaviour.

## Test

- New `reviewAssigneeFacet.test.ts` covers ordering (current user first; then count desc, name asc), the Unassigned bucket appearing only when present, the unknown-user fallback, and `matchesAssigneeFilter` (empty = pass-through, unassigned sentinel vs `null` assignee, specific uuid).
- Because the board and table now consume `useApp()` + `useOrganizationUsers()`, their existing test suites (`ReviewKanbanBoard.test.tsx`, `AiAgentAdminReviewItemsTable.test.tsx`) were updated to mock those hooks with stable values — the table's row-click test was otherwise re-rendering mid-interaction (the `AppProviderMock` user query settling) and detaching the clicked node.
- All three suites green (9/9); oxlint clean.

Closes: ZAP-524
