### PR TITLE
fix(pivot): keep hidden row-index dim context in pivot drill-down

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1248,3 +1248,140 @@ describe('hidden-metric conditional-formatting side-channel (PROD-2372)', () => 
         expect(result.hiddenContextValues).toBeUndefined();
     });
 });
+
+describe('hidden row-index dim drill-down side-channel (PROD-7841)', () => {
+    // Two index dims: a visible one (year) and a hidden one (cost tier). The
+    // hidden index dim is dropped from the rendered `indexValues`, but its
+    // per-row value must be stashed on `hiddenIndexValues` so interactive
+    // drill-down can still scope by it.
+    const rows: ResultRow[] = [
+        {
+            orders_order_date_year: {
+                value: { raw: '2025-01-01T00:00:00Z', formatted: '2025' },
+            },
+            orders_shipping_cost_tier: {
+                value: { raw: 'high', formatted: 'High ($20-$30)' },
+            },
+            orders_total_order_amount_any_bank_transfer: {
+                value: { raw: 200, formatted: '200' },
+            },
+        },
+        {
+            orders_order_date_year: {
+                value: { raw: '2024-01-01T00:00:00Z', formatted: '2024' },
+            },
+            orders_shipping_cost_tier: {
+                value: { raw: 'low', formatted: 'Low (<$10)' },
+            },
+            orders_total_order_amount_any_bank_transfer: {
+                value: { raw: 75, formatted: '75' },
+            },
+        },
+    ];
+
+    const pivotDetails = {
+        totalColumnCount: 1,
+        valuesColumns: [
+            {
+                aggregation: VizAggregationOptions.ANY,
+                pivotValues: [
+                    {
+                        value: 'bank_transfer',
+                        referenceField: 'payments_payment_method',
+                    },
+                ],
+                referenceField: 'orders_total_order_amount',
+                pivotColumnName: 'orders_total_order_amount_any_bank_transfer',
+            },
+        ],
+        indexColumn: [
+            { type: VizIndexType.TIME, reference: 'orders_order_date_year' },
+            {
+                type: VizIndexType.CATEGORY,
+                reference: 'orders_shipping_cost_tier',
+            },
+        ],
+        groupByColumns: [{ reference: 'payments_payment_method' }],
+        sortBy: [
+            {
+                direction: SortByDirection.DESC,
+                reference: 'orders_order_date_year',
+            },
+        ],
+        originalColumns: {},
+    };
+
+    const pivotConfig = {
+        rowTotals: false,
+        columnTotals: false,
+        metricsAsRows: false,
+        columnOrder: [
+            'orders_order_date_year',
+            'orders_shipping_cost_tier',
+            'payments_payment_method',
+            'orders_total_order_amount',
+        ],
+        hiddenDimensionFieldIds: ['orders_shipping_cost_tier'],
+    };
+
+    it('stashes hidden index dim values on hiddenIndexValues, aligned by row, and excludes them from indexValues', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig,
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        // Rendered index values carry only the visible dim (year), never the
+        // hidden cost tier.
+        result.indexValues.forEach((indexRow) => {
+            expect(indexRow.map((cell) => cell.fieldId)).not.toContain(
+                'orders_shipping_cost_tier',
+            );
+        });
+        expect(result.indexValues[0]).toEqual([
+            {
+                type: 'value',
+                fieldId: 'orders_order_date_year',
+                value: { raw: '2025-01-01T00:00:00Z', formatted: '2025' },
+                colSpan: 1,
+            },
+        ]);
+
+        // Hidden index dim values are stashed, aligned by row index, so
+        // drill-down can scope by them.
+        expect(result.hiddenIndexValues).toEqual([
+            [
+                {
+                    type: 'value',
+                    fieldId: 'orders_shipping_cost_tier',
+                    value: { raw: 'high', formatted: 'High ($20-$30)' },
+                    colSpan: 1,
+                },
+            ],
+            [
+                {
+                    type: 'value',
+                    fieldId: 'orders_shipping_cost_tier',
+                    value: { raw: 'low', formatted: 'Low (<$10)' },
+                    colSpan: 1,
+                },
+            ],
+        ]);
+    });
+
+    it('omits hiddenIndexValues entirely when no index dim is hidden', () => {
+        const result = convertSqlPivotedRowsToPivotData({
+            rows,
+            pivotDetails,
+            pivotConfig: { ...pivotConfig, hiddenDimensionFieldIds: [] },
+            getField: getFieldMock,
+            getFieldLabel: (fieldId) => fieldId,
+            groupedSubtotals: undefined,
+        });
+
+        expect(result.hiddenIndexValues).toBeUndefined();
+    });
+});

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1322,6 +1322,34 @@ export const convertSqlPivotedRowsToPivotData = ({
         }
     }
 
