### PR TITLE
feat: steer running ai agents

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -334,6 +334,8 @@ import {
     AiPromptContextTableName,
     AiPromptInterruptTable,
     AiPromptInterruptTableName,
+    AiPromptSteerTable,
+    AiPromptSteerTableName,
     AiPromptTable,
     AiPromptTableName,
     AiSlackPromptTable,
@@ -558,6 +560,7 @@ declare module 'knex/types/tables' {
         [AiWebAppThreadTableName]: AiWebAppThreadTable;
         [AiPromptTableName]: AiPromptTable;
         [AiPromptInterruptTableName]: AiPromptInterruptTable;
+        [AiPromptSteerTableName]: AiPromptSteerTable;
         [AiPromptContextTableName]: AiPromptContextTable;
         [AiThreadCompactionTableName]: AiThreadCompactionTable;
         [AiArtifactsTableName]: AiArtifactsTable;

--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -25,6 +25,7 @@ import {
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageInterruptResponse,
+    ApiAiAgentThreadMessageSteerResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadPullRequestResponse,
     ApiAiAgentThreadResponse,
@@ -46,6 +47,7 @@ import {
     ApiConnectGithubMcpServerBody,
     ApiCreateAiAgent,
     ApiCreateAiAgentResponse,
+    ApiCreateAiAgentThreadMessageSteer,
     ApiCreateAiMcpServer,
     ApiCreateEvaluationRequest,
     ApiCreateEvaluationResponse,
@@ -1139,6 +1141,36 @@ export class AiAgentController extends BaseController {
         return {
             status: 'ok',
             results: { interrupted: true },
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/steers')
+    @OperationId('createAgentThreadMessageSteer')
+    async createAgentThreadMessageSteer(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() agentUuid: string,
+        @Path() threadUuid: string,
+        @Path() messageUuid: string,
+        @Body() body: ApiCreateAiAgentThreadMessageSteer,
+    ): Promise<ApiAiAgentThreadMessageSteerResponse> {
+        assertRegisteredAccount(req.account);
+        const steer =
+            await this.getAiAgentService().createAgentThreadMessageSteer(
+                toSessionUser(req.account),
+                {
+                    agentUuid,
+                    threadUuid,
+                    messageUuid,
+                    message: body.message,
+                },
+            );
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: { steer },
         };
     }
 

--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -185,6 +185,29 @@ export type AiPromptInterruptTable = Knex.CompositeTableType<
     never
 >;
 
+export const AiPromptSteerTableName = 'ai_prompt_steer';
+
+export type DbAiPromptSteer = {
+    ai_prompt_steer_uuid: string;
+    ai_prompt_uuid: string;
+    created_by_user_uuid: string;
+    message: string;
+    created_at: Date;
+    consumed_at: Date | null;
+    consumed_step: number | null;
+};
+
+export type AiPromptSteerTable = Knex.CompositeTableType<
+    DbAiPromptSteer,
+    Pick<
+        DbAiPromptSteer,
+        'ai_prompt_uuid' | 'created_by_user_uuid' | 'message'
+    >,
+    Partial<Pick<DbAiPromptSteer, 'consumed_step'>> & {
+        consumed_at?: Date | Knex.Raw;
+    }
+>;
+
 export const AiThreadCompactionTableName = 'ai_thread_compaction';
 
 export type DbAiThreadCompaction = {

--- a/packages/backend/src/ee/database/migrations/20260622121000_add_ai_prompt_steer.ts
+++ b/packages/backend/src/ee/database/migrations/20260622121000_add_ai_prompt_steer.ts
@@ -1,0 +1,37 @@
+import { Knex } from 'knex';
+
+const AiPromptSteerTableName = 'ai_prompt_steer';
+const AiPromptTableName = 'ai_prompt';
+const UserTableName = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AiPromptSteerTableName, (table) => {
+        table
+            .uuid('ai_prompt_steer_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('ai_prompt_uuid')
+            .notNullable()
+            .references('ai_prompt_uuid')
+            .inTable(AiPromptTableName)
+            .onDelete('CASCADE');
+        table
+            .uuid('created_by_user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(UserTableName)
+            .onDelete('CASCADE');
+        table.text('message').notNullable();
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.timestamp('consumed_at').nullable();
+        table.integer('consumed_step').nullable();
+
+        table.index(['ai_prompt_uuid', 'consumed_at']);
+        table.index('created_at');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AiPromptSteerTableName);
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -35,6 +35,7 @@ import {
     AiPromptContextInput,
     AiPromptContextItem,
     AiPromptProposedChangePayload,
+    AiPromptSteer,
     AiResultType,
     AiThread,
     AiThreadCompaction,
@@ -101,6 +102,7 @@ import {
     AiPromptContextEntityType,
     AiPromptContextTableName,
     AiPromptInterruptTableName,
+    AiPromptSteerTableName,
     AiPromptTableName,
     AiSlackPromptTableName,
     AiSlackThreadTableName,
@@ -115,6 +117,7 @@ import {
     DbAiPrompt,
     DbAiPromptContext,
     DbAiPromptInterrupt,
+    DbAiPromptSteer,
     DbAiSlackPrompt,
     DbAiSlackThread,
     DbAiSqlApproval,
@@ -298,6 +301,25 @@ const normalizeToolName = (toolName: string): string =>
 // than failing the whole thread read.
 const isParseableToolName = (toolName: string): boolean =>
     isAiAgentToolName(normalizeToolName(toolName));
+
+type AiPromptSteerRow = Pick<
+    DbAiPromptSteer,
+    | 'ai_prompt_steer_uuid'
+    | 'ai_prompt_uuid'
+    | 'message'
+    | 'created_at'
+    | 'consumed_at'
+    | 'consumed_step'
+>;
+
+const toAiPromptSteer = (row: AiPromptSteerRow): AiPromptSteer => ({
+    uuid: row.ai_prompt_steer_uuid,
+    promptUuid: row.ai_prompt_uuid,
+    message: row.message,
+    createdAt: row.created_at.toISOString(),
+    consumedAt: row.consumed_at?.toISOString() ?? null,
+    consumedStep: row.consumed_step,
+});
 
 export class AiAgentModel {
     private database: Knex;
@@ -3220,6 +3242,7 @@ export class AiAgentModel {
             { promptUuids },
         );
         const contextMap = await this.getContextForPromptUuids(promptUuids);
+        const steersMap = await this.findPromptSteers(promptUuids);
 
         const messagesPromises = promptRows.map(async (row) => {
             const messages: AiAgentMessage<{
@@ -3240,6 +3263,7 @@ export class AiAgentModel {
                     slackUserId: row.slack_user_id,
                 },
                 context: contextMap.get(row.ai_prompt_uuid) ?? [],
+                steers: steersMap.get(row.ai_prompt_uuid) ?? [],
                 hidden: row.hidden ?? false,
             });
 
@@ -3980,6 +4004,10 @@ export class AiAgentModel {
         );
         const referencedArtifacts =
             referencedArtifactsMap.get(row.ai_prompt_uuid) ?? null;
+        const steers =
+            (await this.findPromptSteers([row.ai_prompt_uuid])).get(
+                row.ai_prompt_uuid,
+            ) ?? [];
 
         switch (role) {
             case 'user':
@@ -3999,6 +4027,7 @@ export class AiAgentModel {
                                 row.ai_prompt_uuid,
                             ])
                         ).get(row.ai_prompt_uuid) ?? [],
+                    steers,
                     hidden: row.hidden ?? false,
                 } satisfies AiAgentMessageUser;
             case 'assistant':
@@ -4382,6 +4411,89 @@ export class AiAgentModel {
             .first();
 
         return row !== undefined;
+    }
+
+    async createAiPromptSteer(data: {
+        promptUuid: string;
+        createdByUserUuid: string;
+        message: string;
+    }): Promise<AiPromptSteer> {
+        const [row] = await this.database(AiPromptSteerTableName)
+            .insert({
+                ai_prompt_uuid: data.promptUuid,
+                created_by_user_uuid: data.createdByUserUuid,
+                message: data.message,
+            })
+            .returning([
+                'ai_prompt_steer_uuid',
+                'ai_prompt_uuid',
+                'message',
+                'created_at',
+                'consumed_at',
+                'consumed_step',
+            ]);
+
+        if (row === undefined) {
+            throw new UnexpectedServerError('Failed to create AI prompt steer');
+        }
+
+        return toAiPromptSteer(row);
+    }
+
+    async findPromptSteers(
+        promptUuids: string[],
+    ): Promise<Map<string, AiPromptSteer[]>> {
+        if (promptUuids.length === 0) return new Map();
+
+        const rows = await this.database(AiPromptSteerTableName)
+            .select<AiPromptSteerRow[]>(
+                `${AiPromptSteerTableName}.ai_prompt_steer_uuid`,
+                `${AiPromptSteerTableName}.ai_prompt_uuid`,
+                `${AiPromptSteerTableName}.message`,
+                `${AiPromptSteerTableName}.created_at`,
+                `${AiPromptSteerTableName}.consumed_at`,
+                `${AiPromptSteerTableName}.consumed_step`,
+            )
+            .whereIn(`${AiPromptSteerTableName}.ai_prompt_uuid`, promptUuids)
+            .orderBy(`${AiPromptSteerTableName}.created_at`, 'asc');
+
+        return rows.reduce((map, row) => {
+            const steers = map.get(row.ai_prompt_uuid) ?? [];
+            steers.push(toAiPromptSteer(row));
+            map.set(row.ai_prompt_uuid, steers);
+            return map;
+        }, new Map<string, AiPromptSteer[]>());
+    }
+
+    async consumeUnconsumedPromptSteers(data: {
+        promptUuid: string;
+        stepNumber: number;
+    }): Promise<AiPromptSteer[]> {
+        return this.database.transaction(async (trx) => {
+            const consumedRows = await trx(AiPromptSteerTableName)
+                .where({
+                    ai_prompt_uuid: data.promptUuid,
+                    consumed_at: null,
+                })
+                .update({
+                    consumed_at: trx.fn.now(),
+                    consumed_step: data.stepNumber,
+                })
+                .returning<AiPromptSteerRow[]>([
+                    'ai_prompt_steer_uuid',
+                    'ai_prompt_uuid',
+                    'message',
+                    'created_at',
+                    'consumed_at',
+                    'consumed_step',
+                ]);
+
+            if (consumedRows.length === 0) return [];
+
+            return consumedRows
+                .sort((a, b) => a.created_at.getTime() - b.created_at.getTime())
+                .map(toAiPromptSteer);
+        });
     }
 
     async createThreadCompaction(data: {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -26,6 +26,7 @@ import {
     AiMetricQueryWithFilters,
     AiModelOption,
     AiPromptContext,
+    AiPromptSteer,
     AiResultType,
     AiVizMetadata,
     AiWebAppPrompt,
@@ -4158,6 +4159,81 @@ export class AiAgentService extends BaseService {
         });
     }
 
+    async createAgentThreadMessageSteer(
+        user: SessionUser,
+        {
+            agentUuid,
+            threadUuid,
+            messageUuid,
+            message,
+        }: {
+            agentUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+            message: string;
+        },
+    ): Promise<AiPromptSteer> {
+        if (!user.organizationUuid) {
+            throw new ForbiddenError();
+        }
+
+        const trimmedMessage = message.trim();
+        if (trimmedMessage.length === 0) {
+            throw new ParameterError('Steer message is required');
+        }
+
+        const prompt = await this.aiAgentModel.findWebAppPrompt(messageUuid);
+
+        if (
+            !prompt ||
+            prompt.organizationUuid !== user.organizationUuid ||
+            prompt.agentUuid !== agentUuid ||
+            prompt.threadUuid !== threadUuid
+        ) {
+            throw new NotFoundError(`Prompt not found: ${messageUuid}`);
+        }
+
+        const agent = await this.aiAgentModel.getAgent({
+            organizationUuid: user.organizationUuid,
+            agentUuid,
+        });
+        if (!agent) {
+            throw new NotFoundError(`Agent not found: ${agentUuid}`);
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid: user.organizationUuid,
+            agentUuid,
+            threadUuid,
+        });
+        if (!thread) {
+            throw new NotFoundError(`Thread not found: ${threadUuid}`);
+        }
+
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to steer this agent thread',
+            );
+        }
+
+        const isInterrupted =
+            await this.aiAgentModel.hasAiPromptInterrupt(messageUuid);
+        if (isInterrupted) {
+            throw new ParameterError('Cannot steer an interrupted prompt');
+        }
+
+        return this.aiAgentModel.createAiPromptSteer({
+            promptUuid: messageUuid,
+            createdByUserUuid: user.userUuid,
+            message: trimmedMessage,
+        });
+    }
+
     async getEmbedAgentModelOptions(
         account: AnonymousAccount,
         projectUuid: string,
@@ -6737,6 +6813,14 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeReasoning,
             isPromptInterrupted: (promptUuid: string) =>
                 this.aiAgentModel.hasAiPromptInterrupt(promptUuid),
+            consumePromptSteers: (args: {
+                promptUuid: string;
+                stepNumber: number;
+            }) =>
+                this.aiAgentModel.consumeUnconsumedPromptSteers({
+                    promptUuid: args.promptUuid,
+                    stepNumber: args.stepNumber,
+                }),
             searchFieldValues: toolsRuntime.searchFieldValues,
             editDbtProject,
             editProjectContext,
@@ -6903,6 +6987,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeToolResults,
             storeReasoning,
             isPromptInterrupted,
+            consumePromptSteers,
             searchFieldValues,
             editDbtProject,
             editProjectContext,
@@ -7315,6 +7400,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             storeToolResults,
             storeReasoning,
             isPromptInterrupted,
+            consumePromptSteers,
             searchFieldValues,
             editDbtProject,
             editProjectContext,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -156,6 +156,55 @@ const buildForcedFirstStep = (args: AiAgentArgs, tools: ToolSet) => {
             : {};
 };
 
+const buildPrepareStep = ({
+    args,
+    dependencies,
+    tools,
+    logger,
+}: {
+    args: AiAgentArgs;
+    dependencies: AiAgentDependencies;
+    tools: ToolSet;
+    logger: ReturnType<typeof createAiAgentLogger>;
+}) => {
+    const forcedFirstStep = buildForcedFirstStep(args, tools);
+
+    return async ({
+        stepNumber,
+        messages,
+    }: {
+        stepNumber: number;
+        messages: ModelMessage[];
+    }) => {
+        const forced = forcedFirstStep?.({ stepNumber }) ?? {};
+        const steers = await dependencies.consumePromptSteers({
+            promptUuid: args.promptUuid,
+            stepNumber,
+        });
+
+        if (steers.length === 0) return forced;
+
+        logger(
+            'Prepare Step',
+            `Injecting ${steers.length} steer(s) for prompt UUID: ${args.promptUuid}`,
+        );
+
+        return {
+            ...forced,
+            messages: [
+                ...messages,
+                {
+                    role: 'user' as const,
+                    content: [
+                        'Additional guidance from the user while you were working:',
+                        ...steers.map((steer) => `- ${steer.message}`),
+                    ].join('\n'),
+                },
+            ],
+        };
+    };
+};
+
 const getAgentTools = (
     args: AiAgentArgs,
     dependencies: AiAgentDependencies,
@@ -617,11 +666,16 @@ export const generateAgentResponse = async ({
             'Generate Agent Response',
             `Calling generateText with model: ${modelName}`,
         );
-        const forcedFirstStep = buildForcedFirstStep(args, tools);
+        const prepareStep = buildPrepareStep({
+            args,
+            dependencies,
+            tools,
+            logger,
+        });
         const result = await generateText({
             ...defaultAgentOptions,
             ...args.callOptions,
-            ...(forcedFirstStep ? { prepareStep: forcedFirstStep } : {}),
+            prepareStep,
             providerOptions: args.providerOptions,
             model: args.model,
             tools,
@@ -853,7 +907,12 @@ export const streamAgentResponse = async ({
             'Stream Agent Response',
             `Calling streamText with model: ${modelName}`,
         );
-        const forcedFirstStep = buildForcedFirstStep(args, tools);
+        const prepareStep = buildPrepareStep({
+            args,
+            dependencies,
+            tools,
+            logger,
+        });
         const stopWhenPromptInterrupted = async () => {
             const interrupted = await dependencies.isPromptInterrupted(
                 args.promptUuid,
@@ -869,7 +928,7 @@ export const streamAgentResponse = async ({
         const result = streamText({
             ...defaultAgentOptions,
             ...args.callOptions,
-            ...(forcedFirstStep ? { prepareStep: forcedFirstStep } : {}),
+            prepareStep,
             stopWhen: [stepCountIs(STEP_CAP), stopWhenPromptInterrupted],
             providerOptions: args.providerOptions,
             model: args.model,

--- a/packages/backend/src/ee/services/ai/compaction.test.ts
+++ b/packages/backend/src/ee/services/ai/compaction.test.ts
@@ -48,6 +48,7 @@ describe('AI context compaction helpers', () => {
                         chartKind: null,
                     },
                 ],
+                steers: [],
                 hidden: false,
             },
             {
@@ -113,6 +114,7 @@ describe('AI context compaction helpers', () => {
                     { type: 'file', path: 'hello/world' },
                     { type: 'repository', fullName: 'hello/world' },
                 ],
+                steers: [],
                 hidden: false,
             },
         ]);

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -15,6 +15,7 @@ import { AiModel, AiProvider } from '../models/types';
 import { AiAgentSkillReference } from '../skills/types';
 import {
     AnalyzeFieldImpactFn,
+    ConsumePromptSteersFn,
     CreateContentFn,
     CreateOrUpdateArtifactFn,
     DescribeWarehouseTableFn,
@@ -184,6 +185,7 @@ export type AiAgentDependencies = {
     storeToolResults: StoreToolResultsFn;
     storeReasoning: StoreReasoningFn;
     isPromptInterrupted: IsPromptInterruptedFn;
+    consumePromptSteers: ConsumePromptSteersFn;
     searchFieldValues: SearchFieldValuesFn;
     trackEvent: TrackEventFn;
     createOrUpdateArtifact: CreateOrUpdateArtifactFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -6,6 +6,7 @@ import {
     AiAgentJudgeProjectContextEntry,
     AiArtifact,
     AiMetricQueryWithFilters,
+    AiPromptSteer,
     AiWebAppPrompt,
     AiWritebackRunResult,
     AllChartsSearchResult,
@@ -371,6 +372,11 @@ export type StoreReasoningFn = (
 ) => Promise<void>;
 
 export type IsPromptInterruptedFn = (promptUuid: string) => Promise<boolean>;
+
+export type ConsumePromptSteersFn = (args: {
+    promptUuid: string;
+    stepNumber: number;
+}) => Promise<AiPromptSteer[]>;
 
 export type TrackEventFn = (
     event:

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13527,12 +13527,51 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiPromptSteer_AiAgentUser_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                user: { ref: 'AiAgentUser', required: true },
+                consumedStep: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                consumedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'string', required: true },
+                message: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentMessageUser_AiAgentUser_: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 hidden: { dataType: 'boolean', required: true },
+                steers: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AiPromptSteer_AiAgentUser_',
+                    },
+                    required: true,
+                },
                 context: { ref: 'AiPromptContext', required: true },
                 user: { ref: 'AiAgentUser', required: true },
                 createdAt: { dataType: 'string', required: true },
@@ -16264,6 +16303,71 @@ const models: TsoaRoute.Models = {
     ApiAiAgentThreadMessageInterruptResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccess__interrupted-true__', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiPromptSteer: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                user: { ref: 'AiAgentUser', required: true },
+                consumedStep: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                consumedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                createdAt: { dataType: 'string', required: true },
+                message: { dataType: 'string', required: true },
+                promptUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess__steer-AiPromptSteer__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        steer: { ref: 'AiPromptSteer', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiAgentThreadMessageSteerResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess__steer-AiPromptSteer__', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCreateAiAgentThreadMessageSteer: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                message: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAiAgentThreadGenerateResponse: {
@@ -49587,6 +49691,89 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'interruptAgentThreadMessage',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentController_createAgentThreadMessageSteer: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        agentUuid: {
+            in: 'path',
+            name: 'agentUuid',
+            required: true,
+            dataType: 'string',
+        },
+        threadUuid: {
+            in: 'path',
+            name: 'threadUuid',
+            required: true,
+            dataType: 'string',
+        },
+        messageUuid: {
+            in: 'path',
+            name: 'messageUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiCreateAiAgentThreadMessageSteer',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/aiAgents/:agentUuid/threads/:threadUuid/messages/:messageUuid/steers',
+        ...fetchMiddlewares<RequestHandler>(AiAgentController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentController.prototype.createAgentThreadMessageSteer,
+        ),
+
+        async function AiAgentController_createAgentThreadMessageSteer(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentController_createAgentThreadMessageSteer,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentController>(AiAgentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createAgentThreadMessageSteer',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15126,11 +15126,55 @@
                 },
                 "type": "array"
             },
+            "AiPromptSteer_AiAgentUser_": {
+                "properties": {
+                    "user": {
+                        "$ref": "#/components/schemas/AiAgentUser"
+                    },
+                    "consumedStep": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "consumedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "user",
+                    "consumedStep",
+                    "consumedAt",
+                    "createdAt",
+                    "message",
+                    "promptUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "AiAgentMessageUser_AiAgentUser_": {
                 "properties": {
                     "hidden": {
                         "type": "boolean",
                         "description": "Hidden turn: the agent received and responded to this prompt, but the UI\nshould not render its user bubble (e.g. the post-merge migration prompt\ninjected from the writeback PR card)."
+                    },
+                    "steers": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiPromptSteer_AiAgentUser_"
+                        },
+                        "type": "array"
                     },
                     "context": {
                         "$ref": "#/components/schemas/AiPromptContext"
@@ -15158,6 +15202,7 @@
                 },
                 "required": [
                     "hidden",
+                    "steers",
                     "context",
                     "user",
                     "createdAt",
@@ -16906,6 +16951,76 @@
             },
             "ApiAiAgentThreadMessageInterruptResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__interrupted-true__"
+            },
+            "AiPromptSteer": {
+                "properties": {
+                    "user": {
+                        "$ref": "#/components/schemas/AiAgentUser"
+                    },
+                    "consumedStep": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "consumedAt": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "promptUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "user",
+                    "consumedStep",
+                    "consumedAt",
+                    "createdAt",
+                    "message",
+                    "promptUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess__steer-AiPromptSteer__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "steer": {
+                                "$ref": "#/components/schemas/AiPromptSteer"
+                            }
+                        },
+                        "required": ["steer"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiAgentThreadMessageSteerResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__steer-AiPromptSteer__"
+            },
+            "ApiCreateAiAgentThreadMessageSteer": {
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "required": ["message"],
+                "type": "object"
             },
             "ApiAiAgentThreadGenerateResponse": {
                 "properties": {
@@ -44347,6 +44462,78 @@
                         }
                     }
                 ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}/messages/{messageUuid}/steers": {
+            "post": {
+                "operationId": "createAgentThreadMessageSteer",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentThreadMessageSteerResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "agentUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "threadUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "messageUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCreateAiAgentThreadMessageSteer"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/projects/{projectUuid}/aiAgents/{agentUuid}/threads/{threadUuid}/generate": {

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -219,12 +219,22 @@ export type AiAgentMessageUser<TUser extends AiAgentUser = AiAgentUser> = {
 
     user: TUser;
     context: AiPromptContext;
+    steers: AiPromptSteer[];
     /**
      * Hidden turn: the agent received and responded to this prompt, but the UI
      * should not render its user bubble (e.g. the post-merge migration prompt
      * injected from the writeback PR card).
      */
     hidden: boolean;
+};
+
+export type AiPromptSteer = {
+    uuid: string;
+    promptUuid: string;
+    message: string;
+    createdAt: string;
+    consumedAt: string | null;
+    consumedStep: number | null;
 };
 
 export type AiAgentMessageAssistantArtifact = Pick<
@@ -532,6 +542,14 @@ export type ApiAiAgentSqlApprovalResponse = ApiSuccess<{
 export type ApiAiAgentThreadMessageInterruptResponse = ApiSuccess<{
     interrupted: true;
 }>;
+
+export type ApiAiAgentThreadMessageSteerResponse = ApiSuccess<{
+    steer: AiPromptSteer;
+}>;
+
+export type ApiCreateAiAgentThreadMessageSteer = {
+    message: string;
+};
 
 export type ApiAiAgentThreadMessageCreateResponse = ApiSuccess<
     AiAgentMessageUser<AiAgentUser>

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -19,6 +19,7 @@ import type {
     ApiAiAgentThreadGenerateTitleResponse,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageInterruptResponse,
+    ApiAiAgentThreadMessageSteerResponse,
     ApiAiAgentThreadMessageVizQueryResponse,
     ApiAiAgentThreadMessageVizResponse,
     ApiAiAgentThreadPullRequestResponse,
@@ -1101,6 +1102,7 @@ type ApiResults =
     | ApiCloneAiAgentThreadShareResponse['results']
     | ApiAiAgentThreadMessageCreateResponse['results']
     | ApiAiAgentThreadMessageInterruptResponse['results']
+    | ApiAiAgentThreadMessageSteerResponse['results']
     | ApiAiAgentArtifactResponse['results']
     | ApiAiAgentThreadGenerateTitleResponse['results']
     | ApiAiAgentThreadSummaryListResponse['results']

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.module.css
@@ -392,6 +392,10 @@
     }
 }
 
+.minimalStreamActionButton {
+    align-self: center;
+}
+
 .editorRoot {
     border: none;
     background: transparent;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatInput.tsx
@@ -23,7 +23,10 @@ import useUser from '../../../../../hooks/user/useUser';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
 import { useAgentSuggestions } from '../../hooks/useAgentSuggestions';
-import { useInterruptAiAgentThreadMessageMutation } from '../../hooks/useProjectAiAgents';
+import {
+    useCreateAiAgentThreadMessageSteerMutation,
+    useInterruptAiAgentThreadMessageMutation,
+} from '../../hooks/useProjectAiAgents';
 import { useAiAgentThreadStreamQuery } from '../../streaming/useAiAgentThreadStreamQuery';
 import { AgentSelector } from '../AgentSelector';
 import { type Agent } from '../AgentSelector/AgentSelectorUtils';
@@ -167,6 +170,7 @@ export const AgentChatInput = ({
     const [hasRequestedInterrupt, setHasRequestedInterrupt] = useState(false);
     const threadStream = useAiAgentThreadStreamQuery(threadUuid ?? '');
     const interruptMutation = useInterruptAiAgentThreadMessageMutation();
+    const steerMutation = useCreateAiAgentThreadMessageSteerMutation();
     useEffect(() => {
         const el = rootRef.current;
         if (!el) return undefined;
@@ -435,12 +439,18 @@ export const AgentChatInput = ({
         threadStream?.isStreaming &&
         activeMessageUuid,
     );
+    const canSteer = canInterrupt && !disabled && !hasRequestedInterrupt;
 
     const handleSubmit = () => {
         const ed = editorRef.current;
         if (!ed) return;
         const text = ed.getText().trim();
-        if (!text || disabled || loading) return;
+        if (!text || disabled) return;
+        if (canSteer) {
+            void handleSteer(text);
+            return;
+        }
+        if (loading) return;
         onSubmitRef.current({
             message: text,
             toolHints: extractToolHints(ed),
@@ -450,6 +460,22 @@ export const AgentChatInput = ({
             ed.commands.clearContent();
             setValueState('');
         }
+    };
+
+    const handleSteer = async (message: string) => {
+        if (!projectUuid || !agentUuid || !threadUuid || !activeMessageUuid) {
+            return;
+        }
+
+        await steerMutation.mutateAsync({
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            messageUuid: activeMessageUuid,
+            message,
+        });
+        editorRef.current?.commands.clearContent();
+        setValueState('');
     };
 
     const handleInterrupt = async () => {
@@ -591,14 +617,29 @@ export const AgentChatInput = ({
                             </Text>
                         )}
 
-                        {canInterrupt ? (
+                        {canSteer && hasValue ? (
                             <ActionIcon
-                                right={12}
-                                bottom={10}
+                                variant="filled"
+                                size="md"
+                                className={`${styles.minimalSubmitButton} ${styles.minimalStreamActionButton}`}
+                                disabled={steerMutation.isLoading}
+                                loading={steerMutation.isLoading}
+                                onClick={handleSubmit}
+                                aria-label="Send guidance"
+                            >
+                                <MantineIcon
+                                    icon={IconArrowUp}
+                                    color="ldGray.0"
+                                    size={18}
+                                    stroke={2}
+                                />
+                            </ActionIcon>
+                        ) : canInterrupt ? (
+                            <ActionIcon
                                 variant="filled"
                                 color="red"
                                 size="md"
-                                className={styles.minimalSubmitButton}
+                                className={`${styles.minimalSubmitButton} ${styles.minimalStreamActionButton}`}
                                 disabled={hasRequestedInterrupt}
                                 loading={
                                     interruptMutation.isLoading ||
@@ -724,7 +765,24 @@ export const AgentChatInput = ({
                                 </Box>
                             )}
 
-                        {canInterrupt ? (
+                        {canSteer && hasValue ? (
+                            <ActionIcon
+                                variant="filled"
+                                size="lg"
+                                className={styles.submitButton}
+                                disabled={steerMutation.isLoading}
+                                loading={steerMutation.isLoading}
+                                onClick={handleSubmit}
+                                aria-label="Send guidance"
+                            >
+                                <MantineIcon
+                                    icon={IconArrowUp}
+                                    color="ldGray.0"
+                                    size={20}
+                                    stroke={2}
+                                />
+                            </ActionIcon>
+                        ) : canInterrupt ? (
                             <ActionIcon
                                 variant="filled"
                                 color="red"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.module.css
@@ -40,6 +40,21 @@
     }
 }
 
+.steerCard {
+    max-width: min(100%, rem(520px));
+    border-style: dashed;
+
+    @mixin light {
+        background-color: transparent;
+        border-color: var(--mantine-color-ldGray-3);
+    }
+
+    @mixin dark {
+        background-color: transparent;
+        border-color: var(--mantine-color-ldGray-7);
+    }
+}
+
 .markdown {
     background-color: transparent;
     font-size: 0.8125rem;
@@ -65,5 +80,14 @@
 
 .inlineMarkdown :global(p) {
     display: inline;
+    margin: 0;
+}
+
+.steerMarkdown {
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.steerMarkdown :global(p) {
     margin: 0;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -183,6 +183,26 @@ export const UserBubble: FC<Props> = ({
                     />
                 )}
             </Card>
+
+            {message.steers.length > 0 && (
+                <Stack gap={4} align="flex-end">
+                    {message.steers.map((steer) => (
+                        <Card
+                            key={steer.uuid}
+                            radius="md"
+                            py={4}
+                            px="xs"
+                            withBorder
+                            className={styles.steerCard}
+                        >
+                            <MDEditor.Markdown
+                                source={steer.message}
+                                className={`${styles.markdown} ${styles.steerMarkdown}`}
+                            />
+                        </Card>
+                    ))}
+                </Stack>
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useProjectAiAgents.ts
@@ -11,6 +11,7 @@ import type {
     ApiAiAgentThreadMessageCreateRequest,
     ApiAiAgentThreadMessageCreateResponse,
     ApiAiAgentThreadMessageInterruptResponse,
+    ApiAiAgentThreadMessageSteerResponse,
     ApiAiAgentThreadMessageVizQuery,
     ApiAiAgentThreadResponse,
     ApiAiAgentThreadShareResponse,
@@ -696,6 +697,7 @@ const createOptimisticMessages = (
                 uuid: user?.userUuid ?? 'unknown',
             },
             context,
+            steers: [],
             hidden,
         },
         {
@@ -1260,6 +1262,60 @@ export const useInterruptAiAgentThreadMessageMutation = () =>
                 body: undefined,
             }),
     });
+
+export const useCreateAiAgentThreadMessageSteerMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<
+        ApiAiAgentThreadMessageSteerResponse['results'],
+        ApiError,
+        {
+            projectUuid: string;
+            agentUuid: string;
+            threadUuid: string;
+            messageUuid: string;
+            message: string;
+        }
+    >({
+        mutationFn: ({
+            projectUuid,
+            agentUuid,
+            threadUuid,
+            messageUuid,
+            message,
+        }) =>
+            lightdashApi<ApiAiAgentThreadMessageSteerResponse['results']>({
+                url: `${getAiAgentApiBase(
+                    projectUuid,
+                )}/${agentUuid}/threads/${threadUuid}/messages/${messageUuid}/steers`,
+                method: 'POST',
+                body: JSON.stringify({ message }),
+            }),
+        onSuccess: (
+            result,
+            { projectUuid, agentUuid, threadUuid, messageUuid },
+        ) => {
+            queryClient.setQueryData<ApiAiAgentThreadResponse['results']>(
+                [AI_AGENTS_KEY, projectUuid, agentUuid, 'threads', threadUuid],
+                (currentData) => {
+                    if (!currentData) return currentData;
+
+                    return {
+                        ...currentData,
+                        messages: currentData.messages.map((item) =>
+                            item.role === 'user' && item.uuid === messageUuid
+                                ? {
+                                      ...item,
+                                      steers: [...item.steers, result.steer],
+                                  }
+                                : item,
+                        ),
+                    };
+                },
+            );
+        },
+    });
+};
 
 // Feedback and query management functionality
 const updatePromptFeedback = async (


### PR DESCRIPTION
### Description
- Adds Postgres-backed steer rows for guidance submitted during a run
- Adds a steer endpoint for thread messages
- Uses `prepareStep` to inject unconsumed steers between model steps
- Shows guidance send control while an agent is streaming
- Renders guidance as sub-messages under the original user prompt

Closes: PROD-8253