### PR TITLE
feat(reviews): sortable board with reorder + persisted order (ZAP-525)

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -11,9 +11,11 @@ import {
     ApiAiAgentSummaryResponse,
     ApiAiOrganizationSettingsResponse,
     ApiErrorPayload,
+    ApiSuccessEmpty,
     ApiUpdateAiOrganizationSettingsResponse,
     assertRegisteredAccount,
     KnexPaginateArgs,
+    ReorderAiAgentReviewItems,
     UpdateAiAgentReviewItemAssignee,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
@@ -257,6 +259,32 @@ export class AiAgentAdminController extends BaseController {
                     threadUuid,
                 ),
         };
+    }
+
+    /**
+     * Persist the board's manual card order for one lane. Declared before the
+     * `{fingerprint}` route so "reorder" isn't matched as a fingerprint.
+     * @summary Reorder AI agent review items on the board
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/review-items/reorder')
+    @OperationId('reorderAiAgentReviewItems')
+    async reorderReviewItems(
+        @Request() req: express.Request,
+        @Body() body: ReorderAiAgentReviewItems,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getAiAgentAdminService().reorderReviewItems(
+            toSessionUser(req.account),
+            body.orderedFingerprints,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
     }
 
     /**

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -222,6 +222,7 @@ export type DbAiAgentReviewItem = {
     pr_writeback_message: string | null;
     status_updated_at: Date | null;
     status_updated_by_user_uuid: string | null;
+    board_position: number | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/ee/database/migrations/20260622120000_add_board_position_to_review_items.ts
+++ b/packages/backend/src/ee/database/migrations/20260622120000_add_board_position_to_review_items.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const reviewItemTable = 'ai_agent_review_item';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        // Fractional manual sort key for the review board. Null = fall back to
+        // the default (last-seen) order; a drag-reorder sets the midpoint
+        // between neighbours so only one row updates.
+        table.double('board_position').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table.dropColumn('board_position');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260622120000_add_board_position_to_review_items.ts
+++ b/packages/backend/src/ee/database/migrations/20260622120000_add_board_position_to_review_items.ts
@@ -11,8 +11,8 @@ export async function up(knex: Knex): Promise<void> {
     });
 }
 
-export async function down(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(reviewItemTable, (table) => {
-        table.dropColumn('board_position');
-    });
+export async function down(_knex: Knex): Promise<void> {
+    // Dropping a column is a disallowed, data-losing operation; this down
+    // migration is intentionally a no-op (the nullable column is harmless if
+    // the code is rolled back).
 }

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -195,6 +195,9 @@ type UpsertReviewItemStateArgs = {
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     statusUpdatedByUserUuid: string | null;
+    // undefined = leave the manual board order untouched (plain status change);
+    // a number repositions the card; null clears it back to default order.
+    boardPosition?: number | null;
 };
 
 type CreateReviewRemediationArgs = {
@@ -1070,6 +1073,18 @@ export class AiAgentReviewClassifierModel {
             }),
         ]);
 
+        // Manual board order: items with a board_position sort first (ascending);
+        // the rest keep the default last-seen order. V8's stable sort preserves
+        // that fallback order for nulls and ties.
+        fingerprints.sort((a, b) => {
+            const pa = persisted.get(a)?.board_position;
+            const pb = persisted.get(b)?.board_position;
+            if (pa == null && pb == null) return 0;
+            if (pa == null) return 1;
+            if (pb == null) return -1;
+            return pa - pb;
+        });
+
         const reviewItems = fingerprints
             .map((fingerprint): AiAgentReviewItemSummary | null => {
                 const latest = latestByFingerprint.get(fingerprint);
@@ -1116,6 +1131,7 @@ export class AiAgentReviewClassifierModel {
                     prWritebackMessage: writebackStale
                         ? WRITEBACK_TIMED_OUT_MESSAGE
                         : (item?.pr_writeback_message ?? null),
+                    boardPosition: item?.board_position ?? null,
                     writebackEligible: false,
                     writebackEligibility: defaultWritebackEligibility,
                     remediation,
@@ -1620,6 +1636,9 @@ export class AiAgentReviewClassifierModel {
                 dismissed_reason: args.dismissedReason,
                 status_updated_at: this.database.fn.now() as never,
                 status_updated_by_user_uuid: args.statusUpdatedByUserUuid,
+                ...(args.boardPosition !== undefined
+                    ? { board_position: args.boardPosition }
+                    : {}),
             })
             .onConflict('fingerprint')
             .merge({
@@ -1627,6 +1646,35 @@ export class AiAgentReviewClassifierModel {
                 dismissed_reason: args.dismissedReason,
                 status_updated_at: this.database.fn.now(),
                 status_updated_by_user_uuid: args.statusUpdatedByUserUuid,
+                updated_at: this.database.fn.now(),
+                ...(args.boardPosition !== undefined
+                    ? { board_position: args.boardPosition }
+                    : {}),
+            });
+    }
+
+    // Sets only the manual board sort key, leaving status/assignee/timestamps
+    // untouched on existing rows. Inserts a triage-status row when the item has
+    // never been acted on (so a never-triaged card can still be ordered).
+    async setReviewItemBoardPosition(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        agentUuid: string;
+        fingerprint: string;
+        boardPosition: number;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .insert({
+                fingerprint: args.fingerprint,
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid: args.agentUuid,
+                status: 'triage',
+                board_position: args.boardPosition,
+            })
+            .onConflict('fingerprint')
+            .merge({
+                board_position: args.boardPosition,
                 updated_at: this.database.fn.now(),
             });
     }

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1660,7 +1660,11 @@ export class AiAgentReviewClassifierModel {
     // never-triaged card can still be ordered).
     async setReviewItemBoardPositions(args: {
         organizationUuid: string;
-        items: { fingerprint: string; projectUuid: string; agentUuid: string }[];
+        items: {
+            fingerprint: string;
+            projectUuid: string;
+            agentUuid: string;
+        }[];
     }): Promise<void> {
         if (args.items.length === 0) return;
         await this.database.transaction(async (trx) => {

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1653,30 +1653,36 @@ export class AiAgentReviewClassifierModel {
             });
     }
 
-    // Sets only the manual board sort key, leaving status/assignee/timestamps
-    // untouched on existing rows. Inserts a triage-status row when the item has
-    // never been acted on (so a never-triaged card can still be ordered).
-    async setReviewItemBoardPosition(args: {
+    // Persists the board order for a lane: board_position = array index for each
+    // item, in a single transaction so a mid-list failure can't leave the lane
+    // half-reordered. Sets only the sort key (status/assignee/timestamps stay)
+    // and inserts a triage-status row for items never acted on (so a
+    // never-triaged card can still be ordered).
+    async setReviewItemBoardPositions(args: {
         organizationUuid: string;
-        projectUuid: string;
-        agentUuid: string;
-        fingerprint: string;
-        boardPosition: number;
+        items: { fingerprint: string; projectUuid: string; agentUuid: string }[];
     }): Promise<void> {
-        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
-            .insert({
-                fingerprint: args.fingerprint,
-                organization_uuid: args.organizationUuid,
-                project_uuid: args.projectUuid,
-                agent_uuid: args.agentUuid,
-                status: 'triage',
-                board_position: args.boardPosition,
-            })
-            .onConflict('fingerprint')
-            .merge({
-                board_position: args.boardPosition,
-                updated_at: this.database.fn.now(),
-            });
+        if (args.items.length === 0) return;
+        await this.database.transaction(async (trx) => {
+            await Promise.all(
+                args.items.map((item, index) =>
+                    trx<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+                        .insert({
+                            fingerprint: item.fingerprint,
+                            organization_uuid: args.organizationUuid,
+                            project_uuid: item.projectUuid,
+                            agent_uuid: item.agentUuid,
+                            status: 'triage',
+                            board_position: index,
+                        })
+                        .onConflict('fingerprint')
+                        .merge({
+                            board_position: index,
+                            updated_at: trx.fn.now(),
+                        }),
+                ),
+            );
+        });
     }
 
     async updateReviewItemAssignee(args: {

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -61,6 +61,7 @@ const makeReviewItem = (
     prState: null,
     prWritebackStatus: null,
     prWritebackMessage: null,
+    boardPosition: null,
     createdAt: NOW,
     updatedAt: NOW,
     writebackEligible: false,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -836,6 +836,7 @@ export class AiAgentAdminService extends BaseService {
             status: update.status,
             dismissedReason: update.dismissedReason,
             statusUpdatedByUserUuid: user.userUuid,
+            boardPosition: update.boardPosition,
         });
 
         const reviewItem =
@@ -891,6 +892,42 @@ export class AiAgentAdminService extends BaseService {
             );
         }
         return this.getReviewItem(user, fingerprint);
+    }
+
+    /**
+     * Persists the board's manual card order by reindexing the given
+     * fingerprints (board_position = index). Scope is resolved per fingerprint
+     * so it works for the cross-project board; callers pass a lane's full order.
+     */
+    async reorderReviewItems(
+        user: SessionUser,
+        orderedFingerprints: string[],
+    ): Promise<void> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        await Promise.all(
+            orderedFingerprints.map(async (fingerprint, index) => {
+                const scope =
+                    await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+                        organizationUuid,
+                        fingerprint,
+                    );
+                if (!scope) return;
+                await this.aiAgentReviewClassifierModel.setReviewItemBoardPosition(
+                    {
+                        organizationUuid,
+                        projectUuid: scope.projectUuid,
+                        agentUuid: scope.agentUuid,
+                        fingerprint,
+                        boardPosition: index,
+                    },
+                );
+            }),
+        );
     }
 
     async updateReviewItemAssignee(

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -909,25 +909,31 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkOrganizationAdminAccess(user);
 
-        await Promise.all(
-            orderedFingerprints.map(async (fingerprint, index) => {
+        // Resolve scope per fingerprint (reads — safe to parallelise), drop any
+        // that are no longer promoted, then persist the whole lane order in one
+        // transaction so a failure can't leave it half-reordered.
+        const resolved = await Promise.all(
+            orderedFingerprints.map(async (fingerprint) => {
                 const scope =
                     await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
                         organizationUuid,
                         fingerprint,
                     );
-                if (!scope) return;
-                await this.aiAgentReviewClassifierModel.setReviewItemBoardPosition(
-                    {
-                        organizationUuid,
-                        projectUuid: scope.projectUuid,
-                        agentUuid: scope.agentUuid,
-                        fingerprint,
-                        boardPosition: index,
-                    },
-                );
+                return scope
+                    ? {
+                          fingerprint,
+                          projectUuid: scope.projectUuid,
+                          agentUuid: scope.agentUuid,
+                      }
+                    : null;
             }),
         );
+        await this.aiAgentReviewClassifierModel.setReviewItemBoardPositions({
+            organizationUuid,
+            items: resolved.filter(
+                (item): item is NonNullable<typeof item> => item !== null,
+            ),
+        });
     }
 
     async updateReviewItemAssignee(

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -29,6 +29,7 @@ const baseItem = (
     prState: null,
     prWritebackStatus: null,
     prWritebackMessage: null,
+    boardPosition: null,
     writebackEligible: true,
     writebackEligibility: {
         eligible: true,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13309,11 +13309,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13328,11 +13328,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13347,11 +13347,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13366,11 +13366,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13470,13 +13470,13 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -13602,11 +13602,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13751,13 +13751,13 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -13799,11 +13799,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13818,11 +13818,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13837,11 +13837,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -13855,13 +13855,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'double',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -13884,11 +13884,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -14036,26 +14036,6 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -14084,22 +14064,42 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldId:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -14271,11 +14271,6 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['success'],
-                                                    required: true,
-                                                },
                                                 uuid: {
                                                     dataType: 'string',
                                                     required: true,
@@ -14284,6 +14279,11 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                status: {
+                                                    dataType: 'enum',
+                                                    enums: ['success'],
+                                                    required: true,
+                                                },
                                             },
                                         },
                                         {
@@ -14294,11 +14294,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14313,11 +14313,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14332,11 +14332,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14351,11 +14351,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14452,6 +14452,11 @@ const models: TsoaRoute.Models = {
                                                                     'nestedObjectLiteral',
                                                                 nestedProperties:
                                                                     {
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
                                                                         kind: {
                                                                             dataType:
                                                                                 'union',
@@ -14493,11 +14498,6 @@ const models: TsoaRoute.Models = {
                                                                                         ],
                                                                                     },
                                                                                 ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
                                                                             required: true,
                                                                         },
                                                                     },
@@ -14596,11 +14596,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14628,13 +14628,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                name: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
-                                                    required: true,
-                                                },
-                                                name: {
-                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                             },
@@ -14661,11 +14661,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14680,11 +14680,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14699,11 +14699,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -14726,11 +14726,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14820,13 +14820,13 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                fieldType:
+                                                                                tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                tableName:
+                                                                                fieldType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -14888,11 +14888,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14907,11 +14907,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14926,11 +14926,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14945,11 +14945,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14964,11 +14964,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21026,6 +21026,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                boardPosition: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 prWritebackMessage: {
                     dataType: 'union',
                     subSchemas: [
@@ -22241,11 +22249,33 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiAgentReviewItemPrDiff_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ReorderAiAgentReviewItems: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                orderedFingerprints: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdateAiAgentReviewItemStatus: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                boardPosition: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 dismissedReason: {
                     dataType: 'union',
                     subSchemas: [
@@ -29979,7 +30009,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29989,7 +30019,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -29999,7 +30029,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30012,7 +30042,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30667,7 +30697,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30677,7 +30707,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30687,7 +30717,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30700,7 +30730,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -54174,6 +54204,67 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getReviewItemByPreviewThread',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_reorderReviewItems: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ReorderAiAgentReviewItems',
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/admin/review-items/reorder',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.reorderReviewItems,
+        ),
+
+        async function AiAgentAdminController_reorderReviewItems(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_reorderReviewItems,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'reorderReviewItems',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14894,8 +14894,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -14924,10 +14924,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -14938,8 +14938,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
+                                                                        "fieldType",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -14989,8 +14989,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15049,10 +15049,10 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
@@ -15063,8 +15063,8 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
+                                                                                    "fieldType",
                                                                                     "label",
                                                                                     "name"
                                                                                 ],
@@ -15093,8 +15093,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15107,19 +15107,19 @@
                                                         "type": "number",
                                                         "format": "double"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "contentSizeBytes",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -15128,8 +15128,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "not_found"
                                                         ]
                                                     }
@@ -15206,10 +15206,6 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
@@ -15220,14 +15216,18 @@
                                                                                 "table": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
                                                                                 }
                                                                             },
                                                                             "required": [
@@ -15235,12 +15235,12 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
                                                                                 "table",
-                                                                                "fieldId",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "description"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -15368,16 +15368,16 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["success"],
-                                                        "nullable": false
-                                                    },
                                                     "uuid": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": ["success"],
+                                                        "nullable": false
                                                     }
                                                 },
                                                 "required": [
@@ -15385,9 +15385,9 @@
                                                     "warnings",
                                                     "href",
                                                     "slug",
-                                                    "status",
                                                     "uuid",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -15423,6 +15423,9 @@
                                                     "steps": {
                                                         "items": {
                                                             "properties": {
+                                                                "label": {
+                                                                    "type": "string"
+                                                                },
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
@@ -15432,14 +15435,11 @@
                                                                         "compile",
                                                                         "stage"
                                                                     ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "kind",
-                                                                "label"
+                                                                "label",
+                                                                "kind"
                                                             ],
                                                             "type": "object"
                                                         },
@@ -15491,20 +15491,20 @@
                                                     "slug": {
                                                         "type": "string"
                                                     },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "href",
                                                     "slug",
-                                                    "status",
-                                                    "name"
+                                                    "name",
+                                                    "status"
                                                 ],
                                                 "type": "object"
                                             },
