### PR TITLE
feat(ai): surface reviews in navbar ask ai

### DIFF
--- a/packages/frontend/src/components/NavBar/AiAgentsButton.module.css
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.module.css
@@ -1,0 +1,111 @@
+.reviewButton {
+    position: relative;
+    overflow: hidden;
+    border-color: color-mix(in oklch, #b6eee4 70%, #aae972);
+    color: #18322f;
+    background:
+        radial-gradient(
+            100% 140% at 16% 0%,
+            rgba(255, 255, 255, 0.78),
+            transparent 44%
+        ),
+        linear-gradient(135deg, #b6eee4 0%, #c9f2f4 52%, #aae972 100%);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.74),
+        0 0 0 1px rgba(182, 238, 228, 0.18),
+        0 6px 18px rgba(170, 233, 114, 0.16);
+    transition:
+        filter 180ms ease,
+        box-shadow 180ms ease,
+        transform 180ms ease;
+}
+
+.reviewButton:hover {
+    filter: saturate(1.06) brightness(1.02);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.8),
+        0 0 0 1px rgba(201, 242, 244, 0.3),
+        0 8px 22px rgba(170, 233, 114, 0.22);
+    transform: translateY(-1px);
+}
+
+.reviewButton:active {
+    transform: translateY(0);
+}
+
+.reviewIcon {
+    --ai-agent-icon-shadow: color-mix(in oklch, #b6eee4 42%, transparent);
+
+    background:
+        radial-gradient(
+            120% 120% at 28% 22%,
+            rgba(255, 255, 255, 0.76) 0%,
+            transparent 40%
+        ),
+        radial-gradient(115% 130% at 82% 24%, #c9f2f4 0%, transparent 52%),
+        radial-gradient(130% 120% at 84% 84%, #b6eee4 0%, transparent 56%),
+        radial-gradient(120% 130% at 16% 82%, #aae972 0%, transparent 56%),
+        conic-gradient(
+            from 210deg at 50% 50%,
+            #b6eee4,
+            #c9f2f4,
+            #aae972,
+            #75d9c8,
+            #b6eee4
+        );
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.66),
+        inset 0 -4px 10px rgba(117, 217, 200, 0.24),
+        0 2px 6px rgba(170, 233, 114, 0.2),
+        0 0 0 1px color-mix(in oklch, #b6eee4 38%, transparent);
+}
+
+.reviewButton .reviewIcon::before {
+    background:
+        radial-gradient(46% 56% at 30% 28%, #f4fffb 0%, transparent 60%),
+        radial-gradient(48% 60% at 66% 34%, #c9f2f4 0%, transparent 64%),
+        radial-gradient(46% 58% at 60% 70%, #aae972 0%, transparent 64%),
+        radial-gradient(44% 56% at 24% 66%, #75d9c8 0%, transparent 62%);
+}
+
+.reviewButton .reviewIcon::after {
+    background: conic-gradient(
+        from 90deg,
+        transparent,
+        rgba(255, 255, 255, 0.72),
+        rgba(201, 242, 244, 0.58),
+        transparent,
+        rgba(170, 233, 114, 0.62),
+        rgba(117, 217, 200, 0.62),
+        transparent
+    );
+}
+
+.reviewPill,
+.reviewCount {
+    display: inline-flex;
+    align-items: center;
+    height: 16px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.reviewPill {
+    padding: 0 6px;
+    color: #1d3d37;
+    background: rgba(255, 255, 255, 0.48);
+    box-shadow: inset 0 0 0 1px rgba(24, 50, 47, 0.08);
+}
+
+.reviewCount {
+    min-width: 16px;
+    justify-content: center;
+    padding: 0 5px;
+    color: #18322f;
+    background: #aae972;
+    box-shadow:
+        inset 0 0 0 1px rgba(24, 50, 47, 0.1),
+        0 1px 4px rgba(170, 233, 114, 0.34);
+}

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.module.css
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.module.css
@@ -1,111 +1,15 @@
-.reviewButton {
-    position: relative;
-    overflow: hidden;
-    border-color: color-mix(in oklch, #b6eee4 70%, #aae972);
-    color: #18322f;
-    background:
-        radial-gradient(
-            100% 140% at 16% 0%,
-            rgba(255, 255, 255, 0.78),
-            transparent 44%
-        ),
-        linear-gradient(135deg, #b6eee4 0%, #c9f2f4 52%, #aae972 100%);
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.74),
-        0 0 0 1px rgba(182, 238, 228, 0.18),
-        0 6px 18px rgba(170, 233, 114, 0.16);
-    transition:
-        filter 180ms ease,
-        box-shadow 180ms ease,
-        transform 180ms ease;
-}
-
-.reviewButton:hover {
-    filter: saturate(1.06) brightness(1.02);
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.8),
-        0 0 0 1px rgba(201, 242, 244, 0.3),
-        0 8px 22px rgba(170, 233, 114, 0.22);
-    transform: translateY(-1px);
-}
-
-.reviewButton:active {
-    transform: translateY(0);
-}
-
-.reviewIcon {
-    --ai-agent-icon-shadow: color-mix(in oklch, #b6eee4 42%, transparent);
-
-    background:
-        radial-gradient(
-            120% 120% at 28% 22%,
-            rgba(255, 255, 255, 0.76) 0%,
-            transparent 40%
-        ),
-        radial-gradient(115% 130% at 82% 24%, #c9f2f4 0%, transparent 52%),
-        radial-gradient(130% 120% at 84% 84%, #b6eee4 0%, transparent 56%),
-        radial-gradient(120% 130% at 16% 82%, #aae972 0%, transparent 56%),
-        conic-gradient(
-            from 210deg at 50% 50%,
-            #b6eee4,
-            #c9f2f4,
-            #aae972,
-            #75d9c8,
-            #b6eee4
-        );
-    box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.66),
-        inset 0 -4px 10px rgba(117, 217, 200, 0.24),
-        0 2px 6px rgba(170, 233, 114, 0.2),
-        0 0 0 1px color-mix(in oklch, #b6eee4 38%, transparent);
-}
-
-.reviewButton .reviewIcon::before {
-    background:
-        radial-gradient(46% 56% at 30% 28%, #f4fffb 0%, transparent 60%),
-        radial-gradient(48% 60% at 66% 34%, #c9f2f4 0%, transparent 64%),
-        radial-gradient(46% 58% at 60% 70%, #aae972 0%, transparent 64%),
-        radial-gradient(44% 56% at 24% 66%, #75d9c8 0%, transparent 62%);
-}
-
-.reviewButton .reviewIcon::after {
-    background: conic-gradient(
-        from 90deg,
-        transparent,
-        rgba(255, 255, 255, 0.72),
-        rgba(201, 242, 244, 0.58),
-        transparent,
-        rgba(170, 233, 114, 0.62),
-        rgba(117, 217, 200, 0.62),
-        transparent
-    );
-}
-
-.reviewPill,
-.reviewCount {
+.countBadge {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    min-width: 16px;
     height: 16px;
+    padding: 0 5px;
     border-radius: 999px;
     font-size: 10px;
     font-weight: 700;
     line-height: 1;
-}
-
-.reviewPill {
-    padding: 0 6px;
-    color: #1d3d37;
-    background: rgba(255, 255, 255, 0.48);
-    box-shadow: inset 0 0 0 1px rgba(24, 50, 47, 0.08);
-}
-
-.reviewCount {
-    min-width: 16px;
-    justify-content: center;
-    padding: 0 5px;
-    color: #18322f;
-    background: #aae972;
-    box-shadow:
-        inset 0 0 0 1px rgba(24, 50, 47, 0.1),
-        0 1px 4px rgba(170, 233, 114, 0.34);
+    color: var(--mantine-color-text);
+    background-color: var(--mantine-color-default-hover);
+    border: 1px solid var(--mantine-color-default-border);
 }

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,29 +1,131 @@
-import { Button, Text } from '@mantine-8/core';
-import { useNavigate } from 'react-router';
+import { Button, getDefaultZIndex, Group, Menu, Text } from '@mantine-8/core';
+import { IconChevronDown, IconGitPullRequest } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import { Link, useNavigate } from 'react-router';
 import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
+import { useAiAgentAdminReviewItems } from '../../ee/features/aiCopilot/hooks/useAiAgentAdmin';
 import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
-import { useActiveProject } from '../../hooks/useActiveProject';
+import { useAiAgentPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import MantineIcon from '../common/MantineIcon';
+import classes from './AiAgentsButton.module.css';
 
-export const AiAgentsButton = () => {
-    // Using `navigate` instead of the `Link` component to ensure round corners within a button group
+type Props = {
+    projectUuid: string;
+};
+
+export const AiAgentsButton = ({ projectUuid }: Props) => {
     const navigate = useNavigate();
-    const { data: projectUuid } = useActiveProject();
     const isVisible = useAiAgentButtonVisibility();
+    const canViewReviews = useAiAgentPermission({ action: 'manage' });
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
+    const reviewsEnabled =
+        aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;
+    const showReviews = !!canViewReviews && reviewsEnabled;
+    const { data: reviewItems } = useAiAgentAdminReviewItems(
+        { statuses: ['open'] },
+        { enabled: showReviews },
+    );
+
+    const projectReviewCount = useMemo(
+        () =>
+            (reviewItems ?? []).filter(
+                (item) =>
+                    item.projectUuid === projectUuid ||
+                    item.latestFinding?.projectUuid === projectUuid,
+            ).length,
+        [projectUuid, reviewItems],
+    );
+
+    const reviewsUrl = `/generalSettings/ai/reviews?projects=${encodeURIComponent(
+        projectUuid,
+    )}`;
+    const reviewCountLabel =
+        projectReviewCount > 99 ? '99+' : `${projectReviewCount}`;
+
     if (!isVisible) {
         return null;
     }
 
+    if (!showReviews) {
+        return (
+            <Button
+                size="xs"
+                variant="default"
+                fz="sm"
+                leftSection={<AiAgentIcon size={14} />}
+                onClick={() => navigate(`/projects/${projectUuid}/ai-agents`)}
+            >
+                <Text span truncate="end" maw={150} size="sm">
+                    Ask AI
+                </Text>
+            </Button>
+        );
+    }
+
     return (
-        <Button
-            size="xs"
-            variant="default"
-            fz="sm"
-            leftSection={<AiAgentIcon size={14} />}
-            onClick={() => navigate(`/projects/${projectUuid}/ai-agents`)}
+        <Menu
+            withArrow
+            shadow="lg"
+            position="bottom-start"
+            arrowOffset={28}
+            offset={-2}
+            zIndex={getDefaultZIndex('max')}
+            portalProps={{ target: '#navbar-header' }}
         >
-            <Text span truncate="end" maw={150} size="sm">
-                Ask AI
-            </Text>
-        </Button>
+            <Menu.Target>
+                <Button
+                    size="xs"
+                    variant="default"
+                    fz="sm"
+                    leftSection={
+                        <AiAgentIcon
+                            size={15}
+                            animated={projectReviewCount > 0}
+                            className={classes.reviewIcon}
+                        />
+                    }
+                    rightSection={
+                        <Group gap={4} wrap="nowrap">
+                            {projectReviewCount > 0 && (
+                                <span className={classes.reviewCount}>
+                                    {reviewCountLabel}
+                                </span>
+                            )}
+                            <MantineIcon icon={IconChevronDown} size={12} />
+                        </Group>
+                    }
+                    className={classes.reviewButton}
+                >
+                    <Group gap={6} wrap="nowrap">
+                        <Text span truncate="end" maw={88} size="sm">
+                            Ask AI
+                        </Text>
+                        <span className={classes.reviewPill}>Reviews</span>
+                    </Group>
+                </Button>
+            </Menu.Target>
+
+            <Menu.Dropdown>
+                <Menu.Item
+                    leftSection={<AiAgentIcon size={14} />}
+                    onClick={() =>
+                        navigate(`/projects/${projectUuid}/ai-agents`)
+                    }
+                >
+                    Ask AI
+                </Menu.Item>
+                <Menu.Item
+                    component={Link}
+                    to={reviewsUrl}
+                    leftSection={
+                        <MantineIcon icon={IconGitPullRequest} size={14} />
+                    }
+                >
+                    Review findings
+                    {projectReviewCount > 0 && ` (${projectReviewCount} open)`}
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
     );
 };

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,14 +1,15 @@
-import { Button, getDefaultZIndex, Group, Menu, Text } from '@mantine-8/core';
-import { IconChevronDown, IconGitPullRequest } from '@tabler/icons-react';
+import { Button, HoverCard, Text } from '@mantine-8/core';
 import { useMemo } from 'react';
-import { Link, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
+import { ReviewFindingsPreview } from '../../ee/features/aiCopilot/components/ReviewFindingsPreview';
 import { useAiAgentAdminReviewItems } from '../../ee/features/aiCopilot/hooks/useAiAgentAdmin';
-import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useAiAgentPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
-import MantineIcon from '../common/MantineIcon';
 import classes from './AiAgentsButton.module.css';
+
+const PREVIEW_LIMIT = 3;
 
 type Props = {
     projectUuid: string;
@@ -27,34 +28,38 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         { enabled: showReviews },
     );
 
-    const projectReviewCount = useMemo(
+    const projectReviewItems = useMemo(
         () =>
-            (reviewItems ?? []).filter(
-                (item) =>
-                    item.projectUuid === projectUuid ||
-                    item.latestFinding?.projectUuid === projectUuid,
-            ).length,
+            (reviewItems ?? [])
+                .filter(
+                    (item) =>
+                        item.projectUuid === projectUuid ||
+                        item.latestFinding?.projectUuid === projectUuid,
+                )
+                .sort(
+                    (a, b) =>
+                        new Date(b.lastSeenAt).getTime() -
+                        new Date(a.lastSeenAt).getTime(),
+                ),
         [projectUuid, reviewItems],
     );
 
-    const reviewsUrl = `/generalSettings/ai/reviews?projects=${encodeURIComponent(
-        projectUuid,
-    )}`;
-    const reviewCountLabel =
-        projectReviewCount > 99 ? '99+' : `${projectReviewCount}`;
+    const reviewCount = projectReviewItems.length;
+    const goToAskAi = () => navigate(`/projects/${projectUuid}/ai-agents`);
 
     if (!isVisible) {
         return null;
     }
 
-    if (!showReviews) {
+    // Original button — nothing to surface (no review access, or no open findings).
+    if (!showReviews || reviewCount === 0) {
         return (
             <Button
                 size="xs"
                 variant="default"
                 fz="sm"
                 leftSection={<AiAgentIcon size={14} />}
-                onClick={() => navigate(`/projects/${projectUuid}/ai-agents`)}
+                onClick={goToAskAi}
             >
                 <Text span truncate="end" maw={150} size="sm">
                     Ask AI
@@ -63,69 +68,45 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         );
     }
 
+    const reviewsUrl = `/generalSettings/ai/reviews?projects=${encodeURIComponent(
+        projectUuid,
+    )}`;
+    const countLabel = reviewCount > 99 ? '99+' : `${reviewCount}`;
+
     return (
-        <Menu
-            withArrow
+        <HoverCard
+            width={290}
             shadow="lg"
             position="bottom-start"
-            arrowOffset={28}
-            offset={-2}
-            zIndex={getDefaultZIndex('max')}
+            offset={6}
+            openDelay={120}
+            closeDelay={80}
+            withinPortal
             portalProps={{ target: '#navbar-header' }}
         >
-            <Menu.Target>
+            <HoverCard.Target>
                 <Button
                     size="xs"
                     variant="default"
                     fz="sm"
-                    leftSection={
-                        <AiAgentIcon
-                            size={15}
-                            animated={projectReviewCount > 0}
-                            className={classes.reviewIcon}
-                        />
-                    }
+                    leftSection={<AiAgentIcon size={15} animated calm />}
                     rightSection={
-                        <Group gap={4} wrap="nowrap">
-                            {projectReviewCount > 0 && (
-                                <span className={classes.reviewCount}>
-                                    {reviewCountLabel}
-                                </span>
-                            )}
-                            <MantineIcon icon={IconChevronDown} size={12} />
-                        </Group>
+                        <span className={classes.countBadge}>{countLabel}</span>
                     }
-                    className={classes.reviewButton}
+                    onClick={goToAskAi}
                 >
-                    <Group gap={6} wrap="nowrap">
-                        <Text span truncate="end" maw={88} size="sm">
-                            Ask AI
-                        </Text>
-                        <span className={classes.reviewPill}>Reviews</span>
-                    </Group>
+                    <Text span truncate="end" maw={150} size="sm">
+                        Ask AI
+                    </Text>
                 </Button>
-            </Menu.Target>
-
-            <Menu.Dropdown>
-                <Menu.Item
-                    leftSection={<AiAgentIcon size={14} />}
-                    onClick={() =>
-                        navigate(`/projects/${projectUuid}/ai-agents`)
-                    }
-                >
-                    Ask AI
-                </Menu.Item>
-                <Menu.Item
-                    component={Link}
-                    to={reviewsUrl}
-                    leftSection={
-                        <MantineIcon icon={IconGitPullRequest} size={14} />
-                    }
-                >
-                    Review findings
-                    {projectReviewCount > 0 && ` (${projectReviewCount} open)`}
-                </Menu.Item>
-            </Menu.Dropdown>
-        </Menu>
+            </HoverCard.Target>
+            <HoverCard.Dropdown p="xs">
+                <ReviewFindingsPreview
+                    items={projectReviewItems.slice(0, PREVIEW_LIMIT)}
+                    totalOpen={reviewCount}
+                    reviewsUrl={reviewsUrl}
+                />
+            </HoverCard.Dropdown>
+        </HoverCard>
     );
 };

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -62,7 +62,9 @@ export const MainNavBarContent: FC<Props> = ({
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
                             <Suspense fallback={null}>
-                                <AiAgentsButton />
+                                <AiAgentsButton
+                                    projectUuid={activeProjectUuid}
+                                />
                             </Suspense>
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.module.css
@@ -149,6 +149,37 @@
     animation-direction: alternate-reverse;
 }
 
+/* Calmer variant — slower morph, softer drift, gentler glow. */
+.calm.animated {
+    animation-duration: 8s;
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.62),
+        inset 0 -4px 10px rgba(94, 76, 255, 0.2),
+        0 1px 4px rgba(152, 54, 255, 0.16),
+        0 0 0 1px color-mix(in oklch, #9836ff 30%, transparent);
+}
+
+.calm.animated::before,
+.calm.animated::after {
+    opacity: 0.85;
+    animation-name: ai-agent-icon-drift-calm;
+    animation-duration: 3.6s;
+}
+
+.calm.animated::after {
+    animation-duration: 3.9s;
+}
+
+@keyframes ai-agent-icon-drift-calm {
+    from {
+        transform: translate3d(-1%, -1%, 0) rotate(-2deg) scale(1);
+    }
+
+    to {
+        transform: translate3d(3%, 2%, 0) rotate(7deg) scale(1.03);
+    }
+}
+
 @keyframes ai-agent-icon-morph {
     0% {
         background-position: 43% 0%;

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon.tsx
@@ -5,6 +5,7 @@ type Props = {
     size?: number | string;
     muted?: boolean;
     animated?: boolean;
+    calm?: boolean;
     className?: string;
     style?: CSSProperties;
 };
@@ -13,6 +14,7 @@ export const AiAgentIcon: FC<Props> = ({
     size = 16,
     muted = false,
     animated = false,
+    calm = false,
     className,
     style,
 }) => {
@@ -25,6 +27,7 @@ export const AiAgentIcon: FC<Props> = ({
                 styles.root,
                 muted && styles.muted,
                 animated && styles.animated,
+                calm && styles.calm,
                 className,
             ]
                 .filter(Boolean)

--- a/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.module.css
@@ -1,0 +1,52 @@
+.heading {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--mantine-color-dimmed);
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 8px;
+    border-radius: var(--mantine-radius-sm);
+    color: var(--mantine-color-text);
+    text-decoration: none;
+}
+
+.row:hover {
+    background-color: var(--mantine-color-default-hover);
+}
+
+.title {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+}
+
+.tag {
+    flex-shrink: 0;
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--mantine-color-dimmed);
+}
+
+.footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 4px;
+    padding: 9px 8px 5px;
+    border-top: 1px solid var(--mantine-color-default-border);
+    color: var(--mantine-color-text);
+    text-decoration: none;
+}
+
+.footer:hover {
+    color: var(--mantine-color-bright);
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
@@ -1,0 +1,62 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { Box, ColorSwatch, Group, Stack, Text } from '@mantine-8/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import {
+    reviewRootCauseColors,
+    reviewRootCauseLabels,
+} from './Admin/reviewItemDetails';
+import classes from './ReviewFindingsPreview.module.css';
+
+type Props = {
+    items: AiAgentReviewItemSummary[];
+    totalOpen: number;
+    reviewsUrl: string;
+};
+
+export const ReviewFindingsPreview: FC<Props> = ({
+    items,
+    totalOpen,
+    reviewsUrl,
+}) => (
+    <Stack gap={2}>
+        <Group justify="space-between" px="xs" pt={4} pb={2} wrap="nowrap">
+            <Text className={classes.heading}>Review findings</Text>
+            <Text className={classes.heading}>{totalOpen} open</Text>
+        </Group>
+
+        {items.map((item) => (
+            <Box
+                key={item.fingerprint}
+                component={Link}
+                to={`/generalSettings/ai/reviews/${encodeURIComponent(
+                    item.fingerprint,
+                )}`}
+                className={classes.row}
+            >
+                <ColorSwatch
+                    size={8}
+                    withShadow={false}
+                    color={`var(--mantine-color-${
+                        reviewRootCauseColors[item.primaryRootCause]
+                    }-5)`}
+                />
+                <Text className={classes.title} truncate="end">
+                    {item.title}
+                </Text>
+                <Text className={classes.tag}>
+                    {reviewRootCauseLabels[item.primaryRootCause]}
+                </Text>
+            </Box>
+        ))}
+
+        <Box component={Link} to={reviewsUrl} className={classes.footer}>
+            <Text size="xs" fw={500}>
+                View all reviews
+            </Text>
+            <MantineIcon icon={IconArrowRight} size={12} />
+        </Box>
+    </Stack>
+);


### PR DESCRIPTION
## Summary
- Turns the navbar Ask AI button into a reviews-aware dropdown for users with AI review access.
- Adds teal/lime review styling, a Reviews pill, and an open-count badge on the existing AI icon button.
- Links admins directly to project-filtered AI reviews from the navbar.

## Validation
- Ran `git diff --check` on touched files.
- Frontend formatter/linter could not run because this worktree has no `node_modules` (`oxfmt`/`oxlint` unavailable).