### PR TITLE
feat: change data app theme

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -159,6 +159,23 @@ When users send follow-up prompts, the system creates a new `DbAppVersion` and e
 
 This means Claude can see what it built previously and make targeted changes rather than starting from scratch.
 
+### Changing themes
+
+The org design (theme) can be applied, changed, or removed from an existing app from the theme chip above the prompt
+input. This creates a normal new app version, but the backend sends Claude a constrained style-only instruction instead
+of treating it like an open-ended user prompt: preserve content, queries, filters, chart semantics, layout intent, and
+interactions; only rework visual styling and theme asset usage.
+
+How the theme-change flow differs from a regular iteration:
+
+- The frontend sends `designUuid` on `POST /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/versions`. Omitted means
+  "inherit the current app theme"; a UUID switches to that org design; `null` removes the theme.
+- The backend validates that the selected design belongs to the app's organization, snapshots it onto
+  `app_versions.resources.design`, updates `apps.design_uuid` for future iterations, and enqueues the normal generation
+  pipeline with the resolved design UUID.
+- The pipeline still calls `copyDesignIntoSandbox` before Claude runs. When the design UUID is `null`, it removes
+  `/app/src/design` from the sandbox so warm sandboxes do not retain stale theme files.
+
 ### Model selection
 
 The chat input carries a `ModelPicker` (next to the send button) that lets the user choose which Claude model runs the generation: `opus` (highest quality, best for complex apps), `sonnet` (default, balanced), or `haiku` (fastest). The choice is editable on every turn — `claude --continue` keeps the prior conversation context but accepts a fresh `--model` flag per invocation, so switching mid-iteration doesn't reset Claude's memory of what it already built.

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -77,8 +77,10 @@ export class AppGenerateController extends BaseController {
             body.clarifications,
             body.spaceUuid,
             body.claudeModel,
-            body.designUuid,
-            body.externalConnections,
+            {
+                designUuidInput: body.designUuid,
+                externalConnections: body.externalConnections,
+            },
         );
         return {
             status: 'ok',
@@ -243,7 +245,10 @@ export class AppGenerateController extends BaseController {
             body.charts,
             body.dashboard,
             body.claudeModel,
-            body.externalConnections,
+            {
+                designUuidInput: body.designUuid,
+                externalConnections: body.externalConnections,
+            },
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -130,6 +130,11 @@ type AppGenerateServiceDeps = {
     externalConnectionModel: ExternalConnectionModel;
 };
 
+type GenerateAppOptions = {
+    designUuidInput?: string | null;
+    externalConnections?: AppExternalConnectionReference[];
+};
+
 type GenerateAppResult = {
     appUuid: string;
     version: number;
@@ -1515,6 +1520,19 @@ export class AppGenerateService extends BaseService {
         ];
     }
 
+    private static buildThemeChangePrompt(themeName: string | null): string {
+        const target = themeName
+            ? `the active organization theme "${themeName}"`
+            : 'the Lightdash default styling with no organization theme';
+
+        return [
+            `Restyle the current app to follow ${target}.`,
+            'Preserve the app content exactly: do not change text, metrics, queries, filters, chart semantics, layout intent, or interactions.',
+            'Only change visual styling needed for the theme: colors, typography, spacing, borders, shadows, chart palette, and appropriate theme asset usage.',
+            'If a theme is active, read and use the files under /app/src/design/ and follow the organization theme instructions. Do not edit files under /app/src/design/.',
+        ].join('\n');
+    }
+
     /**
      * Convert an internal tool description (e.g. "Write /app/src/Dashboard.tsx")
      * into a user-friendly status message (e.g. "Creating Dashboard.tsx").
@@ -1580,9 +1598,19 @@ export class AppGenerateService extends BaseService {
 
         const sections: string[] = [];
         if (designCopy.designSnapshot) {
+            const manifestLines = [
+                ...designCopy.cssEntrypoints.map((path) => `- CSS: ${path}`),
+                ...designCopy.fontPaths.map((path) => `- Font: ${path}`),
+                ...designCopy.imagePaths.map((path) => `- Image: ${path}`),
+            ];
+            const manifest =
+                manifestLines.length > 0
+                    ? `\n\nAvailable theme files:\n${manifestLines.join('\n')}`
+                    : '\n\nNo CSS, font, or image files were copied for this theme.';
+
             sections.push(
                 `## Active organization theme: ${designCopy.designSnapshot.name}\n\n` +
-                    `Theme assets are loaded in \`/app/src/design/\` (${designCopy.designSnapshot.fileCount} file(s)). Follow the rules under "Organization themes" in the main skill — they override your defaults for colors, typography, and chart palette where applicable.`,
+                    `Theme assets are loaded in \`/app/src/design/\` (${designCopy.designSnapshot.fileCount} file(s)). Follow the rules under "Organization themes" in the main skill — they override your defaults for colors, typography, and chart palette where applicable.${manifest}\n\nBefore saying a theme asset is unavailable, inspect \`/app/src/design/\` with Glob or Read.`,
             );
         }
         if (designCopy.instructionMarkdown) {
@@ -2356,7 +2384,7 @@ export class AppGenerateService extends BaseService {
         this.logger.info(
             `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration}, model=${
                 payload.claudeModel ?? DEFAULT_DATA_APP_CLAUDE_MODEL
-            }, llm=${describeClaudeCodeEnv(claudeCodeEnv)})`,
+            }, designUuid=${payload.designUuid ?? 'none'}, llm=${describeClaudeCodeEnv(claudeCodeEnv)})`,
         );
 
         // --- Stage: sandbox ---
@@ -3464,9 +3492,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         clarifications?: AppClarification[],
         spaceUuid?: string,
         claudeModelInput?: DataAppClaudeModel,
-        designUuidInput?: string | null,
-        externalConnections?: AppExternalConnectionReference[],
+        options: GenerateAppOptions = {},
     ): Promise<GenerateAppResult> {
+        const { designUuidInput, externalConnections } = options;
         await this.assertDataAppsEnabled(user);
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
         this.assertDataAppAbility(
@@ -3653,8 +3681,9 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         charts?: AppChartReference[],
         dashboard?: AppDashboardReference,
         claudeModelInput?: DataAppClaudeModel,
-        externalConnections?: AppExternalConnectionReference[],
+        options: GenerateAppOptions = {},
     ): Promise<GenerateAppResult> {
+        const { designUuidInput, externalConnections } = options;
         await this.assertDataAppsEnabled(user);
 
         AppGenerateService.validateImageIds(imageIds);
@@ -3688,7 +3717,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         const newVersion = (latestVersion?.version ?? 0) + 1;
 
         this.logger.info(
-            `App ${appUuid}: iteration started (version=${newVersion}, model=${claudeModel}, promptLength=${prompt.length})`,
+            `App ${appUuid}: iteration started (version=${newVersion}, model=${claudeModel}, promptLength=${prompt.length}, designUuidInput=${
+                designUuidInput === undefined
+                    ? 'inherit'
+                    : (designUuidInput ?? 'none')
+            })`,
         );
 
         const { refs, dashboardName } = await this.collectChartReferences(
@@ -3702,32 +3735,43 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             sampleStats,
         } = await this.resolveChartReferences(refs, user);
 
-        // Iterations always inherit theme from the parent app — the user
-        // can't switch themes after creation (yet). Re-fetch the current
-        // design state so the snapshot reflects any edits/renames since the
-        // last version. If the design was deleted, `apps.design_uuid` was
-        // set to NULL by the FK cascade and we proceed without a theme.
-        let inheritedDesignUuid: string | null = app.design_uuid;
+        // Omitted designUuid means a normal content iteration that inherits
+        // the app's current theme. Explicit string/null means "change the
+        // app theme and run a style-only iteration".
+        const isThemeChange = designUuidInput !== undefined;
+        let effectiveDesignUuid: string | null = isThemeChange
+            ? designUuidInput
+            : app.design_uuid;
         let designSnapshot: AppVersionResources['design'] = null;
-        if (inheritedDesignUuid) {
-            const inherited =
+        if (effectiveDesignUuid) {
+            const design =
                 await this.organizationDesignModel.findInOrganization(
                     app.organization_uuid,
-                    inheritedDesignUuid,
+                    effectiveDesignUuid,
                 );
-            if (inherited) {
+            if (design) {
                 designSnapshot = {
-                    designUuid: inherited.designUuid,
-                    name: inherited.name,
-                    fileCount: inherited.files.length,
+                    designUuid: design.designUuid,
+                    name: design.name,
+                    fileCount: design.files.length,
                 };
+            } else if (isThemeChange) {
+                throw new ParameterError(
+                    `Theme not found: ${effectiveDesignUuid}`,
+                );
             } else {
-                // Defensive: app.design_uuid points at a row that no longer
-                // exists. Should never happen given the FK is ON DELETE SET
-                // NULL, but if it does, treat as untheme rather than fail.
-                inheritedDesignUuid = null;
+                // Defensive: app.design_uuid points at a missing row. Should
+                // never happen given the FK is ON DELETE SET NULL, but if it
+                // does, treat inherited theme as absent rather than fail.
+                effectiveDesignUuid = null;
             }
         }
+
+        const pipelinePrompt = isThemeChange
+            ? AppGenerateService.buildThemeChangePrompt(
+                  designSnapshot?.name ?? null,
+              )
+            : prompt;
 
         const resources: AppVersionResources = {
             images: imageIds.map((id) => ({ imageId: id })),
@@ -3746,6 +3790,14 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             resources,
         );
 
+        if (isThemeChange) {
+            await this.appModel.updateDesignUuid(
+                appUuid,
+                projectUuid,
+                effectiveDesignUuid,
+            );
+        }
+
         this.analytics.track({
             event: 'data_app.iterated',
             userId: user.userUuid,
@@ -3758,6 +3810,8 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 promptLength: prompt.length,
                 imageCount: imageIds.length,
                 claudeModel,
+                themeChanged: isThemeChange,
+                designUuid: effectiveDesignUuid,
                 previousVersionStatus: latestVersion?.status ?? null,
                 msSinceLastVersion: latestVersion?.created_at
                     ? Date.now() - latestVersion.created_at.getTime()
@@ -3773,13 +3827,13 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             projectUuid,
             organizationUuid: user.organizationUuid!,
             userUuid: user.userUuid,
-            prompt,
+            prompt: pipelinePrompt,
             imageIds: imageIds.length > 0 ? imageIds : undefined,
             isIteration: true,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
             claudeModel,
-            designUuid: inheritedDesignUuid,
+            designUuid: effectiveDesignUuid,
         });
 
         return { appUuid, version: newVersion };

--- a/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
@@ -64,9 +64,9 @@ const readS3ObjectAsBuffer = async (
  * Copy the resolved theme's files into the data-app sandbox and return
  * metadata for the system-prompt assembly + version-resources snapshot.
  *
- * When `designUuid` is null (no theme picked and no org default), this is
- * a no-op that returns an empty result — the pipeline continues exactly
- * as it would for a no-theme app.
+ * When `designUuid` is null (no theme picked and no org default), this
+ * clears any previous theme files from a warm sandbox and returns an empty
+ * result — the pipeline continues exactly as it would for a no-theme app.
  *
  * The destination directory is reset on every call (`rm -rf` then
  * `mkdir -p`) so a switched theme can never leave stale files from a
@@ -91,6 +91,15 @@ export async function copyDesignIntoSandbox(args: {
         logger,
     } = args;
 
+    // Reset-and-recreate the design tree. Idempotent and cheap on a warm
+    // sandbox; avoids tracking "what was there before".
+    await sandbox.commands.run(
+        designUuid
+            ? `rm -rf ${DESIGN_DIR} && mkdir -p ${DESIGN_DIR}/css ${DESIGN_DIR}/fonts ${DESIGN_DIR}/images`
+            : `rm -rf ${DESIGN_DIR}`,
+        { timeoutMs: 10_000 },
+    );
+
     if (!designUuid) {
         return EMPTY_RESULT;
     }
@@ -108,13 +117,6 @@ export async function copyDesignIntoSandbox(args: {
         );
         return EMPTY_RESULT;
     }
-
-    // Reset-and-recreate the design tree. Idempotent and cheap on a warm
-    // sandbox; avoids tracking "what was there before".
-    await sandbox.commands.run(
-        `rm -rf ${DESIGN_DIR} && mkdir -p ${DESIGN_DIR}/css ${DESIGN_DIR}/fonts ${DESIGN_DIR}/images`,
-        { timeoutMs: 10_000 },
-    );
 
     const cssEntrypoints: string[] = [];
     const imagePaths: string[] = [];

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -478,6 +478,22 @@ export class AppModel {
         return row;
     }
 
+    async updateDesignUuid(
+        appId: string,
+        projectUuid: string,
+        designUuid: string | null,
+    ): Promise<DbApp> {
+        const [row] = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .update({ design_uuid: designUuid })
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
+    }
+
     /**
      * Record that a preview app has been promoted into a production app. The
      * link lives on the preview (source) row so one production app can be the

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -134,9 +134,10 @@ export type GenerateAppRequestBody = {
     // conversation context but accepts a fresh `--model` flag per turn.
     claudeModel?: DataAppClaudeModel;
     // Theme (org design) to apply to this app's source tree and system
-    // prompt. Only honored on initial creation — iterations always inherit
-    // from the parent app's `apps.design_uuid`. Omit (or null) for "no
-    // theme"; the org default is resolved server-side when this is null.
+    // prompt. On initial creation, omit to use the org default, null for no
+    // theme, or pass a uuid for a specific theme. On iteration, omit to
+    // inherit the current app theme; pass a uuid/null to change the app theme
+    // and run a style-only rebuild.
     designUuid?: string | null;
     // External connections to link to the app before the catalog stage of this
     // build, so the generated app can call them via client.externalFetch.

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -17,9 +17,8 @@ type Props = {
     onSelect: (template: DataAppTemplate) => void;
     /**
      * Theme (org design) selection — picked at the same moment as the
-     * template and frozen into the app at creation time. The picker is
-     * inlined here so users see both the structural starting point and the
-     * brand context in one step.
+     * template. The picker is inlined here so users see both the structural
+     * starting point and the brand context in one step.
      */
     selectedThemeUuid: string | null;
     onThemeChange: (designUuid: string | null) => void;

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -18,6 +18,7 @@ type IterateAppParams = {
     dashboard?: AppDashboardReference;
     claudeModel?: DataAppClaudeModel;
     externalConnections?: AppExternalConnectionReference[];
+    designUuid?: string | null;
 };
 
 type IterateAppResult = ApiGenerateAppResponse['results'];
@@ -31,6 +32,7 @@ const iterateApp = async ({
     dashboard,
     claudeModel,
     externalConnections,
+    designUuid,
 }: IterateAppParams): Promise<IterateAppResult> => {
     const data = await lightdashApi<IterateAppResult>({
         method: 'POST',
@@ -42,6 +44,7 @@ const iterateApp = async ({
             dashboard,
             claudeModel,
             externalConnections,
+            ...(designUuid !== undefined ? { designUuid } : {}),
         }),
     });
     return data;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -33,6 +33,7 @@ import {
 import {
     IconAppsOff,
     IconAppWindow,
+    IconCheck,
     IconArrowUp,
     IconCopy,
     IconDatabase,
@@ -285,15 +286,70 @@ const TemplateChip: FC<{ template: DataAppTemplate }> = ({ template }) => {
     );
 };
 
-const ThemeChip: FC<{ themeName: string }> = ({ themeName }) => (
-    <Badge
-        variant="light"
-        color="gray"
-        size="md"
-        leftSection={<MantineIcon icon={IconBrush} size={12} />}
-    >
-        {themeName}
-    </Badge>
+const NO_THEME_LABEL = 'No theme';
+
+const ThemeChip: FC<{
+    themeName: string;
+    selectedThemeUuid: string | null;
+    themes: { designUuid: string; name: string; isDefault?: boolean }[];
+    disabled?: boolean;
+    onThemeChange: (designUuid: string | null) => void;
+}> = ({ themeName, selectedThemeUuid, themes, disabled, onThemeChange }) => (
+    <Menu position="top-start" shadow="md" withinPortal>
+        <Menu.Target>
+            <Badge
+                component="button"
+                type="button"
+                variant="light"
+                color="gray"
+                size="md"
+                leftSection={<MantineIcon icon={IconBrush} size={12} />}
+                disabled={disabled}
+                styles={{
+                    root: {
+                        cursor: disabled ? 'not-allowed' : 'pointer',
+                    },
+                }}
+            >
+                {themeName}
+            </Badge>
+        </Menu.Target>
+        <Menu.Dropdown>
+            <Menu.Item
+                leftSection={
+                    selectedThemeUuid === null ? (
+                        <MantineIcon icon={IconCheck} size={14} />
+                    ) : undefined
+                }
+                disabled={disabled}
+                onClick={() => onThemeChange(null)}
+            >
+                {NO_THEME_LABEL}
+            </Menu.Item>
+            {themes.length > 0 && <Menu.Divider />}
+            {themes.map((theme) => (
+                <Menu.Item
+                    key={theme.designUuid}
+                    leftSection={
+                        selectedThemeUuid === theme.designUuid ? (
+                            <MantineIcon icon={IconCheck} size={14} />
+                        ) : undefined
+                    }
+                    disabled={disabled}
+                    onClick={() => onThemeChange(theme.designUuid)}
+                >
+                    <Group gap="xs">
+                        <Text size="sm">{theme.name}</Text>
+                        {theme.isDefault && (
+                            <Text size="xs" c="dimmed">
+                                Default
+                            </Text>
+                        )}
+                    </Group>
+                </Menu.Item>
+            ))}
+        </Menu.Dropdown>
+    </Menu>
 );
 
 /** A removable pill for a connection selected for this prompt. */
@@ -401,6 +457,10 @@ const AppGenerate: FC = () => {
     const [modelOverride, setModelOverride] = useState<{
         appUuid: string | null; // null = override set from the new-app page
         model: DataAppClaudeModel;
+    } | null>(null);
+    const [themeChipOverride, setThemeChipOverride] = useState<{
+        appUuid: string | null; // null = override set from the new-app page
+        designUuid: string | null;
     } | null>(null);
     const [wizardStage, setWizardStage] = useState<'pick' | 'confirm'>('pick');
     const [imageAttachments, setImageAttachments] = useState<
@@ -529,6 +589,7 @@ const AppGenerate: FC = () => {
         setScreenshotAvailable(false);
         setIsCapturingScreenshot(false);
         setSelectedTemplate(null);
+        setThemeChipOverride(null);
         setWizardStage('pick');
         setPendingClarification(null);
         setClarificationAnswers([]);
@@ -832,13 +893,12 @@ const AppGenerate: FC = () => {
     // version (any status — a still-building version's model is already a
     // valid signal of the user's intent). `null` when no version data is
     // loaded yet or older versions didn't persist the field.
-    const latestVersionModel: DataAppClaudeModel | null = useMemo(() => {
+    const latestVersion = useMemo(() => {
         if (allVersions.length === 0) return null;
-        const latest = [...allVersions].sort(
-            (a, b) => b.version - a.version,
-        )[0];
-        return latest.resources?.claudeModel ?? null;
+        return [...allVersions].sort((a, b) => b.version - a.version)[0];
     }, [allVersions]);
+    const latestVersionModel: DataAppClaudeModel | null =
+        latestVersion?.resources?.claudeModel ?? null;
 
     // Effective model for the picker / next submit:
     // user's explicit pick (if it's for this app) > latest version's model
@@ -868,13 +928,13 @@ const AppGenerate: FC = () => {
         [activeAppUuid],
     );
 
-    // Theme (org design) picker state — only meaningful on initial creation.
-    // We pre-populate with the org's default theme so the visible selection
-    // matches what the backend would have applied anyway. `null` means
-    // "no theme" (the Lightdash default styling).
-    const { data: orgThemes = [] } = useOrganizationDesigns({
-        enabled: isNewApp,
-    });
+    // Theme (org design) picker state. New apps pre-populate with the org's
+    // default theme so the visible selection matches what the backend would
+    // have applied anyway. Existing apps use the latest version's design
+    // snapshot and send explicit changes as style-only iterations.
+    // `null` means "no theme" (the Lightdash default styling).
+    const { data: orgThemes = [], isFetched: hasFetchedOrgThemes } =
+        useOrganizationDesigns();
     const [themeOverride, setThemeOverride] = useState<
         string | null | undefined
     >(undefined);
@@ -882,21 +942,138 @@ const AppGenerate: FC = () => {
         orgThemes.find((t) => t.isDefault)?.designUuid ?? null;
     const selectedThemeUuid: string | null =
         themeOverride !== undefined ? themeOverride : orgDefaultThemeUuid;
-    const handleThemeChange = useCallback((designUuid: string | null) => {
-        setThemeOverride(designUuid);
-    }, []);
+    const effectiveThemeChipOverride =
+        themeChipOverride &&
+        (themeChipOverride.appUuid === null ||
+            themeChipOverride.appUuid === activeAppUuid)
+            ? themeChipOverride.designUuid
+            : undefined;
+    const currentThemeUuid: string | null = isNewApp
+        ? (effectiveThemeChipOverride ?? selectedThemeUuid)
+        : (effectiveThemeChipOverride ??
+          latestVersion?.resources?.design?.designUuid ??
+          null);
+    const handleThemeChange = useCallback(
+        (designUuid: string | null) => {
+            if (designUuid === currentThemeUuid) return;
+
+            if (isNewApp) {
+                setThemeOverride(designUuid);
+                setThemeChipOverride({ appUuid: null, designUuid });
+                return;
+            }
+
+            if (!projectUuid || !activeAppUuid || isAgentWorking) return;
+
+            const themeName = designUuid
+                ? (orgThemes.find((t) => t.designUuid === designUuid)?.name ??
+                  'Selected theme')
+                : NO_THEME_LABEL;
+            const prompt =
+                designUuid === null
+                    ? `Remove theme`
+                    : `Apply theme: ${themeName}`;
+
+            setLocalMessages((prev) => [
+                ...prev,
+                {
+                    role: 'user',
+                    content: prompt,
+                    imagePreviewUrls: [],
+                    imageResourceIds: [],
+                    charts: [],
+                    dashboardName: null,
+                    clarifications: [],
+                    appUuid: null,
+                    version: null,
+                    timestamp: new Date(),
+                    userName:
+                        [user.data?.firstName, user.data?.lastName]
+                            .filter((s): s is string => !!s && s.length > 0)
+                            .join(' ') || null,
+                    submittedAtVersion: maxHistoryVersion,
+                },
+            ]);
+            setThemeChipOverride({ appUuid: activeAppUuid, designUuid });
+            resetIterate();
+            iterateMutate(
+                {
+                    projectUuid,
+                    appUuid: activeAppUuid,
+                    prompt,
+                    claudeModel: selectedModel,
+                    designUuid,
+                },
+                {
+                    onSuccess: (data: { appUuid: string; version: number }) => {
+                        setActiveAppUuid(data.appUuid);
+                        void queryClient.invalidateQueries({
+                            queryKey: ['app', projectUuid, data.appUuid],
+                        });
+                    },
+                    onError: (err: unknown) => {
+                        setThemeChipOverride(null);
+                        setLocalMessages((prev) => [
+                            ...prev,
+                            {
+                                role: 'assistant',
+                                content:
+                                    err instanceof Error
+                                        ? err.message
+                                        : 'Failed to apply theme',
+                                imagePreviewUrls: [],
+                                imageResourceIds: [],
+                                charts: [],
+                                dashboardName: null,
+                                clarifications: [],
+                                appUuid: null,
+                                version: null,
+                                timestamp: new Date(),
+                                userName: null,
+                            },
+                        ]);
+                    },
+                },
+            );
+        },
+        [
+            activeAppUuid,
+            currentThemeUuid,
+            isAgentWorking,
+            isNewApp,
+            iterateMutate,
+            maxHistoryVersion,
+            orgThemes,
+            projectUuid,
+            queryClient,
+            resetIterate,
+            selectedModel,
+            user.data?.firstName,
+            user.data?.lastName,
+        ],
+    );
 
     // What theme name to render on the chip above the prompt input.
     // - New apps: the just-picked theme's name (from the org themes list).
     // - Existing apps: the snapshot the pipeline persisted on the latest
     //   version's resources — survives org-default changes and theme
     //   renames, so what you see is what the build actually used.
-    const displayThemeName: string | null = isNewApp
-        ? selectedThemeUuid
-            ? (orgThemes.find((t) => t.designUuid === selectedThemeUuid)
-                  ?.name ?? null)
-            : null
-        : (latestReadyVersion?.resources?.design?.name ?? null);
+    const hasThemeChipSource = isNewApp
+        ? currentThemeUuid !== null ||
+          themeOverride === null ||
+          (themeOverride === undefined && hasFetchedOrgThemes)
+        : effectiveThemeChipOverride !== undefined || latestVersion !== null;
+    const latestVersionDesign = latestVersion?.resources?.design ?? null;
+    const latestVersionThemeName =
+        latestVersionDesign?.designUuid === currentThemeUuid
+            ? latestVersionDesign.name
+            : null;
+    const displayThemeName: string | null = hasThemeChipSource
+        ? currentThemeUuid
+            ? (orgThemes.find((t) => t.designUuid === currentThemeUuid)?.name ??
+              latestVersionThemeName)
+            : NO_THEME_LABEL
+        : null;
 
     // User-pinned version override. `null` = follow latest ready (default).
     // We snapshot the app uuid and the latest ready version at the moment of
@@ -1265,6 +1442,12 @@ const AppGenerate: FC = () => {
             // the generate request both use the same app-scoped S3 path.
             const newAppUuid = activeAppUuid ? undefined : uuid4();
             const targetAppUuid = activeAppUuid ?? newAppUuid;
+            if (newAppUuid) {
+                setThemeChipOverride({
+                    appUuid: newAppUuid,
+                    designUuid: selectedThemeUuid,
+                });
+            }
 
             // Upload images sequentially. Two reasons we can't run these in parallel:
             // 1. The backend buffers each body to avoid AWS SDK chunked signing,
@@ -2124,6 +2307,14 @@ const AppGenerate: FC = () => {
                                         {displayThemeName && (
                                             <ThemeChip
                                                 themeName={displayThemeName}
+                                                selectedThemeUuid={
+                                                    currentThemeUuid
+                                                }
+                                                themes={orgThemes}
+                                                disabled={isAgentWorking}
+                                                onThemeChange={
+                                                    handleThemeChange
+                                                }
                                             />
                                         )}
                                         {availableConnectionAliases.length >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #24498 

### Description:

- Makes it possible to change the theme of a data app
- When you select a new theme, the agent gets all of the theme files and a prompt to change it
- The agent will make an attempt to change the theme without changing any of the app content
- If bigger changes need to be made, they can be prompted. The agent now has the new theme. 