### PR TITLE
refactor: remove unused organizationName from FeatureFlagLogicArgs

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -520,7 +520,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                                     user: {
                                         userUuid: user.userUuid,
                                         organizationUuid,
-                                        organizationName: user.organizationName,
                                     },
                                 }),
                             ]);

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -522,7 +522,6 @@ export class AiAgentAdminService extends BaseService {
                 user: {
                     userUuid: user.userUuid,
                     organizationUuid,
-                    organizationName: user.organizationName ?? '',
                 },
             }),
         ]);

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -405,7 +405,6 @@ export class AiAgentReviewClassifierService extends BaseService {
             user: {
                 userUuid: args.requestedByUserUuid ?? 'system',
                 organizationUuid: args.organizationUuid,
-                organizationName: args.organizationName ?? '',
             },
         });
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -60,10 +60,7 @@ export class AiOrganizationSettingsService extends BaseService {
     }
 
     private async getIsCopilotEnabled(
-        user: Pick<
-            LightdashUser,
-            'userUuid' | 'organizationUuid' | 'organizationName'
-        >,
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
     ): Promise<boolean> {
         const isCopilotEnabled = await this.commercialFeatureFlagModel.get({
             user,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -406,7 +406,6 @@ export class AppGenerateService extends BaseService {
             user: {
                 userUuid: user.userUuid,
                 organizationUuid: user.organizationUuid,
-                organizationName: undefined,
             },
             featureFlagId: FeatureFlags.EnableDataAppExternalAccess,
         });

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -398,20 +398,8 @@ export class EmbedService extends BaseService {
         userUuid: string;
         organizationUuid: string;
     }) {
-        const organization = await this.organizationModel.get(
-            user.organizationUuid,
-        );
-
-        if (!organization) {
-            throw new ForbiddenError('Organization not found');
-        }
-
         const isEnabled = await this.featureFlagModel.get({
-            user: {
-                userUuid: user.userUuid,
-                organizationUuid: user.organizationUuid,
-                organizationName: organization.name,
-            },
+            user,
             featureFlagId: CommercialFeatureFlags.Embedding,
         });
 

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.flag.test.ts
@@ -188,7 +188,6 @@ describe('ExternalConnectionService feature flag gate', () => {
                 user: {
                     userUuid: USER_UUID,
                     organizationUuid: ORG_UUID,
-                    organizationName: 'Test Org',
                 },
                 featureFlagId: FeatureFlags.EnableDataAppExternalAccess,
             });

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -70,10 +70,7 @@ export class ExternalConnectionService extends BaseService {
     }
 
     private async assertExternalAccessEnabledForUser(
-        user: Pick<
-            LightdashUser,
-            'userUuid' | 'organizationUuid' | 'organizationName'
-        >,
+        user: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>,
     ): Promise<void> {
         const { enabled } = await this.featureFlagModel.get({
             user,
@@ -92,7 +89,6 @@ export class ExternalConnectionService extends BaseService {
         return this.assertExternalAccessEnabledForUser({
             userUuid: account.user.userUuid,
             organizationUuid: account.organization.organizationUuid,
-            organizationName: account.organization.name,
         });
     }
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -40,7 +40,6 @@ const VALID_USER_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const dbUser = {
     userUuid: VALID_USER_UUID,
     organizationUuid: 'org-uuid',
-    organizationName: 'Org',
 };
 
 type FakeRows = {
@@ -335,7 +334,6 @@ describe('FeatureFlagModel', () => {
                 user: {
                     userUuid: 'external::not-a-uuid',
                     organizationUuid: 'org-uuid',
-                    organizationName: 'Org',
                 },
             });
 
@@ -354,7 +352,6 @@ describe('FeatureFlagModel', () => {
                 user: {
                     userUuid: 'external::not-a-uuid',
                     organizationUuid: 'org-uuid',
-                    organizationName: 'Org',
                 },
             });
 

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -11,10 +11,7 @@ const UUID_REGEX =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export type FeatureFlagLogicArgs = {
-    user?: Pick<
-        LightdashUser,
-        'userUuid' | 'organizationUuid' | 'organizationName'
-    >;
+    user?: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>;
     featureFlagId: string;
 };
 

--- a/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
+++ b/packages/backend/src/services/FeatureFlag/FeatureFlagService.ts
@@ -23,10 +23,7 @@ export class FeatureFlagService extends BaseService {
         user,
         featureFlagId,
     }: {
-        user?: Pick<
-            LightdashUser,
-            'userUuid' | 'organizationUuid' | 'organizationName'
-        >;
+        user?: Pick<LightdashUser, 'userUuid' | 'organizationUuid'>;
         featureFlagId: string;
     }) {
         return this.featureFlagModel.get({ user, featureFlagId });

--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -100,7 +100,6 @@ export class GithubAppService extends BaseService {
             user: {
                 userUuid: user.userUuid,
                 organizationUuid: user.organizationUuid,
-                organizationName: undefined,
             },
             featureFlagId: FeatureFlags.GithubUserCredentials,
         });

--- a/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
+++ b/packages/backend/src/services/OrganizationDomainVerificationService/OrganizationDomainVerificationService.ts
@@ -76,7 +76,6 @@ export class OrganizationDomainVerificationService extends BaseService {
             user: {
                 userUuid: account.user.userUuid,
                 organizationUuid: account.organization?.organizationUuid,
-                organizationName: account.organization?.name,
             },
             featureFlagId: FeatureFlags.SsoOrganizationSettings,
         });

--- a/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
+++ b/packages/backend/src/services/OrganizationSettingsService/OrganizationSettingsService.ts
@@ -66,7 +66,6 @@ export class OrganizationSettingsService extends BaseService {
             user: {
                 userUuid: account.user.userUuid,
                 organizationUuid: account.organization?.organizationUuid,
-                organizationName: account.organization?.name,
             },
             featureFlagId: FeatureFlags.ProLimits,
         });

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.test.ts
@@ -95,7 +95,6 @@ describe('OrganizationSsoService', () => {
                 user: {
                     userUuid: USER_UUID,
                     organizationUuid: ORG_UUID,
-                    organizationName: 'Test Organization',
                 },
                 featureFlagId: FeatureFlags.SsoOrganizationSettings,
             });

--- a/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
+++ b/packages/backend/src/services/OrganizationSsoService/OrganizationSsoService.ts
@@ -159,7 +159,6 @@ export class OrganizationSsoService extends BaseService {
             user: {
                 userUuid: account.user.userUuid,
                 organizationUuid: account.organization?.organizationUuid,
-                organizationName: account.organization?.name,
             },
             featureFlagId: FeatureFlags.SsoOrganizationSettings,
         });


### PR DESCRIPTION
Closes: PROD-8407
Closes: #24551

### Description:

`FeatureFlagLogicArgs.user.organizationName` was a leftover from PostHog-based feature flags and is never read in the current flag logic, which resolves flags purely from env-var allowlists, per-flag config handlers, and DB overrides keyed on `user_uuid` / `organization_uuid`. This PR removes the field from the type, from every call site that constructed it (and the two helper signatures that re-declared the `Pick`), and drops the `organizationModel.get()` call in `EmbedService.isFeatureEnabled` that existed solely to supply it. `LightdashUser.organizationName` itself is unchanged. Typecheck, lint, and the affected backend unit tests all pass.