### PR TITLE
fix(metrics): keep List/Canvas toggle on metrics route when a tree is open

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsTableTopToolbar/index.tsx
@@ -644,10 +644,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                             switch (view) {
                                 case MetricCatalogView.LIST:
                                     void navigate({
-                                        pathname: location.pathname.replace(
-                                            /\/canvas/,
-                                            '',
-                                        ),
+                                        pathname: `/projects/${projectUuid}/metrics`,
                                         search: location.search,
                                     });
                                     break;
@@ -661,7 +658,7 @@ export const MetricsTableTopToolbar: FC<MetricsTableTopToolbarProps> = memo(
                                         },
                                     });
                                     void navigate({
-                                        pathname: `${location.pathname}/canvas`,
+                                        pathname: `/projects/${projectUuid}/metrics/canvas`,
                                         search: location.search,
                                     });
                                     break;


### PR DESCRIPTION
Closes: #24575

### Description:

When a saved tree is open in Canvas mode, switching to **List** view redirected the user to the home page. The destination URL was derived by string-replacing `/canvas` out of the current path, which left a dangling tree slug (`/metrics/<treeSlug>`) that matched no route and fell through to the catch-all redirect.

Both toggle cases now navigate to the known project-scoped metrics route directly, preserving sort/filter query params.
