### PR TITLE
chore: remove ai-agent-suggestions feature flag

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1407,14 +1407,6 @@ export class AiAgentService extends BaseService {
             throw new ForbiddenError('Organization not found');
         }
 
-        const featureEnabled = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.AiAgentSuggestions,
-        });
-        if (!featureEnabled.enabled) {
-            return { chips: [] };
-        }
-
         const agent = await this.getAgent(user, agentUuid, projectUuid);
 
         if (threadUuid) {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -166,14 +166,6 @@ export enum FeatureFlags {
     LockDashboardFilters = 'lock-dashboard-filters',
 
     /**
-     * Show empty-state suggestion chips above the AI agent chat input. Each
-     * chip carries a tool hint that biases the agent toward the implied tool
-     * on the first turn. Gated for staged rollout while we tune the Haiku
-     * prompt and measure click-through.
-     */
-    AiAgentSuggestions = 'ai-agent-suggestions',
-
-    /**
      * Enable the new pivot-column-sort UI: per-pivot-column sort menu on
      * pivot table headers, sort-direction indicators, and the pinned
      * pivot-column entries in the Sort popover. Backend support

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -1,5 +1,4 @@
 import {
-    FeatureFlags,
     type AgentSuggestion,
     type AiPromptContextInput,
     type AiPromptContextItem,
@@ -17,7 +16,6 @@ import { useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { ModelSelector } from '../../../../../components/common/ModelSelector/ModelSelector';
 import useUser from '../../../../../hooks/user/useUser';
-import { useServerFeatureFlag } from '../../../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
@@ -214,18 +212,13 @@ export const AgentChatInput = ({
     );
     const isMinimalMode = !showModelSelector && !showAgentSelector;
 
-    const suggestionsFlag = useServerFeatureFlag(
-        FeatureFlags.AiAgentSuggestions,
-    );
-
     const { emptyStateMode, postResponseMode } = getAgentSuggestionModes({
         disabled,
         isMinimalMode,
         loading,
         messageCount,
         latestAssistantMessageUuid,
-        suggestionsEnabled:
-            showSuggestions && suggestionsFlag.data?.enabled === true,
+        suggestionsEnabled: showSuggestions,
         threadUuid,
     });
 


### PR DESCRIPTION
The flag is enabled for everyone, so remove the gating and keep AI agent suggestions always on. Drops the backend feature-flag check, the frontend useServerFeatureFlag gate, and the FeatureFlags enum entry.


Claude-Session: https://claude.ai/code/session_01KZz4JJirQCPB1RD2LrtfVw

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
