### PR TITLE
fix(filters): save typed filter value on input blur

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -16,6 +16,7 @@ const FilterMultiStringInput: FC<Props> = ({
     disabled,
     onChange,
     placeholder,
+    onBlur: onInputBlur,
     ...rest
 }) => {
     const [search, setSearch] = useState('');
@@ -53,6 +54,17 @@ const FilterMultiStringInput: FC<Props> = ({
             return newValues;
         },
         [handleChange, values],
+    );
+
+    const handleBlur = useCallback(
+        (event: React.FocusEvent<HTMLInputElement>) => {
+            if (search !== '') {
+                handleAdd(search);
+                handleResetSearch();
+            }
+            onInputBlur?.(event);
+        },
+        [handleAdd, handleResetSearch, onInputBlur, search],
     );
 
     const handlePaste = useCallback(
@@ -148,6 +160,7 @@ const FilterMultiStringInput: FC<Props> = ({
                 onDropdownClose={handleResetSearch}
                 onChange={handleChange}
                 onCreate={handleAdd}
+                onBlur={handleBlur}
             />
         </MultiValuePastePopover>
     );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -175,6 +175,59 @@ describe('FilterStringAutoComplete', () => {
         });
     });
 
+    describe('commit on blur', () => {
+        it('adds the typed value when the input loses focus without pressing Enter', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const values = createValues(2);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            const input = screen.getByRole('searchbox');
+            fireEvent.focus(input);
+            await user.type(input, 'typed-but-not-entered');
+            fireEvent.blur(input);
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled();
+            });
+
+            const calledWith = onChange.mock.calls[0][0];
+            expect(calledWith).toContain('typed-but-not-entered');
+            expect(calledWith).toContain('value-0');
+            expect(calledWith).toContain('value-1');
+        });
+
+        it('does not call onChange when blurring with an empty input', async () => {
+            const values = createValues(2);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            const input = screen.getByRole('searchbox');
+            fireEvent.focus(input);
+            fireEvent.blur(input);
+
+            expect(onChange).not.toHaveBeenCalled();
+        });
+    });
+
     describe('summary mode', () => {
         it('shows summary text input when values exceed summary threshold', async () => {
             const values = createValues(600);

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -298,6 +298,17 @@ const FilterStringAutoComplete: FC<Props> = ({
         [handleAdd, handleResetSearch, search],
     );
 
+    const handleBlur = useCallback(
+        (event: React.FocusEvent<HTMLInputElement>) => {
+            if (search !== '') {
+                handleAdd(search);
+                handleResetSearch();
+            }
+            onInputBlur?.(event);
+        },
+        [handleAdd, handleResetSearch, onInputBlur, search],
+    );
+
     const ValueComponent = useCallback(
         (props: MultiSelectValueProps & { value: string }) => {
             if (props.value === MORE_VALUES_TOKEN) {
@@ -597,6 +608,8 @@ const FilterStringAutoComplete: FC<Props> = ({
                         }}
                         onCreate={handleAdd}
                         onKeyDown={handleKeyDown}
+                        onFocus={onInputFocus}
+                        onBlur={handleBlur}
                     />
                 )}
             </MultiValuePastePopover>

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -1,0 +1,111 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+} from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterConfiguration from './index';
+
+vi.mock('../../../providers/Dashboard/useDashboardTileStatusContext', () => ({
+    default: vi.fn((selector) => selector({ sqlChartTilesMetadata: {} })),
+}));
+
+vi.mock('../../../components/common/Filters/useFiltersContext', () => ({
+    default: vi.fn(() => ({
+        projectUuid: 'test-project-uuid',
+        getAutocompleteFilterGroup: vi.fn(() => undefined),
+        getField: vi.fn(() => undefined),
+        parameterValues: {},
+    })),
+}));
+
+vi.mock('../../../hooks/useFieldValues', () => ({
+    MAX_AUTOCOMPLETE_RESULTS: 100,
+    useFieldValues: vi.fn(() => ({
+        isInitialLoading: false,
+        results: new Set<string>(),
+        refreshedAt: new Date(),
+        refetch: vi.fn(),
+        reset: vi.fn(),
+        error: null,
+        isError: false,
+    })),
+}));
+
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: vi.fn(() => ({
+        data: { hasCacheAutocompleResults: false },
+    })),
+}));
+
+const mockField = {
+    name: 'first_name',
+    type: DimensionType.STRING,
+    table: 'customers',
+    tableLabel: 'Customers',
+    label: 'First name',
+    fieldType: FieldType.DIMENSION,
+    sql: 'first_name',
+    hidden: false,
+} as unknown as DashboardFilterableField;
+
+const anyValueRule: DashboardFilterRule = {
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: true,
+    label: undefined,
+};
+
+describe('FilterConfiguration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('saves a value typed into the input when Apply is clicked without pressing Enter', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode={false}
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={anyValueRule}
+                originalFilterRule={anyValueRule}
+                onSave={onSave}
+            />,
+        );
+
+        const input = document.querySelector(
+            'input[data-autofocus]',
+        ) as HTMLInputElement;
+        expect(input).toBeTruthy();
+
+        fireEvent.focus(input);
+        await user.type(input, 'adam');
+
+        // Click Apply WITHOUT pressing Enter — the typed value lives only in the
+        // input's local search state until it's committed on blur.
+        fireEvent.mouseDown(screen.getByRole('button', { name: 'Apply' }));
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        expect(onSave).toHaveBeenCalledWith(
+            expect.objectContaining({ values: ['adam'] }),
+        );
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -33,7 +33,7 @@ import {
 } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -348,6 +348,30 @@ const FilterConfiguration: FC<Props> = ({
         ],
     );
 
+    // Apply runs on mousedown (before the value input's blur grows the panel and
+    // shifts the button, which would swallow a click). Blurring here commits any
+    // typed-but-not-added value; the save is deferred to the effect below so it
+    // reads the committed draft rather than the stale one.
+    const [pendingSave, setPendingSave] = useState(false);
+
+    const handleApply = useCallback(() => {
+        setSelectedTabId(FilterTabs.SETTINGS);
+        const activeElement = document.activeElement;
+        if (
+            activeElement instanceof HTMLInputElement ||
+            activeElement instanceof HTMLTextAreaElement
+        ) {
+            activeElement.blur();
+        }
+        setPendingSave(true);
+    }, []);
+
+    useEffect(() => {
+        if (!pendingSave) return;
+        setPendingSave(false);
+        if (draftFilterRule) onSave(draftFilterRule);
+    }, [pendingSave, draftFilterRule, onSave]);
+
     const isApplyDisabled = !isFilterEnabled(
         draftFilterRule,
         isEditMode,
@@ -567,16 +591,11 @@ const FilterConfiguration: FC<Props> = ({
                             disabled={
                                 isApplyDisabled || isLockedRequiredMissingValue
                             }
-                            // We use onMouseDown instead of onClick: when an
-                            // inline dropdown (Select/MultiSelect) is open,
-                            // Mantine's click-outside detector fires on
-                            // mousedown and the subsequent click event never
-                            // reaches the Apply button — so a real-user click
-                            // would otherwise need two presses to apply.
-                            onMouseDown={() => {
-                                setSelectedTabId(FilterTabs.SETTINGS);
-                                if (!!draftFilterRule) onSave(draftFilterRule);
-                            }}
+                            // mousedown (not click): fires before the value
+                            // input's blur grows the panel and shifts the button,
+                            // which would otherwise swallow a click and force two
+                            // presses.
+                            onMouseDown={handleApply}
                         >
                             Apply
                         </Button>


### PR DESCRIPTION
Closes: PROD-8401
Closes: #3500

### Description:

String filter value inputs (`FilterStringAutoComplete` and `FilterMultiStringInput`) previously only committed the typed value when the user pressed Enter or explicitly picked a dropdown item, so typing a value and clicking away silently discarded it. They now commit the in-progress search value on blur, matching the existing `TagInput` `addOnBlur` behaviour. Number and tag-based inputs already saved on focus change, so they are unchanged. Added unit tests covering blur-commit and the empty-input no-op case.