### PR TITLE
feat(roles): classify scopes as organization- or project-level

### DIFF
--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -1,0 +1,55 @@
+import {
+    getOrgAssignableScopes,
+    getScopes,
+    isOrgAssignableScope,
+} from './scopes';
+
+// Deliberate golden copy of the org-assignable set. Do NOT replace this with a
+// call to getOrgAssignableScopes() — the point is to fail loudly when a scope's
+// `level` is changed to/from 'organization' without a conscious test update.
+const ORG_ASSIGNABLE_SCOPE_NAMES = [
+    'view:Organization',
+    'manage:Organization',
+    'view:OrganizationMemberProfile',
+    'manage:OrganizationMemberProfile',
+    'manage:InviteLink',
+    'manage:Group',
+    'manage:GitIntegration',
+    'view:OrganizationWarehouseCredentials',
+    'manage:OrganizationWarehouseCredentials',
+    'manage:PersonalAccessToken',
+    'impersonate:User',
+    'view:OrganizationDesign',
+    'manage:OrganizationDesign',
+];
+
+describe('scope levels', () => {
+    it('classifies the org-assignable scope set and treats every other scope as project-level', () => {
+        expect(getOrgAssignableScopes()).toEqual(
+            expect.arrayContaining(ORG_ASSIGNABLE_SCOPE_NAMES),
+        );
+        expect(getOrgAssignableScopes()).toHaveLength(
+            ORG_ASSIGNABLE_SCOPE_NAMES.length,
+        );
+
+        ORG_ASSIGNABLE_SCOPE_NAMES.forEach((scopeName) => {
+            expect(isOrgAssignableScope(scopeName)).toBe(true);
+        });
+
+        expect(isOrgAssignableScope('delete:Project')).toBe(false);
+        expect(isOrgAssignableScope('create:Project@preview')).toBe(false);
+        expect(isOrgAssignableScope('manage:SpotlightTableConfig')).toBe(false);
+        expect(isOrgAssignableScope('manage:ContentAsCode')).toBe(false);
+        expect(isOrgAssignableScope('manage:ExternalConnection')).toBe(false);
+    });
+
+    it('keeps every org-assignable scope name backed by a real scope definition', () => {
+        const scopeNames = new Set(
+            getScopes({ isEnterprise: true }).map((scope) => scope.name),
+        );
+
+        getOrgAssignableScopes().forEach((scopeName) => {
+            expect(scopeNames.has(scopeName)).toBe(true);
+        });
+    });
+});

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -1,5 +1,6 @@
 import flow from 'lodash/flow';
 import { ProjectType } from '../types/projects';
