### PR TITLE
fix: share ai agent router flow

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts
@@ -2,11 +2,12 @@ import {
     type AiAgentSummary,
     type AiPromptContext,
     type AiPromptContextInput,
-    type AiRouterDecisionCandidate,
-    type AiRouterRouteResponseResult,
 } from '@lightdash/common';
-import { useCallback, useMemo, useReducer } from 'react';
-import { useAiRouterCommit, useAiRouterRoute } from '../../hooks/useAiRouter';
+import { useCallback } from 'react';
+import {
+    useAiAgentRouterFlow,
+    type AiAgentRouterCandidate,
+} from '../../hooks/useAiAgentRouterFlow';
 import {
     mergeAiPromptContextInput,
     mergeAiPromptContextItems,
@@ -15,32 +16,6 @@ import {
     isLauncherAutoAgent,
     type LauncherSelectedAgent,
 } from './launcherAgentSelection';
-
-type LauncherRouterPhase =
-    | { kind: 'idle' }
-    | { kind: 'routing' }
-    | { kind: 'creating' }
-    | {
-          kind: 'picker';
-          context?: AiPromptContextInput;
-          decision: AiRouterRouteResponseResult;
-          optimisticContext?: AiPromptContext;
-          prompt: string;
-          toolHints: string[];
-      };
-
-type LauncherRouterAction =
-    | { type: 'idle' }
-    | { type: 'routing' }
-    | { type: 'creating' }
-    | {
-          type: 'picker';
-          context?: AiPromptContextInput;
-          decision: AiRouterRouteResponseResult;
-          optimisticContext?: AiPromptContext;
-          prompt: string;
-          toolHints: string[];
-      };
 
 type SubmitArgs = {
     message: string;
@@ -57,35 +32,7 @@ type CreateThreadForAgent = (args: {
     toolHints: string[];
 }) => Promise<{ uuid: string }>;
 
-export type LauncherRouterCandidate = AiRouterDecisionCandidate & {
-    agent: AiAgentSummary | undefined;
-    isRecommended: boolean;
-};
-
-const launcherRouterReducer = (
-    phase: LauncherRouterPhase,
-    action: LauncherRouterAction,
-): LauncherRouterPhase => {
-    switch (action.type) {
-        case 'idle':
-            return { kind: 'idle' };
-        case 'routing':
-            return { kind: 'routing' };
-        case 'creating':
-            return { kind: 'creating' };
-        case 'picker':
-            return {
-                kind: 'picker',
-                context: action.context,
-                decision: action.decision,
-                optimisticContext: action.optimisticContext,
-                prompt: action.prompt,
-                toolHints: action.toolHints,
-            };
-        default:
-            return phase;
-    }
-};
+export type LauncherRouterCandidate = AiAgentRouterCandidate;
 
 export const useAiAgentLauncherRouter = ({
     agent,
@@ -106,50 +53,26 @@ export const useAiAgentLauncherRouter = ({
     previewItems: AiPromptContext;
     projectUuid: string;
 }) => {
-    const [routerPhase, dispatch] = useReducer(launcherRouterReducer, {
-        kind: 'idle',
-    });
-    const { mutateAsync: routePrompt } = useAiRouterRoute();
-    const { mutate: commitDecisionMutate } = useAiRouterCommit();
-    const agentsByUuid = useMemo(
-        () => new Map(agents.map((candidate) => [candidate.uuid, candidate])),
-        [agents],
-    );
-
-    const createAndCommitThread = useCallback(
-        async ({
-            agentUuid,
-            context,
-            decisionUuid,
-            message,
-            optimisticContext,
-            toolHints,
-        }: {
-            agentUuid: string;
-            context?: AiPromptContextInput;
-            decisionUuid?: string;
-            message: string;
-            optimisticContext?: AiPromptContext;
-            toolHints: string[];
-        }) => {
-            dispatch({ type: decisionUuid ? 'creating' : 'idle' });
-            const thread = await createThreadForAgent({
-                agentUuid,
-                context,
-                message,
-                optimisticContext,
-                toolHints,
-            });
-            if (decisionUuid) {
-                commitDecisionMutate({
-                    decisionUuid,
-                    chosenAgentUuid: agentUuid,
-                    threadUuid: thread.uuid,
+    const {
+        confirmPick,
+        handleSubmit: handleRouterSubmit,
+        isLocked,
+        isPickingAgent,
+        isRouting,
+        sortedCandidates,
+    } = useAiAgentRouterFlow({
+        agents,
+        createThreadForAgent,
+        onRouteError: ({ fallbackAgent, ...args }) => {
+            if (fallbackAgent) {
+                void createThreadForAgent({
+                    ...args,
+                    agentUuid: fallbackAgent.uuid,
                 });
             }
         },
-        [commitDecisionMutate, createThreadForAgent],
-    );
+        projectUuid,
+    });
 
     const handleSubmit = useCallback(
         async ({
@@ -170,7 +93,7 @@ export const useAiAgentLauncherRouter = ({
             );
 
             if (!isLauncherAutoAgent(agent)) {
-                void createAndCommitThread({
+                void createThreadForAgent({
                     agentUuid: agent.uuid,
                     message,
                     context: mergedContext,
@@ -180,97 +103,27 @@ export const useAiAgentLauncherRouter = ({
                 return;
             }
 
-            dispatch({ type: 'routing' });
-            try {
-                const result = await routePrompt({
-                    prompt: message,
-                    projectUuid,
-                });
-                if (result.nextAction === 'create_thread') {
-                    await createAndCommitThread({
-                        agentUuid: result.decision.suggestedAgentUuid,
-                        decisionUuid: result.decision.decisionUuid,
-                        message,
-                        context: mergedContext,
-                        optimisticContext: mergedOptimisticContext,
-                        toolHints,
-                    });
-                } else {
-                    dispatch({
-                        type: 'picker',
-                        context: mergedContext,
-                        decision: result,
-                        optimisticContext: mergedOptimisticContext,
-                        prompt: message,
-                        toolHints,
-                    });
-                }
-            } catch {
-                const fallback = agents[0];
-                dispatch({ type: 'idle' });
-                if (fallback) {
-                    void createAndCommitThread({
-                        agentUuid: fallback.uuid,
-                        message,
-                        context: mergedContext,
-                        optimisticContext: mergedOptimisticContext,
-                        toolHints,
-                    });
-                }
-            }
+            void handleRouterSubmit({
+                message,
+                context: mergedContext,
+                optimisticContext: mergedOptimisticContext,
+                toolHints,
+            });
         },
         [
             agent,
-            agents,
             contextInput,
-            createAndCommitThread,
+            createThreadForAgent,
+            handleRouterSubmit,
             isPinnedContextReady,
             previewItems,
-            projectUuid,
-            routePrompt,
         ],
     );
-
-    const confirmPick = useCallback(
-        (agentUuid: string) => {
-            if (routerPhase.kind !== 'picker') return;
-            void createAndCommitThread({
-                agentUuid,
-                context: routerPhase.context,
-                decisionUuid: routerPhase.decision.decision.decisionUuid,
-                message: routerPhase.prompt,
-                optimisticContext: routerPhase.optimisticContext,
-                toolHints: routerPhase.toolHints,
-            });
-        },
-        [createAndCommitThread, routerPhase],
-    );
-
-    const sortedCandidates = useMemo<LauncherRouterCandidate[]>(() => {
-        if (routerPhase.kind !== 'picker') return [];
-        const { candidates, suggestedAgentUuid } =
-            routerPhase.decision.decision;
-        return [...candidates]
-            .sort((a, b) => {
-                if (a.agentUuid === suggestedAgentUuid) return -1;
-                if (b.agentUuid === suggestedAgentUuid) return 1;
-                return 0;
-            })
-            .map((candidate) => ({
-                ...candidate,
-                agent: agentsByUuid.get(candidate.agentUuid),
-                isRecommended: candidate.agentUuid === suggestedAgentUuid,
-            }));
-    }, [agentsByUuid, routerPhase]);
-
-    const isRouting = routerPhase.kind === 'routing';
-    const isCreating = routerPhase.kind === 'creating';
-    const isPickingAgent = routerPhase.kind === 'picker';
 
     return {
         confirmPick,
         handleSubmit,
-        isLocked: isCreatingThread || isRouting || isCreating,
+        isLocked: isCreatingThread || isLocked,
         isPickingAgent,
         isRouting,
         sortedCandidates,

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentRouterFlow.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentRouterFlow.ts
@@ -1,0 +1,232 @@
+import {
+    type AiAgentSummary,
+    type AiPromptContext,
+    type AiPromptContextInput,
+    type AiRouterDecisionCandidate,
+    type AiRouterRouteResponseResult,
+} from '@lightdash/common';
+import { useCallback, useMemo, useReducer } from 'react';
+import { useAiRouterCommit, useAiRouterRoute } from './useAiRouter';
+
+type AiAgentRouterPhase =
+    | { kind: 'idle' }
+    | { kind: 'routing' }
+    | { kind: 'creating' }
+    | {
+          kind: 'picker';
+          context?: AiPromptContextInput;
+          decision: AiRouterRouteResponseResult;
+          optimisticContext?: AiPromptContext;
+          prompt: string;
+          toolHints: string[];
+      };
+
+type AiAgentRouterAction =
+    | { type: 'idle' }
+    | { type: 'routing' }
+    | { type: 'creating' }
+    | {
+          type: 'picker';
+          context?: AiPromptContextInput;
+          decision: AiRouterRouteResponseResult;
+          optimisticContext?: AiPromptContext;
+          prompt: string;
+          toolHints: string[];
+      };
+
+export type AiAgentRouterSubmitArgs = {
+    message: string;
+    toolHints: string[];
+    context?: AiPromptContextInput;
+    optimisticContext?: AiPromptContext;
+};
+
+type CreateThreadForAgent = (args: {
+    agentUuid: string;
+    context?: AiPromptContextInput;
+    message: string;
+    optimisticContext?: AiPromptContext;
+    toolHints: string[];
+}) => Promise<{ uuid: string }>;
+
+export type AiAgentRouterCandidate = AiRouterDecisionCandidate & {
+    agent: AiAgentSummary | undefined;
+    isRecommended: boolean;
+};
+
+const aiAgentRouterReducer = (
+    phase: AiAgentRouterPhase,
+    action: AiAgentRouterAction,
+): AiAgentRouterPhase => {
+    switch (action.type) {
+        case 'idle':
+            return { kind: 'idle' };
+        case 'routing':
+            return { kind: 'routing' };
+        case 'creating':
+            return { kind: 'creating' };
+        case 'picker':
+            return {
+                kind: 'picker',
+                context: action.context,
+                decision: action.decision,
+                optimisticContext: action.optimisticContext,
+                prompt: action.prompt,
+                toolHints: action.toolHints,
+            };
+        default:
+            return phase;
+    }
+};
+
+export const useAiAgentRouterFlow = ({
+    agents,
+    createThreadForAgent,
+    onRouteError,
+    projectUuid,
+}: {
+    agents: AiAgentSummary[];
+    createThreadForAgent: CreateThreadForAgent;
+    onRouteError?: (
+        args: AiAgentRouterSubmitArgs & { fallbackAgent?: AiAgentSummary },
+    ) => void;
+    projectUuid: string | undefined;
+}) => {
+    const [phase, dispatch] = useReducer(aiAgentRouterReducer, {
+        kind: 'idle',
+    });
+    const { mutateAsync: routePrompt } = useAiRouterRoute();
+    const { mutate: commitDecisionMutate } = useAiRouterCommit();
+
+    const agentsByUuid = useMemo(
+        () => new Map(agents.map((candidate) => [candidate.uuid, candidate])),
+        [agents],
+    );
+
+    const createAndCommitThread = useCallback(
+        async ({
+            agentUuid,
+            context,
+            decisionUuid,
+            message,
+            optimisticContext,
+            toolHints,
+        }: AiAgentRouterSubmitArgs & {
+            agentUuid: string;
+            decisionUuid?: string;
+        }) => {
+            dispatch({ type: decisionUuid ? 'creating' : 'idle' });
+            const thread = await createThreadForAgent({
+                agentUuid,
+                context,
+                message,
+                optimisticContext,
+                toolHints,
+            });
+
+            if (decisionUuid) {
+                commitDecisionMutate({
+                    decisionUuid,
+                    chosenAgentUuid: agentUuid,
+                    threadUuid: thread.uuid,
+                });
+            }
+        },
+        [commitDecisionMutate, createThreadForAgent],
+    );
+
+    const handleSubmit = useCallback(
+        async ({
+            message,
+            toolHints,
+            context,
+            optimisticContext,
+        }: AiAgentRouterSubmitArgs) => {
+            if (!projectUuid) return;
+
+            dispatch({ type: 'routing' });
+            try {
+                const result = await routePrompt({
+                    prompt: message,
+                    projectUuid,
+                });
+
+                if (result.nextAction === 'create_thread') {
+                    await createAndCommitThread({
+                        agentUuid: result.decision.suggestedAgentUuid,
+                        decisionUuid: result.decision.decisionUuid,
+                        message,
+                        context,
+                        optimisticContext,
+                        toolHints,
+                    });
+                } else {
+                    dispatch({
+                        type: 'picker',
+                        context,
+                        decision: result,
+                        optimisticContext,
+                        prompt: message,
+                        toolHints,
+                    });
+                }
+            } catch {
+                dispatch({ type: 'idle' });
+                onRouteError?.({
+                    context,
+                    fallbackAgent: agents[0],
+                    message,
+                    optimisticContext,
+                    toolHints,
+                });
+            }
+        },
+        [agents, createAndCommitThread, onRouteError, projectUuid, routePrompt],
+    );
+
+    const confirmPick = useCallback(
+        (agentUuid: string) => {
+            if (phase.kind !== 'picker') return;
+            void createAndCommitThread({
+                agentUuid,
+                context: phase.context,
+                decisionUuid: phase.decision.decision.decisionUuid,
+                message: phase.prompt,
+                optimisticContext: phase.optimisticContext,
+                toolHints: phase.toolHints,
+            });
+        },
+        [createAndCommitThread, phase],
+    );
+
+    const sortedCandidates = useMemo<AiAgentRouterCandidate[]>(() => {
+        if (phase.kind !== 'picker') return [];
+        const { candidates, suggestedAgentUuid } = phase.decision.decision;
+        return [...candidates]
+            .sort((a, b) => {
+                if (a.agentUuid === suggestedAgentUuid) return -1;
+                if (b.agentUuid === suggestedAgentUuid) return 1;
+                return 0;
+            })
+            .map((candidate) => ({
+                ...candidate,
+                agent: agentsByUuid.get(candidate.agentUuid),
+                isRecommended: candidate.agentUuid === suggestedAgentUuid,
+            }));
+    }, [agentsByUuid, phase]);
+
+    const isRouting = phase.kind === 'routing';
+    const isCreating = phase.kind === 'creating';
+    const isPickingAgent = phase.kind === 'picker';
+
+    return {
+        confirmPick,
+        handleSubmit,
+        isCreating,
+        isLocked: phase.kind !== 'idle',
+        isPickingAgent,
+        isRouting,
+        phase,
+        sortedCandidates,
+    };
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -1,8 +1,6 @@
 import {
-    type AiAgentSummary,
     type AiPromptContext,
     type AiPromptContextInput,
-    type AiRouterRouteResponseResult,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -22,8 +20,14 @@ import {
     IconInfoCircle,
     IconSettings,
 } from '@tabler/icons-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useLocation, useNavigate, useParams } from 'react-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    Link,
+    useLocation,
+    useNavigate,
+    useParams,
+    useSearchParams,
+} from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getModelKey } from '../../../components/common/ModelSelector/utils';
@@ -31,15 +35,19 @@ import { useProject } from '../../../hooks/useProject';
 import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
+import {
+    mergeAiPromptContextInput,
+    mergeAiPromptContextItems,
+} from '../../features/aiCopilot/components/ChatElements/contentMentions';
+import { getPromptContextItemKey } from '../../features/aiCopilot/components/ChatElements/contentReferenceUtils';
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
+import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentRouterFlow } from '../../features/aiCopilot/hooks/useAiAgentRouterFlow';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
-import {
-    useAiRouterCommit,
-    useAiRouterRoute,
-} from '../../features/aiCopilot/hooks/useAiRouter';
 import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
+import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
     useProjectAiAgents,
@@ -48,23 +56,11 @@ import { setThreadSqlMode } from '../../features/aiCopilot/store/aiAgentThreadMo
 import { useAiAgentStoreDispatch } from '../../features/aiCopilot/store/hooks';
 import classes from './AgentsRouterPage.module.css';
 
-type Phase =
-    | { kind: 'idle' }
-    | { kind: 'routing' }
-    | {
-          kind: 'picker';
-          context?: AiPromptContextInput;
-          decision: AiRouterRouteResponseResult;
-          optimisticContext?: AiPromptContext;
-          prompt: string;
-          toolHints: string[];
-      }
-    | { kind: 'creating' };
-
 const AgentsRouterPage = () => {
     const { projectUuid } = useParams();
     const navigate = useNavigate();
     const location = useLocation();
+    const [searchParams] = useSearchParams();
     const dispatch = useAiAgentStoreDispatch();
 
     const { data: agents } = useProjectAiAgents({
@@ -92,6 +88,19 @@ const AgentsRouterPage = () => {
     const [extendedThinking, setExtendedThinking] = useState(false);
     const [sqlMode, setSqlMode] = useState(false);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
+    const chartUuid = searchParams.get('chartUuid');
+    const dashboardUuid = searchParams.get('dashboardUuid');
+
+    const {
+        contextInput,
+        previewItems,
+        contentMentionItems,
+        isReady: isPinnedContextReady,
+    } = usePinnedContext({
+        projectUuid,
+        chartUuidOrSlug: chartUuid,
+        dashboardUuidOrSlug: dashboardUuid,
+    });
 
     const handleSelectedModelKeyChange = useCallback(
         (modelKey: string) => {
@@ -122,28 +131,18 @@ const AgentsRouterPage = () => {
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
-    const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
     const consumedAutoSubmitKeyRef = useRef<string | undefined>(undefined);
 
-    const agentsByUuid = useMemo(() => {
-        const m = new Map<string, AiAgentSummary>();
-        (agents ?? []).forEach((a) => m.set(a.uuid, a));
-        return m;
-    }, [agents]);
-
-    const route = useAiRouterRoute();
-    const { mutate: commitDecisionMutate } = useAiRouterCommit();
     const { mutateAsync: createThread } = useCreateAgentThreadMutation(
         projectUuid!,
     );
 
-    const startThreadForDecision = useCallback(
+    const createThreadForAgent = useCallback(
         async (args: {
             agentUuid: string;
             context?: AiPromptContextInput;
-            decisionUuid: string;
+            message: string;
             optimisticContext?: AiPromptContext;
-            prompt: string;
             toolHints: string[];
         }) => {
             const thread = await createThread({
@@ -151,7 +150,7 @@ const AgentsRouterPage = () => {
                 context: args.context,
                 enableSqlMode: sqlModeAvailable && sqlMode,
                 optimisticContext: args.optimisticContext,
-                prompt: args.prompt,
+                prompt: args.message,
                 toolHints: args.toolHints,
                 modelConfig: selectedModel
                     ? {
@@ -169,16 +168,10 @@ const AgentsRouterPage = () => {
                     enabled: sqlModeAvailable && sqlMode,
                 }),
             );
-            // Fire-and-forget telemetry — the user is already navigating away.
-            commitDecisionMutate({
-                decisionUuid: args.decisionUuid,
-                chosenAgentUuid: args.agentUuid,
-                threadUuid: thread.uuid,
-            });
+            return thread;
         },
         [
             createThread,
-            commitDecisionMutate,
             dispatch,
             extendedThinking,
             selectedModel,
@@ -187,6 +180,40 @@ const AgentsRouterPage = () => {
             sqlModeAvailable,
         ],
     );
+
+    const handleRouteError = useCallback(
+        ({
+            fallbackAgent,
+            message,
+        }: {
+            fallbackAgent?: { uuid: string };
+            message: string;
+        }) => {
+            setPendingPrompt(message);
+            if (fallbackAgent && projectUuid) {
+                void navigate(
+                    `/projects/${projectUuid}/ai-agents/${fallbackAgent.uuid}/threads`,
+                );
+            }
+        },
+        [navigate, projectUuid, setPendingPrompt],
+    );
+
+    const {
+        confirmPick,
+        handleSubmit: handleRouterSubmit,
+        isCreating,
+        isLocked,
+        isPickingAgent,
+        isRouting,
+        phase,
+        sortedCandidates,
+    } = useAiAgentRouterFlow({
+        agents: agents ?? [],
+        createThreadForAgent,
+        onRouteError: handleRouteError,
+        projectUuid,
+    });
 
     const handleSubmit = useCallback(
         async ({
@@ -200,57 +227,29 @@ const AgentsRouterPage = () => {
             optimisticContext?: AiPromptContext;
             toolHints: string[];
         }) => {
-            if (!projectUuid) return;
-            setPhase({ kind: 'routing' });
+            if (!isPinnedContextReady) return;
             setPendingPrompt('');
-
-            try {
-                const result = await route.mutateAsync({
-                    prompt: message,
-                    projectUuid,
-                });
-
-                if (result.nextAction === 'create_thread') {
-                    setPhase({ kind: 'creating' });
-                    await startThreadForDecision({
-                        agentUuid: result.decision.suggestedAgentUuid,
-                        context,
-                        decisionUuid: result.decision.decisionUuid,
-                        optimisticContext,
-                        prompt: message,
-                        toolHints,
-                    });
-                } else {
-                    setPhase({
-                        kind: 'picker',
-                        context,
-                        decision: result,
-                        optimisticContext,
-                        prompt: message,
-                        toolHints,
-                    });
-                }
-            } catch {
-                // Router unreachable — fall back to the first accessible
-                // agent silently. The draft survives via PendingPromptContext,
-                // which the new-thread page reads on mount.
-                setPhase({ kind: 'idle' });
-                setPendingPrompt(message);
-                const fallback = agents?.[0];
-                if (fallback && projectUuid) {
-                    void navigate(
-                        `/projects/${projectUuid}/ai-agents/${fallback.uuid}/threads`,
-                    );
-                }
-            }
+            const mergedContext = mergeAiPromptContextInput(
+                contextInput,
+                context,
+            );
+            const mergedOptimisticContext = mergeAiPromptContextItems(
+                previewItems,
+                optimisticContext,
+            );
+            await handleRouterSubmit({
+                context: mergedContext,
+                message,
+                optimisticContext: mergedOptimisticContext,
+                toolHints,
+            });
         },
         [
-            agents,
-            navigate,
-            projectUuid,
-            route,
+            contextInput,
+            handleRouterSubmit,
+            isPinnedContextReady,
+            previewItems,
             setPendingPrompt,
-            startThreadForDecision,
         ],
     );
 
@@ -260,7 +259,13 @@ const AgentsRouterPage = () => {
             : '';
 
     useEffect(() => {
-        if (!autoSubmitPrompt || phase.kind !== 'idle') return;
+        if (
+            !autoSubmitPrompt ||
+            phase.kind !== 'idle' ||
+            !isPinnedContextReady
+        ) {
+            return;
+        }
         if (consumedAutoSubmitKeyRef.current === location.key) return;
 
         consumedAutoSubmitKeyRef.current = location.key;
@@ -281,44 +286,15 @@ const AgentsRouterPage = () => {
         location.search,
         navigate,
         phase.kind,
+        isPinnedContextReady,
     ]);
 
-    const confirmPick = useCallback(
-        async (agentUuid: string) => {
-            if (phase.kind !== 'picker') return;
-            const { context, decision, optimisticContext, prompt, toolHints } =
-                phase;
-            setPhase({ kind: 'creating' });
-            await startThreadForDecision({
-                agentUuid,
-                context,
-                decisionUuid: decision.decision.decisionUuid,
-                optimisticContext,
-                prompt,
-                toolHints,
-            });
-        },
-        [phase, startThreadForDecision],
-    );
-
-    const sortedCandidates = useMemo(() => {
-        if (phase.kind !== 'picker') return [];
-        const { candidates, suggestedAgentUuid } = phase.decision.decision;
-        return [...candidates].sort((a, b) => {
-            if (a.agentUuid === suggestedAgentUuid) return -1;
-            if (b.agentUuid === suggestedAgentUuid) return 1;
-            return 0;
-        });
-    }, [phase]);
-
-    const isLocked = phase.kind !== 'idle';
-    const isWorking = phase.kind === 'routing' || phase.kind === 'creating';
-    const workingLabel =
-        phase.kind === 'routing'
-            ? 'Finding the right agent…'
-            : phase.kind === 'creating'
-              ? 'Opening the conversation…'
-              : null;
+    const isWorking = isRouting || isCreating;
+    const workingLabel = isRouting
+        ? 'Finding the right agent…'
+        : isCreating
+          ? 'Opening the conversation…'
+          : null;
 
     const title = project?.name ? `Ask ${project.name}` : 'Ask this project';
     const placeholder = project?.name
@@ -364,12 +340,35 @@ const AgentsRouterPage = () => {
                             <Title order={2}>{title}</Title>
                         </Stack>
 
+                        {previewItems.length > 0 && (
+                            <Stack gap="xxs" w="100%">
+                                <Text
+                                    size="xs"
+                                    fw={600}
+                                    c="dimmed"
+                                    tt="uppercase"
+                                >
+                                    Pinned context
+                                </Text>
+                                <Group gap="xs" wrap="wrap">
+                                    {previewItems.map((item) => (
+                                        <PinnedContextCard
+                                            key={getPromptContextItemKey(item)}
+                                            item={item}
+                                            projectUuid={projectUuid!}
+                                        />
+                                    ))}
+                                </Group>
+                            </Stack>
+                        )}
+
                         <AgentChatInput
                             projectUuid={projectUuid}
                             agents={agents ?? []}
                             selectedAgent="auto"
                             placeholder={placeholder}
                             loading={isLocked}
+                            disabled={!isPinnedContextReady}
                             onSubmit={handleSubmit}
                             defaultValue={pendingPrompt}
                             onValueChange={setPendingPrompt}
@@ -393,6 +392,7 @@ const AgentsRouterPage = () => {
                             clearOnSubmit={false}
                             fullWidth
                             showSuggestions={false}
+                            contentMentionPriorityItems={contentMentionItems}
                         />
 
                         {isWorking && workingLabel && (
@@ -413,7 +413,7 @@ const AgentsRouterPage = () => {
                             </Group>
                         )}
 
-                        {phase.kind === 'picker' && (
+                        {isPickingAgent && phase.kind === 'picker' && (
                             <Stack gap="xs" className={classes.pickerStack}>
                                 <div className={classes.pickerHeader}>
                                     <Text size="sm" fw={600}>
@@ -453,13 +453,6 @@ const AgentsRouterPage = () => {
 
                                 <Box className={classes.pickerScroll}>
                                     {sortedCandidates.map((c) => {
-                                        const agent = agentsByUuid.get(
-                                            c.agentUuid,
-                                        );
-                                        const isRecommended =
-                                            c.agentUuid ===
-                                            phase.decision.decision
-                                                .suggestedAgentUuid;
                                         return (
                                             <UnstyledButton
                                                 key={c.agentUuid}
@@ -467,7 +460,7 @@ const AgentsRouterPage = () => {
                                                     confirmPick(c.agentUuid)
                                                 }
                                                 className={`${classes.candidateButton} ${
-                                                    isRecommended
+                                                    c.isRecommended
                                                         ? classes.recommended
                                                         : ''
                                                 }`}
@@ -481,7 +474,7 @@ const AgentsRouterPage = () => {
                                                     <LightdashUserAvatar
                                                         size={32}
                                                         name={c.name}
-                                                        src={agent?.imageUrl}
+                                                        src={c.agent?.imageUrl}
                                                     />
                                                     <Stack
                                                         gap={2}
@@ -499,7 +492,7 @@ const AgentsRouterPage = () => {
                                                             >
                                                                 {c.name}
                                                             </Text>
-                                                            {isRecommended && (
+                                                            {c.isRecommended && (
                                                                 <Badge
                                                                     size="xs"
                                                                     color="violet"


### PR DESCRIPTION
### Summary
- Extract shared AI agent router flow hook
- Reuse the shared flow in both launcher and fullscreen router page
- Keep launcher-specific context merging and fullscreen-specific thread options in their adapters

### Testing
- pnpm -F frontend run linter -- src/ee/features/aiCopilot/hooks/useAiAgentRouterFlow.ts src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts src/ee/pages/AiAgents/AgentsRouterPage.tsx
- pnpm -F frontend exec oxfmt src/ee/features/aiCopilot/hooks/useAiAgentRouterFlow.ts src/ee/features/aiCopilot/components/Launcher/useAiAgentLauncherRouter.ts src/ee/pages/AiAgents/AgentsRouterPage.tsx --check
- pnpm -F frontend typecheck:fast (fails on existing ThreadPreviewSidebar.test.tsx matcher type errors)