### PR TITLE
feat: thread reserved date zoom parameter through query compilation

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -48,8 +48,7 @@ test('Should compile without table calculations', () => {
 });
 
 test('Should compile custom SQL dimension referencing a reserved parameter', () => {
-    // Reserved parameters must be available even when the caller passes no
-    // parameters (e.g. the async query fields path), so this should not throw.
+    // Reserved parameters must be available even when the caller passes none.
     const metricQuery = {
         ...METRIC_QUERY_NO_CALCS,
         dimensions: ['table1_dim_1'],

--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -47,6 +47,35 @@ test('Should compile without table calculations', () => {
     ).toStrictEqual(expected);
 });
 
+test('Should compile custom SQL dimension referencing a reserved parameter', () => {
+    // Reserved parameters must be available even when the caller passes no
+    // parameters (e.g. the async query fields path), so this should not throw.
+    const metricQuery = {
+        ...METRIC_QUERY_NO_CALCS,
+        dimensions: ['table1_dim_1'],
+        metrics: [],
+        customDimensions: [
+            {
+                id: 'my_date_zoom',
+                name: 'My date zoom',
+                table: 'table1',
+                type: CustomDimensionType.SQL,
+                sql: '${ld.parameters.date_zoom}',
+                dimensionType: DimensionType.STRING,
+            } as const,
+        ],
+    };
+
+    expect(() =>
+        compileMetricQuery({
+            explore: EXPLORE,
+            metricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        }),
+    ).not.toThrow();
+});
+
 test('Should compile table calculations', () => {
     expect(
         compileMetricQuery({

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -12,6 +12,7 @@ import {
     Explore,
     ExploreCompiler,
     getItemId,
+    getReservedParameterNames,
     isCustomBinDimension,
     isFormulaTableCalculation,
     isPeriodOverPeriodAdditionalMetric,
@@ -395,6 +396,13 @@ export const compileMetricQuery = ({
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 
+    // Reserved (system-owned) parameters are always referenceable in custom SQL, so
+    // include them here once to cover every caller's parameter-reference validation.
+    const availableParametersWithReserved = [
+        ...availableParameters,
+        ...getReservedParameterNames(),
+    ];
+
     const popMetricIds = (metricQuery.additionalMetrics ?? [])
         .filter(isPeriodOverPeriodAdditionalMetric)
         .map(getItemId);
@@ -411,7 +419,7 @@ export const compileMetricQuery = ({
                 additionalMetric,
                 explore,
                 warehouseSqlBuilder,
-                availableParameters,
+                availableParameters: availableParametersWithReserved,
             }),
     );
 
@@ -421,7 +429,7 @@ export const compileMetricQuery = ({
             compiler.compileCustomDimension(
                 customDimension,
                 explore.tables,
-                availableParameters,
+                availableParametersWithReserved,
             ),
     );
     const customBinDimensionIds = new Set(

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -396,8 +396,7 @@ export const compileMetricQuery = ({
 }: CompileMetricQueryArgs): CompiledMetricQuery => {
     const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
 
-    // Reserved (system-owned) parameters are always referenceable in custom SQL, so
-    // include them here once to cover every caller's parameter-reference validation.
+    // Reserved parameters are always referenceable in custom SQL; include them once here.
     const availableParametersWithReserved = [
         ...availableParameters,
         ...getReservedParameterNames(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -54,6 +54,7 @@ import {
     getMetricOverridesWithPopInheritance,
     getMetrics,
     getMetricsWithValidParameters,
+    hasReservedParameterReference,
     isCartesianChartConfig,
     isCustomBinDimension,
     isCustomDimension,
@@ -5316,7 +5317,12 @@ export class AsyncQueryService extends ProjectService {
             fields: fieldsWithOverrides,
             parameterReferences,
             usedParametersValues: usedParameters,
-            dateZoomApplied,
+            // Date zoom is in effect when its date dimension was overridden, or when a
+            // grain is selected and the chart references a reserved date-zoom parameter.
+            dateZoomApplied:
+                dateZoomApplied ||
+                (!!dateZoom?.granularity &&
+                    hasReservedParameterReference(parameterReferences)),
             resolvedTimezone: displayTimezone,
         };
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5317,8 +5317,8 @@ export class AsyncQueryService extends ProjectService {
             fields: fieldsWithOverrides,
             parameterReferences,
             usedParametersValues: usedParameters,
-            // Date zoom is in effect when its date dimension was overridden, or when a
-            // grain is selected and the chart references a reserved date-zoom parameter.
+            // In effect when a date dimension was overridden, or a grain is selected and
+            // the chart references a reserved date-zoom parameter.
             dateZoomApplied:
                 dateZoomApplied ||
                 (!!dateZoom?.granularity &&

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -175,6 +175,44 @@ export const validExplore: Explore = {
     },
 };
 
+const reservedParameterDimensionSql =
+    "{% if ld.parameters.date_zoom == 'week' %}'weekly'{% else %}'other'{% endif %}";
+
+export const exploreWithReservedParameterDimension: Explore = {
+    ...validExplore,
+    tables: {
+        ...validExplore.tables,
+        a: {
+            ...validExplore.tables.a,
+            dimensions: {
+                ...validExplore.tables.a.dimensions,
+                grain_flag: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.STRING,
+                    name: 'grain_flag',
+                    label: 'grain_flag',
+                    table: 'a',
+                    tableLabel: '',
+                    sql: reservedParameterDimensionSql,
+                    hidden: false,
+                    compiledSql: reservedParameterDimensionSql,
+                    tablesReferences: ['a'],
+                },
+            },
+        },
+    },
+};
+
+export const metricQueryReservedParameterDimension: MetricQuery = {
+    exploreName: validExplore.name,
+    filters: {},
+    limit: 10,
+    dimensions: ['a_grain_flag'],
+    metrics: [],
+    sorts: [],
+    tableCalculations: [],
+};
+
 export const exploreWithError: ExploreError = {
     name: 'error',
     label: 'error',

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2559,9 +2559,7 @@ describe('ProjectService._compileQuery reserved parameters', () => {
     });
 
     it('lets a user parameter named date_zoom win over the reserved value', async () => {
-        // No date zoom is applied, so the reserved value would resolve to '' (the
-        // else branch). A user-defined date_zoom set to 'week' must take priority and
-        // drive the 'week' branch instead, proving user-wins precedence.
+        // With no date zoom the reserved value is ''; a user date_zoom of 'week' must win.
         const compiled = await ProjectService._compileQuery({
             metricQuery: metricQueryReservedParameterDimension,
             explore: exploreWithReservedParameterDimension,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -2557,4 +2557,26 @@ describe('ProjectService._compileQuery reserved parameters', () => {
         expect(compiled.query).not.toContain('ld.parameters.date_zoom');
         expect(compiled.query).not.toContain('{% if');
     });
+
+    it('lets a user parameter named date_zoom win over the reserved value', async () => {
+        // No date zoom is applied, so the reserved value would resolve to '' (the
+        // else branch). A user-defined date_zoom set to 'week' must take priority and
+        // drive the 'week' branch instead, proving user-wins precedence.
+        const compiled = await ProjectService._compileQuery({
+            metricQuery: metricQueryReservedParameterDimension,
+            explore: exploreWithReservedParameterDimension,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: {},
+            userAttributes: {},
+            timezone: 'UTC',
+            parameters: { date_zoom: 'week' },
+            availableParameterDefinitions: {
+                date_zoom: { label: 'My date zoom' },
+            },
+        });
+
+        expect(compiled.query).toContain("'weekly'");
+        expect(compiled.query).not.toContain("'other'");
+        expect(compiled.query).not.toContain('ld.parameters.date_zoom');
+    });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -78,9 +78,11 @@ import {
     expectedExploreSummaryFilteredByTags,
     exploreToSummaryWithAttributes,
     exploreWithRequiredAttributes,
+    exploreWithReservedParameterDimension,
     job,
     lightdashConfigWithNoSMTP,
     metricQueryMock,
+    metricQueryReservedParameterDimension,
     preAggregateExplore,
     projectSummary,
     projectWithSensitiveFields,
@@ -2534,5 +2536,25 @@ describe('ProjectService', () => {
                 }),
             ).rejects.toThrowError(ForbiddenError);
         });
+    });
+});
+
+describe('ProjectService._compileQuery reserved parameters', () => {
+    it('resolves date_zoom to the else branch when no date zoom is applied', async () => {
+        const compiled = await ProjectService._compileQuery({
+            metricQuery: metricQueryReservedParameterDimension,
+            explore: exploreWithReservedParameterDimension,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: {},
+            userAttributes: {},
+            timezone: 'UTC',
+            parameters: {},
+            availableParameterDefinitions: {},
+        });
+
+        expect(compiled.query).toContain("'other'");
+        expect(compiled.query).not.toContain("'weekly'");
+        expect(compiled.query).not.toContain('ld.parameters.date_zoom');
+        expect(compiled.query).not.toContain('{% if');
     });
 });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -88,6 +88,7 @@ import {
     getMetrics,
     getParameterReferences,
     getPreAggregateExploreName,
+    getReservedParameterDefinitions,
     getTimeDimensionsMap,
     getTimezoneLabel,
     GroupType,
@@ -149,6 +150,7 @@ import {
     RequestMethod,
     ResolvedProjectColorPalette,
     resolveQueryTimezone,
+    resolveReservedParameterValues,
     resolveToBaseTimeDimension,
     ResultRow,
     SavedChartDAO,
@@ -3850,7 +3852,16 @@ export class ProjectService extends BaseService {
          */
         applyDateZoomToFilters?: boolean;
     }): Promise<CompiledQuery> {
-        const availableParameters = Object.keys(availableParameterDefinitions);
+        // Reserved (system-owned) parameters share the user-parameter pipeline. Fold
+        // their definitions in so ad-hoc custom SQL referencing them compiles, and key
+        // availability off the combined map.
+        const parameterDefinitionsWithReserved: ParameterDefinitions = {
+            ...availableParameterDefinitions,
+            ...getReservedParameterDefinitions(),
+        };
+        const availableParameters = Object.keys(
+            parameterDefinitionsWithReserved,
+        );
 
         const {
             explore: exploreWithOverride,
@@ -3863,6 +3874,13 @@ export class ProjectService extends BaseService {
             availableParameters,
             dateZoom,
         );
+
+        // Resolve reserved parameter values from the query context. Reserved values win
+        // over any same-named user value.
+        const parametersWithReserved: ParametersValuesMap = {
+            ...(parameters ?? {}),
+            ...resolveReservedParameterValues({ dateZoom, dateZoomApplied }),
+        };
 
         const compiledMetricQuery = compileMetricQuery({
             explore: exploreWithOverride,
@@ -3878,8 +3896,8 @@ export class ProjectService extends BaseService {
             intrinsicUserAttributes,
             userAttributes,
             timezone,
-            parameters,
-            parameterDefinitions: availableParameterDefinitions,
+            parameters: parametersWithReserved,
+            parameterDefinitions: parameterDefinitionsWithReserved,
             pivotConfiguration,
             pivotDimensions,
             continueOnError,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3853,10 +3853,8 @@ export class ProjectService extends BaseService {
          */
         applyDateZoomToFilters?: boolean;
     }): Promise<CompiledQuery> {
-        // Reserved (system-owned) parameters share the user-parameter pipeline. Fold
-        // their definitions in so ad-hoc custom SQL referencing them compiles, and key
-        // availability off the combined map. A user parameter of the same name wins
-        // (shadows the reserved one).
+        // Fold reserved definitions in so custom SQL referencing them compiles; a
+        // same-named user parameter wins (shadows the reserved one).
         const parameterDefinitionsWithReserved: ParameterDefinitions =
             mergeReservedDefinitions(availableParameterDefinitions);
         const availableParameters = Object.keys(
@@ -3875,10 +3873,8 @@ export class ProjectService extends BaseService {
             dateZoom,
         );
 
-        // Resolve reserved parameter values from the query context. The date zoom value
-        // reflects the selected grain whenever a zoom reaches the query, independent of
-        // whether a date dimension was physically overridden. A same-named user value
-        // wins (shadows the reserved value).
+        // Resolve reserved values from the query context (date zoom reflects the selected
+        // grain whenever a zoom reaches the query); a same-named user value wins.
         const parametersWithReserved: ParametersValuesMap = mergeReservedValues(
             parameters,
             resolveReservedParameterValues({ dateZoom }),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -88,7 +88,6 @@ import {
     getMetrics,
     getParameterReferences,
     getPreAggregateExploreName,
-    getReservedParameterDefinitions,
     getTimeDimensionsMap,
     getTimezoneLabel,
     GroupType,
@@ -118,6 +117,8 @@ import {
     maybeOverrideDbtConnection,
     maybeOverrideWarehouseConnection,
     maybeReplaceFieldsInChartVersion,
+    mergeReservedDefinitions,
+    mergeReservedValues,
     mergeWarehouseCredentials,
     MetricQuery,
     MissingWarehouseCredentialsError,
@@ -3854,11 +3855,10 @@ export class ProjectService extends BaseService {
     }): Promise<CompiledQuery> {
         // Reserved (system-owned) parameters share the user-parameter pipeline. Fold
         // their definitions in so ad-hoc custom SQL referencing them compiles, and key
-        // availability off the combined map.
-        const parameterDefinitionsWithReserved: ParameterDefinitions = {
-            ...availableParameterDefinitions,
-            ...getReservedParameterDefinitions(),
-        };
+        // availability off the combined map. A user parameter of the same name wins
+        // (shadows the reserved one).
+        const parameterDefinitionsWithReserved: ParameterDefinitions =
+            mergeReservedDefinitions(availableParameterDefinitions);
         const availableParameters = Object.keys(
             parameterDefinitionsWithReserved,
         );
@@ -3877,12 +3877,12 @@ export class ProjectService extends BaseService {
 
         // Resolve reserved parameter values from the query context. The date zoom value
         // reflects the selected grain whenever a zoom reaches the query, independent of
-        // whether a date dimension was physically overridden. Reserved values win over
-        // any same-named user value.
-        const parametersWithReserved: ParametersValuesMap = {
-            ...(parameters ?? {}),
-            ...resolveReservedParameterValues({ dateZoom }),
-        };
+        // whether a date dimension was physically overridden. A same-named user value
+        // wins (shadows the reserved value).
+        const parametersWithReserved: ParametersValuesMap = mergeReservedValues(
+            parameters,
+            resolveReservedParameterValues({ dateZoom }),
+        );
 
         const compiledMetricQuery = compileMetricQuery({
             explore: exploreWithOverride,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3875,11 +3875,13 @@ export class ProjectService extends BaseService {
             dateZoom,
         );
 
-        // Resolve reserved parameter values from the query context. Reserved values win
-        // over any same-named user value.
+        // Resolve reserved parameter values from the query context. The date zoom value
+        // reflects the selected grain whenever a zoom reaches the query, independent of
+        // whether a date dimension was physically overridden. Reserved values win over
+        // any same-named user value.
         const parametersWithReserved: ParametersValuesMap = {
             ...(parameters ?? {}),
-            ...resolveReservedParameterValues({ dateZoom, dateZoomApplied }),
+            ...resolveReservedParameterValues({ dateZoom }),
         };
 
         const compiledMetricQuery = compileMetricQuery({

--- a/packages/backend/src/utils/QueryBuilder/parameters.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.test.ts
@@ -511,4 +511,37 @@ describe('safeReplaceParametersWithTypes', () => {
             "SELECT * FROM orders WHERE user_id = 42 AND order_date >= CAST('2025-01-01' AS DATE) AND status = 'active'",
         );
     });
+
+    it('substitutes an empty reserved parameter as an empty value, not missing', () => {
+        // date_zoom is a reserved (system-owned) parameter. When no date zoom is applied
+        // it resolves to an empty string, which is a valid value, not a missing one.
+        const sql = 'SELECT ${ld.parameters.date_zoom} AS grain';
+
+        const result = safeReplaceParametersWithTypes({
+            sql,
+            parameterValuesMap: { date_zoom: '' },
+            parameterDefinitions: {
+                date_zoom: { label: 'Date zoom', type: 'string' as const },
+            },
+            sqlBuilder: mockSqlBuilder,
+        });
+
+        expect(result.replacedSql).toBe("SELECT '' AS grain");
+        expect(result.missingReferences.has('date_zoom')).toBe(false);
+    });
+
+    it('still treats an empty non-reserved parameter as missing', () => {
+        const sql = 'SELECT ${ld.parameters.region} AS region';
+
+        const result = safeReplaceParametersWithTypes({
+            sql,
+            parameterValuesMap: { region: '' },
+            parameterDefinitions: {
+                region: { label: 'Region', type: 'string' as const },
+            },
+            sqlBuilder: mockSqlBuilder,
+        });
+
+        expect(result.missingReferences.has('region')).toBe(true);
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/parameters.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.test.ts
@@ -513,8 +513,7 @@ describe('safeReplaceParametersWithTypes', () => {
     });
 
     it('substitutes an empty reserved parameter as an empty value, not missing', () => {
-        // date_zoom is a reserved (system-owned) parameter. When no date zoom is applied
-        // it resolves to an empty string, which is a valid value, not a missing one.
+        // An unapplied date_zoom resolves to '', a valid value rather than a missing one.
         const sql = 'SELECT ${ld.parameters.date_zoom} AS grain';
 
         const result = safeReplaceParametersWithTypes({

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -90,6 +90,7 @@ export const safeReplaceParameters = ({
     quoteChar,
     wrapChar,
     cast,
+    allowEmptyKeys,
 }: {
     sql: string;
     parameterValuesMap: ParametersValuesMap;
@@ -97,6 +98,7 @@ export const safeReplaceParameters = ({
     quoteChar: string;
     wrapChar?: string;
     cast?: 'DATE';
+    allowEmptyKeys?: Set<string>;
 }) => {
     // Don't allow empty quote char
     if (quoteChar === '') {
@@ -115,6 +117,7 @@ export const safeReplaceParameters = ({
             replacementName: 'parameter',
             throwOnMissing: false,
             cast,
+            allowEmptyKeys,
         },
     );
 };
@@ -184,6 +187,16 @@ export const safeReplaceParametersWithTypes = ({
         sqlBuilder.escapeString.bind(sqlBuilder),
     );
 
+    // An empty reserved value (e.g. no date zoom applied) is a valid value, not missing:
+    // allow-list these keys so an empty string substitutes as a quoted empty value rather
+    // than being treated as missing. Non-reserved empty params stay missing.
+    const allowEmptyKeys = new Set(
+        Object.keys(parameterValuesMap).filter(
+            (key) =>
+                isReservedParameterName(key) && parameterValuesMap[key] === '',
+        ),
+    );
+
     // First, get all parameter references from the original SQL using the standard function
     // This ensures we capture ALL parameter references, not just the ones we have values for
     const allParametersResult = safeReplaceParameters({
@@ -192,6 +205,7 @@ export const safeReplaceParametersWithTypes = ({
         escapeString: sqlBuilder.escapeString.bind(sqlBuilder),
         quoteChar: sqlBuilder.getStringQuoteChar(),
         wrapChar,
+        allowEmptyKeys,
     });
 
     // Liquid blocks (e.g. `{% if ld.parameters.x == "y" %}...{% endif %}`) reference parameters
@@ -201,15 +215,6 @@ export const safeReplaceParametersWithTypes = ({
     getParameterReferences(sql).forEach((ref) => {
         allParametersResult.references.add(ref);
     });
-
-    // An empty reserved value (e.g. no date zoom applied) is valid, not missing: drop it
-    // from the missing set and substitute its token as an empty value below.
-    const emptyReservedParameterNames = Object.keys(parameterValuesMap).filter(
-        (key) => isReservedParameterName(key) && parameterValuesMap[key] === '',
-    );
-    emptyReservedParameterNames.forEach((key) =>
-        allParametersResult.missingReferences.delete(key),
-    );
 
     // If no parameter definitions are provided, use the standard replacement
     if (!parameterDefinitions) {
@@ -222,11 +227,6 @@ export const safeReplaceParametersWithTypes = ({
     const dateParameters: ParametersValuesMap = {};
 
     Object.entries(parameterValuesMap).forEach(([key, value]) => {
-        // Empty reserved parameters are substituted as an empty value separately below.
-        if (emptyReservedParameterNames.includes(key)) {
-            return;
-        }
-
         const paramDef = parameterDefinitions?.[key];
         const paramType = paramDef?.type;
 
@@ -260,6 +260,7 @@ export const safeReplaceParametersWithTypes = ({
             escapeString: sqlBuilder.escapeString.bind(sqlBuilder),
             quoteChar: sqlBuilder.getStringQuoteChar(),
             wrapChar,
+            allowEmptyKeys,
         });
         processedSql = stringResult.replacedSql;
     }
@@ -285,21 +286,6 @@ export const safeReplaceParametersWithTypes = ({
             sqlBuilder,
         );
         processedSql = numberResult.replacedSql;
-    }
-
-    // Substitute empty reserved parameters as a quoted empty value so no token is stranded.
-    if (emptyReservedParameterNames.length > 0) {
-        const quoteChar = sqlBuilder.getStringQuoteChar();
-        emptyReservedParameterNames.forEach((key) => {
-            const tokenRegex = new RegExp(
-                `\\$\\{(?:lightdash|ld)\\.parameters\\.${key}\\}`,
-                'g',
-            );
-            processedSql = processedSql.replace(
-                tokenRegex,
-                `${quoteChar}${quoteChar}`,
-            );
-        });
     }
 
     // Return the processed SQL but use the original references from the full parameter scan

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -202,9 +202,8 @@ export const safeReplaceParametersWithTypes = ({
         allParametersResult.references.add(ref);
     });
 
-    // Reserved (system-owned) parameters always carry a system-provided value. An empty
-    // value (e.g. no date zoom applied) is valid, not missing: substitute its token as an
-    // empty value below and drop it from the missing set so it isn't reported or stranded.
+    // An empty reserved value (e.g. no date zoom applied) is valid, not missing: drop it
+    // from the missing set and substitute its token as an empty value below.
     const emptyReservedParameterNames = Object.keys(parameterValuesMap).filter(
         (key) => isReservedParameterName(key) && parameterValuesMap[key] === '',
     );
@@ -288,8 +287,7 @@ export const safeReplaceParametersWithTypes = ({
         processedSql = numberResult.replacedSql;
     }
 
-    // Substitute empty reserved parameters as an empty quoted value (e.g. '') so the
-    // token isn't left stranded in the SQL when the system value is empty.
+    // Substitute empty reserved parameters as a quoted empty value so no token is stranded.
     if (emptyReservedParameterNames.length > 0) {
         const quoteChar = sqlBuilder.getStringQuoteChar();
         emptyReservedParameterNames.forEach((key) => {

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -1,5 +1,6 @@
 import {
     getParameterReferences,
+    isReservedParameterName,
     parameterRegex,
     renderLiquidSql,
     UnexpectedServerError,
@@ -201,6 +202,16 @@ export const safeReplaceParametersWithTypes = ({
         allParametersResult.references.add(ref);
     });
 
+    // Reserved (system-owned) parameters always carry a system-provided value. An empty
+    // value (e.g. no date zoom applied) is valid, not missing: substitute its token as an
+    // empty value below and drop it from the missing set so it isn't reported or stranded.
+    const emptyReservedParameterNames = Object.keys(parameterValuesMap).filter(
+        (key) => isReservedParameterName(key) && parameterValuesMap[key] === '',
+    );
+    emptyReservedParameterNames.forEach((key) =>
+        allParametersResult.missingReferences.delete(key),
+    );
+
     // If no parameter definitions are provided, use the standard replacement
     if (!parameterDefinitions) {
         return allParametersResult;
@@ -212,6 +223,11 @@ export const safeReplaceParametersWithTypes = ({
     const dateParameters: ParametersValuesMap = {};
 
     Object.entries(parameterValuesMap).forEach(([key, value]) => {
+        // Empty reserved parameters are substituted as an empty value separately below.
+        if (emptyReservedParameterNames.includes(key)) {
+            return;
+        }
+
         const paramDef = parameterDefinitions?.[key];
         const paramType = paramDef?.type;
 
@@ -270,6 +286,22 @@ export const safeReplaceParametersWithTypes = ({
             sqlBuilder,
         );
         processedSql = numberResult.replacedSql;
+    }
+
+    // Substitute empty reserved parameters as an empty quoted value (e.g. '') so the
+    // token isn't left stranded in the SQL when the system value is empty.
+    if (emptyReservedParameterNames.length > 0) {
+        const quoteChar = sqlBuilder.getStringQuoteChar();
+        emptyReservedParameterNames.forEach((key) => {
+            const tokenRegex = new RegExp(
+                `\\$\\{(?:lightdash|ld)\\.parameters\\.${key}\\}`,
+                'g',
+            );
+            processedSql = processedSql.replace(
+                tokenRegex,
+                `${quoteChar}${quoteChar}`,
+            );
+        });
     }
 
     // Return the processed SQL but use the original references from the full parameter scan

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -165,11 +165,15 @@ export const replaceLightdashValues = (
         replacementName = 'user attribute',
         cast,
         escapeString,
+        // Keys whose empty-string value is a legitimate value (substituted as quoted empty)
+        // rather than treated as missing. Used for reserved params like date_zoom.
+        allowEmptyKeys = new Set<string>(),
     }: {
         throwOnMissing?: boolean;
         replacementName?: 'user attribute' | 'parameter';
         cast?: 'DATE';
         escapeString?: (value: string) => string;
+        allowEmptyKeys?: Set<string>;
     } = {},
 ): {
     replacedSql: string;
@@ -203,11 +207,16 @@ export const replaceLightdashValues = (
                 );
             }
 
-            if (
-                (isArray(attributeValues) && attributeValues.length === 0) ||
-                (typeof attributeValues === 'string' &&
-                    attributeValues.length === 0)
-            ) {
+            const isEmptyArray =
+                isArray(attributeValues) && attributeValues.length === 0;
+            const isEmptyString =
+                typeof attributeValues === 'string' &&
+                attributeValues.length === 0;
+            // An empty string is a valid value for allow-listed keys (e.g. reserved
+            // params): fall through to substitute it as a quoted empty value.
+            const emptyIsAllowed =
+                isEmptyString && allowEmptyKeys.has(attribute);
+            if ((isEmptyArray || isEmptyString) && !emptyIsAllowed) {
                 missingReferences.add(attribute);
                 if (!throwOnMissing) return acc;
                 throw new ForbiddenError(


### PR DESCRIPTION
Threads the reserved `date_zoom` parameter through query compilation so custom SQL dimensions and metrics can reference `${ld.parameters.date_zoom}` (and use it in Liquid). Resolves the reserved value in `_compileQuery` and makes reserved parameters available across all metric query compile paths. An empty value (no zoom applied) substitutes cleanly.

A user parameter that shares the `date_zoom` name wins: the merge precedence in `_compileQuery` shadows the reserved value with the user value at both the definition and value seams.

Relates: GLITCH-195