+    // Row-index dims hidden via hiddenDimensionFieldIds are dropped from the
+    // rendered `indexValues`, but interactive drill-down ("View underlying
+    // data" / "Drill into") needs their per-row values to scope correctly
+    // (PROD-7841). `allIndexColumnRefs` includes hidden dims; `indexColumns`
+    // is visible-only, so the difference is the hidden set. Stash them in a
+    // parallel array aligned by row index with `indexValues`.
+    const hiddenIndexColumns = allIndexColumnRefs.filter(
+        (ref) => !indexColumns.includes(ref),
+    );
+    if (hiddenIndexColumns.length > 0) {
+        const buildHiddenCells = (row: (typeof rows)[number]) =>
+            hiddenIndexColumns.map((col) => ({
+                type: 'value' as const,
+                fieldId: col,
+                value: row[col].value,
+                colSpan: 1,
+            }));
+        retrofitted.hiddenIndexValues = pivotConfig.metricsAsRows
+            ? rows.reduce<PivotData['indexValues']>((acc, row) => {
+                  // mirror the per-metric row multiplication of `indexValues`
+                  baseMetricsArray.forEach(() => {
+                      acc.push(buildHiddenCells(row));
+                  });
+                  return acc;
+              }, [])
+            : rows.map((row) => buildHiddenCells(row));
+    }
+
     return retrofitted;
 };
 

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -132,5 +132,13 @@ export type PivotData = {
      * Absent when no metrics are hidden.
      */
     hiddenContextValues?: Record<string, Record<string, ResultValue>>;
+    /**
+     * Per-row values for row-index dims hidden via `hiddenDimensionFieldIds`.
+     * These are excluded from the rendered `indexValues`, but interactive
+     * drill-down ("View underlying data" / "Drill into") needs them to scope
+     * correctly (PROD-7841). Aligned by row index with `indexValues`. Absent
+     * when no index dim is hidden.
+     */
+    hiddenIndexValues?: FieldValue[][];
     groupedSubtotals?: Record<string, Record<string, number>[]>;
 };

