### PR TITLE
feat: surface unauthenticated MCP connections

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -479,7 +479,30 @@ const withEarlyToolProgress = (
         }),
     ) as ToolSet;
 
-const getAgentMessages = (args: AiAgentArgs, availableExplores: Explore[]) => {
+const getUnauthenticatedMcpServerNames = (
+    args: AiAgentArgs,
+    mcpToolSetup: AgentMcpToolSetup,
+) => {
+    const oauthServerUuids = new Set(
+        args.mcpServers
+            .filter((server) => server.authType === 'oauth')
+            .map((server) => server.uuid),
+    );
+
+    return mcpToolSetup.unavailableMcpServers
+        .filter(
+            (server) =>
+                server.status === 'not_connected' &&
+                oauthServerUuids.has(server.serverUuid),
+        )
+        .map((server) => server.serverName);
+};
+
+const getAgentMessages = (
+    args: AiAgentArgs,
+    availableExplores: Explore[],
+    mcpToolSetup: AgentMcpToolSetup,
+) => {
     const logger = createAiAgentLogger(args.debugLoggingEnabled);
     logger('Agent Messages', 'Getting agent messages.');
 
@@ -513,6 +536,10 @@ const getAgentMessages = (args: AiAgentArgs, availableExplores: Explore[]) => {
             canRunSql: args.canRunSql,
             warehouseType: args.warehouseType,
             warehouseSchema: args.warehouseSchema,
+            unauthenticatedMcpServerNames: getUnauthenticatedMcpServerNames(
+                args,
+                mcpToolSetup,
+            ),
         }),
         ...messageHistory,
     ];
@@ -571,7 +598,11 @@ export const generateAgentResponse = async ({
             getAgentTools(args, dependencies, availableExplores, mcpToolSetup),
             dependencies.updateProgress,
         );
-        const messages = getAgentMessages(args, availableExplores);
+        const messages = getAgentMessages(
+            args,
+            availableExplores,
+            mcpToolSetup,
+        );
         logger(
             'Generate Agent Response',
             `Calling generateText with model: ${modelName}`,
@@ -803,7 +834,11 @@ export const streamAgentResponse = async ({
             availableExplores,
             mcpToolSetup,
         );
-        const messages = getAgentMessages(args, availableExplores);
+        const messages = getAgentMessages(
+            args,
+            availableExplores,
+            mcpToolSetup,
+        );
         logger(
             'Stream Agent Response',
             `Calling streamText with model: ${modelName}`,

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.test.ts
@@ -33,6 +33,20 @@ describe('getSystemPromptV2 project context', () => {
     });
 });
 
+describe('getSystemPromptV2 MCP connections', () => {
+    test('lists unauthenticated MCP server login status', () => {
+        const content = promptText({
+            availableExplores: [],
+            unauthenticatedMcpServerNames: ['Linear'],
+        });
+
+        expect(content).toContain('## MCP connections');
+        expect(content).toContain(
+            'Linear MCP connection is setup, but the current user is not logged in',
+        );
+    });
+});
+
 describe('getSystemPromptV2 writeback attribution', () => {
     test('omits the writeback section entirely when writeback is disabled', () => {
         const content = promptText({

--- a/packages/backend/src/ee/services/ai/prompts/systemV2.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2.ts
@@ -46,6 +46,7 @@ export const getSystemPromptV2 = (args: {
     canRunSql?: boolean;
     warehouseType?: WarehouseTypes | null;
     warehouseSchema?: string | null;
+    unauthenticatedMcpServerNames?: string[];
 }): SystemModelMessage => {
     const {
         instructions,
@@ -63,6 +64,7 @@ export const getSystemPromptV2 = (args: {
         canRunSql = false,
         warehouseType = null,
         warehouseSchema = null,
+        unauthenticatedMcpServerNames = [],
     } = args;
 
     const crossExploreJoinRule = canRunSql
@@ -187,10 +189,23 @@ export const getSystemPromptV2 = (args: {
         .replace('{{project_context}}', projectContextContent);
 
     const skillsSection = renderAvailableSkills(args.availableSkills ?? []);
+    const mcpConnectionsSection =
+        unauthenticatedMcpServerNames.length > 0
+            ? `## MCP connections\n${unauthenticatedMcpServerNames
+                  .map(
+                      (name) =>
+                          `${name} MCP connection is setup, but the current user is not logged in`,
+                  )
+                  .join('\n')}`
+            : '';
+
+    const finalContent = [content, mcpConnectionsSection, skillsSection]
+        .filter(Boolean)
+        .join('\n\n');
 
     return {
         role: 'system',
-        content: skillsSection ? `${content}\n\n${skillsSection}` : content,
+        content: finalContent,
         providerOptions: {
             anthropic: { cacheControl: { type: 'ephemeral' } },
         },


### PR DESCRIPTION
### Summary
- Add MCP connection context to the agent system prompt for OAuth servers that require user login.
- Pass unavailable MCP runtime state into prompt assembly for both sync and streaming agent paths.
- Cover prompt rendering with focused tests.

### Tests
- pnpm -F backend test -- systemV2.test.ts --runInBand
- pnpm -F backend typecheck:fast

Closes: PROD-7877