### PR TITLE
feat: dbt Cloud webhook signature verification and payload validation

### DIFF
--- a/packages/backend/src/@types/express.d.ts
+++ b/packages/backend/src/@types/express.d.ts
@@ -18,6 +18,7 @@ declare global {
              */
             clients: ClientRepository;
             account?: Account;
+            rawBody?: Buffer;
         }
 
         interface User extends SessionUser {}

--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -378,6 +378,20 @@ export default class App {
             '/api/v1/gdrive/upload-gsheet-from-rows',
             express.json({ limit: UPLOAD_GSHEET_FROM_ROWS_MAX_BYTES }),
         );
+        // Capture the raw request body for the dbt Cloud webhook so its HMAC
+        // signature can be verified against the exact bytes that were signed.
+        expressApp.use((req, res, next) => {
+            if (req.path.endsWith('/dbt-cloud/webhook')) {
+                express.json({
+                    limit: this.lightdashConfig.maxPayloadSize,
+                    verify: (request, _res, buf) => {
+                        (request as Request).rawBody = buf;
+                    },
+                })(req, res, next);
+            } else {
+                next();
+            }
+        });
         expressApp.use(
             express.json({ limit: this.lightdashConfig.maxPayloadSize }),
         );

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -92,6 +92,8 @@ import {
 } from './authentication';
 import { BaseController } from './baseController';
 
