### PR TITLE
feat: add reserved parameters registry

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -769,6 +769,32 @@ describe('Explore compilation with model-level parameters', () => {
                 /Missing parameters: active_status\..*Hint:.*"active_status" is a model-level parameter.*\${lightdash\.parameters\.b\.active_status}/,
             );
         });
+
+        test('should treat reserved parameter names as available during compilation', () => {
+            const exploreWithReservedParameterReference: UncompiledExplore = {
+                ...exploreWithParameters,
+                tables: {
+                    ...exploreWithParameters.tables,
+                    a: {
+                        ...exploreWithParameters.tables.a,
+                        dimensions: {
+                            ...exploreWithParameters.tables.a.dimensions,
+                            grain_flag: {
+                                ...exploreWithParameters.tables.a.dimensions
+                                    .dim1,
+                                name: 'grain_flag',
+                                label: 'grain_flag',
+                                sql: "{% if ld.parameters.date_zoom == 'week' %}1{% else %}0{% endif %}",
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(() =>
+                compiler.compileExplore(exploreWithReservedParameterReference),
+            ).not.toThrow();
+        });
     });
 
     describe('Partial compilation surfaces field-level errors clearly', () => {

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -795,6 +795,28 @@ describe('Explore compilation with model-level parameters', () => {
                 compiler.compileExplore(exploreWithReservedParameterReference),
             ).not.toThrow();
         });
+
+        test('should warn (not throw) when a model parameter shadows a reserved name', () => {
+            const exploreShadowingReservedName: UncompiledExplore = {
+                ...exploreWithParameters,
+                meta: {
+                    parameters: {
+                        date_zoom: { label: 'My date zoom', default: 'custom' },
+                    },
+                },
+            };
+
+            const result = compiler.compileExplore(
+                exploreShadowingReservedName,
+            );
+
+            expect(result.warnings).toBeDefined();
+            expect(
+                result.warnings?.some((w) =>
+                    /reserved|overrides/i.test(w.message),
+                ),
+            ).toBe(true);
+        });
     });
 
     describe('Partial compilation surfaces field-level errors clearly', () => {

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -464,27 +464,26 @@ export class ExploreCompiler {
         } = validateParameterNames(meta.parameters);
 
         if (hasInvalidParameterNames) {
-            const reasons = [
-                invalidParameters.length > 0
-                    ? `Invalid parameter names: ${invalidParameters.join(', ')}`
-                    : undefined,
-                reservedParameters.length > 0
-                    ? `Reserved parameter names cannot be used: ${reservedParameters.join(
-                          ', ',
-                      )}`
-                    : undefined,
-            ]
-                .filter(Boolean)
-                .join('. ');
             throw new CompileError(
-                `Failed to compile explore "${name}". ${reasons}`,
-                {
-                    invalidParameters: [
-                        ...invalidParameters,
-                        ...reservedParameters,
-                    ],
-                },
+                `Failed to compile explore "${name}". Invalid parameter names: ${invalidParameters.join(
+                    ', ',
+                )}.`,
+                { invalidParameters },
             );
+        }
+
+        // A parameter that collides with a reserved (system-owned) name doesn't fail
+        // compilation: the user parameter takes priority and shadows the reserved one.
+        // Warn so the override is discoverable rather than silent.
+        if (reservedParameters.length > 0) {
+            exploreWarnings.push({
+                type: InlineErrorType.INVALID_PARAMETER,
+                message: `Parameter${
+                    reservedParameters.length > 1 ? 's' : ''
+                } ${reservedParameters.join(', ')} ${
+                    reservedParameters.length > 1 ? 'override' : 'overrides'
+                } a reserved system variable and will take priority over it.`,
+            });
         }
 
         const { isValid, error: paramConfigError } =

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -472,8 +472,7 @@ export class ExploreCompiler {
             );
         }
 
-        // A parameter that collides with a reserved (system-owned) name doesn't fail
-        // compilation: the user parameter takes priority and shadows the reserved one.
+        // Collisions with a reserved name don't fail compilation: the user parameter wins.
         // Warn so the override is discoverable rather than silent.
         if (reservedParameters.length > 0) {
             exploreWarnings.push({

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -457,16 +457,32 @@ export class ExploreCompiler {
             );
         }
 
-        const { isInvalid: hasInvalidParameterNames, invalidParameters } =
-            validateParameterNames(meta.parameters);
+        const {
+            isInvalid: hasInvalidParameterNames,
+            invalidParameters,
+            reservedParameters,
+        } = validateParameterNames(meta.parameters);
 
         if (hasInvalidParameterNames) {
+            const reasons = [
+                invalidParameters.length > 0
+                    ? `Invalid parameter names: ${invalidParameters.join(', ')}`
+                    : undefined,
+                reservedParameters.length > 0
+                    ? `Reserved parameter names cannot be used: ${reservedParameters.join(
+                          ', ',
+                      )}`
+                    : undefined,
+            ]
+                .filter(Boolean)
+                .join('. ');
             throw new CompileError(
-                `Failed to compile explore "${name}". Invalid parameter names: ${invalidParameters.join(
-                    ', ',
-                )}`,
+                `Failed to compile explore "${name}". ${reasons}`,
                 {
-                    invalidParameters,
+                    invalidParameters: [
+                        ...invalidParameters,
+                        ...reservedParameters,
+                    ],
                 },
             );
         }

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -461,8 +461,7 @@ describe('getMissingRequiredParameters', () => {
     });
 
     it('never flags a reserved parameter as missing', () => {
-        // Reserved parameters are resolved server-side and are never present in the
-        // user-facing values map, so they must not be treated as required.
+        // Reserved parameters are resolved server-side, so never user-required.
         const result = getMissingRequiredParameters(['date_zoom'], {}, {});
         expect(result).toEqual([]);
     });

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -395,16 +395,16 @@ describe('validateParameterNames', () => {
         expect(result.invalidParameters).toContain('another invalid');
     });
 
-    it('should reject reserved parameter names', () => {
+    it('should not fail on reserved parameter names (user param wins, surfaced separately)', () => {
         const result = validateParameterNames({
             date_zoom: { label: 'Date zoom', default: 'week' },
         });
-        expect(result.isInvalid).toBe(true);
+        expect(result.isInvalid).toBe(false);
         expect(result.reservedParameters).toContain('date_zoom');
         expect(result.invalidParameters).toEqual([]);
     });
 
-    it('should report invalid and reserved names separately', () => {
+    it('should report invalid and reserved names separately (only invalid fails)', () => {
         const result = validateParameterNames({
             'bad.name': { label: 'Bad', default: 'x' },
             date_zoom: { label: 'Date zoom', default: 'week' },

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -392,6 +392,26 @@ describe('validateParameterNames', () => {
         expect(result.invalidParameters).toContain('invalid.param');
         expect(result.invalidParameters).toContain('another invalid');
     });
+
+    it('should reject reserved parameter names', () => {
+        const result = validateParameterNames({
+            date_zoom: { label: 'Date zoom', default: 'week' },
+        });
+        expect(result.isInvalid).toBe(true);
+        expect(result.reservedParameters).toContain('date_zoom');
+        expect(result.invalidParameters).toEqual([]);
+    });
+
+    it('should report invalid and reserved names separately', () => {
+        const result = validateParameterNames({
+            'bad.name': { label: 'Bad', default: 'x' },
+            date_zoom: { label: 'Date zoom', default: 'week' },
+            good_name: { label: 'Good', default: 'y' },
+        });
+        expect(result.isInvalid).toBe(true);
+        expect(result.invalidParameters).toEqual(['bad.name']);
+        expect(result.reservedParameters).toEqual(['date_zoom']);
+    });
 });
 
 describe('validateParameterConfiguration', () => {

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -1,5 +1,7 @@
 import {
+    getMissingRequiredParameters,
     getParameterReferences,
+    hasReservedParameterReference,
     validateParameterConfiguration,
     validateParameterNames,
 } from './parameters';
@@ -411,6 +413,58 @@ describe('validateParameterNames', () => {
         expect(result.isInvalid).toBe(true);
         expect(result.invalidParameters).toEqual(['bad.name']);
         expect(result.reservedParameters).toEqual(['date_zoom']);
+    });
+});
+
+describe('hasReservedParameterReference', () => {
+    it('returns true when a reserved parameter is referenced', () => {
+        expect(hasReservedParameterReference(['region', 'date_zoom'])).toBe(
+            true,
+        );
+    });
+
+    it('returns false when only user parameters are referenced', () => {
+        expect(hasReservedParameterReference(['region', 'status'])).toBe(false);
+    });
+
+    it('returns false for an empty list', () => {
+        expect(hasReservedParameterReference([])).toBe(false);
+    });
+});
+
+describe('getMissingRequiredParameters', () => {
+    it('flags a referenced parameter with no value and no default', () => {
+        const result = getMissingRequiredParameters(
+            ['region'],
+            {},
+            { region: { label: 'Region' } },
+        );
+        expect(result).toEqual(['region']);
+    });
+
+    it('does not flag a parameter that has a value', () => {
+        const result = getMissingRequiredParameters(
+            ['region'],
+            { region: 'EU' },
+            { region: { label: 'Region' } },
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('does not flag a parameter that has a default', () => {
+        const result = getMissingRequiredParameters(
+            ['region'],
+            {},
+            { region: { label: 'Region', default: 'EU' } },
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('never flags a reserved parameter as missing', () => {
+        // Reserved parameters are resolved server-side and are never present in the
+        // user-facing values map, so they must not be treated as required.
+        const result = getMissingRequiredParameters(['date_zoom'], {}, {});
+        expect(result).toEqual([]);
     });
 });
 

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -6,8 +6,8 @@ import Ajv from 'ajv';
 import AjvErrors from 'ajv-errors';
 import betterAjvErrors from 'better-ajv-errors';
 import {
-    getReservedParameterNames,
     isReservedParameterName,
+    mergeReservedNames,
 } from '../parameters/reservedParameters';
 import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
 import { CompileError } from '../types/errors';
@@ -120,9 +120,11 @@ export const getAvailableParameterNames = (
     projectParameters: Record<string, LightdashProjectParameter> | undefined,
     exploreParameters: Record<string, LightdashProjectParameter> | undefined,
 ): string[] =>
-    Object.keys(projectParameters || {})
-        .concat(Object.keys(exploreParameters || {}))
-        .concat(getReservedParameterNames());
+    mergeReservedNames(
+        Object.keys(projectParameters || {}).concat(
+            Object.keys(exploreParameters || {}),
+        ),
+    );
 
 /**
  * Whether any of the given parameter references is a reserved (system-owned) parameter.
@@ -189,11 +191,13 @@ export const getAvailableParametersFromTables = (
     }, {});
 
 /**
- * Validate parameter names. A name is rejected when it doesn't match the valid pattern
- * or when it collides with a reserved (system-owned) parameter name.
+ * Validate parameter names. A name is invalid only when it doesn't match the valid
+ * pattern. Names that collide with a reserved (system-owned) parameter are NOT invalid:
+ * the user parameter takes priority (shadows the reserved one) and the collision is
+ * surfaced as a non-fatal warning by callers, never as a failure.
  * @param parameters - The parameters to validate
  * @returns invalid names (bad pattern) and reserved names (collisions) separately so
- * callers can surface a clear message for each case.
+ * callers can fail on the former and warn on the latter.
  */
 export const validateParameterNames = (
     parameters: Record<string, LightdashProjectParameter> | undefined,
@@ -207,8 +211,7 @@ export const validateParameterNames = (
         isReservedParameterName(paramName),
     );
     return {
-        isInvalid:
-            invalidParameters.length > 0 || reservedParameters.length > 0,
+        isInvalid: invalidParameters.length > 0,
         invalidParameters,
         reservedParameters,
     };

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -13,6 +13,10 @@ import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
 import { CompileError } from '../types/errors';
 import type { CompiledTable, Table } from '../types/explore';
 import type { LightdashProjectParameter } from '../types/lightdashProjectConfig';
+import type {
+    ParameterDefinitions,
+    ParametersValuesMap,
+} from '../types/parameters';
 
 // Regex for SQL parameter substitution - requires the full ${...} syntax.
 // Used by `replaceLightdashValues` to find substitution sites.
@@ -119,6 +123,33 @@ export const getAvailableParameterNames = (
     Object.keys(projectParameters || {})
         .concat(Object.keys(exploreParameters || {}))
         .concat(getReservedParameterNames());
+
+/**
+ * Whether any of the given parameter references is a reserved (system-owned) parameter.
+ * Reserved parameters are currently all date-zoom values, so this doubles as "is this
+ * query affected by date zoom through a parameter reference".
+ */
+export const hasReservedParameterReference = (
+    parameterReferences: string[],
+): boolean => parameterReferences.some(isReservedParameterName);
+
+/**
+ * Determine which referenced parameters still need a value before a query can run.
+ * A parameter is required when it has no value and no default. Reserved (system-owned)
+ * parameters are resolved server-side from the query context and are never user-provided,
+ * so they are never treated as missing.
+ */
+export const getMissingRequiredParameters = (
+    parameterReferences: string[],
+    parameterValues: ParametersValuesMap | undefined,
+    parameterDefinitions: ParameterDefinitions | undefined,
+): string[] =>
+    parameterReferences.filter(
+        (name) =>
+            !isReservedParameterName(name) &&
+            !parameterValues?.[name] &&
+            !parameterDefinitions?.[name]?.default,
+    );
 
 /**
  * Get all available parameter names for a project and explore

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -126,11 +126,7 @@ export const getAvailableParameterNames = (
         ),
     );
 
-/**
- * Whether any of the given parameter references is a reserved (system-owned) parameter.
- * Reserved parameters are currently all date-zoom values, so this doubles as "is this
- * query affected by date zoom through a parameter reference".
- */
+/** Whether any reference is a reserved (system-owned) parameter. */
 export const hasReservedParameterReference = (
     parameterReferences: string[],
 ): boolean => parameterReferences.some(isReservedParameterName);
@@ -191,13 +187,8 @@ export const getAvailableParametersFromTables = (
     }, {});
 
 /**
- * Validate parameter names. A name is invalid only when it doesn't match the valid
- * pattern. Names that collide with a reserved (system-owned) parameter are NOT invalid:
- * the user parameter takes priority (shadows the reserved one) and the collision is
- * surfaced as a non-fatal warning by callers, never as a failure.
- * @param parameters - The parameters to validate
- * @returns invalid names (bad pattern) and reserved names (collisions) separately so
- * callers can fail on the former and warn on the latter.
+ * Validate parameter names. Only bad-pattern names are invalid; names colliding with a
+ * reserved parameter are returned separately so callers can warn (the user param wins).
  */
 export const validateParameterNames = (
     parameters: Record<string, LightdashProjectParameter> | undefined,

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -5,6 +5,10 @@
 import Ajv from 'ajv';
 import AjvErrors from 'ajv-errors';
 import betterAjvErrors from 'better-ajv-errors';
+import {
+    getReservedParameterNames,
+    isReservedParameterName,
+} from '../parameters/reservedParameters';
 import lightdashDbtYamlSchema from '../schemas/json/lightdash-dbt-2.0.json';
 import { CompileError } from '../types/errors';
 import type { CompiledTable, Table } from '../types/explore';
@@ -112,9 +116,9 @@ export const getAvailableParameterNames = (
     projectParameters: Record<string, LightdashProjectParameter> | undefined,
     exploreParameters: Record<string, LightdashProjectParameter> | undefined,
 ): string[] =>
-    Object.keys(projectParameters || {}).concat(
-        Object.keys(exploreParameters || {}),
-    );
+    Object.keys(projectParameters || {})
+        .concat(Object.keys(exploreParameters || {}))
+        .concat(getReservedParameterNames());
 
 /**
  * Get all available parameter names for a project and explore
@@ -154,20 +158,28 @@ export const getAvailableParametersFromTables = (
     }, {});
 
 /**
- * Validate parameter names
+ * Validate parameter names. A name is rejected when it doesn't match the valid pattern
+ * or when it collides with a reserved (system-owned) parameter name.
  * @param parameters - The parameters to validate
- * @returns True if any parameter name doesn't match the valid pattern, false otherwise
+ * @returns invalid names (bad pattern) and reserved names (collisions) separately so
+ * callers can surface a clear message for each case.
  */
 export const validateParameterNames = (
     parameters: Record<string, LightdashProjectParameter> | undefined,
 ) => {
     const validNamePattern = /^[a-zA-Z0-9_-]+$/;
-    const invalidParameters = Object.keys(parameters || {}).filter(
+    const parameterNames = Object.keys(parameters || {});
+    const invalidParameters = parameterNames.filter(
         (paramName) => !validNamePattern.test(paramName),
     );
+    const reservedParameters = parameterNames.filter((paramName) =>
+        isReservedParameterName(paramName),
+    );
     return {
-        isInvalid: invalidParameters.length > 0,
+        isInvalid:
+            invalidParameters.length > 0 || reservedParameters.length > 0,
         invalidParameters,
+        reservedParameters,
     };
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -65,6 +65,7 @@ export * from './compiler/filtersCompiler';
 export * from './compiler/lightdashModelConverter';
 export * from './compiler/parameters';
 export * from './compiler/translator';
+export * from './parameters/reservedParameters';
 export * from './constants/screenshot';
 export * from './constants/sessionStorageKeys';
 export * from './constants/spaces';

--- a/packages/common/src/parameters/reservedParameters.test.ts
+++ b/packages/common/src/parameters/reservedParameters.test.ts
@@ -1,0 +1,69 @@
+import { DateGranularity } from '../types/timeFrames';
+import {
+    getReservedParameterDefinitions,
+    getReservedParameterNames,
+    isReservedParameterName,
+    resolveReservedParameterValues,
+} from './reservedParameters';
+
+describe('reservedParameters', () => {
+    describe('isReservedParameterName', () => {
+        it('returns true for a reserved name', () => {
+            expect(isReservedParameterName('date_zoom')).toBe(true);
+        });
+
+        it('returns false for a non-reserved name', () => {
+            expect(isReservedParameterName('region')).toBe(false);
+            expect(isReservedParameterName('dateZoom')).toBe(false);
+        });
+    });
+
+    describe('getReservedParameterNames', () => {
+        it('includes date_zoom', () => {
+            expect(getReservedParameterNames()).toContain('date_zoom');
+        });
+    });
+
+    describe('getReservedParameterDefinitions', () => {
+        it('exposes definitions without the resolver', () => {
+            const definitions = getReservedParameterDefinitions();
+            expect(definitions.date_zoom).toBeDefined();
+            expect(definitions.date_zoom.label).toBe('Date zoom');
+            expect('resolve' in definitions.date_zoom).toBe(false);
+        });
+    });
+
+    describe('resolveReservedParameterValues', () => {
+        it('resolves the active granularity in lowercase when applied', () => {
+            const values = resolveReservedParameterValues({
+                dateZoom: { granularity: DateGranularity.WEEK },
+                dateZoomApplied: true,
+            });
+            expect(values.date_zoom).toBe('week');
+        });
+
+        it('passes a custom granularity through in lowercase', () => {
+            const values = resolveReservedParameterValues({
+                dateZoom: { granularity: 'Fiscal Week' },
+                dateZoomApplied: true,
+            });
+            expect(values.date_zoom).toBe('fiscal week');
+        });
+
+        it('resolves to empty string when no date zoom is applied', () => {
+            const values = resolveReservedParameterValues({
+                dateZoom: { granularity: DateGranularity.WEEK },
+                dateZoomApplied: false,
+            });
+            expect(values.date_zoom).toBe('');
+        });
+
+        it('resolves to empty string when there is no date zoom', () => {
+            const values = resolveReservedParameterValues({
+                dateZoom: undefined,
+                dateZoomApplied: true,
+            });
+            expect(values.date_zoom).toBe('');
+        });
+    });
+});

--- a/packages/common/src/parameters/reservedParameters.test.ts
+++ b/packages/common/src/parameters/reservedParameters.test.ts
@@ -2,7 +2,11 @@ import { DateGranularity } from '../types/timeFrames';
 import {
     getReservedParameterDefinitions,
     getReservedParameterNames,
+    getShadowedReservedNames,
     isReservedParameterName,
+    mergeReservedDefinitions,
+    mergeReservedNames,
+    mergeReservedValues,
     resolveReservedParameterValues,
 } from './reservedParameters';
 
@@ -60,6 +64,72 @@ describe('reservedParameters', () => {
                 dateZoom: undefined,
             });
             expect(values.date_zoom).toBe('');
+        });
+    });
+
+    describe('collision precedence (user wins)', () => {
+        describe('getShadowedReservedNames', () => {
+            it('returns reserved names taken by a user parameter', () => {
+                expect(
+                    getShadowedReservedNames(['region', 'date_zoom']),
+                ).toEqual(['date_zoom']);
+            });
+
+            it('returns nothing when there is no collision', () => {
+                expect(getShadowedReservedNames(['region', 'status'])).toEqual(
+                    [],
+                );
+            });
+        });
+
+        describe('mergeReservedNames', () => {
+            it('appends reserved names not already taken (deduped)', () => {
+                expect(mergeReservedNames(['region'])).toEqual([
+                    'region',
+                    'date_zoom',
+                ]);
+            });
+
+            it('keeps the user name once on collision (no duplicate)', () => {
+                const merged = mergeReservedNames(['date_zoom', 'region']);
+                expect(merged).toEqual(['date_zoom', 'region']);
+                expect(merged.filter((n) => n === 'date_zoom')).toHaveLength(1);
+            });
+        });
+
+        describe('mergeReservedDefinitions', () => {
+            it('lets the user definition shadow the reserved one', () => {
+                const userDef = { label: 'My date zoom', default: 'custom' };
+                const merged = mergeReservedDefinitions({ date_zoom: userDef });
+                expect(merged.date_zoom).toEqual(userDef);
+            });
+
+            it('keeps the reserved definition when not shadowed', () => {
+                const merged = mergeReservedDefinitions({
+                    region: { label: 'Region' },
+                });
+                expect(merged.region).toBeDefined();
+                expect(merged.date_zoom.label).toBe('Date zoom');
+            });
+        });
+
+        describe('mergeReservedValues', () => {
+            it('lets the user value shadow the reserved value', () => {
+                const merged = mergeReservedValues(
+                    { date_zoom: 'custom' },
+                    { date_zoom: 'week' },
+                );
+                expect(merged.date_zoom).toBe('custom');
+            });
+
+            it('keeps the reserved value when not shadowed', () => {
+                const merged = mergeReservedValues(
+                    { region: 'US' },
+                    { date_zoom: 'week' },
+                );
+                expect(merged.region).toBe('US');
+                expect(merged.date_zoom).toBe('week');
+            });
         });
     });
 });

--- a/packages/common/src/parameters/reservedParameters.test.ts
+++ b/packages/common/src/parameters/reservedParameters.test.ts
@@ -34,10 +34,9 @@ describe('reservedParameters', () => {
     });
 
     describe('resolveReservedParameterValues', () => {
-        it('resolves the active granularity in lowercase when applied', () => {
+        it('resolves the selected granularity in lowercase', () => {
             const values = resolveReservedParameterValues({
                 dateZoom: { granularity: DateGranularity.WEEK },
-                dateZoomApplied: true,
             });
             expect(values.date_zoom).toBe('week');
         });
@@ -45,23 +44,20 @@ describe('reservedParameters', () => {
         it('passes a custom granularity through in lowercase', () => {
             const values = resolveReservedParameterValues({
                 dateZoom: { granularity: 'Fiscal Week' },
-                dateZoomApplied: true,
             });
             expect(values.date_zoom).toBe('fiscal week');
         });
 
-        it('resolves to empty string when no date zoom is applied', () => {
+        it('reflects the selected grain regardless of whether a date dimension is zoomed', () => {
             const values = resolveReservedParameterValues({
-                dateZoom: { granularity: DateGranularity.WEEK },
-                dateZoomApplied: false,
+                dateZoom: { granularity: DateGranularity.MONTH },
             });
-            expect(values.date_zoom).toBe('');
+            expect(values.date_zoom).toBe('month');
         });
 
         it('resolves to empty string when there is no date zoom', () => {
             const values = resolveReservedParameterValues({
                 dateZoom: undefined,
-                dateZoomApplied: true,
             });
             expect(values.date_zoom).toBe('');
         });

--- a/packages/common/src/parameters/reservedParameters.ts
+++ b/packages/common/src/parameters/reservedParameters.ts
@@ -13,7 +13,6 @@ import { getGranularityReferenceValue } from '../types/timeFrames';
  */
 export type ReservedParameterContext = {
     dateZoom: DateZoom | undefined;
-    dateZoomApplied: boolean;
 };
 
 /**
@@ -35,10 +34,10 @@ export const RESERVED_PARAMETERS: Record<string, ReservedParameterDefinition> =
         date_zoom: {
             label: 'Date zoom',
             description:
-                'The active date zoom granularity in lowercase (e.g. "week"). Empty when no date zoom is applied.',
+                'The selected date zoom granularity in lowercase (e.g. "week"). Empty when no date zoom is selected.',
             type: 'string',
-            resolve: ({ dateZoom, dateZoomApplied }) =>
-                dateZoomApplied && dateZoom?.granularity
+            resolve: ({ dateZoom }) =>
+                dateZoom?.granularity
                     ? getGranularityReferenceValue(dateZoom.granularity)
                     : '',
         },

--- a/packages/common/src/parameters/reservedParameters.ts
+++ b/packages/common/src/parameters/reservedParameters.ts
@@ -75,3 +75,51 @@ export const resolveReservedParameterValues = (
         }),
         {},
     );
+
+/**
+ * Reserved names that are shadowed by a user/project/explore parameter of the same name.
+ * A user-defined parameter always takes priority over a reserved one (collisions never
+ * fail). Used to surface the override in the UI and as a non-fatal compile warning.
+ */
+export const getShadowedReservedNames = (
+    userParameterNames: string[],
+): string[] => {
+    const userNames = new Set(userParameterNames);
+    return getReservedParameterNames().filter((name) => userNames.has(name));
+};
+
+/**
+ * Shared precedence rule for name collisions: user parameters win, reserved names are
+ * appended only when not already taken. Deduplicated. Used wherever reserved names join
+ * the available-parameter set so availability never disagrees with values/definitions.
+ */
+export const mergeReservedNames = (userParameterNames: string[]): string[] => {
+    const userNames = new Set(userParameterNames);
+    return [
+        ...userParameterNames,
+        ...getReservedParameterNames().filter((name) => !userNames.has(name)),
+    ];
+};
+
+/**
+ * Merge reserved definitions under user definitions; a user definition of the same name
+ * wins (shadows the reserved entry).
+ */
+export const mergeReservedDefinitions = (
+    userDefinitions: ParameterDefinitions | undefined,
+): ParameterDefinitions => ({
+    ...getReservedParameterDefinitions(),
+    ...(userDefinitions ?? {}),
+});
+
+/**
+ * Merge resolved reserved values under user values; a user value of the same name wins
+ * (shadows the reserved value).
+ */
+export const mergeReservedValues = (
+    userValues: ParametersValuesMap | undefined,
+    reservedValues: ParametersValuesMap,
+): ParametersValuesMap => ({
+    ...reservedValues,
+    ...(userValues ?? {}),
+});

--- a/packages/common/src/parameters/reservedParameters.ts
+++ b/packages/common/src/parameters/reservedParameters.ts
@@ -7,28 +7,20 @@ import {
 } from '../types/parameters';
 import { getGranularityReferenceValue } from '../types/timeFrames';
 
-/**
- * Context handed to reserved parameter resolvers. Each reserved parameter reads only
- * what it needs. Extend this as new system values are exposed as reserved parameters.
- */
+/** Context from which reserved parameters resolve their values. */
 export type ReservedParameterContext = {
     dateZoom: DateZoom | undefined;
 };
 
 /**
- * A reserved (system-owned) parameter. It shares the user-parameter definition shape so
- * it rides the existing substitution/Liquid/autocomplete pipeline, plus a `resolve`
- * function that computes its value from the query context.
+ * A reserved (system-owned) parameter: the user-parameter shape plus a `resolve` that
+ * computes its value from the query context, so it rides the existing parameter pipeline.
  */
 export type ReservedParameterDefinition = LightdashProjectParameter & {
     resolve: (context: ReservedParameterContext) => ParameterValue;
 };
 
-/**
- * The registry of reserved parameters. Add an entry here to expose a new system value;
- * everything else (availability during compilation, name collision rejection, value
- * injection, UI) is driven off this map.
- */
+/** Registry of reserved parameters. Add an entry here to expose a new system value. */
 export const RESERVED_PARAMETERS: Record<string, ReservedParameterDefinition> =
     {
         date_zoom: {
@@ -76,11 +68,7 @@ export const resolveReservedParameterValues = (
         {},
     );
 
-/**
- * Reserved names that are shadowed by a user/project/explore parameter of the same name.
- * A user-defined parameter always takes priority over a reserved one (collisions never
- * fail). Used to surface the override in the UI and as a non-fatal compile warning.
- */
+/** Reserved names shadowed by a same-named user parameter (used to surface the override). */
 export const getShadowedReservedNames = (
     userParameterNames: string[],
 ): string[] => {
@@ -88,11 +76,7 @@ export const getShadowedReservedNames = (
     return getReservedParameterNames().filter((name) => userNames.has(name));
 };
 
-/**
- * Shared precedence rule for name collisions: user parameters win, reserved names are
- * appended only when not already taken. Deduplicated. Used wherever reserved names join
- * the available-parameter set so availability never disagrees with values/definitions.
- */
+/** Append reserved names not already taken by a user parameter (deduped, user wins). */
 export const mergeReservedNames = (userParameterNames: string[]): string[] => {
     const userNames = new Set(userParameterNames);
     return [

--- a/packages/common/src/parameters/reservedParameters.ts
+++ b/packages/common/src/parameters/reservedParameters.ts
@@ -1,0 +1,78 @@
+import { type DateZoom } from '../types/api/paginatedQuery';
+import { type LightdashProjectParameter } from '../types/lightdashProjectConfig';
+import {
+    type ParameterDefinitions,
+    type ParametersValuesMap,
+    type ParameterValue,
+} from '../types/parameters';
+import { getGranularityReferenceValue } from '../types/timeFrames';
+
+/**
+ * Context handed to reserved parameter resolvers. Each reserved parameter reads only
+ * what it needs. Extend this as new system values are exposed as reserved parameters.
+ */
+export type ReservedParameterContext = {
+    dateZoom: DateZoom | undefined;
+    dateZoomApplied: boolean;
+};
+
+/**
+ * A reserved (system-owned) parameter. It shares the user-parameter definition shape so
+ * it rides the existing substitution/Liquid/autocomplete pipeline, plus a `resolve`
+ * function that computes its value from the query context.
+ */
+export type ReservedParameterDefinition = LightdashProjectParameter & {
+    resolve: (context: ReservedParameterContext) => ParameterValue;
+};
+
+/**
+ * The registry of reserved parameters. Add an entry here to expose a new system value;
+ * everything else (availability during compilation, name collision rejection, value
+ * injection, UI) is driven off this map.
+ */
+export const RESERVED_PARAMETERS: Record<string, ReservedParameterDefinition> =
+    {
+        date_zoom: {
+            label: 'Date zoom',
+            description:
+                'The active date zoom granularity in lowercase (e.g. "week"). Empty when no date zoom is applied.',
+            type: 'string',
+            resolve: ({ dateZoom, dateZoomApplied }) =>
+                dateZoomApplied && dateZoom?.granularity
+                    ? getGranularityReferenceValue(dateZoom.granularity)
+                    : '',
+        },
+    };
+
+export const getReservedParameterNames = (): string[] =>
+    Object.keys(RESERVED_PARAMETERS);
+
+export const isReservedParameterName = (name: string): boolean =>
+    name in RESERVED_PARAMETERS;
+
+/**
+ * Reserved parameter definitions in the shared definition shape (without resolvers), for
+ * merging into the available-parameter map and rendering in the parameters UI.
+ */
+export const getReservedParameterDefinitions = (): ParameterDefinitions =>
+    Object.entries(RESERVED_PARAMETERS).reduce<ParameterDefinitions>(
+        (acc, [name, { resolve, ...definition }]) => ({
+            ...acc,
+            [name]: definition,
+        }),
+        {},
+    );
+
+/**
+ * Resolve every reserved parameter to its value for the given query context.
+ */
+export const resolveReservedParameterValues = (
+    context: ReservedParameterContext,
+): ParametersValuesMap =>
+    Object.entries(RESERVED_PARAMETERS).reduce<ParametersValuesMap>(
+        (acc, [name, { resolve }]) => ({
+            ...acc,
+            [name]: resolve(context),
+        }),
+        {},
+    );

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -75,10 +75,8 @@ export type DefaultTimeDimension = {
 };
 
 /**
- * Single source of truth for turning a date zoom granularity (a standard
- * `DateGranularity` or a custom-granularity string) into the value used to
- * reference it across surfaces (custom SQL parameters, chart labels). Lowercased
- * so the same grain reads identically everywhere it is referenced.
+ * Single source of truth for the value used to reference a date zoom granularity across
+ * surfaces (custom SQL parameters, chart labels). Lowercased so it reads the same everywhere.
  */
 export const getGranularityReferenceValue = (
     granularity: DateGranularity | string,

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -73,3 +73,13 @@ export type DefaultTimeDimension = {
     field: string;
     interval: TimeFrames;
 };
+
+/**
+ * Single source of truth for turning a date zoom granularity (a standard
+ * `DateGranularity` or a custom-granularity string) into the value used to
+ * reference it across surfaces (custom SQL parameters, chart labels). Lowercased
+ * so the same grain reads identically everywhere it is referenced.
+ */
+export const getGranularityReferenceValue = (
+    granularity: DateGranularity | string,
+): string => granularity.toLowerCase();

--- a/packages/common/src/utils/bigNumber.ts
+++ b/packages/common/src/utils/bigNumber.ts
@@ -1,4 +1,7 @@
-import { type DateGranularity } from '../types/timeFrames';
+import {
+    getGranularityReferenceValue,
+    type DateGranularity,
+} from '../types/timeFrames';
 
 const GRANULARITY_PATTERN = /\$\{([^}]+)\.granularity\}/g;
 
@@ -14,7 +17,9 @@ export const resolveGranularityInLabel = (
         GRANULARITY_PATTERN,
         (match, fieldBaseId: string) => {
             const granularity = granularityMap[fieldBaseId];
-            return granularity ? granularity.toLowerCase() : match;
+            return granularity
+                ? getGranularityReferenceValue(granularity)
+                : match;
         },
     );
 };

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -64,26 +64,23 @@ export const loadLightdashProjectConfig = async (
     } = validateParameterNames(configFile.parameters);
 
     if (hasInvalidParameterNames) {
-        const reasons = [
-            invalidParameters.length > 0
-                ? `invalid parameter names: ${invalidParameters.join(', ')}`
-                : undefined,
-            reservedParameters.length > 0
-                ? `reserved parameter names cannot be used: ${reservedParameters.join(
-                      ', ',
-                  )}`
-                : undefined,
-        ]
-            .filter(Boolean)
-            .join('. ');
         throw new LightdashProjectConfigError(
-            `Invalid lightdash.config.yml with ${reasons}`,
-            {
-                invalidParameters: [
-                    ...invalidParameters,
-                    ...reservedParameters,
-                ],
-            },
+            `Invalid lightdash.config.yml with invalid parameter names: ${invalidParameters.join(
+                ', ',
+            )}`,
+            { invalidParameters },
+        );
+    }
+
+    // A parameter colliding with a reserved (system-owned) name takes priority over the
+    // reserved one rather than failing config load. Warn so the override is visible.
+    if (reservedParameters.length > 0) {
+        console.warn(
+            `lightdash.config.yml: parameter${
+                reservedParameters.length > 1 ? 's' : ''
+            } ${reservedParameters.join(', ')} ${
+                reservedParameters.length > 1 ? 'override' : 'overrides'
+            } a reserved system variable and will take priority over it.`,
         );
     }
 

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -72,8 +72,7 @@ export const loadLightdashProjectConfig = async (
         );
     }
 
-    // A parameter colliding with a reserved (system-owned) name takes priority over the
-    // reserved one rather than failing config load. Warn so the override is visible.
+    // Collisions with a reserved name don't fail config load: the user param wins; warn.
     if (reservedParameters.length > 0) {
         console.warn(
             `lightdash.config.yml: parameter${

--- a/packages/common/src/utils/loadLightdashProjectConfig.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.ts
@@ -57,16 +57,32 @@ export const loadLightdashProjectConfig = async (
         configFile.parameters = undefined;
     }
 
-    const { isInvalid: hasInvalidParameterNames, invalidParameters } =
-        validateParameterNames(configFile.parameters);
+    const {
+        isInvalid: hasInvalidParameterNames,
+        invalidParameters,
+        reservedParameters,
+    } = validateParameterNames(configFile.parameters);
 
     if (hasInvalidParameterNames) {
+        const reasons = [
+            invalidParameters.length > 0
+                ? `invalid parameter names: ${invalidParameters.join(', ')}`
+                : undefined,
+            reservedParameters.length > 0
+                ? `reserved parameter names cannot be used: ${reservedParameters.join(
+                      ', ',
+                  )}`
+                : undefined,
+        ]
+            .filter(Boolean)
+            .join('. ');
         throw new LightdashProjectConfigError(
-            `Invalid lightdash.config.yml with invalid parameter names: ${invalidParameters.join(
-                ', ',
-            )}`,
+            `Invalid lightdash.config.yml with ${reasons}`,
             {
-                invalidParameters,
+                invalidParameters: [
+                    ...invalidParameters,
+                    ...reservedParameters,
+                ],
             },
         );
     }


### PR DESCRIPTION
Adds a first-class `reserved_parameters` registry in `@lightdash/common`. Reserved parameters are system-owned values (starting with date zoom) that reuse the existing parameters pipeline (substitution + Liquid + autocomplete) but live in a distinct category (`source: 'reserved'`), separate from user-defined params.

Collisions with user parameters do not fail. When a user/project/explore parameter shares a reserved name, the user parameter takes priority (shadows the reserved one) and the collision is surfaced as a non-fatal warning instead of a thrown error, so adding a reserved name never breaks an existing project. A single shadow-merge helper (names, definitions, values) enforces user-wins precedence at every seam, so availability, definitions and values can not disagree.

Relates: GLITCH-195