--- a/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
+++ b/packages/frontend/src/components/SimpleTable/ValueCellMenu.test.tsx
@@ -1,40 +1,180 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { collectPivotUnderlyingValues } from '../common/PivotTable/getUnderlyingFieldValues';
 
 /**
- * Regression tests for ValueCellMenu drill-down behavior with hidden pivot
- * dimensions.
+ * Regression tests for ValueCellMenu drill-down behaviour with hidden pivot
+ * dimensions (PROD-7841).
  *
- * DONE_WITH_CONCERNS: The intended regression guard (asserting that
- * `getUnderlyingFieldValues` returns ALL dimension values — including hidden
- * ones — when `hiddenDimensionFieldIds` is set) cannot be written as a
- * unit test without a full TanStack Table + React mounting environment,
- * because `getUnderlyingFieldValues` is a `useCallback` inside
- * `PivotTable/index.tsx` that reads directly from `rows[rowIndex].getVisibleCells()`.
+ * The value-collection logic behind PivotTable's `getUnderlyingFieldValues`
+ * — which produces the `fieldId -> value` context passed to
+ * `openUnderlyingDataModal` / `openDrillDownModal` — was extracted into the
+ * pure `collectPivotUnderlyingValues` helper so it can be unit-tested without
+ * mounting a TanStack Table + React tree.
  *
- * KNOWN LIMITATION: Hidden row-index dimensions (excluded from
- * `indexValues` via `indexDimensionsForDisplay` in `pivotQueryResults.ts`)
- * will be ABSENT from the drill-down/underlying-data context passed to
- * `openUnderlyingDataModal` / `openDrillDownModal`. This means:
- *   - Right-click → "View underlying data" on a pivot cell may return broader
- *     results than expected when a row-index dim is hidden.
- *   - Right-click → "Drill into" on a metric cell may not correctly scope the
- *     drill by the hidden dimension values.
- *
- * RECOMMENDED FIX (follow-up ticket):
- *   Option A — Keep hidden dims in `indexValues` with a `hidden: true` marker;
- *              `PivotTable` skips rendering them but `getUnderlyingFieldValues`
- *              still collects their values.
- *   Option B — Add a separate `hiddenIndexValues` array to `PivotData` that
- *              `getUnderlyingFieldValues` merges alongside visible `indexValue`
- *              cells.
- *
- * Note: `hiddenDimensionFieldIds` correctly excludes hidden dims from the
- * rendered table AND from CSV/XLSX exports (tested in the common-package and
- * backend test suites). The concern here is limited to the interactive
- * drill-down path.
+ * The headline guard: row-index dims hidden via `hiddenDimensionFieldIds` are
+ * excluded from the rendered cells, so they are now supplied separately via
+ * `hiddenIndexCells` (from `PivotData.hiddenIndexValues`) and must end up in the
+ * drill-down context — otherwise "View underlying data" / "Drill into" silently
+ * widens its scope.
  */
