### PR TITLE
chore(pivot): require metricQuery in getPivotConfig, drop silent fallback

### DIFF
--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -17,6 +17,7 @@ describe('getPivotConfig', () => {
                 },
                 pivotConfig: { columns: ['dim_b'] },
                 tableConfig: { columnOrder: [] },
+                metricQuery: { dimensions: ['dim_a', 'dim_b'] },
             });
 
             expect(result).toBeDefined();
@@ -41,6 +42,7 @@ describe('getPivotConfig', () => {
                 },
                 pivotConfig: undefined,
                 tableConfig: { columnOrder: [] },
+                metricQuery: { dimensions: ['dim_a'] },
             });
 
             expect(result).toBeUndefined();
@@ -54,6 +56,7 @@ describe('getPivotConfig', () => {
                 },
                 pivotConfig: { columns: ['dim_b'] },
                 tableConfig: { columnOrder: [] },
+                metricQuery: { dimensions: ['dim_b'] },
             });
 
             expect(result).toBeDefined();
@@ -163,33 +166,29 @@ describe('getPivotConfig', () => {
             expect(result?.hiddenMetricFieldIds).toBeUndefined();
         });
 
-        it('falls back to hiddenMetricFieldIds for all hidden fields when metricQuery is absent', () => {
-            // Backward-compat: callers that cannot provide metricQuery (e.g. ChartDownloadMenu)
-            // get the legacy flat list in hiddenMetricFieldIds.
-            const result = getPivotConfig({
-                chartConfig: {
-                    type: ChartType.TABLE,
-                    config: {
-                        columns: {
-                            orders_status: { visible: false },
-                            payments_total_revenue: { visible: false },
+        it('requires metricQuery by type for table charts — there is no silent fallback', () => {
+            // Replaces the old footgun tests. metricQuery is now mandatory, so a
+            // table chart can never reach getPivotConfig without it and hidden
+            // dimensions can always be classified instead of being misfiled into
+            // hiddenMetricFieldIds (where pivotQueryResults would ignore them and
+            // leak the dim into the CSV/XLSX export).
+            const callWithoutMetricQuery = () =>
+                getPivotConfig({
+                    chartConfig: {
+                        type: ChartType.TABLE,
+                        config: {
+                            columns: { sort_helper_dim: { visible: false } },
                         },
                     },
-                },
-                pivotConfig: { columns: ['payments_payment_method'] },
-                tableConfig: { columnOrder: [] },
-                // No metricQuery provided
-            });
+                    pivotConfig: { columns: ['shipping_method'] },
+                    tableConfig: { columnOrder: [] },
+                    // @ts-expect-error metricQuery is required — omitting it must not type-check
+                    metricQuery: undefined,
+                });
 
-            expect(result).toBeDefined();
-            // Both fields land in hiddenMetricFieldIds (legacy behaviour)
-            expect(result?.hiddenMetricFieldIds).toEqual(
-                expect.arrayContaining([
-                    'orders_status',
-                    'payments_total_revenue',
-                ]),
-            );
-            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
+            // The assertion that matters is the @ts-expect-error above; we never
+            // invoke the callback so there is no runtime path without metricQuery.
+            expect(callWithoutMetricQuery).toBeInstanceOf(Function);
         });
 
         it('routes hidden dimensions into hiddenDimensionFieldIds (not hiddenMetricFieldIds) when getPivotConfig receives metricQuery', () => {
@@ -219,29 +218,6 @@ describe('getPivotConfig', () => {
             // The hidden dim must NOT appear in hiddenMetricFieldIds, otherwise
             // pivotQueryResults would ignore it and the dim leaks into the export.
             expect(result?.hiddenMetricFieldIds).toBeUndefined();
-        });
-
-        it('falls back to hiddenMetricFieldIds when metricQuery is omitted (footgun: callers must pass metricQuery for dim hiding to work)', () => {
-            // Documentation test: demonstrates why ChartDownloadMenu MUST pass
-            // metricQuery. Without it the hidden sort-helper dim ends up in
-            // hiddenMetricFieldIds, which pivotQueryResults ignores for
-            // dimension-typed columns — so the dim leaks into the CSV/XLSX export.
-            const result = getPivotConfig({
-                chartConfig: {
-                    type: ChartType.TABLE,
-                    config: {
-                        columns: { sort_helper_dim: { visible: false } },
-                    },
-                },
-                pivotConfig: { columns: ['shipping_method'] },
-                tableConfig: { columnOrder: [] },
-                // metricQuery intentionally omitted
-            });
-
-            // Footgun: without metricQuery we can't classify, so hidden dims end up
-            // in hiddenMetricFieldIds — where pivotQueryResults will ignore them.
-            expect(result?.hiddenMetricFieldIds).toEqual(['sort_helper_dim']);
-            expect(result?.hiddenDimensionFieldIds).toBeUndefined();
         });
     });
 });

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -41,37 +41,25 @@ const getTablePivotConfig = (
     tableChartConfig: TableChartConfig,
     pivotConfig: CreateSavedChartVersion['pivotConfig'],
     tableConfig: CreateSavedChartVersion['tableConfig'],
-    metricQuery?: Pick<MetricQuery, 'dimensions'>,
+    metricQuery: Pick<MetricQuery, 'dimensions'>,
 ): PivotConfig | undefined => {
     if (!pivotConfig || pivotConfig.columns.length === 0) {
         return undefined;
     }
 
-    if (metricQuery) {
-        const { hiddenDimensions, hiddenMetrics } =
-            splitHiddenTableFieldsByKind(tableChartConfig, metricQuery);
-        return {
-            pivotDimensions: pivotConfig.columns,
-            metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
-            ...(hiddenMetrics.length > 0 && {
-                hiddenMetricFieldIds: hiddenMetrics,
-            }),
-            ...(hiddenDimensions.length > 0 && {
-                hiddenDimensionFieldIds: hiddenDimensions,
-            }),
-            columnOrder: tableConfig.columnOrder,
-            rowTotals: tableChartConfig.config?.showRowCalculation ?? false,
-            columnTotals:
-                tableChartConfig.config?.showColumnCalculation ?? false,
-        };
-    }
-
-    // Fallback: no metricQuery available — put all hidden fields in hiddenMetricFieldIds
-    // for backward compatibility (previous behaviour).
+    const { hiddenDimensions, hiddenMetrics } = splitHiddenTableFieldsByKind(
+        tableChartConfig,
+        metricQuery,
+    );
     return {
         pivotDimensions: pivotConfig.columns,
         metricsAsRows: tableChartConfig.config?.metricsAsRows ?? false,
-        hiddenMetricFieldIds: getHiddenTableFields(tableChartConfig),
+        ...(hiddenMetrics.length > 0 && {
+            hiddenMetricFieldIds: hiddenMetrics,
+        }),
+        ...(hiddenDimensions.length > 0 && {
+            hiddenDimensionFieldIds: hiddenDimensions,
+        }),
         columnOrder: tableConfig.columnOrder,
         rowTotals: tableChartConfig.config?.showRowCalculation ?? false,
         columnTotals: tableChartConfig.config?.showColumnCalculation ?? false,
@@ -95,7 +83,7 @@ export const getPivotConfig = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
+    > & { metricQuery: Pick<MetricQuery, 'dimensions'> },
 ): PivotConfig | undefined => {
     switch (savedChart.chartConfig.type) {
         case ChartType.TABLE:
@@ -116,7 +104,7 @@ export const getDownloadPivotConfig = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
+    > & { metricQuery: Pick<MetricQuery, 'dimensions'> },
     exportPivotedData: boolean = true,
 ): PivotConfig | undefined => {
     switch (savedChart.chartConfig.type) {
@@ -133,7 +121,7 @@ export const getDownloadPivotOptions = (
     savedChart: Pick<
         CreateSavedChartVersion,
         'chartConfig' | 'pivotConfig' | 'tableConfig'
-    > & { metricQuery?: Pick<MetricQuery, 'dimensions'> },
+    > & { metricQuery: Pick<MetricQuery, 'dimensions'> },
     exportPivotedData: boolean = true,
 ): { pivotConfig: PivotConfig | undefined; exportPivotedData: boolean } => ({
     pivotConfig: getDownloadPivotConfig(savedChart, exportPivotedData),

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -67,19 +67,20 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
             [chartRef],
         );
 
-        // Build pivot config with pivot dimensions
-        const pivotConfig = getPivotConfig({
-            chartConfig,
-            pivotConfig: pivotDimensions
-                ? {
-                      columns: pivotDimensions,
-                  }
-                : undefined,
-            tableConfig: {
-                columnOrder,
-            },
-            metricQuery: resultsData?.metricQuery,
-        });
+        // Build pivot config with pivot dimensions. metricQuery is required to
+        // classify hidden fields; without results there is nothing to pivot yet.
+        const pivotConfig = resultsData?.metricQuery
+            ? getPivotConfig({
+                  chartConfig,
+                  pivotConfig: pivotDimensions
+                      ? { columns: pivotDimensions }
+                      : undefined,
+                  tableConfig: {
+                      columnOrder,
+                  },
+                  metricQuery: resultsData.metricQuery,
+              })
+            : undefined;
 
         const getChartDownloadQueryUuid = useCallback(
             (


### PR DESCRIPTION
## What

Follow-up hardening for the hide-pivot-dimensions work. `getTablePivotConfig` had a backward-compat fallback: when `metricQuery` was missing it lumped **all** hidden field IDs into `hiddenMetricFieldIds`. For hidden *dimensions* that's wrong — `pivotQueryResults` only filters metric IDs there, so a hidden dimension silently leaked into CSV/XLSX exports. This was a footgun waiting for the next `getPivotConfig` consumer.

This removes the trap by making `metricQuery` **required by type**, so a table chart can never reach `getPivotConfig` without it.

## Changes

- `metricQuery` is now required on `getTablePivotConfig` and the public entry points (`getPivotConfig`, `getDownloadPivotConfig`, `getDownloadPivotOptions`); the silent fallback branch is deleted.
- All callers already pass a full chart object with `metricQuery`. The only exception, `ChartDownloadMenu`, now guards on `resultsData.metricQuery` (absent only when there are no results to export anyway, where the menu is already disabled).
- Replaced the footgun-documentation tests with a type-contract test (`@ts-expect-error`) asserting that omitting `metricQuery` for a table chart no longer type-checks. Under `ts-jest` this is enforced at test time.

## Testing

- `pnpm -F common test pivotConfig.test.ts` — 9/9 pass.
- Manual, end-to-end against the real app + export pipeline: a pivoted table with a hidden row dimension now sends `pivotConfig.hiddenDimensionFieldIds = ["<dim>"]` (not `hiddenMetricFieldIds`), and the downloaded CSV excludes the dimension. Un-hiding it produces a clean `pivotConfig` (no hidden arrays) and the dimension reappears.

Closes: PROD-7818
Relates: #13700

🤖 Generated with [Claude Code](https://claude.com/claude-code)