### PR TITLE
feat(data-apps): favorite an app from the preview overflow menu

### DIFF
--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { FeatureFlags } from '@lightdash/common';
+import { ContentType, FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import {
     IconAppsOff,
@@ -8,6 +8,8 @@ import {
     IconPencil,
     IconRefresh,
     IconSend,
+    IconStar,
+    IconStarFilled,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
@@ -21,6 +23,8 @@ import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQuerie
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
 import { AppSchedulersModal } from '../features/scheduler/components/SchedulerModals';
+import { useFavoriteMutation } from '../hooks/favorites/useFavoriteMutation';
+import { useFavorites } from '../hooks/favorites/useFavorites';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
@@ -72,6 +76,11 @@ export default function AppPreviewTest() {
                 createdByUserUuid: appCreatedByUserUuid,
             }),
         ) === true;
+
+    const { data: favorites } = useFavorites(projectUuid);
+    const isFavorited =
+        favorites?.some((favorite) => favorite.data.uuid === appUuid) ?? false;
+    const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
 
     const version = explicitVersion ?? latestReadyVersion;
 
@@ -216,6 +225,25 @@ export default function AppPreviewTest() {
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
+                        <Menu.Item
+                            leftSection={
+                                isFavorited ? (
+                                    <IconStarFilled size={14} color="orange" />
+                                ) : (
+                                    <IconStar size={14} />
+                                )
+                            }
+                            onClick={() =>
+                                toggleFavorite({
+                                    contentType: ContentType.DATA_APP,
+                                    contentUuid: appUuid,
+                                })
+                            }
+                        >
+                            {isFavorited
+                                ? 'Remove from favorites'
+                                : 'Add to favorites'}
+                        </Menu.Item>
                         {canEditApp && (
                             <Menu.Item
                                 leftSection={<IconPencil size={14} />}


### PR DESCRIPTION
Adds an "Add to favorites" / "Remove from favorites" item to the overflow menu shown while viewing a Data App, so users can favorite an app without leaving it to navigate back to the parent space.

Reuses the existing favorites hooks (`useFavorites` for current state, `useFavoriteMutation` to toggle), matching how favoriting works in the resource view action menu. The backend `FavoritesService` already supports `ContentType.DATA_APP`, so no API changes were needed.

### Changes
- `AppPreviewTest.tsx`: new menu item with star icon reflecting favorited state, toggling via the favorites mutation.
