### PR TITLE
feat(ai-copilot): reframe review cards around impact + ready fix

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -68,6 +68,21 @@
 .card:hover .startAction {
     opacity: 1;
 }
+.fixReadyWrap {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 140ms ease;
+}
+.card:has(.cardBody:hover) .fixReadyWrap,
+.cardSelected .fixReadyWrap {
+    grid-template-rows: 1fr;
+}
+.fixReadyRow {
+    overflow: hidden;
+    min-height: 0;
+    border-left: 2px solid var(--mantine-color-indigo-3);
+    padding-left: var(--mantine-spacing-xs);
+}
 .assigneeUnassigned {
     opacity: 0.4;
     transition: opacity 120ms ease;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -44,6 +44,8 @@ const items = [
         linkedPrUrl: null,
         agentUuid: null,
         firstSeenAt: new Date('2026-06-01'),
+        lastSeenAt: new Date('2026-06-01'),
+        findingCount: 1,
         writebackEligibility: { eligible: false, reason: 'no_fix_targets' },
         latestFinding: {
             fixTargets: [],
@@ -62,6 +64,8 @@ const items = [
         linkedPrUrl: null,
         agentUuid: null,
         firstSeenAt: new Date('2026-06-01'),
+        lastSeenAt: new Date('2026-06-01'),
+        findingCount: 1,
         writebackEligibility: { eligible: false, reason: 'no_fix_targets' },
         latestFinding: {
             fixTargets: [],

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -3,12 +3,15 @@ import {
     Badge,
     Box,
     Button,
+    Code,
     Group,
     HoverCard,
     Stack,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
 import {
+    IconArrowRight,
     IconArrowUpRight,
     IconBox,
     IconGitPullRequest,
@@ -26,8 +29,11 @@ import { AiAgentIcon } from '../AiAgentIcon';
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
 import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
 import {
+    formatRelativeReviewDate,
     formatReviewDate,
+    getFixReadyText,
     getIssueTitle,
+    getTargetAnchor,
     reviewRootCauseColors,
     reviewRootCauseLabels,
 } from './reviewItemDetails';
@@ -51,6 +57,13 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
     const isAgentRunning =
         item.prWritebackStatus === 'queued' ||
         item.prWritebackStatus === 'running';
+
+    const title = getIssueTitle(item);
+    const targetAnchor = getTargetAnchor(item);
+    const isRecurring = item.findingCount > 1;
+    // The fix row would just echo a fix-framed title; only surface it when it adds something.
+    const fixReadyText = getFixReadyText(item);
+    const showFixReady = fixReadyText !== null && fixReadyText !== title;
 
     const startKind = getStartWritebackKind(item);
 
@@ -96,22 +109,80 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                         align="flex-start"
                         wrap="nowrap"
                     >
-                        <Text fz="sm" fw={550} lineClamp={2}>
-                            {getIssueTitle(item)}
-                        </Text>
+                        <Stack gap={2} style={{ minWidth: 0 }}>
+                            <Text fz="sm" fw={550} lineClamp={2}>
+                                {title}
+                            </Text>
+                            {targetAnchor && (
+                                <Code
+                                    fz={10}
+                                    c="dimmed"
+                                    w="fit-content"
+                                    maw="100%"
+                                >
+                                    {targetAnchor}
+                                </Code>
+                            )}
+                        </Stack>
                         <Group gap={8} wrap="nowrap" align="center">
                             {isAgentRunning && (
                                 <AiAgentIcon size={14} animated />
                             )}
-                            <Text
-                                fz="xs"
-                                c="dimmed"
-                                style={{ whiteSpace: 'nowrap' }}
+                            {isRecurring && (
+                                <Tooltip
+                                    variant="xs"
+                                    label={`Seen ${item.findingCount} times`}
+                                    position="top"
+                                >
+                                    <Badge
+                                        size="sm"
+                                        radius="sm"
+                                        variant="light"
+                                        color="orange"
+                                    >
+                                        {item.findingCount}×
+                                    </Badge>
+                                </Tooltip>
+                            )}
+                            <Tooltip
+                                variant="xs"
+                                position="top"
+                                label={`First seen ${formatReviewDate(
+                                    item.firstSeenAt,
+                                )} · last seen ${formatReviewDate(
+                                    item.lastSeenAt,
+                                )}`}
                             >
-                                {formatReviewDate(item.firstSeenAt)}
-                            </Text>
+                                <Text
+                                    fz="xs"
+                                    c="dimmed"
+                                    style={{ whiteSpace: 'nowrap' }}
+                                >
+                                    {formatRelativeReviewDate(item.lastSeenAt)}
+                                </Text>
+                            </Tooltip>
                         </Group>
                     </Group>
+
+                    {showFixReady && (
+                        <Box className={styles.fixReadyWrap}>
+                            <Group
+                                gap={6}
+                                wrap="nowrap"
+                                align="flex-start"
+                                className={styles.fixReadyRow}
+                            >
+                                <MantineIcon
+                                    icon={IconArrowRight}
+                                    size={13}
+                                    color="indigo"
+                                />
+                                <Text fz="xs" c="dimmed" lineClamp={2}>
+                                    {fixReadyText}
+                                </Text>
+                            </Group>
+                        </Box>
+                    )}
 
                     <Group
                         gap={6}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.test.ts
@@ -1,0 +1,154 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    formatRelativeReviewDate,
+    getFixReadyText,
+    getIssueTitle,
+    getTargetAnchor,
+} from './reviewItemDetails';
+
+const makeItem = (
+    overrides: Omit<Partial<AiAgentReviewItemSummary>, 'latestFinding'> & {
+        latestFinding?: Record<string, unknown> | null;
+    },
+): AiAgentReviewItemSummary =>
+    ({
+        title: 'Fallback title',
+        description: 'desc',
+        primaryRootCause: 'semantic_layer',
+        findingCount: 1,
+        ...overrides,
+        latestFinding:
+            overrides.latestFinding === null
+                ? null
+                : {
+                      fixTargets: [],
+                      targetRefs: [],
+                      evidenceExcerpts: [],
+                      recommendation: null,
+                      projectContextEntry: null,
+                      ...overrides.latestFinding,
+                  },
+    }) as unknown as AiAgentReviewItemSummary;
+
+describe('getIssueTitle', () => {
+    it('no longer special-cases semantic_layer into a "Review {target}" title', () => {
+        const item = makeItem({
+            primaryRootCause: 'semantic_layer',
+            latestFinding: {
+                targetRefs: [
+                    {
+                        type: 'dimension',
+                        modelName: 'users',
+                        dimensionName: 'users',
+                    },
+                ],
+                recommendation: {
+                    actionType: 'update_semantic_yaml',
+                    title: 'Add weekly_active_users metric',
+                    rationale: 'because',
+                    targetRefs: [],
+                },
+            },
+        });
+
+        expect(getIssueTitle(item)).toBe('Add weekly_active_users metric');
+        expect(getIssueTitle(item)).not.toMatch(/^Review /);
+    });
+
+    it('falls back to the item title when there is no recommendation', () => {
+        const item = makeItem({
+            title: 'No metric for weekly active users',
+            latestFinding: { recommendation: null },
+        });
+        expect(getIssueTitle(item)).toBe('No metric for weekly active users');
+    });
+});
+
+describe('getTargetAnchor', () => {
+    it('returns the model.field anchor for the first target ref', () => {
+        const item = makeItem({
+            latestFinding: {
+                targetRefs: [
+                    {
+                        type: 'metric',
+                        modelName: 'orders',
+                        metricName: 'total_revenue',
+                    },
+                ],
+            },
+        });
+        expect(getTargetAnchor(item)).toBe('orders.total_revenue');
+    });
+
+    it('returns null when there are no target refs', () => {
+        expect(getTargetAnchor(makeItem({ latestFinding: null }))).toBeNull();
+    });
+});
+
+describe('getFixReadyText', () => {
+    it('uses the literal project-context sentence when present', () => {
+        const item = makeItem({
+            primaryRootCause: 'project_context',
+            latestFinding: {
+                projectContextEntry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'definition',
+                    content: 'Active user means signed in within 28 days.',
+                    terms: [],
+                    objects: [],
+                },
+            },
+        });
+        expect(getFixReadyText(item)).toBe(
+            'Active user means signed in within 28 days.',
+        );
+    });
+
+    it('falls back to the recommendation title for semantic-layer fixes', () => {
+        const item = makeItem({
+            latestFinding: {
+                recommendation: {
+                    actionType: 'update_semantic_yaml',
+                    title: 'Add weekly_active_users metric',
+                    rationale: 'because',
+                    targetRefs: [],
+                },
+            },
+        });
+        expect(getFixReadyText(item)).toBe('Add weekly_active_users metric');
+    });
+
+    it('returns null when the finding is too thin to promise a fix', () => {
+        expect(getFixReadyText(makeItem({ latestFinding: null }))).toBeNull();
+        expect(
+            getFixReadyText(
+                makeItem({ latestFinding: { recommendation: null } }),
+            ),
+        ).toBeNull();
+    });
+});
+
+describe('formatRelativeReviewDate', () => {
+    it('renders coarse relative recency for recent findings', () => {
+        const now = Date.now();
+        expect(formatRelativeReviewDate(new Date(now - 30_000))).toBe(
+            'just now',
+        );
+        expect(formatRelativeReviewDate(new Date(now - 5 * 60_000))).toBe(
+            '5m ago',
+        );
+        expect(formatRelativeReviewDate(new Date(now - 3 * 3_600_000))).toBe(
+            '3h ago',
+        );
+        expect(formatRelativeReviewDate(new Date(now - 2 * 86_400_000))).toBe(
+            '2d ago',
+        );
+    });
+
+    it('falls back to an absolute date once older than a week', () => {
+        const old = new Date(Date.now() - 30 * 86_400_000);
+        expect(formatRelativeReviewDate(old)).not.toMatch(/ago/);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -94,6 +94,31 @@ export const formatReviewDate = (date: Date): string => {
     });
 };
 
+/**
+ * Coarse "last seen 2h ago" recency, falling back to an absolute date once the
+ * finding is more than a week old (where relative phrasing stops being useful).
+ */
+export const formatRelativeReviewDate = (date: Date): string => {
+    const parsedDate = new Date(date);
+    const diffMs = new Date().getTime() - parsedDate.getTime();
+    const diffMinutes = Math.floor(diffMs / 60_000);
+
+    if (diffMinutes < 1) return 'just now';
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+
+    return formatReviewDate(parsedDate);
+};
+
+export const getTargetAnchor = (
+    reviewItem: AiAgentReviewItemSummary,
+): string | null => getTargetLabel(reviewItem.latestFinding?.targetRefs ?? []);
+
 const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
     const targetRef = targetRefs[0];
     if (!targetRef) return null;
@@ -129,14 +154,27 @@ export const getIssueTitle = (reviewItem: AiAgentReviewItemSummary): string => {
         return 'Triage correction signal';
     }
 
-    const targetLabel = getTargetLabel(
-        reviewItem.latestFinding?.targetRefs ?? [],
-    );
-    if (targetLabel && reviewItem.primaryRootCause === 'semantic_layer') {
-        return `Review ${targetLabel}`;
+    return reviewItem.latestFinding?.recommendation?.title ?? reviewItem.title;
+};
+
+/**
+ * The concrete change a writeback would make, used for the card's fix-ready row:
+ * the literal project-context sentence, or the semantic-layer recommendation.
+ * Returns null when the data is too thin to promise a fix.
+ */
+export const getFixReadyText = (
+    reviewItem: AiAgentReviewItemSummary,
+): string | null => {
+    if (isTriageReviewItem(reviewItem)) return null;
+
+    const finding = reviewItem.latestFinding;
+    if (!finding) return null;
+
+    if (finding.projectContextEntry) {
+        return finding.projectContextEntry.content;
     }
 
-    return reviewItem.latestFinding?.recommendation?.title ?? reviewItem.title;
+    return finding.recommendation?.title ?? null;
 };
 
 export const getWhatHappened = (


### PR DESCRIPTION
Review board cards used to title every `semantic_layer` finding `Review {model}.{field}` — a wall of repeated "Review …" that duplicated the `Semantic layer` badge and named the object but never what was wrong. This reframes each card around evidence of a recurring failure with a ready fix, using data already on `AiAgentReviewItemSummary` that we weren't surfacing.

Changes to `ReviewKanbanCard`:
- **Problem-led title** — drop the `semantic_layer` special case in `getIssueTitle()` so every card leads with the descriptive `recommendation.title` / finding title, like every other root cause.
- **Frequency pill** — `{findingCount}×` flags a recurring pattern vs a one-off (shown only when >1).
- **Recency** — relative `lastSeenAt` ("2h ago", absolute date past a week) replaces `firstSeenAt`, with first/last seen in a tooltip.
- **`model.field` anchor** — kept as a quiet monospace line under the title.
- **Fix-ready row** — the literal `projectContextEntry.content` sentence (project-context) or the semantic recommendation, revealed on hover/select via CSS progressive disclosure. Skipped when it would just echo the title.

Out of scope (per the issue): verbatim user-correction quotes (`evidenceExcerpts`) — PII risk and card bloat.

Note: I went straight to the component change rather than the suggested throwaway HTML prototype, since the visual direction was already validated in the design chat.

Unit tests added for the new `reviewItemDetails` helpers (`getIssueTitle`, `getTargetAnchor`, `getFixReadyText`, `formatRelativeReviewDate`).