### PR TITLE
feat: surface slack mcp oauth logins

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.integration.test.ts
@@ -845,6 +845,9 @@ describe('AiAgentService MCP support', () => {
                 userUuid: viewerUser.userUuid,
             }),
         );
+        expect(startOAuthConnectionSpy.mock.calls[0][0]).not.toHaveProperty(
+            'connectionStatusOnAuthorization',
+        );
 
         await expect(
             services.aiAgentService.disconnectMcpOAuthConnection(

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -245,7 +245,11 @@ import {
 import { RepoFs } from '../ai/repoFs/RepoFs';
 import { renderBlocks as renderSqlApprovalBlocks } from '../ai/tools/slackSqlAggregate';
 import { markSlackThreadAutoApproved } from '../ai/tools/sqlApprovals';
-import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
+import {
+    AiAgentArgs,
+    AiAgentDependencies,
+    type AiAgentMcpServer,
+} from '../ai/types/aiAgent';
 import {
     DiscoverReposFn,
     EditDbtProjectFn,
@@ -3338,6 +3342,9 @@ export class AiAgentService extends BaseService {
         projectUuid: string,
         mcpServerUuid: string,
         body?: ApiAiMcpOAuthCredentialRequest,
+        options?: {
+            connectionStatusOnAuthorization?: 'connecting' | 'not_connected';
+        },
     ): Promise<string> {
         const server = await this.getProjectMcpServerOrThrow(
             projectUuid,
@@ -3369,6 +3376,8 @@ export class AiAgentService extends BaseService {
             userUuid: credentialScope === 'user' ? user.userUuid : undefined,
             actorUserUuid: user.userUuid,
             serverUrl: server.url,
+            connectionStatusOnAuthorization:
+                options?.connectionStatusOnAuthorization,
         });
     }
 
@@ -5357,6 +5366,123 @@ export class AiAgentService extends BaseService {
         );
     }
 
+    private static getSlackMcpOAuthLoginServers(
+        mcpServers: AiAgentMcpServer[],
+        mcpToolSetup: AgentMcpToolSetup,
+    ) {
+        const oauthServersByUuid = new Map(
+            mcpServers
+                .filter((server) => server.authType === 'oauth')
+                .map((server) => [server.uuid, server]),
+        );
+        const seenServerUuids = new Set<string>();
+
+        return mcpToolSetup.unavailableMcpServers.flatMap(
+            (unavailableServer) => {
+                const mcpServer = oauthServersByUuid.get(
+                    unavailableServer.serverUuid,
+                );
+
+                if (
+                    !mcpServer ||
+                    unavailableServer.status !== 'not_connected' ||
+                    seenServerUuids.has(unavailableServer.serverUuid)
+                ) {
+                    return [];
+                }
+
+                seenServerUuids.add(unavailableServer.serverUuid);
+                return [{ ...unavailableServer, mcpServer }];
+            },
+        );
+    }
+
+    private async postSlackMcpOAuthLoginMessages({
+        user,
+        prompt,
+        mcpServers,
+        mcpToolSetup,
+    }: {
+        user: SessionUser;
+        prompt: SlackPrompt;
+        mcpServers: AiAgentMcpServer[];
+        mcpToolSetup: AgentMcpToolSetup;
+    }) {
+        const loginServers = AiAgentService.getSlackMcpOAuthLoginServers(
+            mcpServers,
+            mcpToolSetup,
+        );
+
+        if (loginServers.length === 0) {
+            return;
+        }
+
+        let client: WebClient;
+        try {
+            client = await this.slackClient.getWebClient(
+                prompt.organizationUuid,
+            );
+        } catch (error) {
+            Logger.error(
+                'Failed to get Slack client for MCP OAuth login messages',
+                error,
+            );
+            return;
+        }
+
+        await Promise.all(
+            loginServers.map(async ({ serverName, serverUuid, mcpServer }) => {
+                try {
+                    const authorizationUrl = await this.startMcpOAuthConnection(
+                        user,
+                        prompt.projectUuid,
+                        serverUuid,
+                        undefined,
+                        {
+                            connectionStatusOnAuthorization: 'not_connected',
+                        },
+                    );
+                    const text = `${serverName} MCP needs you to log in before I can use it.`;
+
+                    await client.chat.postEphemeral({
+                        channel: prompt.slackChannelId,
+                        user: prompt.slackUserId,
+                        thread_ts: prompt.slackThreadTs || prompt.promptSlackTs,
+                        text,
+                        blocks: [
+                            {
+                                type: 'section',
+                                text: {
+                                    type: 'mrkdwn',
+                                    text,
+                                },
+                            },
+                            {
+                                type: 'actions',
+                                elements: [
+                                    {
+                                        type: 'button',
+                                        text: {
+                                            type: 'plain_text',
+                                            text: `Log in to ${serverName}`,
+                                        },
+                                        url: authorizationUrl,
+                                        style: 'primary',
+                                    },
+                                ],
+                            },
+                        ],
+                    });
+                } catch (error) {
+                    Logger.error(
+                        `Failed to post Slack MCP OAuth login message for ${mcpServer.name}`,
+                        error,
+                    );
+                }
+            }),
+        );
+    }
+
     async retrieveRelevantArtifacts({
         promptUuid,
         organizationUuid,
@@ -7056,6 +7182,20 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 debugLoggingEnabled:
                     this.lightdashConfig.ai.copilot.debugLoggingEnabled,
             });
+
+        if (isSlackPrompt(prompt) && hasTrustedPromptUserIdentity) {
+            void this.postSlackMcpOAuthLoginMessages({
+                user,
+                prompt,
+                mcpServers,
+                mcpToolSetup,
+            }).catch((error) => {
+                Logger.error(
+                    'Failed to post Slack MCP OAuth login messages',
+                    error,
+                );
+            });
+        }
 
         const dependencies: AiAgentDependencies = {
             listExplores,

--- a/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/ackReactionLifecycle.test.ts
@@ -12,6 +12,7 @@ const buildSlackPrompt = (overrides: Record<string, unknown> = {}) => ({
     projectUuid: 'proj-1',
     threadUuid: 'thread-1',
     slackChannelId: 'C123',
+    slackUserId: 'U123',
     promptSlackTs: '1700000000.000100',
     slackThreadTs: '1700000000.000000',
     createdByUserUuid: 'user-1',
@@ -19,9 +20,15 @@ const buildSlackPrompt = (overrides: Record<string, unknown> = {}) => ({
 });
 
 const buildService = () => {
+    const webClient = {
+        chat: {
+            postEphemeral: jest.fn().mockResolvedValue(undefined),
+        },
+    };
     const slackClient = {
         addReaction: jest.fn().mockResolvedValue(undefined),
         removeReaction: jest.fn().mockResolvedValue(undefined),
+        getWebClient: jest.fn().mockResolvedValue(webClient),
     };
     const aiAgentModel = {
         findSlackPrompt: jest.fn().mockResolvedValue(buildSlackPrompt()),
@@ -32,8 +39,49 @@ const buildService = () => {
         lightdashConfig: {},
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
-    return { service, slackClient, aiAgentModel };
+    return { service, slackClient, aiAgentModel, webClient };
 };
+
+const postMcpOAuthLoginMessages = (
+    service: AiAgentService,
+    overrides: {
+        prompt?: Record<string, unknown>;
+        mcpServers?: { uuid: string; name: string; authType: string }[];
+        unavailableMcpServers?: {
+            serverUuid: string;
+            serverName: string;
+            message: string;
+            status: string;
+        }[];
+    } = {},
+) =>
+    (
+        service as unknown as {
+            postSlackMcpOAuthLoginMessages: (
+                args: Record<string, unknown>,
+            ) => Promise<void>;
+        }
+    ).postSlackMcpOAuthLoginMessages({
+        user: { userUuid: 'user-1', organizationUuid: 'org-1' },
+        prompt: buildSlackPrompt(overrides.prompt),
+        mcpServers: overrides.mcpServers ?? [
+            {
+                uuid: 'mcp-1',
+                name: 'Linear',
+                authType: 'oauth',
+            },
+        ],
+        mcpToolSetup: {
+            unavailableMcpServers: overrides.unavailableMcpServers ?? [
+                {
+                    serverUuid: 'mcp-1',
+                    serverName: 'Linear',
+                    message: 'Unauthorized',
+                    status: 'not_connected',
+                },
+            ],
+        },
+    });
 
 describe('AiAgentService :eyes: ack reaction lifecycle', () => {
     afterEach(() => {
@@ -108,5 +156,82 @@ describe('AiAgentService :eyes: ack reaction lifecycle', () => {
         await expect(
             service.replyToSlackPrompt('prompt-1'),
         ).resolves.toBeUndefined();
+    });
+
+    it('posts one MCP OAuth login ephemeral per unavailable OAuth server', async () => {
+        const { service, slackClient, webClient } = buildService();
+        const startOAuth = jest
+            .spyOn(service, 'startMcpOAuthConnection')
+            .mockImplementation(
+                async (_user, _projectUuid, mcpServerUuid) =>
+                    `https://oauth.example/${mcpServerUuid}`,
+            );
+
+        await postMcpOAuthLoginMessages(service, {
+            mcpServers: [
+                {
+                    uuid: 'mcp-1',
+                    name: 'Linear',
+                    authType: 'oauth',
+                },
+                {
+                    uuid: 'mcp-2',
+                    name: 'GitHub',
+                    authType: 'oauth',
+                },
+                {
+                    uuid: 'mcp-3',
+                    name: 'Docs',
+                    authType: 'bearer',
+                },
+            ],
+            unavailableMcpServers: [
+                {
+                    serverUuid: 'mcp-1',
+                    serverName: 'Linear',
+                    message: 'Unauthorized',
+                    status: 'not_connected',
+                },
+                {
+                    serverUuid: 'mcp-2',
+                    serverName: 'GitHub',
+                    message: 'Unauthorized',
+                    status: 'not_connected',
+                },
+                {
+                    serverUuid: 'mcp-3',
+                    serverName: 'Docs',
+                    message: 'Broken',
+                    status: 'error',
+                },
+            ],
+        });
+
+        expect(slackClient.getWebClient).toHaveBeenCalledWith('org-1');
+        expect(startOAuth).toHaveBeenCalledTimes(2);
+        expect(startOAuth).toHaveBeenNthCalledWith(
+            1,
+            expect.any(Object),
+            'proj-1',
+            'mcp-1',
+            undefined,
+            { connectionStatusOnAuthorization: 'not_connected' },
+        );
+        expect(webClient.chat.postEphemeral).toHaveBeenCalledTimes(2);
+        expect(webClient.chat.postEphemeral).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                channel: 'C123',
+                user: 'U123',
+                thread_ts: '1700000000.000000',
+                text: 'Linear MCP needs you to log in before I can use it.',
+            }),
+        );
+        expect(webClient.chat.postEphemeral).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                text: 'GitHub MCP needs you to log in before I can use it.',
+            }),
+        );
     });
 });

--- a/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
+++ b/packages/backend/src/ee/services/ai/AiAgentMcpRuntimeClient.ts
@@ -175,6 +175,8 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
 
     private readonly forceReauth: boolean;
 
+    private readonly connectionStatusOnAuthorization: AiMcpServerConnectionStatus;
+
     private readonly defaultClientMetadata: OAuthClientMetadata;
 
     constructor(args: {
@@ -184,6 +186,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         saveCredential: (payload: AiMcpOAuthCredentialPayload) => Promise<void>;
         onAuthorizationUrl?: (url: URL) => void | Promise<void>;
         forceReauth?: boolean;
+        connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
         clientMetadata?: OAuthClientMetadata;
     }) {
         this.credentialScope = args.credentialScope;
@@ -192,6 +195,8 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         this.saveCredential = args.saveCredential;
         this.onAuthorizationUrl = args.onAuthorizationUrl;
         this.forceReauth = args.forceReauth ?? false;
+        this.connectionStatusOnAuthorization =
+            args.connectionStatusOnAuthorization ?? 'connecting';
         this.defaultClientMetadata =
             args.clientMetadata ??
             buildDefaultClientMetadata(this.redirectTargetUrl);
@@ -285,7 +290,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         const payload = await this.loadPayload();
         await this.persist({
             ...payload,
-            connectionStatus: 'connecting',
+            connectionStatus: this.connectionStatusOnAuthorization,
             lastError: undefined,
         });
 
@@ -297,7 +302,7 @@ class PersistentMcpOAuthClientProvider implements OAuthClientProvider {
         await this.persist({
             ...payload,
             codeVerifier,
-            connectionStatus: 'connecting',
+            connectionStatus: this.connectionStatusOnAuthorization,
             lastError: undefined,
         });
     }
@@ -713,6 +718,7 @@ export class AiAgentMcpRuntimeClient {
         actorUserUuid?: string;
         onAuthorizationUrl?: (url: URL) => void | Promise<void>;
         forceReauth?: boolean;
+        connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
     }) {
         return new PersistentMcpOAuthClientProvider({
             credentialScope: args.credentialScope,
@@ -739,6 +745,8 @@ export class AiAgentMcpRuntimeClient {
             },
             onAuthorizationUrl: args.onAuthorizationUrl,
             forceReauth: args.forceReauth,
+            connectionStatusOnAuthorization:
+                args.connectionStatusOnAuthorization,
         });
     }
 
@@ -788,6 +796,7 @@ export class AiAgentMcpRuntimeClient {
         userUuid?: string;
         serverUrl: string;
         actorUserUuid: string;
+        connectionStatusOnAuthorization?: AiMcpServerConnectionStatus;
     }): Promise<string> {
         let authorizationUrl: URL | undefined;
         const provider = this.createMcpOAuthProvider({
@@ -797,6 +806,8 @@ export class AiAgentMcpRuntimeClient {
             userUuid: args.userUuid,
             actorUserUuid: args.actorUserUuid,
             forceReauth: true,
+            connectionStatusOnAuthorization:
+                args.connectionStatusOnAuthorization,
             onAuthorizationUrl: (url) => {
                 authorizationUrl = url;
             },


### PR DESCRIPTION
### Description
- Post Slack ephemeral login prompts for unavailable OAuth MCP servers.
- Keep Slack-started MCP OAuth credentials in `not_connected` while preserving OAuth callback state.
- Keep notice posting off the response path.
- Cover Slack notice filtering and default OAuth start behavior.

Closes: PROD-7877