### PR TITLE
feat(reviews): editProjectContext tool + project_context work threads (ZAP-521)

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -312,6 +312,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentContentValidation: new AiAgentContentValidation(),
                     aiWritebackService:
                         repository.getAiWritebackService<AiWritebackService>(),
+                    projectContextService:
+                        repository.getProjectContextService<ProjectContextService>(),
                     writebackPreviewService:
                         repository.getWritebackPreviewService<WritebackPreviewService>(),
                     previewDeploySetupService:

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -66,6 +66,7 @@ import { AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
 import {
+    buildProjectContextWorkThreadPrompt,
     buildYmlPathByModel,
     planReviewWriteback,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
@@ -1049,40 +1050,42 @@ export class AiAgentAdminService extends BaseService {
                 promptUuid: finding.promptUuid,
             });
 
-        // Create the Build-fix thread before the remediation row so a failed
+        // Create the work thread before the remediation row so a failed
         // unique-index insert leaves only a harmless orphan thread, never a
         // remediation pointing at a thread that doesn't exist. The source
         // project/agent were validated above (eligibility + scope), so the
-        // auth-bypassing model call is safe.
-        let workThreadUuid: string | null = null;
-        if (plan.strategy === 'prompt') {
-            const created =
-                await this.aiAgentModel.createWebAppThreadWithPrompt({
-                    thread: {
-                        organizationUuid,
-                        projectUuid: scope.projectUuid,
-                        userUuid: user.userUuid,
-                        createdFrom: 'web_app' as const,
-                        agentUuid: scope.agentUuid,
-                    },
-                    prompt: {
-                        createdByUserUuid: user.userUuid,
-                        prompt: plan.promptText,
-                        context: [
-                            {
-                                type: 'thread',
-                                threadUuid: finding.threadUuid,
-                                promptUuid: finding.promptUuid,
-                            },
-                        ],
-                    },
-                });
-            workThreadUuid = created.threadUuid;
-            await this.aiAgentModel.updateThreadTitle({
-                threadUuid: workThreadUuid,
-                title: `Fix review: ${reviewItem.title}`,
+        // auth-bypassing model call is safe. semantic_layer seeds a Build-fix
+        // prompt the job runs; project_context seeds a refine-context prompt the
+        // user drives in the workspace (the initial PR is deterministic).
+        const workThreadPrompt =
+            plan.strategy === 'project_context'
+                ? buildProjectContextWorkThreadPrompt(reviewItem, plan.entry)
+                : plan.promptText;
+        const { threadUuid: workThreadUuid } =
+            await this.aiAgentModel.createWebAppThreadWithPrompt({
+                thread: {
+                    organizationUuid,
+                    projectUuid: scope.projectUuid,
+                    userUuid: user.userUuid,
+                    createdFrom: 'web_app' as const,
+                    agentUuid: scope.agentUuid,
+                },
+                prompt: {
+                    createdByUserUuid: user.userUuid,
+                    prompt: workThreadPrompt,
+                    context: [
+                        {
+                            type: 'thread',
+                            threadUuid: finding.threadUuid,
+                            promptUuid: finding.promptUuid,
+                        },
+                    ],
+                },
             });
-        }
+        await this.aiAgentModel.updateThreadTitle({
+            threadUuid: workThreadUuid,
+            title: `Fix review: ${reviewItem.title}`,
+        });
 
         // The one-active-per-fingerprint index can still reject the insert in
         // a race (concurrent retry, or a worker reviving the row between the

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -289,11 +289,11 @@ import { validateSelectedFieldsExistence } from '../ai/utils/validators';
 import { AiAgentToolsService } from '../AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
-import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import { buildChangesetWritebackPrompt } from '../AiWritebackService/changesetPrompt';
 import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
 import { PreviewDeploySetupService } from '../PreviewDeploySetupService/PreviewDeploySetupService';
+import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import { canGeneratePostResponseSuggestions } from './suggestionAccess';
 
 type ThreadMessageContext = Array<

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -249,6 +249,7 @@ import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
 import {
     DiscoverReposFn,
     EditDbtProjectFn,
+    EditProjectContextFn,
     ExploreRepoFn,
     GetPromptFn,
     SendFileFn,
@@ -288,6 +289,7 @@ import { validateSelectedFieldsExistence } from '../ai/utils/validators';
 import { AiAgentToolsService } from '../AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import { AiWritebackService } from '../AiWritebackService/AiWritebackService';
+import { ProjectContextService } from '../ProjectContextService/ProjectContextService';
 import { buildChangesetWritebackPrompt } from '../AiWritebackService/changesetPrompt';
 import type { AiWritebackSource } from '../AiWritebackService/types';
 import { type WritebackPreviewService } from '../AiWritebackService/WritebackPreviewService';
@@ -373,6 +375,7 @@ type AiAgentServiceDependencies = {
     persistentDownloadFileService: PersistentDownloadFileService;
     aiAgentContentValidation: AiAgentContentValidation;
     aiWritebackService: AiWritebackService;
+    projectContextService: ProjectContextService;
     previewDeploySetupService: PreviewDeploySetupService;
     writebackPreviewService: WritebackPreviewService;
     githubAppInstallationsModel: GithubAppInstallationsModel;
@@ -622,6 +625,8 @@ export class AiAgentService extends BaseService {
     private readonly aiAgentContentValidation: AiAgentContentValidation;
 
     private readonly aiWritebackService: AiWritebackService;
+
+    private readonly projectContextService: ProjectContextService;
 
     private readonly previewDeploySetupService: PreviewDeploySetupService;
 
@@ -877,6 +882,7 @@ export class AiAgentService extends BaseService {
             dependencies.persistentDownloadFileService;
         this.aiAgentContentValidation = dependencies.aiAgentContentValidation;
         this.aiWritebackService = dependencies.aiWritebackService;
+        this.projectContextService = dependencies.projectContextService;
         this.previewDeploySetupService = dependencies.previewDeploySetupService;
         this.writebackPreviewService = dependencies.writebackPreviewService;
         this.githubAppInstallationsModel =
@@ -4269,6 +4275,7 @@ export class AiAgentService extends BaseService {
             forceToolHints,
             onStepProgress,
             suppressWritebackPreview,
+            isReviewRemediationWorkThread,
         }: {
             agentUuid: string;
             threadUuid: string;
@@ -4282,6 +4289,9 @@ export class AiAgentService extends BaseService {
                 progressStatus?: 'in_progress' | 'complete' | 'error',
             ) => void;
             suppressWritebackPreview?: boolean;
+            // Enables the work-thread-only editProjectContext tool so the agent
+            // can open/change the project_context PR from this thread.
+            isReviewRemediationWorkThread?: boolean;
         },
     ): Promise<string> {
         try {
@@ -4323,6 +4333,7 @@ export class AiAgentService extends BaseService {
                     forceToolHints,
                     onSlackStepProgress: onStepProgress,
                     suppressWritebackPreview,
+                    isReviewRemediationWorkThread,
                 },
             );
             return response;
@@ -6416,6 +6427,29 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             return (await getInstallationAccess()).listRepos();
         };
 
+        // Deterministic project_context.yml writeback (no sandbox). Only wired
+        // into review-remediation work threads; the source thread is linked
+        // from the PR body so a reviewer can trace the entry.
+        const editProjectContext: EditProjectContextFn = async (entry) => {
+            const sourceThread = prompt.agentUuid
+                ? {
+                      threadUrl: `${this.lightdashConfig.siteUrl}/projects/${projectUuid}/ai-agents/${prompt.agentUuid}/threads/${prompt.threadUuid}`,
+                      promptUuid: prompt.promptUuid,
+                      threadUuid: prompt.threadUuid,
+                  }
+                : null;
+            const writeback = await this.projectContextService.writebackEntry({
+                projectUuid,
+                entry,
+                branchTimestamp: Date.now(),
+                sourceThread,
+            });
+            return {
+                prUrl: writeback.prUrl,
+                prAction: writeback.op === 'update' ? 'updated' : 'opened',
+            };
+        };
+
         return {
             listExplores: toolsRuntime.listExplores,
             getProjectContextDocument,
@@ -6451,6 +6485,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeReasoning,
             searchFieldValues: toolsRuntime.searchFieldValues,
             editDbtProject,
+            editProjectContext,
             setupPreviewDeploy: toolsRuntime.setupPreviewDeploy,
             exploreRepo,
             discoverRepos,
@@ -6495,6 +6530,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             // Forces the first tool hint on the opening step instead of merely
             // suggesting it (review Build-fix guarantees editDbtProject runs).
             forceToolHints?: boolean;
+            // Enables the work-thread-only editProjectContext tool.
+            isReviewRemediationWorkThread?: boolean;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -6534,6 +6571,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             autoApproveSql?: boolean;
             suppressWritebackPreview?: boolean;
             forceToolHints?: boolean;
+            isReviewRemediationWorkThread?: boolean;
             toolHints?: string[];
             onSlackStepProgress?: (
                 progress: string,
@@ -6612,6 +6650,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeReasoning,
             searchFieldValues,
             editDbtProject,
+            editProjectContext,
             setupPreviewDeploy,
             exploreRepo,
             discoverRepos,
@@ -6878,6 +6917,21 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             provider: prompt.modelConfig?.modelProvider as AnyType,
         });
 
+        // editProjectContext is scoped to review-remediation work threads, so a
+        // normal chat never exposes it. Resolve from the thread (not just the
+        // explicit option) so user-driven follow-ups in the workspace — where
+        // people actually change the PR — also get the tool.
+        const isReviewRemediationWorkThread =
+            options.isReviewRemediationWorkThread ??
+            (isSlackPrompt(prompt)
+                ? false
+                : !!(await this.aiAgentReviewClassifierModel.findReviewRemediationByWorkThread(
+                      {
+                          organizationUuid: user.organizationUuid,
+                          workThreadUuid: prompt.threadUuid,
+                      },
+                  )));
+
         const args: AiAgentArgs = {
             organizationId: user.organizationUuid,
             userId: user.userUuid,
@@ -6902,6 +6956,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             enableContentTools: canUseContentTools,
             enableSearchSemanticLayer: searchSemanticLayerEnabled,
             enableAiWriteback: aiWritebackEnabled,
+            enableEditProjectContext: isReviewRemediationWorkThread,
             writebackAttribution,
             enablePreviewDeploySetup: aiPreviewDeploySetupEnabled,
             enableRepoDiscovery: repoDiscoveryEnabled,
@@ -6992,6 +7047,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeReasoning,
             searchFieldValues,
             editDbtProject,
+            editProjectContext,
             setupPreviewDeploy,
             exploreRepo,
             discoverRepos,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -23,6 +23,7 @@ import { getDescribeWarehouseTable } from '../tools/describeWarehouseTable';
 import { getDiscoverRepos } from '../tools/discoverRepos';
 import { getEditContent } from '../tools/editContent';
 import { getEditDbtProject } from '../tools/editDbtProject';
+import { getEditProjectContext } from '../tools/editProjectContext';
 import { getExploreRepo } from '../tools/exploreRepo';
 import { getFindContent } from '../tools/findContent';
 import { getGenerateDashboardV2 } from '../tools/generateDashboardV2';
@@ -307,6 +308,14 @@ const getAgentTools = (
           })
         : null;
 
+    // Only present in review-remediation work threads, where the user can
+    // rebuild/change the project_context PR conversationally.
+    const editProjectContext = args.enableEditProjectContext
+        ? getEditProjectContext({
+              editProjectContext: dependencies.editProjectContext,
+          })
+        : null;
+
     const syncDbtProject = args.enableAiWriteback
         ? getSyncDbtProject({
               syncDbtProject: dependencies.syncDbtProject,
@@ -418,6 +427,7 @@ const getAgentTools = (
         generateUuids,
         ...(args.canManageAgent ? { improveContext } : {}),
         ...(editDbtProject ? { editDbtProject } : {}),
+        ...(editProjectContext ? { editProjectContext } : {}),
         ...(syncDbtProject ? { syncDbtProject } : {}),
         ...(setupPreviewDeploy ? { setupPreviewDeploy } : {}),
         ...(exploreRepo ? { exploreRepo } : {}),

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -2,7 +2,10 @@ import {
     PullRequestProvider,
     type AiAgentReviewItemSummary,
 } from '@lightdash/common';
-import { planReviewWriteback } from './buildReviewWritebackPrompt';
+import {
+    buildProjectContextWorkThreadPrompt,
+    planReviewWriteback,
+} from './buildReviewWritebackPrompt';
 
 const baseItem = (
     overrides: Partial<AiAgentReviewItemSummary> = {},
@@ -144,5 +147,37 @@ describe('planReviewWriteback', () => {
                 baseItem({ primaryRootCause: 'runtime_reliability' }),
             ),
         ).toThrow('not supported');
+    });
+});
+
+describe('buildProjectContextWorkThreadPrompt', () => {
+    const entry = {
+        op: 'create' as const,
+        id: null,
+        kind: 'definition' as const,
+        content: '"HR" = high-risk cohort.',
+        terms: ['HR', 'high risk'],
+        objects: ['patients'],
+    };
+
+    it('states the applied entry and points at the editProjectContext tool', () => {
+        const prompt = buildProjectContextWorkThreadPrompt(
+            baseItem({ primaryRootCause: 'project_context' }),
+            entry,
+        );
+        expect(prompt).toContain('Applied project context definition');
+        expect(prompt).toContain('"HR" = high-risk cohort.');
+        expect(prompt).toContain('Triggers: HR, high risk');
+        expect(prompt).toContain('Related objects: patients');
+        expect(prompt).toContain('editProjectContext tool');
+    });
+
+    it('omits the triggers/objects lines when empty', () => {
+        const prompt = buildProjectContextWorkThreadPrompt(
+            baseItem({ primaryRootCause: 'project_context' }),
+            { ...entry, terms: [], objects: [] },
+        );
+        expect(prompt).not.toContain('Triggers:');
+        expect(prompt).not.toContain('Related objects:');
     });
 });

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -120,6 +120,32 @@ const buildSemanticLayerWritebackPrompt = (
 };
 
 /**
+ * Seeds the project_context remediation work thread. Unlike the semantic prompt
+ * (run in a sandbox), this thread is not auto-run: the initial PR is opened
+ * deterministically, and the thread is where a human refines/rebuilds the entry
+ * via the editProjectContext tool. The prompt states the applied entry so the
+ * Build pane reads as a coherent starting point.
+ */
+export const buildProjectContextWorkThreadPrompt = (
+    item: AiAgentReviewItemSummary,
+    entry: AiAgentJudgeProjectContextEntry,
+): string => {
+    const sections = [
+        'You are refining this project’s Lightdash project context to close a gap surfaced by AI agent review. The original conversation where the agent answered incorrectly is attached as pinned context.',
+        `Issue: ${item.title}`,
+        item.description ? item.description : null,
+        `Applied project context ${entry.kind}: "${entry.content}"`,
+        entry.terms.length > 0 ? `Triggers: ${entry.terms.join(', ')}` : null,
+        entry.objects.length > 0
+            ? `Related objects: ${entry.objects.join(', ')}`
+            : null,
+        'A pull request applying this entry to lightdash.project_context.yml is opened automatically. To change or extend the definition, tell me what to adjust and I will open an updated pull request with the editProjectContext tool.',
+    ].filter((section): section is string => section !== null);
+
+    return sections.join('\n\n');
+};
+
+/**
  * Per-root-cause strategy dispatcher. Two strategies are implemented:
  * `semantic_layer` → a sandbox prompt, and `project_context` → a structured
  * entry for the deterministic GitHub-API merge. Other root causes throw until

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -3731,6 +3731,147 @@ Parameters:
     },
   },
   {
+    "description": "Open or update a pull request that changes this project's Lightdash project context — the lightdash.project_context.yml living document of business definitions and routing/context facts the AI agents read before answering. Use this ONLY to add or refine a durable, project-specific fact: a business definition or acronym ("HR" = high-risk cohort, not human resources), routing/join guidance about which explore answers a question, or an object-scoped context note — something that would prevent a class of wrong answers in future turns. Do NOT use this for dbt / semantic-layer YAML changes (use editDbtProject for those) or for read-only questions. The change is applied deterministically via a GitHub-API merge of the YAML — there is no sandbox — and a pull request is opened or updated. The call is synchronous. Treat the result as your own work when you report it to the user.",
+    "inputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "description": "A single self-contained sentence stating the fact (e.g. '"HR" = the high-risk diabetes cohort, not human resources.').",
+          "type": "string",
+        },
+        "id": {
+          "description": "The id of the existing entry to replace when op="update"; otherwise null.",
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+        "kind": {
+          "description": "Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for routing/join rules, guidance, or durable object-scoped facts.",
+          "enum": [
+            "definition",
+            "context",
+          ],
+          "type": "string",
+        },
+        "objects": {
+          "description": "The semantic objects this fact concerns — explore names and/or field ids in the table_field form (e.g. "payments_total_amount"); [] when purely prompt-driven.",
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "op": {
+          "description": "Use "update" to replace an existing project-context entry (set id), otherwise "create".",
+          "enum": [
+            "create",
+            "update",
+          ],
+          "type": "string",
+        },
+        "terms": {
+          "description": "The prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.",
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
+        "op",
+        "id",
+        "kind",
+        "content",
+        "terms",
+        "objects",
+      ],
+      "type": "object",
+    },
+    "name": "editProjectContext",
+    "outputSchema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "prAction": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "opened",
+                        "updated",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "prUrl": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "status": {
+                  "const": "success",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+                "prUrl",
+              ],
+              "type": "object",
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "errorCode": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "github_not_installed",
+                        "unsupported_source_control",
+                        "git_write_permission",
+                        "unknown",
+                      ],
+                      "type": "string",
+                    },
+                    {
+                      "type": "null",
+                    },
+                  ],
+                },
+                "status": {
+                  "const": "error",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "status",
+              ],
+              "type": "object",
+            },
+          ],
+        },
+        "result": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "result",
+        "metadata",
+      ],
+      "type": "object",
+    },
+  },
+  {
     "description": "Open a pull request that sets up Lightdash preview-project deploys for this project via GitHub Actions. Call this whenever the user wants to add Lightdash preview deploys — EITHER when they accept the offer surfaced by editDbtProject, OR when they ask directly (e.g. "set up preview deploys", "add the Lightdash preview GitHub Action", "deploy a preview project for each PR"). A prior writeback or offer is NOT required. It adds the canonical Lightdash preview workflow (a temporary preview project per pull request, torn down when the PR closes) on its own pull request. The target repository and dbt sub-folder are resolved server-side; this tool takes no arguments. The run is synchronous and can take a few minutes.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -6767,6 +6908,7 @@ exports[`AI agent tool contracts matches the shared agent tool definition names 
   "loadProjectContext",
   "proposeChange",
   "editDbtProject",
+  "editProjectContext",
   "syncDbtProject",
   "exploreRepo",
   "discoverRepos",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -6,6 +6,7 @@ import { getDescribeWarehouseTable } from './describeWarehouseTable';
 import { getDiscoverRepos } from './discoverRepos';
 import { getEditContent } from './editContent';
 import { getEditDbtProject } from './editDbtProject';
+import { getEditProjectContext } from './editProjectContext';
 import { getExploreRepo } from './exploreRepo';
 import { getFindContent } from './findContent';
 import { getFindExplores } from './findExplores';
@@ -139,6 +140,9 @@ const makeAgentTools = () => {
         loadSkill: getLoadSkill({ loadSkill: noop }),
         editDbtProject: getEditDbtProject({
             editDbtProject: noop,
+        }),
+        editProjectContext: getEditProjectContext({
+            editProjectContext: noop,
         }),
         setupPreviewDeploy: getSetupPreviewDeploy({
             setupPreviewDeploy: noop,

--- a/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
+++ b/packages/backend/src/ee/services/ai/tools/editProjectContext.ts
@@ -1,0 +1,75 @@
+import {
+    editProjectContextToolDefinition,
+    InsufficientGitPermissionsError,
+    PullRequestProvider,
+} from '@lightdash/common';
+import { tool } from 'ai';
+import { WritebackGitNotConnectedError } from '../../AiWritebackService/errors';
+import type { EditProjectContextFn } from '../types/aiAgentDependencies';
+import { toModelOutput } from '../utils/toModelOutput';
+import { toolErrorHandler } from '../utils/toolErrorHandler';
+
+type Dependencies = {
+    editProjectContext: EditProjectContextFn;
+};
+
+type EditProjectContextErrorCode =
+    | 'github_not_installed'
+    | 'unsupported_source_control'
+    | 'git_write_permission'
+    | 'unknown';
+
+const classifyError = (error: unknown): EditProjectContextErrorCode => {
+    if (error instanceof WritebackGitNotConnectedError) {
+        return error.provider === PullRequestProvider.GITHUB
+            ? 'github_not_installed'
+            : 'unsupported_source_control';
+    }
+    if (error instanceof InsufficientGitPermissionsError) {
+        return 'git_write_permission';
+    }
+    return 'unknown';
+};
+
+const toolDefinition = editProjectContextToolDefinition.for('agent');
+
+export const getEditProjectContext = ({ editProjectContext }: Dependencies) =>
+    tool({
+        ...toolDefinition,
+        execute: async ({ op, id, kind, content, terms, objects }) => {
+            try {
+                const { prUrl, prAction } = await editProjectContext({
+                    op,
+                    id,
+                    kind,
+                    content,
+                    terms,
+                    objects,
+                });
+
+                const verb = prAction === 'updated' ? 'Updated' : 'Opened';
+                return {
+                    result: `${verb} a pull request that ${
+                        op === 'update' ? 'updates' : 'adds'
+                    } a project context entry. A "View pull request" button is shown to the user, so do NOT include the pull request URL in your reply — summarise the entry you wrote ("${content}") and that it now applies to this project's context.`,
+                    metadata: {
+                        status: 'success' as const,
+                        prUrl,
+                        prAction,
+                    },
+                };
+            } catch (error) {
+                return {
+                    result: toolErrorHandler(
+                        error,
+                        'Error updating project context. No pull request was opened.',
+                    ),
+                    metadata: {
+                        status: 'error' as const,
+                        errorCode: classifyError(error),
+                    },
+                };
+            }
+        },
+        toModelOutput: ({ output }) => toModelOutput(output),
+    });

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -21,6 +21,7 @@ import {
     DiscoverReposFn,
     EditContentFn,
     EditDbtProjectFn,
+    EditProjectContextFn,
     ExploreRepoFn,
     FindContentFn,
     FindExploresFn,
@@ -95,6 +96,9 @@ export type AiAgentArgs = AnyAiModel & {
     enableContentTools: boolean;
     enableSearchSemanticLayer: boolean;
     enableAiWriteback: boolean;
+    // Only on inside review-remediation work threads: lets the agent open/update
+    // the project_context.yml PR via the deterministic editProjectContext tool.
+    enableEditProjectContext: boolean;
     // Which GitHub identity a writeback PR would be attributed to (advisory,
     // resolved at prompt-assembly time). null when not applicable/unresolved.
     writebackAttribution: AiWritebackAttribution | null;
@@ -182,6 +186,7 @@ export type AiAgentDependencies = {
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;
     editDbtProject: EditDbtProjectFn;
+    editProjectContext: EditProjectContextFn;
     syncDbtProject: SyncDbtProjectFn;
     setupPreviewDeploy: SetupPreviewDeployFn;
     exploreRepo: ExploreRepoFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -3,6 +3,7 @@ import {
     AgentToolOutput,
     AiAgentDocumentContent,
     AiAgentDocumentSummary,
+    AiAgentJudgeProjectContextEntry,
     AiArtifact,
     AiMetricQueryWithFilters,
     AiWebAppPrompt,
@@ -455,6 +456,12 @@ export type EditDbtProjectFn = (args: {
         previewUrl: string | null;
     }
 >;
+
+// Applies a structured project-context entry to lightdash.project_context.yml
+// via the deterministic GitHub-API merge (no sandbox) and opens/updates a PR.
+export type EditProjectContextFn = (
+    entry: AiAgentJudgeProjectContextEntry,
+) => Promise<{ prUrl: string; prAction: 'opened' | 'updated' }>;
 
 export type SetupPreviewDeployFn = () => Promise<PreviewDeploySetupResult>;
 

--- a/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
+++ b/packages/backend/src/ee/services/ai/utils/llmAsJudgeForTools.ts
@@ -49,6 +49,7 @@ const TOOL_NAME_TO_DB_TOOL_NAME = {
     getProjectInfo: 'get_project_info',
     proposeChange: 'propose_change',
     editDbtProject: 'edit_dbt_project',
+    editProjectContext: 'edit_project_context',
     syncDbtProject: 'sync_dbt_project',
     exploreRepo: 'explore_repo',
     discoverRepos: 'discover_repos',

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -10,6 +10,7 @@ export * from './toolLoadProjectContextArgs';
 export * from './toolLoadSkillArgs';
 export * from './toolMcpQueryResultDescription';
 export * from './toolEditDbtProjectArgs';
+export * from './toolEditProjectContextArgs';
 export * from './toolSyncDbtProjectArgs';
 export * from './toolExploreRepoArgs';
 export * from './toolDiscoverReposArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -71,6 +71,11 @@ import {
     toolEditDbtProjectOutputSchema,
 } from './toolEditDbtProjectArgs';
 import {
+    TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION,
+    toolEditProjectContextArgsSchema,
+    toolEditProjectContextOutputSchema,
+} from './toolEditProjectContextArgs';
+import {
     TOOL_EXPLORE_REPO_DESCRIPTION,
     toolExploreRepoArgsSchema,
     toolExploreRepoOutputSchema,
@@ -615,6 +620,15 @@ export const editDbtProjectToolDefinition = defineTool({
     agent: { outputSchema: toolEditDbtProjectOutputSchema },
 });
 
+export const editProjectContextToolDefinition = defineTool({
+    name: 'editProjectContext',
+    title: 'Edit project context',
+    description: TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION,
+    availability: ['agent'],
+    inputSchema: toolEditProjectContextArgsSchema,
+    agent: { outputSchema: toolEditProjectContextOutputSchema },
+});
+
 export const syncDbtProjectToolDefinition = defineTool({
     name: 'syncDbtProject',
     title: 'Sync dbt project',
@@ -949,6 +963,7 @@ type AgentToolDefinitionsByName = {
     loadProjectContext: typeof loadProjectContextToolDefinition;
     proposeChange: typeof proposeChangeToolDefinition;
     editDbtProject: typeof editDbtProjectToolDefinition;
+    editProjectContext: typeof editProjectContextToolDefinition;
     syncDbtProject: typeof syncDbtProjectToolDefinition;
     exploreRepo: typeof exploreRepoToolDefinition;
     discoverRepos: typeof discoverReposToolDefinition;
@@ -993,6 +1008,7 @@ export const agentToolDefinitionsByName: AgentToolDefinitionsByName = {
     loadProjectContext: loadProjectContextToolDefinition,
     proposeChange: proposeChangeToolDefinition,
     editDbtProject: editDbtProjectToolDefinition,
+    editProjectContext: editProjectContextToolDefinition,
     syncDbtProject: syncDbtProjectToolDefinition,
     exploreRepo: exploreRepoToolDefinition,
     discoverRepos: discoverReposToolDefinition,
@@ -1039,6 +1055,7 @@ export const builtInToolDefinitions: readonly ToolDefinitionInstance[] = [
     loadProjectContextToolDefinition,
     proposeChangeToolDefinition,
     editDbtProjectToolDefinition,
+    editProjectContextToolDefinition,
     syncDbtProjectToolDefinition,
     exploreRepoToolDefinition,
     discoverReposToolDefinition,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditProjectContextArgs.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+export const TOOL_EDIT_PROJECT_CONTEXT_DESCRIPTION = [
+    "Open or update a pull request that changes this project's Lightdash project context — the lightdash.project_context.yml living document of business definitions and routing/context facts the AI agents read before answering.",
+    'Use this ONLY to add or refine a durable, project-specific fact: a business definition or acronym ("HR" = high-risk cohort, not human resources), routing/join guidance about which explore answers a question, or an object-scoped context note — something that would prevent a class of wrong answers in future turns.',
+    'Do NOT use this for dbt / semantic-layer YAML changes (use editDbtProject for those) or for read-only questions.',
+    'The change is applied deterministically via a GitHub-API merge of the YAML — there is no sandbox — and a pull request is opened or updated. The call is synchronous. Treat the result as your own work when you report it to the user.',
+].join(' ');
+
+// Mirrors AiAgentJudgeProjectContextEntry — the structured entry the
+// deterministic ProjectContextService.writebackEntry applies to the YAML.
+export const toolEditProjectContextArgsSchema = z.object({
+    op: z
+        .enum(['create', 'update'])
+        .describe(
+            'Use "update" to replace an existing project-context entry (set id), otherwise "create".',
+        ),
+    id: z
+        .string()
+        .nullable()
+        .describe(
+            'The id of the existing entry to replace when op="update"; otherwise null.',
+        ),
+    kind: z
+        .enum(['definition', 'context'])
+        .describe(
+            'Use "definition" for acronyms and business vocabulary ("X means Y"); use "context" for routing/join rules, guidance, or durable object-scoped facts.',
+        ),
+    content: z
+        .string()
+        .describe(
+            'A single self-contained sentence stating the fact (e.g. \'"HR" = the high-risk diabetes cohort, not human resources.\').',
+        ),
+    terms: z
+        .array(z.string())
+        .describe(
+            'The prompt-facing trigger words/phrases that should surface this entry (e.g. ["HR","high risk"]). Required for definitions.',
+        ),
+    objects: z
+        .array(z.string())
+        .describe(
+            'The semantic objects this fact concerns — explore names and/or field ids in the table_field form (e.g. "payments_total_amount"); [] when purely prompt-driven.',
+        ),
+});
+
+export const toolEditProjectContextOutputSchema = z.object({
+    result: z.string(),
+    metadata: z.discriminatedUnion('status', [
+        z.object({
+            status: z.literal('success'),
+            prUrl: z.string().nullable(),
+            // Nullish, not required: tool-call metadata is persisted, so cards
+            // rendered from rows written before this field existed must parse.
+            prAction: z.enum(['opened', 'updated']).nullish(),
+        }),
+        z.object({
+            status: z.literal('error'),
+            errorCode: z
+                .enum([
+                    'github_not_installed',
+                    'unsupported_source_control',
+                    'git_write_permission',
+                    'unknown',
+                ])
+                .nullish(),
+        }),
+    ]),
+});
+
+export type ToolEditProjectContextArgs = z.infer<
+    typeof toolEditProjectContextArgsSchema
+>;
+
+export type ToolEditProjectContextOutput = z.infer<
+    typeof toolEditProjectContextOutputSchema
+>;

--- a/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/visualizations/index.ts
@@ -38,6 +38,7 @@ export const ToolNameSchema = z.enum([
     'loadProjectContext',
     'proposeChange',
     'editDbtProject',
+    'editProjectContext',
     'syncDbtProject',
     'exploreRepo',
     'discoverRepos',

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -329,6 +329,7 @@ export const ToolCallDescription: FC<{
         case 'discoverRepos':
         case 'proposeChange':
         case 'editDbtProject':
+        case 'editProjectContext':
         case 'syncDbtProject':
         case 'setupPreviewDeploy':
         case 'runSavedChart':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/utils/toolIcons.ts
@@ -59,6 +59,7 @@ export const getToolIcon = (toolName: AiAgentToolName) => {
             loadProjectContext: IconVocabulary,
             proposeChange: IconPencil,
             editDbtProject: IconPencil,
+            editProjectContext: IconVocabulary,
             syncDbtProject: IconRefresh,
             exploreRepo: IconTerminal2,
             discoverRepos: IconFolders,


### PR DESCRIPTION
## Problem

In the review remediation workspace, **semantic_layer** fixes get a conversational "Build" work thread (`editDbtProject` opens/iterates the dbt PR), so a human can change/rebuild the PR. **project_context** fixes had no equivalent: the PR was opened deterministically by `ProjectContextService.writebackEntry` with **no work thread** (`work_thread_uuid = null`), so the workspace Build pane was empty and there was no way to rebuild/change the project-context PR conversationally.

There was also no agent tool that writes `lightdash.project_context.yml` from the structured entry — the only writer (`writebackEntry`) was locked inside the writeback job.

## Fix

Give project_context parity with semantic_layer, plus the missing tool:

- **New `editProjectContext` agent tool** — its input schema *is* the project-context entry (`op / id / kind / content / terms / objects`, mirroring `AiAgentJudgeProjectContextEntry`). It wraps the existing **deterministic `writebackEntry`** (GitHub-API merge, no sandbox), so the agent can open/update the project_context PR. `availability: ['agent']` → never exposed to MCP.
- **Scoped to work threads only** — a new `enableEditProjectContext` gate in `agentV2` includes the tool only when the run is a review-remediation work thread. `AiAgentService` resolves this from the thread via `findReviewRemediationByWorkThread`, so the tool appears both on the job's run *and* when a user continues the work thread in the workspace — which is where people actually change the PR. (`ProjectContextService` is now injected into `AiAgentService` for the tool's closure.)
- **Work thread for project_context** — `createReviewItemWriteback` now creates a work thread for project_context too (seeded by a new `buildProjectContextWorkThreadPrompt` stating the applied entry and pointing at the tool), so the workspace renders the Build pane.

The **initial** PR stays deterministic (the job still calls `writebackEntry` directly and already has the URL — no thread round-trip). The work thread + tool are for **rebuilding/changing** the entry afterwards.

## Why not route the initial PR through the thread

`editDbtProject` PRs are discovered by the job via the `ai_writeback_thread` link (written by the sandbox flow). `editProjectContext` doesn't write that link, and replicating it would couple the deterministic path to the sandbox machinery. Keeping the initial writeback deterministic (and the thread for changes) avoids that and matches the intended UX. Auto-running the thread for the initial PR is a possible follow-up if we add thread→PR linking for project_context.

## Regression analysis

- **semantic_layer unchanged.** The job's `else` branch still reads `remediation.workThreadUuid` (now always set) and forces `editDbtProject`; project_context never enters it.
- **project_context PR creation unchanged.** The job still opens the initial PR via `writebackEntry`; only a work thread is now created alongside it.
- **No new tool in normal chats or MCP.** The gate requires a remediation work thread; `availability: ['agent']` keeps it out of MCP. Cost: one indexed `work_thread_uuid` lookup per web agent run (skipped for Slack).
- New required `AiAgentArgs.enableEditProjectContext` / `AiAgentDependencies.editProjectContext` — backend typecheck confirms every construction site is covered.

## Test

- New `buildProjectContextWorkThreadPrompt` unit tests (entry rendered, tool referenced, empty triggers/objects omitted).
- `agentToolContracts.snapshot.test.ts` updated to include `editProjectContext` (names + contract snapshots).
- Backend typecheck **0 errors**; common + backend ESLint clean; Jest **9/9** green.
- **Not yet exercised end-to-end** (real GitHub + the agent calling the tool) — that needs staging; flagging for review.

Closes: ZAP-521