-describe('ValueCellMenu — drill-down with hidden pivot dims', () => {
-    it.todo(
-        'getUnderlyingFieldValues includes hidden index dim values (follow-up ticket)',
-    );
+describe('collectPivotUnderlyingValues — drill-down with hidden pivot dims', () => {
+    const tierCell = {
+        type: 'value' as const,
+        fieldId: 'orders_shipping_cost_tier',
+        value: { raw: 'high', formatted: 'High ($20-$30)' },
+        colSpan: 1,
+    };
+
+    it('includes a hidden row-index dim value in the drill-down context', () => {
+        const result = collectPivotUnderlyingValues({
+            cells: [
+                {
+                    type: 'indexValue',
+                    id: 'orders_order_date_month',
+                    value: {
+                        value: { raw: '2026-01-01', formatted: '2026-01' },
+                    },
+                    headerInfo: undefined,
+                },
+                {
+                    type: undefined,
+                    id: 'col_0',
+                    value: { value: { raw: 32, formatted: '$32.00' } },
+                    headerInfo: {
+                        orders_shipping_method: {
+                            raw: 'express',
+                            formatted: 'express',
+                        },
+                    },
+                },
+            ],
+            clickedColIndex: 1,
+            clickedItemId: 'orders_total_order_amount',
+            clickedValue: { raw: 32, formatted: '$32.00' },
+            labelFieldId: undefined,
+            hiddenIndexCells: [tierCell],
+        });
+
+        expect(result).toEqual({
+            orders_total_order_amount: { raw: 32, formatted: '$32.00' },
+            orders_order_date_month: {
+                raw: '2026-01-01',
+                formatted: '2026-01',
+            },
+            orders_shipping_method: { raw: 'express', formatted: 'express' },
+            // The hidden dim is recovered from hiddenIndexCells.
+            orders_shipping_cost_tier: {
+                raw: 'high',
+                formatted: 'High ($20-$30)',
+            },
+        });
+    });
+
+    it('omits the hidden dim when no hiddenIndexCells are supplied (documents the pre-fix gap)', () => {
+        const result = collectPivotUnderlyingValues({
+            cells: [
+                {
+                    type: 'indexValue',
+                    id: 'orders_order_date_month',
+                    value: {
+                        value: { raw: '2026-01-01', formatted: '2026-01' },
+                    },
+                    headerInfo: undefined,
+                },
+            ],
+            clickedColIndex: 0,
+            clickedItemId: 'orders_total_order_amount',
+            clickedValue: { raw: 32, formatted: '$32.00' },
+            labelFieldId: undefined,
+            hiddenIndexCells: [],
+        });
+
+        expect(result).not.toHaveProperty('orders_shipping_cost_tier');
+    });
+
+    it('maps the clicked metric value to the label field in metricsAsRows mode and still merges the hidden dim', () => {
+        const result = collectPivotUnderlyingValues({
+            cells: [
+                {
+                    type: 'label',
+                    id: 'label-0',
+                    value: {
+                        value: {
+                            raw: 'Total order amount',
+                            formatted: 'Total order amount',
+                        },
+                    },
+                    headerInfo: undefined,
+                },
+                {
+                    type: undefined,
+                    id: 'col_0',
+                    value: { value: { raw: 32, formatted: '$32.00' } },
+                    headerInfo: {
+                        orders_order_date_month: {
+                            raw: '2026-01-01',
+                            formatted: '2026-01',
+                        },
+                    },
+                },
+            ],
+            clickedColIndex: 1,
+            clickedItemId: undefined,
+            clickedValue: { raw: 32, formatted: '$32.00' },
+            labelFieldId: 'orders_total_order_amount',
+            hiddenIndexCells: [tierCell],
+        });
+
+        expect(result).toEqual({
+            orders_total_order_amount: { raw: 32, formatted: '$32.00' },
+            orders_order_date_month: {
+                raw: '2026-01-01',
+                formatted: '2026-01',
+            },
+            orders_shipping_cost_tier: {
+                raw: 'high',
+                formatted: 'High ($20-$30)',
+            },
+        });
+    });
+
+    it('merges pivot-dim headerInfo only for the clicked column', () => {
+        const result = collectPivotUnderlyingValues({
+            cells: [
+                {
+                    type: undefined,
+                    id: 'c0',
+                    value: { value: { raw: 1, formatted: '1' } },
+                    headerInfo: {
+                        orders_order_date_month: {
+                            raw: '2026-01-01',
+                            formatted: '2026-01',
+                        },
+                    },
+                },
+                {
+                    type: undefined,
+                    id: 'c1',
+                    value: { value: { raw: 2, formatted: '2' } },
+                    headerInfo: {
+                        orders_order_date_month: {
+                            raw: '2026-02-01',
+                            formatted: '2026-02',
+                        },
+                    },
+                },
+            ],
+            clickedColIndex: 1,
+            clickedItemId: 'orders_total_order_amount',
+            clickedValue: { raw: 2, formatted: '2' },
+            labelFieldId: undefined,
+            hiddenIndexCells: [],
+        });
+
+        // Only the clicked column's month context is included.
+        expect(result.orders_order_date_month).toEqual({
+            raw: '2026-02-01',
+            formatted: '2026-02',
+        });
+    });
 });

--- a/packages/frontend/src/components/common/PivotTable/getUnderlyingFieldValues.ts
+++ b/packages/frontend/src/components/common/PivotTable/getUnderlyingFieldValues.ts
@@ -1,0 +1,77 @@
+import {
+    type PivotData,
+    type ResultRow,
+    type ResultValue,
+} from '@lightdash/common';
+
+/**
+ * Normalised view of a TanStack pivot cell — the subset of `cell` /
+ * `cell.column.columnDef.meta` that the value-collection logic reads. Mapping
+ * the live table cells to this shape lets the logic below be unit-tested
+ * without mounting a TanStack Table + React tree (PROD-7841).
+ */
+export type PivotUnderlyingCell = {
+    /** `meta.type` — e.g. 'indexValue' | 'label' | a data column type */
+    type: string | undefined;
+    /** `columnDef.id` */
+    id: string | undefined;
+    /** The cell's full value (`{ value: ResultValue }`), if any */
+    value: ResultRow[string] | undefined;
+    /** Pivot-dimension context on data columns (`meta.headerInfo`) */
+    headerInfo: Record<string, ResultValue> | undefined;
+};
+
+/**
+ * Builds the `fieldId -> ResultValue` map that scopes "View underlying data" /
+ * "Drill into" for a clicked pivot cell. Pure value-collection logic extracted
+ * from PivotTable's `getUnderlyingFieldValues` callback so it is testable in
+ * isolation.
+ *
+ * `hiddenIndexCells` carries row-index dims hidden via `hiddenDimensionFieldIds`
+ * — they are absent from the rendered `cells`, so without merging them the
+ * drill scope silently widens (PROD-7841).
+ */
+export const collectPivotUnderlyingValues = ({
+    cells,
+    clickedColIndex,
+    clickedItemId,
+    clickedValue,
+    labelFieldId,
+    hiddenIndexCells,
+}: {
+    cells: PivotUnderlyingCell[];
+    clickedColIndex: number;
+    clickedItemId: string | undefined;
+    clickedValue: ResultValue | undefined;
+    labelFieldId: string | undefined;
+    hiddenIndexCells: PivotData['indexValues'][number];
+}): Record<string, ResultValue> => {
+    let underlyingValues: Record<string, ResultValue> =
+        clickedItemId && clickedValue ? { [clickedItemId]: clickedValue } : {};
+
+    cells.forEach((cell, cellIndex) => {
+        if (cell.type === 'indexValue') {
+            if (cell.id && cell.value) {
+                underlyingValues[cell.id] = cell.value.value;
+            }
+        } else if (cell.type === 'label') {
+            // metricsAsRows: the clicked metric value belongs to the row's
+            // metric label dimension.
+            if (labelFieldId && clickedValue) {
+                underlyingValues[labelFieldId] = clickedValue;
+            }
+        } else if (clickedColIndex === cellIndex && cell.headerInfo) {
+            underlyingValues = { ...underlyingValues, ...cell.headerInfo };
+        }
+    });
+
+    // Hidden row-index dims are not rendered as cells, so merge their per-row
+    // values directly to keep the drill scope precise (PROD-7841).
+    hiddenIndexCells.forEach((cell) => {
+        if (cell.type === 'value') {
+            underlyingValues[cell.fieldId] = cell.value;
+        }
+    });
+
+    return underlyingValues;
+};

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -88,6 +88,7 @@ import {
     type FrozenColumnEntry,
 } from './getFrozenColumnLayout';
 import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
+import { collectPivotUnderlyingValues } from './getUnderlyingFieldValues';
 import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
 import ValueCellMenu from './ValueCellMenu';
@@ -733,44 +734,34 @@ const PivotTable: FC<PivotTableProps> = ({
     const getUnderlyingFieldValues = useCallback(
         (rowIndex: number, colIndex: number) => {
             const visibleCells = rows[rowIndex].getVisibleCells();
-            const visibleCell = visibleCells[colIndex];
-            const item = visibleCell.column.columnDef.meta?.item;
-            const fullItemValue = visibleCell.getValue() as ResultRow[0];
-            const itemValue = fullItemValue.value;
-            let underlyingValues =
-                isField(item) && itemValue
-                    ? { [getItemId(item)]: itemValue }
-                    : {};
-            visibleCells.forEach((cell, cellIndex) => {
-                if (cell.column.columnDef.meta?.type === 'indexValue') {
-                    if (cell.column.columnDef.id) {
-                        const fullValue = cell.getValue() as
-                            | ResultRow[0]
-                            | undefined;
-
-                        if (fullValue) {
-                            underlyingValues[cell.column.columnDef.id] =
-                                fullValue.value;
-                        }
-                    }
-                } else if (cell.column.columnDef.meta?.type === 'label') {
-                    const info = data.indexValues[rowIndex].find(
-                        (indexValue) => indexValue.type === 'label',
-                    );
-                    if (info) underlyingValues[info.fieldId] = itemValue;
-                } else if (
-                    colIndex === cellIndex &&
-                    cell.column.columnDef.meta?.headerInfo
-                ) {
-                    underlyingValues = {
-                        ...underlyingValues,
-                        ...cell.column.columnDef.meta.headerInfo,
-                    };
-                }
+            const clickedItem =
+                visibleCells[colIndex].column.columnDef.meta?.item;
+            const clickedValue = (
+                visibleCells[colIndex].getValue() as
+                    | ResultRow[string]
+                    | undefined
+            )?.value;
+            return collectPivotUnderlyingValues({
+                cells: visibleCells.map((cell) => ({
+                    type: cell.column.columnDef.meta?.type,
+                    id: cell.column.columnDef.id,
+                    value: cell.getValue() as ResultRow[string] | undefined,
+                    headerInfo: cell.column.columnDef.meta?.headerInfo,
+                })),
+                clickedColIndex: colIndex,
+                clickedItemId: isField(clickedItem)
+                    ? getItemId(clickedItem)
+                    : undefined,
+                clickedValue,
+                labelFieldId: data.indexValues[rowIndex].find(
+                    (indexValue) => indexValue.type === 'label',
+                )?.fieldId,
+                // Hidden row-index dims are excluded from the rendered cells;
+                // merge them so drill-down stays scoped (PROD-7841).
+                hiddenIndexCells: data.hiddenIndexValues?.[rowIndex] ?? [],
             });
-            return underlyingValues;
         },
-        [rows, data.indexValues],
+        [rows, data.indexValues, data.hiddenIndexValues],
     );
 
     // Find the data column index from headerInfo by matching against headerValues
@@ -1519,9 +1510,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                               }
                                           >
                                               {totalLabel.fieldId
-                                                  ? `Total ${getFieldLabel(
-                                                        totalLabel.fieldId,
-                                                    )}`
+                                                  ? `Total ${getFieldLabel(totalLabel.fieldId)}`
                                                   : `Total`}
                                           </Table.CellHead>
                                       ) : (
@@ -2126,9 +2115,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                 withBoldFont
                                             >
                                                 {totalLabel.fieldId
-                                                    ? `Total ${getFieldLabel(
-                                                          totalLabel.fieldId,
-                                                      )}`
+                                                    ? `Total ${getFieldLabel(totalLabel.fieldId)}`
                                                     : `Total`}
                                             </Table.CellHead>
                                         ) : (


### PR DESCRIPTION
## What

Follow-up to the hide-pivot-dimensions work (#13700). When a pivot table **row-index** dimension is hidden via `hiddenDimensionFieldIds`, it is stripped from `indexValues`, so `getUnderlyingFieldValues` couldn't collect its per-row value. As a result, the interactive drill-down paths lost that dimension's filter:

- Right-click → **View underlying data** returned broader-than-precise results.
- Right-click → **Drill into** on a metric cell didn't scope by the hidden dimension's value.

(Exports already excluded hidden dims correctly — this was limited to the interactive drill-down path.)

## How

Option B from the ticket — a parallel side-channel, leaving the rendered `indexValues` and all its consumers untouched:

- **`PivotData.hiddenIndexValues`** (new, optional): per-row values for hidden row-index dims, aligned by row index with `indexValues`. Built in `convertSqlPivotedRowsToPivotData` from `allIndexColumnRefs − indexColumns` and attached the same way as the existing `hiddenContextValues` side-channel.
- **`collectPivotUnderlyingValues`** (new helper): the value-collection logic, extracted out of the `PivotTable` `useCallback` so it no longer requires a mounted TanStack table. It merges the hidden index values alongside the rendered cells. `getUnderlyingFieldValues` now maps its cells into this helper and passes `data.hiddenIndexValues`.

## Testing

- Producer unit tests in `pivotQueryResults.test.ts`: hidden index dim is stashed on `hiddenIndexValues` (aligned by row) and excluded from `indexValues`; omitted entirely when nothing is hidden.
- The `it.todo` in `ValueCellMenu.test.tsx` is replaced with real unit tests of the extracted helper (hidden dim recovered; metricsAsRows label mapping; headerInfo merged only for the clicked column).
- Manual, end-to-end against the running app: with a row-index dim hidden, drilling a cell now sends the hidden dimension's filter and returns the precisely-scoped rows (matching the dim-visible baseline) instead of the widened set.

Closes: PROD-7841
Relates: #13700

🤖 Generated with [Claude Code](https://claude.com/claude-code)