### PR TITLE
fix(pivot): carry bin _order column through group_by_query for sort-only dims

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -2818,6 +2818,55 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'dense_rank() over (order by g."amount_binned_amount_order" asc, g."orders_category" desc)',
             );
         });
+
+        test('Should include _order column in group_by_query when sorted bin dimension is a sortOnlyDimension', () => {
+            // A custom bin dimension used as a hidden, sorted pivot column lands
+            // in sortOnlyDimensions. Its _order companion drives the column
+            // ORDER BY, so it must be carried through group_by_query — otherwise
+            // the warehouse errors with "column amount_binned_amount_order does not exist".
+            const itemsMap: ItemsMap = {
+                amount_binned_amount: binDimension,
+            };
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'event_type' }],
+                sortBy: [
+                    {
+                        reference: 'amount_binned_amount',
+                        direction: SortByDirection.DESC,
+                    },
+                ],
+                sortOnlyDimensions: [{ reference: 'amount_binned_amount' }],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+                500,
+                itemsMap,
+            );
+
+            const result = builder.toSql();
+
+            // _order column must be carried through group_by_query SELECT and GROUP BY
+            expect(result).toContain('"amount_binned_amount_order"');
+            expect(replaceWhitespace(result)).toContain(
+                'group by "event_type", "amount_binned_amount", "date", "amount_binned_amount_order"',
+            );
+
+            // column ordering should reference the carried-through _order column
+            expect(result.toLowerCase()).toContain(
+                'g."amount_binned_amount_order" desc',
+            );
+        });
     });
 
     describe('Pivot table calculations referencing metrics not in valuesColumns', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -446,9 +446,13 @@ export class PivotQueryBuilder {
             ...indexColumns.map((col) => `${q}${col.reference}${q}`),
         ];
 
-        // Carry _order columns through for sorted custom bin dimensions
+        // Carry _order columns through for sorted custom bin dimensions.
+        // sortOnlyDimensions must be included: a hidden, sorted custom-bin pivot
+        // column drives the column ORDER BY via its _order companion, so that
+        // column has to survive group_by_query.
         const sortedBinRefs = this.getSortedBinDimensionReferences([
             ...(groupByColumns || []),
+            ...(sortOnlyDimensions || []),
             ...indexColumns,
         ]);
         for (const ref of sortedBinRefs) {


### PR DESCRIPTION
Closes #24559

A custom-bin dimension used as a hidden, sorted pivot column lands in `sortOnlyDimensions`. Its `_order` companion column drives the column `ORDER BY`, but it was never carried through the `group_by_query` CTE, so the warehouse failed with `column "<ref>_order" does not exist`.

`getSortedBinDimensionReferences` was called with `groupByColumns` and `indexColumns` only. This includes `sortOnlyDimensions` too, so the `_order` companion survives `group_by_query`'s SELECT/GROUP BY.

Adding `_order` to the GROUP BY is safe: it is functionally dependent on its bin label and does not change row cardinality.

Added a regression test covering a sorted custom-bin dimension used as a `sortOnlyDimension`.

**Before**
<img width="1219" height="967" alt="CleanShot 2026-06-22 at 12 27 29" src="https://github.com/user-attachments/assets/37ef3d86-ed98-4ab0-b18e-320942b08e39" />


**After**
<img width="1222" height="915" alt="CleanShot 2026-06-22 at 12 26 08" src="https://github.com/user-attachments/assets/8c085b9d-0369-455b-aca1-584f56cd44b2" />