+const isPositiveIntegerString = (value: string): boolean => /^\d+$/.test(value);
+
 @Route('/api/v1/projects')
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('Projects')
@@ -1636,13 +1638,14 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
             throw new ParameterError('Invalid body');
         }
         if (body.eventType === 'job.run.completed') {
-            const isPositiveInteger = (value: unknown): boolean =>
-                /^\d+$/.test(String(value));
+            const accountId = String(body.accountId);
+            const runId =
+                typeof body.data === 'object' && body.data !== null
+                    ? String(body.data.runId)
+                    : '';
             if (
-                typeof body.data !== 'object' ||
-                body.data === null ||
-                !isPositiveInteger(body.accountId) ||
-                !isPositiveInteger(body.data.runId)
+                !isPositiveIntegerString(accountId) ||
+                !isPositiveIntegerString(runId)
             ) {
                 throw new ParameterError('Invalid accountId or runId');
             }
@@ -1650,8 +1653,8 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
                 .getProjectService()
                 .createPreviewFromDbtCloudWebhook(
                     projectUuid,
-                    Number(body.accountId),
-                    Number(body.data.runId),
+                    Number(accountId),
+                    Number(runId),
                     {
                         rawBody: req.rawBody ?? null,
                         signature: req.header('authorization') ?? null,

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1632,17 +1632,31 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
         @Path() projectUuid: string,
         @Body() body: AnyType,
     ) {
-        // TODO validate webhook signature https://docs.getdbt.com/docs/deploy/webhooks#validate-a-webhook
         if (!body) {
             throw new ParameterError('Invalid body');
         }
         if (body.eventType === 'job.run.completed') {
-            // TODO: validate body is an object and has the account id and run id
-            const accountId: string = body.accountId as string;
-            const runId: string = body.data.runId as string;
+            const isPositiveInteger = (value: unknown): boolean =>
+                /^\d+$/.test(String(value));
+            if (
+                typeof body.data !== 'object' ||
+                body.data === null ||
+                !isPositiveInteger(body.accountId) ||
+                !isPositiveInteger(body.data.runId)
+            ) {
+                throw new ParameterError('Invalid accountId or runId');
+            }
             await this.services
                 .getProjectService()
-                .createPreviewWithExplores(projectUuid, accountId, runId);
+                .createPreviewFromDbtCloudWebhook(
+                    projectUuid,
+                    Number(body.accountId),
+                    Number(body.data.runId),
+                    {
+                        rawBody: req.rawBody ?? null,
+                        signature: req.header('authorization') ?? null,
+                    },
+                );
         }
 
         this.setStatus(200);

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -28,6 +28,8 @@ import {
     DashboardAsCode,
     DbtExposure,
     DbtProjectEnvironmentVariable,
+    ForbiddenError,
+    getErrorMessage,
     getRequestMethod,
     isDuplicateDashboardParams,
     LightdashRequestMethodHeader,
@@ -84,6 +86,7 @@ import {
 import express from 'express';
 import { toSessionUser } from '../auth/account';
 import type { DbTagUpdate } from '../database/entities/tags';
+import Logger from '../logging/logger';
 import {
     allowApiKeyAuthentication,
     getDeprecatedRouteMiddleware,
@@ -1649,17 +1652,31 @@ Migrate to the v2 async query flow: [Execute SQL query](https://docs.lightdash.c
             ) {
                 throw new ParameterError('Invalid accountId or runId');
             }
-            await this.services
-                .getProjectService()
-                .createPreviewFromDbtCloudWebhook(
-                    projectUuid,
-                    Number(accountId),
-                    Number(runId),
-                    {
-                        rawBody: req.rawBody ?? null,
-                        signature: req.header('authorization') ?? null,
-                    },
+            try {
+                await this.services
+                    .getProjectService()
+                    .createPreviewFromDbtCloudWebhook(
+                        projectUuid,
+                        Number(accountId),
+                        Number(runId),
+                        {
+                            rawBody: req.rawBody ?? null,
+                            signature: req.header('authorization') ?? null,
+                        },
+                    );
+            } catch (e) {
+                // Reject invalid signatures, but acknowledge other failures
+                // (e.g. dbt Cloud's test webhook references a non-existent run)
+                // so they don't surface as a 500.
+                if (e instanceof ForbiddenError) {
+                    throw e;
+                }
+                Logger.error(
+                    `dbt Cloud webhook for project ${projectUuid} could not create a preview: ${getErrorMessage(
+                        e,
+                    )}`,
                 );
+            }
         }
 
         this.setStatus(200);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -28126,6 +28126,7 @@ const models: TsoaRoute.Models = {
             environment_id: { dataType: 'string', required: true },
             discovery_api_endpoint: { dataType: 'string' },
             tags: { dataType: 'array', array: { dataType: 'string' } },
+            webhook_hmac_secret: { dataType: 'string' },
         },
         additionalProperties: true,
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -28754,6 +28754,9 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "webhook_hmac_secret": {
+                        "type": "string"
                     }
                 },
                 "required": ["type", "api_key", "environment_id"],
@@ -40403,7 +40406,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3204.0",
+        "version": "0.3205.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -202,6 +202,7 @@ import {
     warehouseSqlBuilderFromType,
 } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
+import { createHmac, timingSafeEqual } from 'crypto';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { uniq } from 'lodash';
@@ -351,6 +352,20 @@ export type ProjectServiceArguments = {
     // AppGenerateService depends on ProjectService, so eager injection would
     // create a construction cycle. Resolves undefined in core (non-EE) builds.
     getAppGenerateService?: () => AppGenerateService | undefined;
+};
+
+const isValidDbtCloudWebhookSignature = (
+    secret: string,
+    rawBody: Buffer,
+    signature: string,
+): boolean => {
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    const expectedBuffer = Buffer.from(expected, 'utf8');
+    const signatureBuffer = Buffer.from(signature, 'utf8');
+    if (expectedBuffer.length !== signatureBuffer.length) {
+        return false;
+    }
+    return timingSafeEqual(expectedBuffer, signatureBuffer);
 };
 
 export class ProjectService extends BaseService {
@@ -9091,10 +9106,11 @@ export class ProjectService extends BaseService {
         return updatedCharts;
     }
 
-    async createPreviewWithExplores(
+    async createPreviewFromDbtCloudWebhook(
         projectUuid: string,
-        accountId: string,
-        runId: string,
+        accountId: number,
+        runId: number,
+        webhookAuth: { rawBody: Buffer | null; signature: string | null },
     ): Promise<string> {
         // create preview project permissions are checked in `createWithoutCompile`
         const project =
@@ -9109,6 +9125,25 @@ export class ProjectService extends BaseService {
         if (project.dbtConnection.type !== DbtProjectType.DBT_CLOUD_IDE) {
             throw new ParameterError(
                 `Project ${projectUuid} is not a dbt Cloud IDE project`,
+            );
+        }
+
+        const webhookSecret = project.dbtConnection.webhook_hmac_secret;
+        if (webhookSecret) {
+            if (
+                !webhookAuth.rawBody ||
+                !webhookAuth.signature ||
+                !isValidDbtCloudWebhookSignature(
+                    webhookSecret,
+                    webhookAuth.rawBody,
+                    webhookAuth.signature,
+                )
+            ) {
+                throw new ForbiddenError('Invalid dbt Cloud webhook signature');
+            }
+        } else {
+            this.logger.info(
+                `dbt Cloud webhook for project ${projectUuid} processed without signature verification (no webhook_hmac_secret configured)`,
             );
         }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -639,6 +639,7 @@ export enum DBFieldTypes {
 export const sensitiveDbtCredentialsFieldNames = [
     'personal_access_token',
     'api_key',
+    'webhook_hmac_secret',
 ] as const;
 
 export const DbtProjectTypeLabels: Record<DbtProjectType, string> = {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -781,6 +781,7 @@ export interface DbtCloudIDEProjectConfig extends DbtProjectConfigBase {
     environment_id: string;
     discovery_api_endpoint?: string;
     tags?: string[];
+    webhook_hmac_secret?: string;
 }
 
 export interface DbtGithubProjectConfig extends DbtProjectCompilerBase {

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -1,13 +1,16 @@
 import { DbtProjectType } from '@lightdash/common';
 import {
+    ActionIcon,
     Alert,
     Anchor,
+    CopyButton,
     MultiSelect,
     PasswordInput,
     Stack,
     TextInput,
+    Tooltip,
 } from '@mantine/core';
-import { IconInfoCircle } from '@tabler/icons-react';
+import { IconCheck, IconCopy, IconInfoCircle } from '@tabler/icons-react';
 import React, { useCallback, useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
@@ -30,6 +33,10 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     const form = useFormContext();
 
     const dbtTagsField = form.getInputProps('dbt.tags');
+
+    const webhookUrl = savedProject?.projectUuid
+        ? `${health?.data?.siteUrl}/api/v1/projects/${savedProject.projectUuid}/dbt-cloud/webhook`
+        : undefined;
 
     return (
         <Stack>
@@ -55,8 +62,7 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 label="Service token"
                 description={
                     <p>
-                        The service token must have the "Metadata Only"
-                        permission.
+                        Needs the "Metadata Only" and "Job Viewer" permissions.
                         <DocumentationHelpButton href="https://docs.getdbt.com/docs/dbt-cloud-apis/service-tokens" />
                     </p>
                 }
@@ -81,13 +87,59 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 required
                 disabled={disabled}
             />
-            {savedProject?.projectUuid && (
+            {webhookUrl && (
                 <TextInput
                     label="Webhook for dbt"
-                    value={`${health?.data?.siteUrl}/api/v1/projects/${savedProject?.projectUuid}/dbt-cloud/webhook`}
+                    description={
+                        <p>
+                            Add this URL as a webhook in dbt Cloud (triggered on
+                            job completion) so Lightdash can build a preview
+                            when your dbt job finishes.
+                            <DocumentationHelpButton href="https://docs.getdbt.com/docs/deploy/webhooks" />
+                        </p>
+                    }
+                    value={webhookUrl}
                     readOnly
+                    rightSection={
+                        <CopyButton value={webhookUrl}>
+                            {({ copied, copy }) => (
+                                <Tooltip
+                                    label={copied ? 'Copied' : 'Copy'}
+                                    withArrow
+                                    position="left"
+                                >
+                                    <ActionIcon
+                                        color={copied ? 'teal' : 'gray'}
+                                        onClick={copy}
+                                    >
+                                        <MantineIcon
+                                            icon={copied ? IconCheck : IconCopy}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </CopyButton>
+                    }
                 />
             )}
+            <PasswordInput
+                name="dbt.webhook_hmac_secret"
+                {...form.getInputProps('dbt.webhook_hmac_secret')}
+                label="Webhook secret"
+                description={
+                    <p>
+                        Recommended if you use the dbt webhook above. Paste the
+                        secret that dbt Cloud generated for the webhook so
+                        Lightdash can verify that incoming requests are genuine.
+                        Without it, webhook requests cannot be authenticated.
+                        <DocumentationHelpButton href="https://docs.getdbt.com/docs/deploy/webhooks#validate-a-webhook" />
+                    </p>
+                }
+                placeholder={
+                    disabled || !requireSecrets ? '**************' : undefined
+                }
+                disabled={disabled}
+            />
             <TextInput
                 name="dbt.discovery_api_endpoint"
                 {...form.getInputProps('dbt.discovery_api_endpoint')}

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/defaultValues.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/defaultValues.tsx
@@ -69,6 +69,7 @@ const dbtCloudIdeDefaultValues: DbtCloudIDEProjectConfig = {
     environment_id: '',
     discovery_api_endpoint: '',
     tags: [],
+    webhook_hmac_secret: '',
 } as const;
 
 // Local

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/validators.ts
@@ -28,9 +28,18 @@ const environmentValidator = (
     )}`;
 };
 
+const discoveryApiEndpointValidator = (value?: string): string | undefined => {
+    if (!value) return undefined;
+    if (value.includes('semantic-layer')) {
+        return 'This looks like the Semantic Layer endpoint. Use the Discovery API endpoint instead (e.g. https://metadata.cloud.getdbt.com/graphql).';
+    }
+    return undefined;
+};
+
 export const dbtFormValidators = {
     api_key: hasNoWhiteSpaces('API Key'),
     environment_id: hasNoWhiteSpaces('Environment ID'),
+    discovery_api_endpoint: discoveryApiEndpointValidator,
     environment: environmentValidator,
     selector: selectorValidator,
     // TODO :: improve this for github to detect the prefix


### PR DESCRIPTION
Closes: PROD-8408

### Description:
Adds dbt Cloud webhook signature verification and payload validation. The webhook validates `accountId`/`runId` as integers and, when a project has a webhook secret configured, verifies the dbt Cloud HMAC signature against the raw request body (processing without it when absent, for backwards compatibility). Adds an optional `webhook_hmac_secret` to the dbt Cloud project config (sensitive — stripped from API responses) plus the connection-form fields, a copy button on the webhook URL, and a service-token permission hint. Also adds Discovery API endpoint validation that flags the Semantic Layer domain.

<img width="900" height="540" alt="CleanShot 2026-06-22 at 16 08 28@2x" src="https://github.com/user-attachments/assets/95304240-324d-47ef-ab0f-2da5b538340e" />