+import type { RoleLevel } from '../types/roles';
 import {
     ScopeGroup,
     type Scope,
@@ -510,6 +511,7 @@ const scopes: Scope[] = [
         description: 'View organization details',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -517,6 +519,7 @@ const scopes: Scope[] = [
         description: 'Manage organization settings',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -524,6 +527,7 @@ const scopes: Scope[] = [
         description: 'View organization member profiles',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -531,6 +535,7 @@ const scopes: Scope[] = [
         description: 'Manage organization member profiles and roles',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -538,6 +543,7 @@ const scopes: Scope[] = [
         description: 'Create and manage invite links',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -545,6 +551,7 @@ const scopes: Scope[] = [
         description: 'Manage user groups',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -552,6 +559,7 @@ const scopes: Scope[] = [
         description: 'Manage Git integration settings and create repositories',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -559,6 +567,7 @@ const scopes: Scope[] = [
         description: 'View organization warehouse credentials',
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -566,6 +575,7 @@ const scopes: Scope[] = [
         description: 'Manage organization warehouse credentials',
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -595,6 +605,7 @@ const scopes: Scope[] = [
         description: 'Create and manage personal access tokens',
         isEnterprise: true,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -602,6 +613,7 @@ const scopes: Scope[] = [
         description: 'Impersonate other users in the organization',
         isEnterprise: false,
         group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        level: 'organization',
         getConditions: (context) => [
             { ...addUuidCondition(context), isActive: true },
         ],
@@ -889,6 +901,7 @@ const scopes: Scope[] = [
         description: 'View organization design assets',
         isEnterprise: false,
         group: ScopeGroup.AI,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -896,6 +909,7 @@ const scopes: Scope[] = [
         description: 'Create, edit, and delete organization design assets',
         isEnterprise: false,
         group: ScopeGroup.AI,
+        level: 'organization',
         getConditions: addDefaultUuidCondition,
     },
 
@@ -929,6 +943,27 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
 ] as const;
+
+const isOrgAssignableScopeDefinition = (scope: Scope): boolean =>
+    scope.level === 'organization';
+
+const ORG_ASSIGNABLE_SCOPE_NAMES = new Set<string>(
+    scopes.filter(isOrgAssignableScopeDefinition).map((scope) => scope.name),
+);
+
+export const getOrgAssignableScopes = (): ScopeName[] =>
+    scopes.filter(isOrgAssignableScopeDefinition).map((scope) => scope.name);
+
+export const isOrgAssignableScope = (scopeName: string): boolean =>
+    ORG_ASSIGNABLE_SCOPE_NAMES.has(scopeName);
+
+export const isScopeAssignableAtLevel = (
+    scopeName: string,
+    level: RoleLevel,
+): boolean =>
+    level === 'organization'
+        ? isOrgAssignableScope(scopeName)
+        : !isOrgAssignableScope(scopeName);
 
 const getNonEnterpriseScopes = (): Scope[] =>
     scopes.filter((scope) => !scope.isEnterprise);

--- a/packages/common/src/types/roles.ts
+++ b/packages/common/src/types/roles.ts
@@ -1,5 +1,7 @@
 import type { ApiSuccessEmpty } from './api/success';
 
+export type RoleLevel = 'project' | 'organization';
+
 export type ProjectAccess = {
     projectUuid: string;
     userUuid: string;

--- a/packages/common/src/types/scopes.ts
+++ b/packages/common/src/types/scopes.ts
@@ -3,6 +3,7 @@ import {
     type CaslSubjectNames,
 } from '../authorization/types';
 import { type ProjectType } from './projects';
+import { type RoleLevel } from './roles';
 
 /**
  * Scope groups to organize permissions in the UI for admins.
@@ -84,6 +85,11 @@ export type Scope = {
      * The grouping from the ScopeGroup enum
      */
     group: ScopeGroup;
+    /**
+     * The level at which this scope can be granted by a custom role.
+     * Defaults to 'project'. Single source of truth for level classification.
+     */
+    level?: RoleLevel;
     /**
      * Get the conditions to be applied to the CASL ability derived from the
      * scope. Returning null means the scope emits no rule for this context


### PR DESCRIPTION
## Summary

PR 1 of 3 for [PROD-8195](https://linear.app/lightdash/issue/PROD-8195). Adds the `RoleLevel` type and a scope **assignment-level classification** so the rest of the stack can answer "can this scope be granted at the org level?". Additive and behaviour-neutral on its own — no DB, no consumers wired up yet.

Part of [PROD-8195](https://linear.app/lightdash/issue/PROD-8195) (closed by the data-migration follow-up).

## Why

Custom roles are assigned per-project today, so org-only scopes selected on a role silently no-op (the PROD-8080 bug). Fixing that needs a single source of truth for which scopes are org-assignable. This PR establishes it; PR2 wires the backend, PR3 the UI.

## Changes (common only)

- `RoleLevel = 'project' | 'organization'` in `types/roles.ts`.
- `Scope.level?` on the scope definition (`types/scopes.ts`); the **13 org-only scopes** are tagged `level: 'organization'` in `scopes.ts`, everything else stays project by default.
- Helpers derived from the scope list — `getOrgAssignableScopes()`, `isOrgAssignableScope()`, `isScopeAssignableAtLevel(scope, level)` — so the classification can't drift from the vocabulary.
- `scopes.level.test.ts`: pins the org set against a golden list and asserts every org scope is backed by a real scope definition.

## The classification

```
organization (13)  view/manage:Organization · view/manage:OrganizationMemberProfile
                   manage:InviteLink · manage:Group · manage:GitIntegration
                   view/manage:OrganizationWarehouseCredentials
                   manage:PersonalAccessToken · impersonate:User
                   view/manage:OrganizationDesign
project (default)  every other scope — content, data, project-mgmt, the
                   boundary scopes (delete:Project, ContentAsCode, …)
```

Strict either/or: a scope is org-level *or* project-level, never both. Widening one to dual later is additive (no migration).

## Test plan

- [x] `pnpm -F common typecheck:fast`
- [x] `pnpm -F common build`
- [x] `pnpm -F common test` — `scopes.level` + `roleToScopeParity` green (23 pass)
- [x] `main`'s backend still typechecks against the additive common (verified at this branch in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)