@@ -15517,8 +15517,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15530,8 +15530,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "rejected",
                                                             "timeout"
                                                         ]
@@ -15561,10 +15561,10 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
@@ -15575,8 +15575,8 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
+                                                                        "fieldType",
                                                                         "label",
                                                                         "name"
                                                                     ],
@@ -15604,8 +15604,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -21440,6 +21440,11 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "boardPosition": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "prWritebackMessage": {
                         "type": "string",
                         "nullable": true
@@ -21536,6 +21541,7 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "boardPosition",
                     "prWritebackMessage",
                     "prWritebackStatus",
                     "prState",
@@ -22675,8 +22681,25 @@
             "ApiAiAgentReviewItemPrDiffResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemPrDiff_"
             },
+            "ReorderAiAgentReviewItems": {
+                "properties": {
+                    "orderedFingerprints": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["orderedFingerprints"],
+                "type": "object"
+            },
             "UpdateAiAgentReviewItemStatus": {
                 "properties": {
+                    "boardPosition": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
                     "dismissedReason": {
                         "allOf": [
                             {
@@ -30718,22 +30741,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31293,22 +31316,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -40403,7 +40426,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3204.0",
+        "version": "0.3208.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -47473,6 +47496,47 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/reorder": {
+            "patch": {
+                "operationId": "reorderAiAgentReviewItems",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Persist the board's manual card order for one lane. Declared before the\n`{fingerprint}` route so \"reorder\" isn't matched as a fingerprint.",
+                "summary": "Reorder AI agent review items on the board",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ReorderAiAgentReviewItems"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}/assignee": {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -612,6 +612,8 @@ export type AiAgentReviewItem = {
     prState: AiAgentReviewItemPrState | null;
     prWritebackStatus: AiAgentReviewItemWritebackStatus | null;
     prWritebackMessage: string | null;
+    // Manual board sort key; null = default (last-seen) order.
+    boardPosition: number | null;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -647,10 +649,19 @@ export type ApiAiAgentReviewItemsResponse = ApiSuccess<
 export type UpdateAiAgentReviewItemStatus = {
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
+    // Optional manual board sort key set on drag-reorder (midpoint between
+    // neighbours). Omitted for plain status changes.
+    boardPosition?: number | null;
 };
 
 export type UpdateAiAgentReviewItemAssignee = {
     assignedToUserUuid: string | null;
+};
+
+// Persists the board's manual card order: the fingerprints of one lane in their
+// new top-to-bottom order (board_position = array index).
+export type ReorderAiAgentReviewItems = {
+    orderedFingerprints: string[];
 };
 
 export type ApiAiAgentReviewItemResponse = ApiSuccess<AiAgentReviewItemSummary>;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -126,6 +126,12 @@
     flex-direction: column;
     gap: var(--mantine-spacing-xs);
     padding: 2px;
+    border-radius: var(--mantine-radius-md);
+    outline: 1.5px dashed transparent;
+    outline-offset: 2px;
+    transition:
+        background 120ms ease,
+        outline-color 120ms ease;
 }
 .spacer {
     flex: 1;
@@ -137,32 +143,57 @@
     padding: var(--mantine-spacing-md);
     text-align: center;
 }
+/* Lane the cursor is currently over — strongest affordance. */
 .laneOver {
     background: light-dark(
         var(--mantine-color-indigo-0),
         var(--mantine-color-dark-5)
     );
-    outline: 1.5px dashed var(--mantine-color-indigo-4);
-    border-radius: var(--mantine-radius-md);
+    outline-color: var(--mantine-color-indigo-4);
+}
+/* Every lane the dragged card *could* land in, while a drag is in flight. */
+.laneValidTarget {
+    outline-color: light-dark(
+        var(--mantine-color-indigo-2),
+        var(--mantine-color-dark-3)
+    );
+}
+.draggableCard {
+    cursor: grab;
+}
+.draggableCard:active {
+    cursor: grabbing;
 }
 .cardGhost {
     opacity: 0.4;
     pointer-events: none;
 }
 .dragOverlayCard {
-    transform: rotate(2deg);
-    box-shadow: 0 8px 24px rgba(20, 22, 28, 0.18);
+    transform: rotate(2.5deg) scale(1.02);
+    box-shadow: 0 12px 28px rgba(20, 22, 28, 0.22);
     border-radius: var(--mantine-radius-md);
     cursor: grabbing;
 }
 .dropPlaceholder {
-    height: 64px;
+    flex: none;
+    height: 56px;
     border: 1.5px dashed var(--mantine-color-indigo-4);
     border-radius: var(--mantine-radius-md);
     background: light-dark(
         var(--mantine-color-indigo-0),
         var(--mantine-color-dark-5)
     );
+    animation: ldDropPlaceholderIn 140ms ease;
+}
+@keyframes ldDropPlaceholderIn {
+    from {
+        opacity: 0;
+        transform: scaleY(0.6);
+    }
+    to {
+        opacity: 1;
+        transform: scaleY(1);
+    }
 }
 .assigneeTrigger {
     cursor: pointer;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -5,6 +5,7 @@ import { renderWithProviders } from '../../../../../testing/testUtils';
 import { ReviewKanbanBoard } from './ReviewKanbanBoard';
 
 vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    applyOptimisticReviewBoardOrder: vi.fn(),
     useAiAgentAdminReviewItems: () => ({ data: items }),
     useAiAgentAdminAgents: () => ({ data: [] }),
     useAiAgentReviewItemPrDiff: () => ({ data: null }),

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -16,6 +16,10 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
         mutate: vi.fn(),
         isLoading: false,
     }),
+    useReorderReviewItems: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
     useUpdateAiAgentReviewItemAssignee: () => ({
         mutate: vi.fn(),
         isLoading: false,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -24,15 +24,7 @@ import {
 } from '@lightdash/common';
 import { Badge, Box, Button, Group, Stack, Text } from '@mantine-8/core';
 import { IconBox, IconTag, IconUser } from '@tabler/icons-react';
-import {
-    type FC,
-    useCallback,
-    useDeferredValue,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
     type FilterFacetOption,
 } from '../../../../../components/common/FilterFacet';
@@ -190,16 +182,15 @@ export const ReviewKanbanBoard: FC<Props> = ({
         Partial<Record<ReviewLane, boolean>>
     >({});
     const [activeId, setActiveId] = useState<string | null>(null);
-    // Optimistic per-lane order for drag-and-drop. Seeded from the server (which
-    // sorts by board_position) and reconciled whenever the server data/filters
-    // change while no drag is in flight — see the effect below.
-    const [laneItems, setLaneItems] = useState<
-        Record<ReviewLane, AiAgentReviewItemSummary[]>
-    >({ needs_triage: [], todo: [], in_progress: [], done: [] });
-
-    // Tracks an in-flight drag without re-rendering, so the reconcile effect can
-    // skip while dragging (and right after a drop, before the refetch lands).
-    const draggingRef = useRef(false);
+    // While a drag is in flight we hold the optimistic per-lane order here so
+    // dragging can reorder freely. It's null the rest of the time — the board
+    // then renders straight from server-derived `lanes` (kept current by the
+    // reorder mutation's optimistic cache update), so no effect copies server
+    // state into a parallel variable.
+    const [dragLanes, setDragLanes] = useState<Record<
+        ReviewLane,
+        AiAgentReviewItemSummary[]
+    > | null>(null);
 
     const updateStatus = useUpdateAiAgentReviewItemStatus();
     const createWriteback = useCreateAiAgentReviewItemWriteback();
@@ -325,44 +316,11 @@ export const ReviewKanbanBoard: FC<Props> = ({
         return byLane;
     }, [items]);
 
-    // Reseed from the server only when the server data (or filters) actually
-    // change — never merely because a drag ended, which would otherwise clobber
-    // the optimistic order before the post-drop refetch arrives. After a drop
-    // the reorder/status mutations invalidate the query, the refetch re-derives
-    // `lanes`, and that authoritative order lands here.
-    useEffect(() => {
-        if (draggingRef.current) return;
-        setLaneItems(lanes);
-    }, [lanes]);
+    // During a drag, render the optimistic order; otherwise straight from the
+    // server (the reorder mutation updates the cache optimistically, so `lanes`
+    // already reflects a just-dropped order without a reconcile effect).
+    const displayLanes = dragLanes ?? lanes;
 
-    const findLane = useCallback(
-        (id: string): ReviewLane | null => {
-            if (LANE_IDS.has(id)) return id as ReviewLane;
-            return (
-                REVIEW_LANES.find((lane) =>
-                    laneItems[lane.id].some((item) => item.uuid === id),
-                )?.id ?? null
-            );
-        },
-        [laneItems],
-    );
-
-    const draggingItem = activeId
-        ? (Object.values(laneItems)
-              .flat()
-              .find((item) => item.uuid === activeId) ?? null)
-        : null;
-
-    const handleDragStart = ({ active }: DragStartEvent) => {
-        draggingRef.current = true;
-        setActiveId(String(active.id));
-    };
-
-    // Reorder continuously while dragging — within a lane and across lanes — so
-    // the card already sits in its final slot on release. Without this, dnd-kit
-    // animates the drop back to the original index and the row flashes before
-    // the persisted order lands. Lanes are resolved from `prev` to dodge stale
-    // state across rapid dragOver events.
     const laneOf = (
         state: Record<ReviewLane, AiAgentReviewItemSummary[]>,
         id: string,
@@ -375,12 +333,29 @@ export const ReviewKanbanBoard: FC<Props> = ({
         );
     };
 
+    const draggingItem = activeId
+        ? (Object.values(displayLanes)
+              .flat()
+              .find((item) => item.uuid === activeId) ?? null)
+        : null;
+
+    const handleDragStart = ({ active }: DragStartEvent) => {
+        setDragLanes(lanes);
+        setActiveId(String(active.id));
+    };
+
+    // Reorder continuously while dragging — within a lane and across lanes — so
+    // the card already sits in its final slot on release. Without this, dnd-kit
+    // animates the drop back to the original index and the row flashes before
+    // the persisted order lands. Lanes are resolved from `prev` to dodge stale
+    // state across rapid dragOver events.
     const handleDragOver = ({ active, over }: DragOverEvent) => {
         if (!over) return;
         const activeKey = String(active.id);
         const overKey = String(over.id);
         if (activeKey === overKey) return;
-        setLaneItems((prev) => {
+        setDragLanes((prev) => {
+            if (!prev) return prev;
             const fromLane = laneOf(prev, activeKey);
             const toLane = laneOf(prev, overKey);
             if (!fromLane || !toLane) return prev;
@@ -421,20 +396,16 @@ export const ReviewKanbanBoard: FC<Props> = ({
     // persist that order and apply the status change if it crossed lanes.
     const handleDragEnd = ({ active }: DragEndEvent) => {
         const activeKey = String(active.id);
-        draggingRef.current = false;
+        const snapshot = dragLanes;
         setActiveId(null);
+        setDragLanes(null);
+        if (!snapshot) return;
 
-        const lane = findLane(activeKey);
-        if (!lane) {
-            setLaneItems(lanes);
-            return;
-        }
-        const laneList = laneItems[lane];
+        const lane = laneOf(snapshot, activeKey);
+        if (!lane) return;
+        const laneList = snapshot[lane];
         const moved = laneList.find((item) => item.uuid === activeKey);
-        if (!moved) {
-            setLaneItems(lanes);
-            return;
-        }
+        if (!moved) return;
 
         // Status follows the lane. The deterministic writeback kicks off when a
         // card lands in In progress, same as before.
@@ -456,9 +427,8 @@ export const ReviewKanbanBoard: FC<Props> = ({
     };
 
     const handleDragCancel = () => {
-        draggingRef.current = false;
         setActiveId(null);
-        setLaneItems(lanes);
+        setDragLanes(null);
     };
 
     return (
@@ -510,7 +480,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
                 >
                     <Box className={styles.board}>
                         {REVIEW_LANES.map((lane, laneIndex) => {
-                            const all = laneItems[lane.id];
+                            const all = displayLanes[lane.id];
                             const isExpanded = expandedLanes[lane.id] ?? false;
                             const displayed =
                                 isExpanded || all.length <= VISIBLE_PER_LANE

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -358,20 +358,50 @@ export const ReviewKanbanBoard: FC<Props> = ({
         setActiveId(String(active.id));
     };
 
-    // Live cross-lane preview: move the dragged card into the lane it's hovering
-    // so the gap opens there before the drop.
+    // Reorder continuously while dragging — within a lane and across lanes — so
+    // the card already sits in its final slot on release. Without this, dnd-kit
+    // animates the drop back to the original index and the row flashes before
+    // the persisted order lands. Lanes are resolved from `prev` to dodge stale
+    // state across rapid dragOver events.
+    const laneOf = (
+        state: Record<ReviewLane, AiAgentReviewItemSummary[]>,
+        id: string,
+    ): ReviewLane | null => {
+        if (LANE_IDS.has(id)) return id as ReviewLane;
+        return (
+            REVIEW_LANES.find((lane) =>
+                state[lane.id].some((item) => item.uuid === id),
+            )?.id ?? null
+        );
+    };
+
     const handleDragOver = ({ active, over }: DragOverEvent) => {
         if (!over) return;
         const activeKey = String(active.id);
         const overKey = String(over.id);
-        const fromLane = findLane(activeKey);
-        const toLane = findLane(overKey);
-        if (!fromLane || !toLane || fromLane === toLane) return;
+        if (activeKey === overKey) return;
         setLaneItems((prev) => {
+            const fromLane = laneOf(prev, activeKey);
+            const toLane = laneOf(prev, overKey);
+            if (!fromLane || !toLane) return prev;
             const fromList = prev[fromLane];
-            const index = fromList.findIndex((item) => item.uuid === activeKey);
-            if (index < 0) return prev;
-            const moved = fromList[index];
+            const activeIndex = fromList.findIndex(
+                (item) => item.uuid === activeKey,
+            );
+            if (activeIndex < 0) return prev;
+
+            if (fromLane === toLane) {
+                const overIndex = fromList.findIndex(
+                    (item) => item.uuid === overKey,
+                );
+                if (overIndex < 0 || activeIndex === overIndex) return prev;
+                return {
+                    ...prev,
+                    [fromLane]: arrayMove(fromList, activeIndex, overIndex),
+                };
+            }
+
+            const moved = fromList[activeIndex];
             const toList = prev[toLane];
             const overIndex = toList.findIndex((item) => item.uuid === overKey);
             const insertAt = overIndex >= 0 ? overIndex : toList.length;
@@ -387,55 +417,42 @@ export const ReviewKanbanBoard: FC<Props> = ({
         });
     };
 
-    const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    // dragOver has already placed the card in its final slot/lane; here we just
+    // persist that order and apply the status change if it crossed lanes.
+    const handleDragEnd = ({ active }: DragEndEvent) => {
         const activeKey = String(active.id);
         draggingRef.current = false;
         setActiveId(null);
-        if (!over) {
-            setLaneItems(lanes);
-            return;
-        }
-        const toLane = findLane(String(over.id));
-        if (!toLane) {
-            setLaneItems(lanes);
-            return;
-        }
 
-        const list = laneItems[toLane];
-        const oldIndex = list.findIndex((item) => item.uuid === activeKey);
-        const overIndex = list.findIndex(
-            (item) => item.uuid === String(over.id),
-        );
-        const newList =
-            oldIndex >= 0 && overIndex >= 0 && oldIndex !== overIndex
-                ? arrayMove(list, oldIndex, overIndex)
-                : list;
-        const moved = newList.find((item) => item.uuid === activeKey);
+        const lane = findLane(activeKey);
+        if (!lane) {
+            setLaneItems(lanes);
+            return;
+        }
+        const laneList = laneItems[lane];
+        const moved = laneList.find((item) => item.uuid === activeKey);
         if (!moved) {
             setLaneItems(lanes);
             return;
         }
-        if (newList !== list) {
-            setLaneItems((prev) => ({ ...prev, [toLane]: newList }));
-        }
 
         // Status follows the lane. The deterministic writeback kicks off when a
         // card lands in In progress, same as before.
-        const targetStatus = LANE_TARGET_STATUS[toLane];
+        const targetStatus = LANE_TARGET_STATUS[lane];
         if (targetStatus !== null && moved.status !== targetStatus) {
             updateStatus.mutate({
                 fingerprint: moved.fingerprint,
                 body: { status: targetStatus, dismissedReason: null },
             });
-            if (toLane === 'in_progress') {
+            if (lane === 'in_progress') {
                 const kind = getStartWritebackKind(moved);
                 if (kind === 'mutate') createWriteback.mutate(moved.fingerprint);
             }
         }
 
-        // Persist the target lane's order (reindexes board_position). The source
-        // lane keeps its relative order, so only the target needs rewriting.
-        reorderItems.mutate(newList.map((item) => item.fingerprint));
+        // Persist the dropped lane's order (reindexes board_position). The source
+        // lane keeps its relative order, so only this lane needs rewriting.
+        reorderItems.mutate(laneList.map((item) => item.fingerprint));
     };
 
     const handleDragCancel = () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -106,7 +106,9 @@ const DraggableCard: FC<DraggableCardProps> = ({
     return (
         <Box
             ref={setNodeRef}
-            className={isDragging ? styles.cardGhost : undefined}
+            className={`${styles.draggableCard}${
+                isDragging ? ` ${styles.cardGhost}` : ''
+            }`}
             {...listeners}
             {...attributes}
         >
@@ -121,23 +123,27 @@ const DraggableCard: FC<DraggableCardProps> = ({
 
 type DroppableLaneProps = {
     laneId: ReviewLane;
-    isDraggingValidTarget: boolean;
+    isDragActive: boolean;
+    canDrop: boolean;
     children: React.ReactNode;
 };
 
 const DroppableLane: FC<DroppableLaneProps> = ({
     laneId,
-    isDraggingValidTarget,
+    isDragActive,
+    canDrop,
     children,
 }) => {
     const { setNodeRef, isOver } = useDroppable({ id: laneId });
-    const highlight = isOver && isDraggingValidTarget;
+    const isActiveTarget = isOver && canDrop;
+
+    const classNames = [styles.laneScroll];
+    if (isActiveTarget) classNames.push(styles.laneOver);
+    else if (isDragActive && canDrop) classNames.push(styles.laneValidTarget);
 
     return (
-        <Box
-            ref={setNodeRef}
-            className={`${styles.laneScroll}${highlight ? ` ${styles.laneOver}` : ''}`}
-        >
+        <Box ref={setNodeRef} className={classNames.join(' ')}>
+            {isActiveTarget && <Box className={styles.dropPlaceholder} />}
             {children}
         </Box>
     );
@@ -433,9 +439,8 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                     </Group>
                                     <DroppableLane
                                         laneId={lane.id}
-                                        isDraggingValidTarget={isValidTarget(
-                                            lane.id,
-                                        )}
+                                        isDragActive={draggingItemUuid !== null}
+                                        canDrop={isValidTarget(lane.id)}
                                     >
                                         {showSkeletons ? (
                                             Array.from({
@@ -449,11 +454,17 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                 />
                                             ))
                                         ) : cards.length === 0 ? (
-                                            <Box className={styles.emptyLane}>
-                                                <Text fz="xs" c="dimmed">
-                                                    No issues
-                                                </Text>
-                                            </Box>
+                                            // Hide the empty hint while previewing a drop here.
+                                            overLaneId === lane.id &&
+                                            isValidTarget(lane.id) ? null : (
+                                                <Box
+                                                    className={styles.emptyLane}
+                                                >
+                                                    <Text fz="xs" c="dimmed">
+                                                        No issues
+                                                    </Text>
+                                                </Box>
+                                            )
                                         ) : (
                                             <>
                                                 {cards.map((item, index) => {
@@ -510,14 +521,6 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                             : `Show all (${all.length})`}
                                                     </Button>
                                                 )}
-                                                {overLaneId === lane.id &&
-                                                    isValidTarget(lane.id) && (
-                                                        <Box
-                                                            className={
-                                                                styles.dropPlaceholder
-                                                            }
-                                                        />
-                                                    )}
                                             </>
                                         )}
                                     </DroppableLane>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -24,6 +24,7 @@ import {
 } from '@lightdash/common';
 import { Badge, Box, Button, Group, Stack, Text } from '@mantine-8/core';
 import { IconBox, IconTag, IconUser } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import { type FC, useDeferredValue, useMemo, useState } from 'react';
 import FilterFacet, {
     type FilterFacetOption,
@@ -32,6 +33,7 @@ import { useOrgUsersByUuid } from '../../../../../hooks/useOrganizationUsers';
 import { useProjects } from '../../../../../hooks/useProjects';
 import useApp from '../../../../../providers/App/useApp';
 import {
+    applyOptimisticReviewBoardOrder,
     useAiAgentAdminReviewItems,
     useCreateAiAgentReviewItemWriteback,
     useReorderReviewItems,
@@ -192,6 +194,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
         AiAgentReviewItemSummary[]
     > | null>(null);
 
+    const queryClient = useQueryClient();
     const updateStatus = useUpdateAiAgentReviewItemStatus();
     const createWriteback = useCreateAiAgentReviewItemWriteback();
     const reorderItems = useReorderReviewItems();
@@ -397,33 +400,61 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const handleDragEnd = ({ active }: DragEndEvent) => {
         const activeKey = String(active.id);
         const snapshot = dragLanes;
-        setActiveId(null);
-        setDragLanes(null);
-        if (!snapshot) return;
+        const clearDrag = () => {
+            setActiveId(null);
+            setDragLanes(null);
+        };
+        if (!snapshot) {
+            clearDrag();
+            return;
+        }
 
         const lane = laneOf(snapshot, activeKey);
-        if (!lane) return;
+        const moved = lane
+            ? snapshot[lane].find((item) => item.uuid === activeKey)
+            : undefined;
+        if (!lane || !moved) {
+            clearDrag();
+            return;
+        }
         const laneList = snapshot[lane];
-        const moved = laneList.find((item) => item.uuid === activeKey);
-        if (!moved) return;
+        const orderedFingerprints = laneList.map((item) => item.fingerprint);
 
-        // Status follows the lane. The deterministic writeback kicks off when a
-        // card lands in In progress, same as before.
+        // Status follows the lane (null on lanes that don't map to a status).
         const targetStatus = LANE_TARGET_STATUS[lane];
-        if (targetStatus !== null && moved.status !== targetStatus) {
+        const statusOverride =
+            targetStatus !== null && moved.status !== targetStatus
+                ? { fingerprint: moved.fingerprint, status: targetStatus }
+                : null;
+
+        // Commit the dropped arrangement (order + cross-lane status) to the cache
+        // and clear the transient drag order in the same tick, so the board hands
+        // off to the server-derived lanes in one render — no flash to the old
+        // position before the persist settles.
+        applyOptimisticReviewBoardOrder(
+            queryClient,
+            orderedFingerprints,
+            statusOverride,
+        );
+        clearDrag();
+
+        if (statusOverride) {
             updateStatus.mutate({
                 fingerprint: moved.fingerprint,
-                body: { status: targetStatus, dismissedReason: null },
+                body: { status: statusOverride.status, dismissedReason: null },
             });
+            // The deterministic writeback kicks off when a card lands in
+            // In progress, same as before.
             if (lane === 'in_progress') {
                 const kind = getStartWritebackKind(moved);
-                if (kind === 'mutate') createWriteback.mutate(moved.fingerprint);
+                if (kind === 'mutate')
+                    createWriteback.mutate(moved.fingerprint);
             }
         }
 
         // Persist the dropped lane's order (reindexes board_position). The source
         // lane keeps its relative order, so only this lane needs rewriting.
-        reorderItems.mutate(laneList.map((item) => item.fingerprint));
+        reorderItems.mutate(orderedFingerprints);
     };
 
     const handleDragCancel = () => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -1,9 +1,9 @@
 import {
+    closestCorners,
     DndContext,
     DragOverlay,
     KeyboardSensor,
     PointerSensor,
-    useDraggable,
     useDroppable,
     useSensor,
     useSensors,
@@ -12,20 +12,27 @@ import {
     type DragStartEvent,
 } from '@dnd-kit/core';
 import {
+    arrayMove,
+    SortableContext,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
     type AiAgentReviewItemSummary,
     type AiAgentRootCause,
 } from '@lightdash/common';
-import {
-    Badge,
-    Box,
-    Button,
-    Divider,
-    Group,
-    Stack,
-    Text,
-} from '@mantine-8/core';
+import { Badge, Box, Button, Group, Stack, Text } from '@mantine-8/core';
 import { IconBox, IconTag, IconUser } from '@tabler/icons-react';
-import { type FC, useDeferredValue, useMemo, useState } from 'react';
+import {
+    type FC,
+    useCallback,
+    useDeferredValue,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import FilterFacet, {
     type FilterFacetOption,
 } from '../../../../../components/common/FilterFacet';
@@ -35,6 +42,7 @@ import useApp from '../../../../../providers/App/useApp';
 import {
     useAiAgentAdminReviewItems,
     useCreateAiAgentReviewItemWriteback,
+    useReorderReviewItems,
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
 import { type AiAgentAdminReviewItemPreviewTarget } from './AiAgentAdminReviewItemsTable';
@@ -56,7 +64,6 @@ import {
     getReviewLane,
     getStartWritebackKind,
     LANE_TARGET_STATUS,
-    partitionInProgress,
     REVIEW_LANES,
     type ReviewLane,
 } from './reviewLane';
@@ -88,20 +95,25 @@ const toTarget = (
     };
 };
 
-type DraggableCardProps = {
+type SortableCardProps = {
     item: AiAgentReviewItemSummary;
     isSelected: boolean;
     onSelect: () => void;
 };
 
-const DraggableCard: FC<DraggableCardProps> = ({
+const SortableCard: FC<SortableCardProps> = ({
     item,
     isSelected,
     onSelect,
 }) => {
-    const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-        id: item.uuid,
-    });
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ id: item.uuid });
 
     return (
         <Box
@@ -109,6 +121,12 @@ const DraggableCard: FC<DraggableCardProps> = ({
             className={`${styles.draggableCard}${
                 isDragging ? ` ${styles.cardGhost}` : ''
             }`}
+            // dnd-kit drives the per-frame shift that previews where the card
+            // will land; this transform/transition can only be inline.
+            style={{
+                transform: CSS.Translate.toString(transform),
+                transition,
+            }}
             {...listeners}
             {...attributes}
         >
@@ -124,26 +142,24 @@ const DraggableCard: FC<DraggableCardProps> = ({
 type DroppableLaneProps = {
     laneId: ReviewLane;
     isDragActive: boolean;
-    canDrop: boolean;
     children: React.ReactNode;
 };
 
 const DroppableLane: FC<DroppableLaneProps> = ({
     laneId,
     isDragActive,
-    canDrop,
     children,
 }) => {
     const { setNodeRef, isOver } = useDroppable({ id: laneId });
-    const isActiveTarget = isOver && canDrop;
 
     const classNames = [styles.laneScroll];
-    if (isActiveTarget) classNames.push(styles.laneOver);
-    else if (isDragActive && canDrop) classNames.push(styles.laneValidTarget);
+    // Every lane accepts a drop now (reorder within, or move across); the
+    // sortable gap shows exactly where the card will land.
+    if (isOver) classNames.push(styles.laneOver);
+    else if (isDragActive) classNames.push(styles.laneValidTarget);
 
     return (
         <Box ref={setNodeRef} className={classNames.join(' ')}>
-            {isActiveTarget && <Box className={styles.dropPlaceholder} />}
             {children}
         </Box>
     );
@@ -173,13 +189,21 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const [expandedLanes, setExpandedLanes] = useState<
         Partial<Record<ReviewLane, boolean>>
     >({});
-    const [draggingItemUuid, setDraggingItemUuid] = useState<string | null>(
-        null,
-    );
-    const [overLaneId, setOverLaneId] = useState<ReviewLane | null>(null);
+    const [activeId, setActiveId] = useState<string | null>(null);
+    // Optimistic per-lane order for drag-and-drop. Seeded from the server (which
+    // sorts by board_position) and reconciled whenever the server data/filters
+    // change while no drag is in flight — see the effect below.
+    const [laneItems, setLaneItems] = useState<
+        Record<ReviewLane, AiAgentReviewItemSummary[]>
+    >({ needs_triage: [], todo: [], in_progress: [], done: [] });
+
+    // Tracks an in-flight drag without re-rendering, so the reconcile effect can
+    // skip while dragging (and right after a drop, before the refetch lands).
+    const draggingRef = useRef(false);
 
     const updateStatus = useUpdateAiAgentReviewItemStatus();
     const createWriteback = useCreateAiAgentReviewItemWriteback();
+    const reorderItems = useReorderReviewItems();
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -301,55 +325,123 @@ export const ReviewKanbanBoard: FC<Props> = ({
         return byLane;
     }, [items]);
 
-    // Resolve the item being dragged to check if a given lane is a valid target
-    const draggingItem = draggingItemUuid
-        ? (items.find((item) => item.uuid === draggingItemUuid) ?? null)
+    // Reseed from the server only when the server data (or filters) actually
+    // change — never merely because a drag ended, which would otherwise clobber
+    // the optimistic order before the post-drop refetch arrives. After a drop
+    // the reorder/status mutations invalidate the query, the refetch re-derives
+    // `lanes`, and that authoritative order lands here.
+    useEffect(() => {
+        if (draggingRef.current) return;
+        setLaneItems(lanes);
+    }, [lanes]);
+
+    const findLane = useCallback(
+        (id: string): ReviewLane | null => {
+            if (LANE_IDS.has(id)) return id as ReviewLane;
+            return (
+                REVIEW_LANES.find((lane) =>
+                    laneItems[lane.id].some((item) => item.uuid === id),
+                )?.id ?? null
+            );
+        },
+        [laneItems],
+    );
+
+    const draggingItem = activeId
+        ? (Object.values(laneItems)
+              .flat()
+              .find((item) => item.uuid === activeId) ?? null)
         : null;
 
-    const isValidTarget = (laneId: ReviewLane): boolean => {
-        if (!draggingItem) return false;
-        const targetStatus = LANE_TARGET_STATUS[laneId];
-        return targetStatus !== null && targetStatus !== draggingItem.status;
-    };
-
     const handleDragStart = ({ active }: DragStartEvent) => {
-        setDraggingItemUuid(String(active.id));
+        draggingRef.current = true;
+        setActiveId(String(active.id));
     };
 
-    const handleDragOver = ({ over }: DragOverEvent) => {
-        const id = over?.id ? String(over.id) : null;
-        const next = id && LANE_IDS.has(id) ? (id as ReviewLane) : null;
-        setOverLaneId((prev) => (prev === next ? prev : next));
+    // Live cross-lane preview: move the dragged card into the lane it's hovering
+    // so the gap opens there before the drop.
+    const handleDragOver = ({ active, over }: DragOverEvent) => {
+        if (!over) return;
+        const activeKey = String(active.id);
+        const overKey = String(over.id);
+        const fromLane = findLane(activeKey);
+        const toLane = findLane(overKey);
+        if (!fromLane || !toLane || fromLane === toLane) return;
+        setLaneItems((prev) => {
+            const fromList = prev[fromLane];
+            const index = fromList.findIndex((item) => item.uuid === activeKey);
+            if (index < 0) return prev;
+            const moved = fromList[index];
+            const toList = prev[toLane];
+            const overIndex = toList.findIndex((item) => item.uuid === overKey);
+            const insertAt = overIndex >= 0 ? overIndex : toList.length;
+            return {
+                ...prev,
+                [fromLane]: fromList.filter((item) => item.uuid !== activeKey),
+                [toLane]: [
+                    ...toList.slice(0, insertAt),
+                    moved,
+                    ...toList.slice(insertAt),
+                ],
+            };
+        });
     };
 
     const handleDragEnd = ({ active, over }: DragEndEvent) => {
-        setDraggingItemUuid(null);
-        setOverLaneId(null);
-        if (!over) return;
-        if (!LANE_IDS.has(String(over.id))) return;
-        const targetLane = over.id as ReviewLane;
-        const draggedItem = items.find((item) => item.uuid === active.id);
-        if (!draggedItem) return;
+        const activeKey = String(active.id);
+        draggingRef.current = false;
+        setActiveId(null);
+        if (!over) {
+            setLaneItems(lanes);
+            return;
+        }
+        const toLane = findLane(String(over.id));
+        if (!toLane) {
+            setLaneItems(lanes);
+            return;
+        }
 
-        const targetStatus = LANE_TARGET_STATUS[targetLane];
-        if (targetStatus === null) return;
+        const list = laneItems[toLane];
+        const oldIndex = list.findIndex((item) => item.uuid === activeKey);
+        const overIndex = list.findIndex(
+            (item) => item.uuid === String(over.id),
+        );
+        const newList =
+            oldIndex >= 0 && overIndex >= 0 && oldIndex !== overIndex
+                ? arrayMove(list, oldIndex, overIndex)
+                : list;
+        const moved = newList.find((item) => item.uuid === activeKey);
+        if (!moved) {
+            setLaneItems(lanes);
+            return;
+        }
+        if (newList !== list) {
+            setLaneItems((prev) => ({ ...prev, [toLane]: newList }));
+        }
 
-        if (targetStatus !== draggedItem.status) {
+        // Status follows the lane. The deterministic writeback kicks off when a
+        // card lands in In progress, same as before.
+        const targetStatus = LANE_TARGET_STATUS[toLane];
+        if (targetStatus !== null && moved.status !== targetStatus) {
             updateStatus.mutate({
-                fingerprint: draggedItem.fingerprint,
+                fingerprint: moved.fingerprint,
                 body: { status: targetStatus, dismissedReason: null },
             });
-            if (targetLane === 'in_progress') {
-                const kind = getStartWritebackKind(draggedItem);
-                if (kind === 'mutate')
-                    createWriteback.mutate(draggedItem.fingerprint);
+            if (toLane === 'in_progress') {
+                const kind = getStartWritebackKind(moved);
+                if (kind === 'mutate') createWriteback.mutate(moved.fingerprint);
             }
         }
+
+        // Persist the target lane's order (reindexes board_position). The source
+        // lane keeps its relative order, so only the target needs rewriting.
+        reorderItems.mutate(newList.map((item) => item.fingerprint));
     };
 
     const handleDragCancel = () => {
-        setDraggingItemUuid(null);
-        setOverLaneId(null);
+        draggingRef.current = false;
+        setActiveId(null);
+        setLaneItems(lanes);
     };
 
     return (
@@ -393,6 +485,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
             <Box className={styles.boardWrapper}>
                 <DndContext
                     sensors={sensors}
+                    collisionDetection={closestCorners}
                     onDragStart={handleDragStart}
                     onDragOver={handleDragOver}
                     onDragEnd={handleDragEnd}
@@ -400,22 +493,13 @@ export const ReviewKanbanBoard: FC<Props> = ({
                 >
                     <Box className={styles.board}>
                         {REVIEW_LANES.map((lane, laneIndex) => {
-                            const all = lanes[lane.id];
+                            const all = laneItems[lane.id];
                             const isExpanded = expandedLanes[lane.id] ?? false;
                             const displayed =
                                 isExpanded || all.length <= VISIBLE_PER_LANE
                                     ? all
                                     : all.slice(0, VISIBLE_PER_LANE);
                             const hasMore = all.length > VISIBLE_PER_LANE;
-
-                            const { active, rest } =
-                                lane.id === 'in_progress'
-                                    ? partitionInProgress(displayed)
-                                    : { active: [], rest: displayed };
-                            const cards =
-                                lane.id === 'in_progress'
-                                    ? [...active, ...rest]
-                                    : displayed;
 
                             return (
                                 <Box key={lane.id} className={styles.lane}>
@@ -439,8 +523,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                     </Group>
                                     <DroppableLane
                                         laneId={lane.id}
-                                        isDragActive={draggingItemUuid !== null}
-                                        canDrop={isValidTarget(lane.id)}
+                                        isDragActive={activeId !== null}
                                     >
                                         {showSkeletons ? (
                                             Array.from({
@@ -453,38 +536,35 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                     key={i}
                                                 />
                                             ))
-                                        ) : cards.length === 0 ? (
-                                            // Hide the empty hint while previewing a drop here.
-                                            overLaneId === lane.id &&
-                                            isValidTarget(lane.id) ? null : (
-                                                <Box
-                                                    className={styles.emptyLane}
-                                                >
-                                                    <Text fz="xs" c="dimmed">
-                                                        No issues
-                                                    </Text>
-                                                </Box>
-                                            )
                                         ) : (
-                                            <>
-                                                {cards.map((item, index) => {
-                                                    const showDivider =
-                                                        lane.id ===
-                                                            'in_progress' &&
-                                                        active.length > 0 &&
-                                                        index === active.length;
-                                                    const target =
-                                                        toTarget(item);
-                                                    return (
-                                                        <Box key={item.uuid}>
-                                                            {showDivider && (
-                                                                <Divider
-                                                                    my="xs"
-                                                                    label="Other"
-                                                                    labelPosition="left"
-                                                                />
-                                                            )}
-                                                            <DraggableCard
+                                            <SortableContext
+                                                items={displayed.map(
+                                                    (item) => item.uuid,
+                                                )}
+                                                strategy={
+                                                    verticalListSortingStrategy
+                                                }
+                                            >
+                                                {displayed.length === 0 ? (
+                                                    <Box
+                                                        className={
+                                                            styles.emptyLane
+                                                        }
+                                                    >
+                                                        <Text
+                                                            fz="xs"
+                                                            c="dimmed"
+                                                        >
+                                                            No issues
+                                                        </Text>
+                                                    </Box>
+                                                ) : (
+                                                    displayed.map((item) => {
+                                                        const target =
+                                                            toTarget(item);
+                                                        return (
+                                                            <SortableCard
+                                                                key={item.uuid}
                                                                 item={item}
                                                                 isSelected={
                                                                     selectedReviewItemUuid ===
@@ -497,9 +577,9 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                                         );
                                                                 }}
                                                             />
-                                                        </Box>
-                                                    );
-                                                })}
+                                                        );
+                                                    })
+                                                )}
                                                 {hasMore && (
                                                     <Button
                                                         variant="subtle"
@@ -521,7 +601,7 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                             : `Show all (${all.length})`}
                                                     </Button>
                                                 )}
-                                            </>
+                                            </SortableContext>
                                         )}
                                     </DroppableLane>
                                 </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -41,6 +41,7 @@ const makeExampleReviewItem = (
         strategy: null,
     },
     remediation: null,
+    boardPosition: null,
     createdAt: EXAMPLE_SEEN_AT,
     updatedAt: EXAMPLE_SEEN_AT,
     latestFinding: null,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -25,6 +25,7 @@ import {
     useQuery,
     useQueryClient,
     type QueryClient,
+    type QueryKey,
     type UseInfiniteQueryOptions,
     type UseQueryOptions,
 } from '@tanstack/react-query';
@@ -499,23 +500,70 @@ const reorderAiAgentReviewItems = async (orderedFingerprints: string[]) => {
     });
 };
 
-// Silent on success (fires on every drop); the board updates optimistically and
-// a failure re-fetches the authoritative order.
+// Reorders the cached review-item lists so the dragged fingerprints take the
+// given order at the slots they already occupy (other items stay put). Since
+// the board buckets a flat array into lanes by array order, this reflects a
+// drag-reorder without refetching.
+const reorderCachedItems = (
+    items: AiAgentReviewItemSummary[],
+    orderedFingerprints: string[],
+): AiAgentReviewItemSummary[] => {
+    const orderSet = new Set(orderedFingerprints);
+    const byFingerprint = new Map(
+        items
+            .filter((item) => orderSet.has(item.fingerprint))
+            .map((item) => [item.fingerprint, item]),
+    );
+    let next = 0;
+    return items.map((item) => {
+        if (!orderSet.has(item.fingerprint)) return item;
+        const replacement = byFingerprint.get(orderedFingerprints[next]);
+        next += 1;
+        return replacement ?? item;
+    });
+};
+
+// Optimistic + silent: applies the new order to the cache immediately (rolling
+// back on error), so the board never flashes back while the request is in
+// flight. onSettled re-fetches the authoritative order.
 export const useReorderReviewItems = () => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
 
-    return useMutation<undefined, ApiError, string[]>({
+    return useMutation<
+        undefined,
+        ApiError,
+        string[],
+        { previous: [QueryKey, AiAgentReviewItemSummary[] | undefined][] }
+    >({
         mutationFn: reorderAiAgentReviewItems,
+        onMutate: async (orderedFingerprints) => {
+            await queryClient.cancelQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+            const previous =
+                queryClient.getQueriesData<AiAgentReviewItemSummary[]>({
+                    queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+                });
+            queryClient.setQueriesData<AiAgentReviewItemSummary[]>(
+                { queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY] },
+                (old) =>
+                    old ? reorderCachedItems(old, orderedFingerprints) : old,
+            );
+            return { previous };
+        },
+        onError: (error, _orderedFingerprints, context) => {
+            context?.previous.forEach(([key, data]) => {
+                queryClient.setQueryData(key, data);
+            });
+            showToastApiError({
+                title: 'Failed to reorder items',
+                apiError: error.error,
+            });
+        },
         onSettled: () => {
             void queryClient.invalidateQueries({
                 queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
-            });
-        },
-        onError: ({ error }) => {
-            showToastApiError({
-                title: 'Failed to reorder items',
-                apiError: error,
             });
         },
     });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -25,7 +25,6 @@ import {
     useQuery,
     useQueryClient,
     type QueryClient,
-    type QueryKey,
     type UseInfiniteQueryOptions,
     type UseQueryOptions,
 } from '@tanstack/react-query';
@@ -523,42 +522,50 @@ const reorderCachedItems = (
     });
 };
 
-// Optimistic + silent: applies the new order to the cache immediately (rolling
-// back on error), so the board never flashes back while the request is in
-// flight. onSettled re-fetches the authoritative order.
+// Applies a drop to the cached review-item lists synchronously: reorders the
+// dragged fingerprints into the given order at the slots they occupy, and (for a
+// cross-lane drop) moves the dragged item to the target lane by overriding its
+// status. Call this in the drop handler in the same tick the drag's transient
+// order is cleared, so the board hands off to the server-derived lanes in one
+// commit — without it the board flashes back to the pre-drop order for a frame.
+export const applyOptimisticReviewBoardOrder = (
+    queryClient: QueryClient,
+    orderedFingerprints: string[],
+    statusOverride: {
+        fingerprint: string;
+        status: AiAgentReviewItemStatus;
+    } | null,
+) => {
+    queryClient.setQueriesData<AiAgentReviewItemSummary[]>(
+        { queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY] },
+        (old) => {
+            if (!old) return old;
+            const withStatus = statusOverride
+                ? old.map((item) =>
+                      item.fingerprint === statusOverride.fingerprint
+                          ? { ...item, status: statusOverride.status }
+                          : item,
+                  )
+                : old;
+            return reorderCachedItems(withStatus, orderedFingerprints);
+        },
+    );
+};
+
+// Persists the board order. The optimistic update is applied synchronously by
+// the drop handler (applyOptimisticReviewBoardOrder); here we just write through
+// and reconcile to the authoritative order on settle (which also reverts the
+// optimistic order if the request failed).
 export const useReorderReviewItems = () => {
     const queryClient = useQueryClient();
     const { showToastApiError } = useToaster();
 
-    return useMutation<
-        undefined,
-        ApiError,
-        string[],
-        { previous: [QueryKey, AiAgentReviewItemSummary[] | undefined][] }
-    >({
+    return useMutation<undefined, ApiError, string[]>({
         mutationFn: reorderAiAgentReviewItems,
-        onMutate: async (orderedFingerprints) => {
-            await queryClient.cancelQueries({
-                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
-            });
-            const previous =
-                queryClient.getQueriesData<AiAgentReviewItemSummary[]>({
-                    queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
-                });
-            queryClient.setQueriesData<AiAgentReviewItemSummary[]>(
-                { queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY] },
-                (old) =>
-                    old ? reorderCachedItems(old, orderedFingerprints) : old,
-            );
-            return { previous };
-        },
-        onError: (error, _orderedFingerprints, context) => {
-            context?.previous.forEach(([key, data]) => {
-                queryClient.setQueryData(key, data);
-            });
+        onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to reorder items',
-                apiError: error.error,
+                apiError: error,
             });
         },
         onSettled: () => {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -14,6 +14,7 @@ import {
     type ApiAiAgentVerifiedArtifactsResponse,
     type ApiError,
     type ApiUpstreamDiffResponse,
+    type ReorderAiAgentReviewItems,
     type UpdateAiAgentReviewItemAssignee,
     type UpdateAiAgentReviewItemStatus,
 } from '@lightdash/common';
@@ -481,6 +482,39 @@ export const useUpdateAiAgentReviewItemAssignee = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to update assignee',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const reorderAiAgentReviewItems = async (orderedFingerprints: string[]) => {
+    return lightdashApi<undefined>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/reorder`,
+        method: 'PATCH',
+        body: JSON.stringify({
+            orderedFingerprints,
+        } satisfies ReorderAiAgentReviewItems),
+    });
+};
+
+// Silent on success (fires on every drop); the board updates optimistically and
+// a failure re-fetches the authoritative order.
+export const useReorderReviewItems = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<undefined, ApiError, string[]>({
+        mutationFn: reorderAiAgentReviewItems,
+        onSettled: () => {
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to reorder items',
                 apiError: error,
             });
         },


### PR DESCRIPTION
## Problem

The review board's drag-and-drop was weak: you couldn't reorder cards within a column, and the drop preview didn't show where a card would land. There was no persisted ordering at all.

## Fix

Refactor the board to **`@dnd-kit/sortable`** (the Multiple Lists pattern) and persist order end-to-end:

- **Reorder within a column** — cards are now sortable; dragging opens a live **insertion gap** showing exactly where the card will land.
- **Cross-lane moves** still change status (and kick off the deterministic writeback when a card enters *In progress*), with a live preview as the card crosses into the target lane.
- **Persisted order** — a nullable, fractional `board_position` column on `ai_agent_review_item`; `listReviewItems` sorts by it (nulls fall back to the existing last-seen order). A drop reindexes the target lane via a new `PATCH /review-items/reorder` endpoint (`reorderReviewItems` → `setReviewItemBoardPositions`, one transaction, scope resolved per fingerprint so it works on the cross-project board). The source lane keeps its relative order, so only the dropped lane is rewritten.
- **Optimistic UX, no drop flash** — on drop the dropped arrangement (lane order + cross-lane status) is written to the query cache **synchronously**, batched with clearing the transient drag order, so the board hands off to the server-derived lanes in a single commit. `onSettled` invalidates and the refetch reconciles to the authoritative order. (Previously the drag order was cleared synchronously while the optimistic cache write was deferred a microtask behind React Query v4's awaited cache-level `onMutate`, so the board painted the pre-drop order for a frame before snapping to the dropped slot.)

The previous in-progress auto-partition (active-first + divider) is removed — manual ordering replaces it.

## Backend

- Migration `20260622120000_add_board_position_to_review_items` (nullable `double precision`). `down()` is a no-op — dropping a column is a destructive, disallowed operation.
- `UpdateAiAgentReviewItemStatus` gains an optional `boardPosition`; `AiAgentReviewItem` carries `boardPosition`.
- New `reorderAiAgentReviewItems` route (declared before `/review-items/{fingerprint}` so "reorder" isn't matched as a fingerprint). Reorder writes the whole lane's `board_position` in **one transaction** so a mid-list failure can't half-reorder it. Generated spec regenerated.

## Regression analysis

- semantic_layer/project_context writeback flows are untouched; only the board's drag handling + ordering changed.
- The reorder endpoint sets **only** `board_position` (status/assignee/timestamps preserved on existing rows); it inserts a triage-status row for never-acted-on cards so they can still be ordered.
- `listReviewItems` ordering is additive — with no `board_position` set, behaviour is the previous last-seen order.

## Test

- Backend: typecheck clean; `AiAgentAdminService` + `buildReviewWritebackPrompt` suites green (32 tests); migration applied locally.
- Frontend: oxlint + tsc + oxfmt clean; `ReviewKanbanBoard.test.tsx` green.
- **DnD verified hands-on** in the preview app — reorder within a lane and across lanes lands the card in its dropped slot with no flash back to the original position.

Closes: ZAP-525
