### PR TITLE
feat(navbar): move theme switcher into user popover menu

### DIFF
--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -14,7 +14,6 @@ import { MetricsLink } from './MetricsLink';
 import { NotificationsMenu } from './NotificationsMenu';
 import ProjectSwitcher from './ProjectSwitcher';
 import SettingsMenu from './SettingsMenu';
-import { ThemeSwitcher } from './ThemeSwitcher';
 import UserCredentialsSwitcher from './UserCredentialsSwitcher';
 import UserMenu from './UserMenu';
 
@@ -75,8 +74,6 @@ export const MainNavBarContent: FC<Props> = ({
 
             <Group className={classes.rightGroup}>
                 <Button.Group>
-                    <ThemeSwitcher />
-
                     <SettingsMenu />
 
                     {!isLoadingActiveProject && activeProjectUuid && (

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcher.module.css
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcher.module.css
@@ -4,6 +4,8 @@
 }
 
 .themeToggleIcon {
+    font-size: 16px;
+    stroke-width: 2;
     --theme-toggle__classic--duration: 750ms;
 }
 

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,38 +1,10 @@
 import { Button } from '@mantine-8/core';
-import { clsx, useMantineColorScheme } from '@mantine/core';
-import { useProjectUuid } from '../../../hooks/useProjectUuid';
-import { useAccount } from '../../../hooks/user/useAccount';
-import useTracking from '../../../providers/Tracking/useTracking';
-import { EventName } from '../../../types/Events';
 import classes from './ThemeSwitcher.module.css';
+import { ThemeToggleIcon } from './ThemeToggleIcon';
+import { useThemeToggle } from './useThemeToggle';
 
 export const ThemeSwitcher = () => {
-    const { data: account } = useAccount();
-    const { organizationUuid } = account?.organization || {};
-    const projectUuid = useProjectUuid();
-
-    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
-    const { track } = useTracking();
-
-    const isDark = colorScheme === 'dark';
-
-    const handleThemeToggle = () => {
-        if (organizationUuid && account && projectUuid) {
-            const newColorScheme = isDark ? 'light' : 'dark';
-
-            track({
-                name: EventName.THEME_TOGGLED,
-                properties: {
-                    userId: account.user.id,
-                    projectId: projectUuid,
-                    organizationId: organizationUuid,
-                    to: newColorScheme,
-                },
-            });
-        }
-
-        toggleColorScheme();
-    };
+    const { isDark, handleThemeToggle } = useThemeToggle();
 
     return (
         <Button
@@ -43,35 +15,7 @@ export const ThemeSwitcher = () => {
             onClick={handleThemeToggle}
             className={classes.themeToggle}
         >
-            <svg
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
-                width="1em"
-                height="1em"
-                fill="currentColor"
-                strokeLinecap="round"
-                className={clsx(classes.themeToggleIcon, {
-                    [classes.toggled]: !isDark,
-                })}
-                viewBox="0 0 32 32"
-            >
-                <clipPath id="theme-toggle-sun">
-                    <path d="M0-5h30a1 1 0 0 0 9 13v24H0Z" />
-                </clipPath>
-                <g clipPath="url(#theme-toggle-sun)">
-                    <circle cx="16" cy="16" r="9.34" />
-                    <g stroke="currentColor" strokeWidth="1.5">
-                        <path d="M16 5.5v-4" />
-                        <path d="M16 30.5v-4" />
-                        <path d="M1.5 16h4" />
-                        <path d="M26.5 16h4" />
-                        <path d="m23.4 8.6 2.8-2.8" />
-                        <path d="m5.7 26.3 2.9-2.9" />
-                        <path d="m5.8 5.8 2.8 2.8" />
-                        <path d="m23.4 23.4 2.9 2.9" />
-                    </g>
-                </g>
-            </svg>
+            <ThemeToggleIcon isDark={isDark} />
         </Button>
     );
 };

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcherMenuItem.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeSwitcherMenuItem.tsx
@@ -1,0 +1,18 @@
+import { Menu } from '@mantine-8/core';
+import { ThemeToggleIcon } from './ThemeToggleIcon';
+import { useThemeToggle } from './useThemeToggle';
+
+export const ThemeSwitcherMenuItem = () => {
+    const { isDark, handleThemeToggle } = useThemeToggle();
+
+    return (
+        <Menu.Item
+            role="menuitem"
+            closeMenuOnClick={false}
+            onClick={handleThemeToggle}
+            leftSection={<ThemeToggleIcon isDark={isDark} />}
+        >
+            {isDark ? 'Light mode' : 'Dark mode'}
+        </Menu.Item>
+    );
+};

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeToggleIcon.tsx
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/ThemeToggleIcon.tsx
@@ -1,0 +1,39 @@
+import { clsx } from '@mantine/core';
+import { type FC } from 'react';
+import classes from './ThemeSwitcher.module.css';
+
+type Props = {
+    isDark: boolean;
+};
+
+export const ThemeToggleIcon: FC<Props> = ({ isDark }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        width="1em"
+        height="1em"
+        fill="currentColor"
+        strokeLinecap="round"
+        className={clsx(classes.themeToggleIcon, {
+            [classes.toggled]: !isDark,
+        })}
+        viewBox="0 0 32 32"
+    >
+        <clipPath id="theme-toggle-sun">
+            <path d="M0-5h30a1 1 0 0 0 9 13v24H0Z" />
+        </clipPath>
+        <g clipPath="url(#theme-toggle-sun)">
+            <circle cx="16" cy="16" r="9.34" />
+            <g stroke="currentColor" strokeWidth="1.5">
+                <path d="M16 5.5v-4" />
+                <path d="M16 30.5v-4" />
+                <path d="M1.5 16h4" />
+                <path d="M26.5 16h4" />
+                <path d="m23.4 8.6 2.8-2.8" />
+                <path d="m5.7 26.3 2.9-2.9" />
+                <path d="m5.8 5.8 2.8 2.8" />
+                <path d="m23.4 23.4 2.9 2.9" />
+            </g>
+        </g>
+    </svg>
+);

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/index.ts
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/index.ts
@@ -1,1 +1,2 @@
 export { ThemeSwitcher } from './ThemeSwitcher';
+export { ThemeSwitcherMenuItem } from './ThemeSwitcherMenuItem';

--- a/packages/frontend/src/components/NavBar/ThemeSwitcher/useThemeToggle.ts
+++ b/packages/frontend/src/components/NavBar/ThemeSwitcher/useThemeToggle.ts
@@ -1,0 +1,36 @@
+import { useMantineColorScheme } from '@mantine/core';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import { useAccount } from '../../../hooks/user/useAccount';
+import useTracking from '../../../providers/Tracking/useTracking';
+import { EventName } from '../../../types/Events';
+
+export const useThemeToggle = () => {
+    const { data: account } = useAccount();
+    const { organizationUuid } = account?.organization || {};
+    const projectUuid = useProjectUuid();
+
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    const { track } = useTracking();
+
+    const isDark = colorScheme === 'dark';
+
+    const handleThemeToggle = () => {
+        if (organizationUuid && account && projectUuid) {
+            const newColorScheme = isDark ? 'light' : 'dark';
+
+            track({
+                name: EventName.THEME_TOGGLED,
+                properties: {
+                    userId: account.user.id,
+                    projectId: projectUuid,
+                    organizationId: organizationUuid,
+                    to: newColorScheme,
+                },
+            });
+        }
+
+        toggleColorScheme();
+    };
+
+    return { isDark, handleThemeToggle };
+};

--- a/packages/frontend/src/components/NavBar/UserMenu.tsx
+++ b/packages/frontend/src/components/NavBar/UserMenu.tsx
@@ -6,6 +6,7 @@ import useLogoutMutation from '../../hooks/user/useUserLogoutMutation';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import { UserAvatar } from '../UserAvatar';
+import { ThemeSwitcherMenuItem } from './ThemeSwitcher';
 
 const UserMenu: FC = () => {
     const { user } = useApp();
@@ -30,6 +31,8 @@ const UserMenu: FC = () => {
             </Menu.Target>
 
             <Menu.Dropdown>
+                <ThemeSwitcherMenuItem />
+
                 <Menu.Item
                     role="menuitem"
                     component={Link}


### PR DESCRIPTION
Move the dark/light theme switcher out of the NavBar button group and into the user avatar popover, above the "User settings" option, since it's a personal preference.

The mobile drawer keeps the existing button-style switcher. Shared toggle logic and the animated icon are extracted into useThemeToggle and ThemeToggleIcon so both the button and menu-item variants reuse them.


Claude-Session: https://claude.ai/code/session_01LCMUiUG7Kw7MDA9bUT3Soh

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
