### PR TITLE
feat: route ask ai launcher through ai router

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts
@@ -5,6 +5,7 @@ import { EventName } from '../../../../../types/Events';
 import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
 import { store as aiAgentStore } from '../../store';
 import { openPanel } from '../../store/aiAgentLauncherSlice';
+import { getLauncherAgentUuid } from '../Launcher/launcherAgentSelection';
 import { useDefaultAiAgent } from '../Launcher/useDefaultAiAgent';
 
 type Args = {
@@ -27,14 +28,14 @@ export const useAskAiAgentAction = ({
     clickedFrom,
 }: Args) => {
     const isVisible = useAiAgentButtonVisibility();
-    const { agent } = useDefaultAiAgent(projectUuid);
+    const { selectedAgent } = useDefaultAiAgent(projectUuid);
     const { user } = useApp();
     const { track } = useTracking();
 
-    const canAsk = isVisible && !!agent;
+    const canAsk = isVisible && !!selectedAgent;
 
     const handleClick = () => {
-        if (!agent) return;
+        if (!selectedAgent) return;
         track({
             name: EventName.AI_AGENT_ASK_CLICKED,
             properties: {
@@ -49,7 +50,7 @@ export const useAskAiAgentAction = ({
         aiAgentStore.dispatch(
             openPanel({
                 threadId: null,
-                agentUuid: agent.uuid,
+                agentUuid: getLauncherAgentUuid(selectedAgent),
                 pendingContext,
             }),
         );

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css
@@ -145,3 +145,17 @@
 .minWidth0 {
     min-width: 0;
 }
+
+.candidateContent {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    min-width: 0;
+}
+
+.candidateText {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -10,6 +10,10 @@ import {
     useAiAgentStoreSelector,
 } from '../../store/hooks';
 import styles from './AiAgentsLauncher.module.css';
+import {
+    getLauncherPanelAgent,
+    isLauncherAgentAvailable,
+} from './launcherAgentSelection';
 import { LauncherDock } from './LauncherDock';
 import { LauncherPanel } from './LauncherPanel';
 import { launcherSession } from './launcherSession';
@@ -49,7 +53,7 @@ const AiAgentsLauncherInner: FC = () => {
 
     const isAiAgentEnabled = useAiAgentButtonVisibility();
 
-    const { agents } = useDefaultAiAgent(activeProjectUuid);
+    const { agents, selectedAgent } = useDefaultAiAgent(activeProjectUuid);
 
     const dispatch = useAiAgentStoreDispatch();
     const mode = useAiAgentStoreSelector((state) => state.aiAgentLauncher.mode);
@@ -76,19 +80,27 @@ const AiAgentsLauncherInner: FC = () => {
     // current project, e.g. after a project change while the launcher was hidden.
     useEffect(() => {
         if (!activeAgentUuid || agents.length === 0) return;
-        if (!agents.some((a) => a.uuid === activeAgentUuid)) {
+        if (
+            !isLauncherAgentAvailable({
+                activeAgentUuid,
+                agents,
+                selectedAgent,
+            })
+        ) {
             dispatch(resetActivePanel());
         }
-    }, [activeAgentUuid, agents, dispatch]);
+    }, [activeAgentUuid, agents, dispatch, selectedAgent]);
 
     const isAllowed =
         Boolean(activeProjectUuid) && isAiAgentEnabled && agents.length > 0;
 
     // Only mount the panel when the active agent/thread belongs to this project;
     // mounting an existing-thread panel starts the thread query.
-    const activeAgentBelongsToProject =
-        activeAgentUuid !== null &&
-        agents.some((a) => a.uuid === activeAgentUuid);
+    const activeAgentBelongsToProject = isLauncherAgentAvailable({
+        activeAgentUuid,
+        agents,
+        selectedAgent,
+    });
     const activeThreadBelongsToProject =
         activeThreadId !== null &&
         dock.some((item) => item.threadId === activeThreadId);
@@ -110,8 +122,7 @@ const AiAgentsLauncherInner: FC = () => {
     if (!isAllowed || !activeProjectUuid) return null;
     if (!isPanelOpenSafe && dock.length === 0) return null;
 
-    const panelAgent =
-        agents.find((a) => a.uuid === safeActiveAgentUuid) ?? null;
+    const panelAgent = getLauncherPanelAgent(safeActiveAgentUuid, agents);
 
     return (
         <div className={styles.root}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -1,5 +1,19 @@
-import { type AiAgentSummary } from '@lightdash/common';
-import { Center, Group, Loader, Stack, Text } from '@mantine-8/core';
+import {
+    type AiAgentSummary,
+    type AiPromptContext,
+    type AiPromptContextInput,
+} from '@lightdash/common';
+import {
+    Avatar,
+    Badge,
+    Box,
+    Button,
+    Center,
+    Group,
+    Loader,
+    Stack,
+    Text,
+} from '@mantine-8/core';
 import {
     useCallback,
     useMemo,
@@ -32,20 +46,25 @@ import { getDashboardNavigationUrlFromContentToolResult } from '../../utils/cont
 import { AiAgentNewThreadMcpConnections } from '../AiAgentNewThreadMcpConnections';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { AgentChatInput } from '../ChatElements/AgentChatInput';
-import {
-    contextItemsToContentMentionSuggestions,
-    mergeAiPromptContextInput,
-    mergeAiPromptContextItems,
-} from '../ChatElements/contentMentions';
+import { contextItemsToContentMentionSuggestions } from '../ChatElements/contentMentions';
 import { getPromptContextItemKey } from '../ChatElements/contentReferenceUtils';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import styles from './AiAgentsLauncher.module.css';
+import {
+    getConcreteLauncherAgent,
+    isLauncherAutoAgent,
+    type LauncherSelectedAgent,
+} from './launcherAgentSelection';
 import { PanelHeader } from './PanelHeader';
+import {
+    useAiAgentLauncherRouter,
+    type LauncherRouterCandidate,
+} from './useAiAgentLauncherRouter';
 import { useLauncherDock } from './useLauncherDock';
 
 type Props = {
     projectUuid: string;
-    agent: AiAgentSummary | null;
+    agent: LauncherSelectedAgent;
     agents: AiAgentSummary[];
     activeThreadId: string | null;
     style?: CSSProperties;
@@ -75,7 +94,7 @@ export const LauncherPanel: FC<Props> = ({
         );
     }
 
-    return activeThreadId ? (
+    return activeThreadId && !isLauncherAutoAgent(agent) ? (
         <ExistingThreadPanel
             projectUuid={projectUuid}
             agent={agent}
@@ -95,7 +114,7 @@ export const LauncherPanel: FC<Props> = ({
 
 const NewThreadPanel: FC<{
     projectUuid: string;
-    agent: AiAgentSummary;
+    agent: NonNullable<LauncherSelectedAgent>;
     agents: AiAgentSummary[];
     style?: CSSProperties;
 }> = ({ projectUuid, agent, agents, style }) => {
@@ -109,6 +128,8 @@ const NewThreadPanel: FC<{
     const dashboardUuid = pendingContext?.dashboardUuid;
 
     const { addItem: addDockItem } = useLauncherDock(projectUuid);
+    const isAuto = isLauncherAutoAgent(agent);
+    const concreteAgent = getConcreteLauncherAgent(agent);
 
     const {
         contextInput,
@@ -148,13 +169,13 @@ const NewThreadPanel: FC<{
             onCreated: (thread) => {
                 addDockItem({
                     threadId: thread.uuid,
-                    agentUuid: agent.uuid,
+                    agentUuid: thread.agentUuid,
                     title: thread.firstMessage.message,
                 });
                 dispatch(
                     openPanel({
                         threadId: thread.uuid,
-                        agentUuid: agent.uuid,
+                        agentUuid: thread.agentUuid,
                     }),
                 );
                 // Seed the per-thread mode slice with the user's choice so
@@ -169,32 +190,52 @@ const NewThreadPanel: FC<{
             onToolResult: handleToolResult,
         });
 
-    const handleSubmit = ({
-        message,
-        toolHints,
-        context,
-        optimisticContext,
-    }: {
-        message: string;
-        toolHints: string[];
-        context?: typeof contextInput;
-        optimisticContext?: typeof previewItems;
-    }) => {
-        if (!isPinnedContextReady) return;
-        const mergedContext = mergeAiPromptContextInput(contextInput, context);
-        const mergedOptimisticContext = mergeAiPromptContextItems(
-            previewItems,
+    const createThreadForAgent = useCallback(
+        async ({
+            agentUuid,
+            context,
+            message,
             optimisticContext,
-        );
-        void createAgentThread({
-            agentUuid: agent.uuid,
-            prompt: message,
-            context: mergedContext,
-            optimisticContext: mergedOptimisticContext,
-            enableSqlMode: sqlModeAvailable && sqlMode,
             toolHints,
-        });
-    };
+        }: {
+            agentUuid: string;
+            context?: AiPromptContextInput;
+            message: string;
+            optimisticContext?: AiPromptContext;
+            toolHints: string[];
+        }) => {
+            return createAgentThread({
+                agentUuid,
+                prompt: message,
+                context,
+                optimisticContext,
+                enableSqlMode: sqlModeAvailable && sqlMode,
+                toolHints,
+            });
+        },
+        [createAgentThread, sqlMode, sqlModeAvailable],
+    );
+
+    const {
+        confirmPick,
+        handleSubmit,
+        isLocked,
+        isPickingAgent,
+        sortedCandidates,
+    } = useAiAgentLauncherRouter({
+        agent,
+        agents,
+        contextInput,
+        createThreadForAgent,
+        isCreatingThread,
+        isPinnedContextReady,
+        previewItems,
+        projectUuid,
+    });
+    const displayName = isAuto ? 'Auto' : agent.name;
+    const description = isAuto
+        ? 'Routes each new question to the best-fit agent'
+        : agent.description;
 
     return (
         <div className={styles.panel} style={style}>
@@ -202,7 +243,7 @@ const NewThreadPanel: FC<{
                 projectUuid={projectUuid}
                 agent={agent}
                 agents={agents}
-                title={agent.name}
+                title={displayName}
                 threadId={null}
             />
             <div className={styles.panelBody}>
@@ -213,27 +254,37 @@ const NewThreadPanel: FC<{
                     gap="xs"
                     px="md"
                 >
-                    <LightdashUserAvatar
-                        size="lg"
-                        name={agent.name}
-                        src={agent.imageUrl}
-                    />
+                    {isAuto ? (
+                        <Avatar size="lg" color="ldGray" radius="xl">
+                            <Text size="sm" fw={700} c="ldGray.6">
+                                AI
+                            </Text>
+                        </Avatar>
+                    ) : (
+                        <LightdashUserAvatar
+                            size="lg"
+                            name={agent.name}
+                            src={agent.imageUrl}
+                        />
+                    )}
                     <Text size="sm" fw={500}>
-                        {agent.name}
+                        {displayName}
                     </Text>
-                    {agent.description && (
+                    {description && (
                         <Text size="xs" c="dimmed" ta="center" maw={360}>
-                            {agent.description}
+                            {description}
                         </Text>
                     )}
                 </Stack>
-                <Stack px="md" pb="xs">
-                    <AiAgentNewThreadMcpConnections
-                        projectUuid={projectUuid}
-                        agentUuid={agent.uuid}
-                        onSuggestedPrompt={setComposerSeed}
-                    />
-                </Stack>
+                {concreteAgent && (
+                    <Stack px="md" pb="xs">
+                        <AiAgentNewThreadMcpConnections
+                            projectUuid={projectUuid}
+                            agentUuid={concreteAgent.uuid}
+                            onSuggestedPrompt={setComposerSeed}
+                        />
+                    </Stack>
+                )}
                 {previewItems.length > 0 && (
                     <Stack gap="xxs" px="md" pb="xs">
                         <Text size="xs" fw={600} c="dimmed" tt="uppercase">
@@ -250,15 +301,21 @@ const NewThreadPanel: FC<{
                         </Group>
                     </Stack>
                 )}
+                {isPickingAgent && (
+                    <LauncherAgentPicker
+                        candidates={sortedCandidates}
+                        onPick={confirmPick}
+                    />
+                )}
                 <AgentChatInput
                     key={composerSeed ?? 'composer'}
                     defaultValue={composerSeed ?? undefined}
                     onSubmit={handleSubmit}
-                    loading={isCreatingThread}
-                    disabled={!isPinnedContextReady}
-                    placeholder={`Ask ${agent.name} anything...`}
+                    loading={isLocked}
+                    disabled={!isPinnedContextReady || isPickingAgent}
+                    placeholder={`Ask ${displayName} anything...`}
                     projectUuid={projectUuid}
-                    agentUuid={agent.uuid}
+                    agentUuid={concreteAgent?.uuid}
                     fullWidth
                     sqlMode={sqlModeAvailable ? sqlMode : undefined}
                     onSqlModeChange={sqlModeAvailable ? setSqlMode : undefined}
@@ -268,6 +325,50 @@ const NewThreadPanel: FC<{
         </div>
     );
 };
+
+const LauncherAgentPicker: FC<{
+    candidates: LauncherRouterCandidate[];
+    onPick: (agentUuid: string) => void;
+}> = ({ candidates, onPick }) => (
+    <Stack gap="xs" px="md" pb="xs">
+        <Text size="xs" fw={600} c="dimmed" tt="uppercase">
+            Choose agent
+        </Text>
+        <Stack gap="xxs">
+            {candidates.map((candidate) => (
+                <Button
+                    key={candidate.agentUuid}
+                    variant="default"
+                    justify="start"
+                    leftSection={
+                        <LightdashUserAvatar
+                            size="xs"
+                            name={candidate.name}
+                            src={candidate.agent?.imageUrl}
+                        />
+                    }
+                    onClick={() => onPick(candidate.agentUuid)}
+                >
+                    <Box className={styles.candidateContent}>
+                        <Box className={styles.candidateText}>
+                            {candidate.name}
+                        </Box>
+                        {candidate.isRecommended && (
+                            <Badge
+                                size="xs"
+                                color="violet"
+                                variant="light"
+                                radius="sm"
+                            >
+                                Recommended
+                            </Badge>
+                        )}
+                    </Box>
+                </Button>
+            ))}
+        </Stack>
+    </Stack>
+);
 
 const ExistingThreadPanel: FC<{
     projectUuid: string;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx
@@ -1,5 +1,12 @@
 import { type AiAgentSummary } from '@lightdash/common';
-import { ActionIcon, Group, Menu, Text, UnstyledButton } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Avatar,
+    Group,
+    Menu,
+    Text,
+    UnstyledButton,
+} from '@mantine-8/core';
 import {
     IconCheck,
     IconChevronDown,
@@ -10,17 +17,27 @@ import { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiRouterConfig } from '../../hooks/useAiRouter';
 import { closePanel, openPanel } from '../../store/aiAgentLauncherSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import {
+    AI_ROUTING_AUTO_VALUE,
+    AI_ROUTING_SEARCH_PARAM,
+} from '../AgentSelector/AgentSelectorUtils';
 import styles from './AiAgentsLauncher.module.css';
+import {
+    getConcreteLauncherAgent,
+    isLauncherAutoAgent,
+    LAUNCHER_AUTO_AGENT,
+} from './launcherAgentSelection';
 import { launcherSession } from './launcherSession';
 
 type Props = {
     projectUuid: string;
-    agent: AiAgentSummary | null;
+    agent: AiAgentSummary | typeof LAUNCHER_AUTO_AGENT | null;
     agents: AiAgentSummary[];
     title: string;
     threadId: string | null;
@@ -38,8 +55,14 @@ export const PanelHeader: FC<Props> = ({
     const pendingContext = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.pendingContext,
     );
+    const { data: aiRouterConfig } = useAiRouterConfig();
+    const isAuto = isLauncherAutoAgent(agent);
+    const showAutoOption =
+        agents.length > 1 && aiRouterConfig?.enabled === true;
+    const selectedAgentUuid = getConcreteLauncherAgent(agent)?.uuid ?? null;
 
-    const canSwitchAgent = threadId === null && agents.length > 1;
+    const canSwitchAgent =
+        threadId === null && (agents.length > 1 || showAutoOption);
 
     const handleClose = () => dispatch(closePanel());
     const handleSwitchAgent = (nextAgentUuid: string) => {
@@ -56,6 +79,7 @@ export const PanelHeader: FC<Props> = ({
         launcherSession.markExpandedFromBubble();
         let target;
         if (threadId) {
+            if (isAuto) return;
             target = `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads/${threadId}`;
         } else {
             const params = new URLSearchParams();
@@ -65,10 +89,15 @@ export const PanelHeader: FC<Props> = ({
             if (pendingContext?.dashboardUuid) {
                 params.set('dashboardUuid', pendingContext.dashboardUuid);
             }
+            if (isAuto) {
+                params.set(AI_ROUTING_SEARCH_PARAM, AI_ROUTING_AUTO_VALUE);
+            }
             const search = params.toString();
-            target = `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads${
-                search ? `?${search}` : ''
-            }`;
+            target = isAuto
+                ? `/projects/${projectUuid}/ai-agents${search ? `?${search}` : ''}`
+                : `/projects/${projectUuid}/ai-agents/${agent.uuid}/threads${
+                      search ? `?${search}` : ''
+                  }`;
         }
         dispatch(closePanel());
         void navigate(target);
@@ -82,11 +111,27 @@ export const PanelHeader: FC<Props> = ({
                         <Menu.Target>
                             <UnstyledButton aria-label="Switch agent">
                                 <Group gap="xs" wrap="nowrap">
-                                    <LightdashUserAvatar
-                                        size="sm"
-                                        name={agent?.name ?? 'AI'}
-                                        src={agent?.imageUrl}
-                                    />
+                                    {isAuto ? (
+                                        <Avatar
+                                            size="sm"
+                                            color="ldGray"
+                                            radius="xl"
+                                        >
+                                            <Text
+                                                size="10px"
+                                                fw={700}
+                                                c="ldGray.6"
+                                            >
+                                                AI
+                                            </Text>
+                                        </Avatar>
+                                    ) : (
+                                        <LightdashUserAvatar
+                                            size="sm"
+                                            name={agent?.name ?? 'AI'}
+                                            src={agent?.imageUrl}
+                                        />
+                                    )}
                                     <Text
                                         size="sm"
                                         fw={500}
@@ -103,6 +148,35 @@ export const PanelHeader: FC<Props> = ({
                             </UnstyledButton>
                         </Menu.Target>
                         <Menu.Dropdown>
+                            {showAutoOption && (
+                                <Menu.Item
+                                    leftSection={
+                                        <Avatar
+                                            size="xs"
+                                            color="ldGray"
+                                            radius="xl"
+                                        >
+                                            <Text
+                                                size="9px"
+                                                fw={700}
+                                                c="ldGray.6"
+                                            >
+                                                AI
+                                            </Text>
+                                        </Avatar>
+                                    }
+                                    rightSection={
+                                        isAuto ? (
+                                            <MantineIcon icon={IconCheck} />
+                                        ) : null
+                                    }
+                                    onClick={() =>
+                                        handleSwitchAgent(LAUNCHER_AUTO_AGENT)
+                                    }
+                                >
+                                    Auto
+                                </Menu.Item>
+                            )}
                             {agents.map((a) => (
                                 <Menu.Item
                                     key={a.uuid}
@@ -114,7 +188,7 @@ export const PanelHeader: FC<Props> = ({
                                         />
                                     }
                                     rightSection={
-                                        a.uuid === agent?.uuid ? (
+                                        a.uuid === selectedAgentUuid ? (
                                             <MantineIcon icon={IconCheck} />
                                         ) : null
                                     }
@@ -127,11 +201,19 @@ export const PanelHeader: FC<Props> = ({
                     </Menu>
                 ) : (
                     <Group gap="xs" wrap="nowrap" className={styles.minWidth0}>
-                        <LightdashUserAvatar
-                            size="sm"
-                            name={agent?.name ?? 'AI'}
-                            src={agent?.imageUrl}
-                        />
+                        {isAuto ? (
+                            <Avatar size="sm" color="ldGray" radius="xl">
+                                <Text size="10px" fw={700} c="ldGray.6">
+                                    AI
+                                </Text>
+                            </Avatar>
+                        ) : (
+                            <LightdashUserAvatar
+                                size="sm"
+                                name={agent?.name ?? 'AI'}
+                                src={agent?.imageUrl}
+                            />
+                        )}
                         <Text
                             size="sm"
                             fw={500}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/launcherAgentSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/launcherAgentSelection.ts
@@ -1,0 +1,64 @@
+import { type AiAgentSummary } from '@lightdash/common';
+
+export const LAUNCHER_AUTO_AGENT = '__auto__';
+export type LauncherActiveAgentUuid = string;
+export type LauncherSelectedAgent =
+    | AiAgentSummary
+    | typeof LAUNCHER_AUTO_AGENT
+    | null;
+
+export const isLauncherAutoAgent = (
+    agent: unknown,
+): agent is typeof LAUNCHER_AUTO_AGENT => agent === LAUNCHER_AUTO_AGENT;
+
+export const getLauncherAgentUuid = (agent: LauncherSelectedAgent) => {
+    if (!agent) return null;
+    return isLauncherAutoAgent(agent) ? LAUNCHER_AUTO_AGENT : agent.uuid;
+};
+
+export const getConcreteLauncherAgent = (agent: LauncherSelectedAgent) =>
+    agent && !isLauncherAutoAgent(agent) ? agent : null;
+
+export const resolveLauncherDefaultAgent = ({
+    agents,
+    defaultAgentUuid,
+    isRouterEnabled,
+    isRouterLoading,
+}: {
+    agents: AiAgentSummary[] | undefined;
+    defaultAgentUuid: string | undefined;
+    isRouterEnabled: boolean;
+    isRouterLoading: boolean;
+}): LauncherSelectedAgent => {
+    if (!agents || agents.length === 0) return null;
+    const defaultAgent = agents.find((a) => a.uuid === defaultAgentUuid);
+    if (defaultAgent) return defaultAgent;
+    if (agents.length > 1 && isRouterLoading) return null;
+    if (agents.length > 1 && isRouterEnabled) return LAUNCHER_AUTO_AGENT;
+    return agents[0];
+};
+
+export const isLauncherAgentAvailable = ({
+    activeAgentUuid,
+    agents,
+    selectedAgent,
+}: {
+    activeAgentUuid: LauncherActiveAgentUuid | null;
+    agents: AiAgentSummary[];
+    selectedAgent: LauncherSelectedAgent;
+}) => {
+    if (!activeAgentUuid) return false;
+    if (isLauncherAutoAgent(activeAgentUuid)) {
+        return isLauncherAutoAgent(selectedAgent);
+    }
+    return agents.some((a) => a.uuid === activeAgentUuid);
+};
+
+export const getLauncherPanelAgent = (
+    activeAgentUuid: LauncherActiveAgentUuid | null,
+    agents: AiAgentSummary[],
+): LauncherSelectedAgent => {
+    if (!activeAgentUuid) return null;
+    if (isLauncherAutoAgent(activeAgentUuid)) return LAUNCHER_AUTO_AGENT;
+    return agents.find((a) => a.uuid === activeAgentUuid) ?? null;
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts
@@ -1,0 +1,278 @@
+import {
+    type AiAgentSummary,
+    type AiPromptContext,
+    type AiPromptContextInput,
+    type AiRouterDecisionCandidate,
+    type AiRouterRouteResponseResult,
+} from '@lightdash/common';
+import { useCallback, useMemo, useReducer } from 'react';
+import { useAiRouterCommit, useAiRouterRoute } from '../../hooks/useAiRouter';
+import {
+    mergeAiPromptContextInput,
+    mergeAiPromptContextItems,
+} from '../ChatElements/contentMentions';
+import {
+    isLauncherAutoAgent,
+    type LauncherSelectedAgent,
+} from './launcherAgentSelection';
+
+type LauncherRouterPhase =
+    | { kind: 'idle' }
+    | { kind: 'routing' }
+    | { kind: 'creating' }
+    | {
+          kind: 'picker';
+          context?: AiPromptContextInput;
+          decision: AiRouterRouteResponseResult;
+          optimisticContext?: AiPromptContext;
+          prompt: string;
+          toolHints: string[];
+      };
+
+type LauncherRouterAction =
+    | { type: 'idle' }
+    | { type: 'routing' }
+    | { type: 'creating' }
+    | {
+          type: 'picker';
+          context?: AiPromptContextInput;
+          decision: AiRouterRouteResponseResult;
+          optimisticContext?: AiPromptContext;
+          prompt: string;
+          toolHints: string[];
+      };
+
+type SubmitArgs = {
+    message: string;
+    toolHints: string[];
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContext;
+};
+
+type CreateThreadForAgent = (args: {
+    agentUuid: string;
+    context?: AiPromptContextInput;
+    message: string;
+    optimisticContext?: AiPromptContext;
+    toolHints: string[];
+}) => Promise<{ uuid: string }>;
+
+export type LauncherRouterCandidate = AiRouterDecisionCandidate & {
+    agent: AiAgentSummary | undefined;
+    isRecommended: boolean;
+};
+
+const launcherRouterReducer = (
+    phase: LauncherRouterPhase,
+    action: LauncherRouterAction,
+): LauncherRouterPhase => {
+    switch (action.type) {
+        case 'idle':
+            return { kind: 'idle' };
+        case 'routing':
+            return { kind: 'routing' };
+        case 'creating':
+            return { kind: 'creating' };
+        case 'picker':
+            return {
+                kind: 'picker',
+                context: action.context,
+                decision: action.decision,
+                optimisticContext: action.optimisticContext,
+                prompt: action.prompt,
+                toolHints: action.toolHints,
+            };
+        default:
+            return phase;
+    }
+};
+
+export const useAiAgentLauncherRouter = ({
+    agent,
+    agents,
+    contextInput,
+    createThreadForAgent,
+    isCreatingThread,
+    isPinnedContextReady,
+    previewItems,
+    projectUuid,
+}: {
+    agent: NonNullable<LauncherSelectedAgent>;
+    agents: AiAgentSummary[];
+    contextInput: AiPromptContextInput;
+    createThreadForAgent: CreateThreadForAgent;
+    isCreatingThread: boolean;
+    isPinnedContextReady: boolean;
+    previewItems: AiPromptContext;
+    projectUuid: string;
+}) => {
+    const [routerPhase, dispatch] = useReducer(launcherRouterReducer, {
+        kind: 'idle',
+    });
+    const { mutateAsync: routePrompt } = useAiRouterRoute();
+    const { mutate: commitDecisionMutate } = useAiRouterCommit();
+    const agentsByUuid = useMemo(
+        () => new Map(agents.map((candidate) => [candidate.uuid, candidate])),
+        [agents],
+    );
+
+    const createAndCommitThread = useCallback(
+        async ({
+            agentUuid,
+            context,
+            decisionUuid,
+            message,
+            optimisticContext,
+            toolHints,
+        }: {
+            agentUuid: string;
+            context?: AiPromptContextInput;
+            decisionUuid?: string;
+            message: string;
+            optimisticContext?: AiPromptContext;
+            toolHints: string[];
+        }) => {
+            dispatch({ type: decisionUuid ? 'creating' : 'idle' });
+            const thread = await createThreadForAgent({
+                agentUuid,
+                context,
+                message,
+                optimisticContext,
+                toolHints,
+            });
+            if (decisionUuid) {
+                commitDecisionMutate({
+                    decisionUuid,
+                    chosenAgentUuid: agentUuid,
+                    threadUuid: thread.uuid,
+                });
+            }
+        },
+        [commitDecisionMutate, createThreadForAgent],
+    );
+
+    const handleSubmit = useCallback(
+        async ({
+            message,
+            toolHints,
+            context,
+            optimisticContext,
+        }: SubmitArgs) => {
+            if (!isPinnedContextReady) return;
+
+            const mergedContext = mergeAiPromptContextInput(
+                contextInput,
+                context,
+            );
+            const mergedOptimisticContext = mergeAiPromptContextItems(
+                previewItems,
+                optimisticContext,
+            );
+
+            if (!isLauncherAutoAgent(agent)) {
+                void createAndCommitThread({
+                    agentUuid: agent.uuid,
+                    message,
+                    context: mergedContext,
+                    optimisticContext: mergedOptimisticContext,
+                    toolHints,
+                });
+                return;
+            }
+
+            dispatch({ type: 'routing' });
+            try {
+                const result = await routePrompt({
+                    prompt: message,
+                    projectUuid,
+                });
+                if (result.nextAction === 'create_thread') {
+                    await createAndCommitThread({
+                        agentUuid: result.decision.suggestedAgentUuid,
+                        decisionUuid: result.decision.decisionUuid,
+                        message,
+                        context: mergedContext,
+                        optimisticContext: mergedOptimisticContext,
+                        toolHints,
+                    });
+                } else {
+                    dispatch({
+                        type: 'picker',
+                        context: mergedContext,
+                        decision: result,
+                        optimisticContext: mergedOptimisticContext,
+                        prompt: message,
+                        toolHints,
+                    });
+                }
+            } catch {
+                const fallback = agents[0];
+                dispatch({ type: 'idle' });
+                if (fallback) {
+                    void createAndCommitThread({
+                        agentUuid: fallback.uuid,
+                        message,
+                        context: mergedContext,
+                        optimisticContext: mergedOptimisticContext,
+                        toolHints,
+                    });
+                }
+            }
+        },
+        [
+            agent,
+            agents,
+            contextInput,
+            createAndCommitThread,
+            isPinnedContextReady,
+            previewItems,
+            projectUuid,
+            routePrompt,
+        ],
+    );
+
+    const confirmPick = useCallback(
+        (agentUuid: string) => {
+            if (routerPhase.kind !== 'picker') return;
+            void createAndCommitThread({
+                agentUuid,
+                context: routerPhase.context,
+                decisionUuid: routerPhase.decision.decision.decisionUuid,
+                message: routerPhase.prompt,
+                optimisticContext: routerPhase.optimisticContext,
+                toolHints: routerPhase.toolHints,
+            });
+        },
+        [createAndCommitThread, routerPhase],
+    );
+
+    const sortedCandidates = useMemo<LauncherRouterCandidate[]>(() => {
+        if (routerPhase.kind !== 'picker') return [];
+        const { candidates, suggestedAgentUuid } =
+            routerPhase.decision.decision;
+        return [...candidates]
+            .sort((a, b) => {
+                if (a.agentUuid === suggestedAgentUuid) return -1;
+                if (b.agentUuid === suggestedAgentUuid) return 1;
+                return 0;
+            })
+            .map((candidate) => ({
+                ...candidate,
+                agent: agentsByUuid.get(candidate.agentUuid),
+                isRecommended: candidate.agentUuid === suggestedAgentUuid,
+            }));
+    }, [agentsByUuid, routerPhase]);
+
+    const isRouting = routerPhase.kind === 'routing';
+    const isCreating = routerPhase.kind === 'creating';
+    const isPickingAgent = routerPhase.kind === 'picker';
+
+    return {
+        confirmPick,
+        handleSubmit,
+        isLocked: isCreatingThread || isRouting || isCreating,
+        isPickingAgent,
+        isRouting,
+        sortedCandidates,
+    };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 import { useAiOrganizationSettings } from '../../hooks/useAiOrganizationSettings';
+import { useAiRouterConfig } from '../../hooks/useAiRouter';
 import { useProjectAiAgents } from '../../hooks/useProjectAiAgents';
 import { useGetUserAgentPreferences } from '../../hooks/useUserAgentPreferences';
+import {
+    getConcreteLauncherAgent,
+    resolveLauncherDefaultAgent,
+} from './launcherAgentSelection';
 
 export const useDefaultAiAgent = (projectUuid: string | undefined) => {
     const aiOrganizationSettingsQuery = useAiOrganizationSettings();
@@ -15,14 +20,27 @@ export const useDefaultAiAgent = (projectUuid: string | undefined) => {
         redirectOnUnauthorized: false,
     });
     const { data: preferences } = useGetUserAgentPreferences(projectUuid);
+    const aiRouterConfigQuery = useAiRouterConfig();
 
-    const agent = useMemo(() => {
-        if (!agents || agents.length === 0) return null;
-        return (
-            agents.find((a) => a.uuid === preferences?.defaultAgentUuid) ??
-            agents[0]
-        );
-    }, [agents, preferences?.defaultAgentUuid]);
+    const selectedAgent = useMemo(
+        () =>
+            resolveLauncherDefaultAgent({
+                agents,
+                defaultAgentUuid: preferences?.defaultAgentUuid,
+                isRouterEnabled: aiRouterConfigQuery.data?.enabled === true,
+                isRouterLoading: aiRouterConfigQuery.isLoading,
+            }),
+        [
+            agents,
+            aiRouterConfigQuery.data?.enabled,
+            aiRouterConfigQuery.isLoading,
+            preferences?.defaultAgentUuid,
+        ],
+    );
 
-    return { agent, agents: agents ?? [] };
+    return {
+        agent: getConcreteLauncherAgent(selectedAgent),
+        selectedAgent,
+        agents: agents ?? [],
+    };
 };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { type LauncherActiveAgentUuid } from '../components/Launcher/launcherAgentSelection';
 
 export type LauncherDockItem = {
     threadId: string;
@@ -29,7 +30,7 @@ type LauncherMode = 'collapsed' | 'panel-open';
 export interface AiAgentLauncherState {
     mode: LauncherMode;
     activeThreadId: string | null;
-    activeAgentUuid: string | null;
+    activeAgentUuid: LauncherActiveAgentUuid | null;
     pendingContext: LauncherPendingContext | null;
     currentDashboard: LauncherCurrentDashboard | null;
     dashboardRefreshRequest: DashboardRefreshRequest | null;
@@ -52,7 +53,7 @@ export const aiAgentLauncherSlice = createSlice({
             state,
             action: PayloadAction<{
                 threadId: string | null;
-                agentUuid: string | null;
+                agentUuid: LauncherActiveAgentUuid | null;
                 pendingContext?: LauncherPendingContext | null;
             }>,
         ) => {


### PR DESCRIPTION
## Summary
- add Auto as the launcher default when router is enabled and no favorite exists
- route Auto launcher submissions through the AI router
- show the router picker and Recommended badge in the bubble launcher

## Testing
- pnpm -F frontend run linter src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts src/ee/features/aiCopilot/components/Launcher/launcherAgentSelection.ts src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts
- pnpm -F frontend exec oxfmt src/ee/features/aiCopilot/components/AskAiAgentMenuItem/useAskAiAgentAction.ts src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx src/ee/features/aiCopilot/components/Launcher/PanelHeader.tsx src/ee/features/aiCopilot/components/Launcher/useDefaultAiAgent.ts src/ee/features/aiCopilot/components/Launcher/launcherAgentSelection.ts src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts src/ee/features/aiCopilot/store/aiAgentLauncherSlice.ts --check
- git diff --check
- pnpm -F frontend typecheck:fast (fails on existing ThreadPreviewSidebar.test.tsx matcher typings)

Closes: ZAP-494