### PR TITLE
feat(roles): add org/project level to the custom role UI

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -166,14 +166,17 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
     });
 
     const rolesData = useMemo(() => {
-        return organizationRoles?.map(
-            (role: Pick<Role, 'roleUuid' | 'name' | 'ownerType'>) => ({
+        return organizationRoles
+            ?.filter(
+                (role: Role) =>
+                    role.ownerType === 'system' || role.level === 'project',
+            )
+            .map((role: Pick<Role, 'roleUuid' | 'name' | 'ownerType'>) => ({
                 value: role.roleUuid,
                 label: role.name,
                 group:
                     role.ownerType === 'system' ? 'System role' : 'Custom role',
-            }),
-        );
+            }));
     }, [organizationRoles]);
 
     // Convert flat grouped format (v6) to nested grouped format (v8) for Select

--- a/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
+++ b/packages/frontend/src/components/UserSettings/UsersAndGroupsPanel/UsersTable.tsx
@@ -2,8 +2,10 @@ import {
     FeatureFlags,
     isOrganizationMemberProfileWithGroups,
     OrganizationMemberRole,
+    OrganizationMemberRoleLabels,
     type OrganizationMemberProfile,
     type OrganizationMemberProfileWithGroups,
+    type Role,
 } from '@lightdash/common';
 import {
     Badge,
@@ -23,7 +25,6 @@ import {
     IconArrowUp,
     IconUserCircle,
 } from '@tabler/icons-react';
-import capitalize from 'lodash/capitalize';
 import {
     useCallback,
     useEffect,
@@ -34,7 +35,10 @@ import {
     type UIEvent,
 } from 'react';
 import { useCreateInviteLinkMutation } from '../../../hooks/useInviteLink';
-import { useUpsertOrganizationUserRoleAssignmentMutation } from '../../../hooks/useOrganizationRoles';
+import {
+    useOrganizationRoles,
+    useUpsertOrganizationUserRoleAssignmentMutation,
+} from '../../../hooks/useOrganizationRoles';
 import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
@@ -137,6 +141,34 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
     }, [fetchMoreOnBottomReached]);
 
     const updateUserRole = useUpsertOrganizationUserRoleAssignmentMutation();
+    const organizationRolesQuery = useOrganizationRoles();
+
+    const organizationRoleOptions = useMemo(() => {
+        const systemRoles = Object.values(OrganizationMemberRole).map(
+            (orgMemberRole) => ({
+                value: orgMemberRole,
+                label: OrganizationMemberRoleLabels[orgMemberRole],
+            }),
+        );
+        const customRoles =
+            organizationRolesQuery.data
+                ?.filter(
+                    (role: Role) =>
+                        role.ownerType === 'user' &&
+                        role.level === 'organization',
+                )
+                .map((role: Role) => ({
+                    value: role.roleUuid,
+                    label: role.name,
+                })) ?? [];
+
+        return customRoles.length > 0
+            ? [
+                  { group: 'System roles', items: systemRoles },
+                  { group: 'Custom roles', items: customRoles },
+              ]
+            : systemRoles;
+    }, [organizationRolesQuery.data]);
 
     const canManageUsers =
         activeUser.data?.ability?.can('manage', 'OrganizationMemberProfile') ??
@@ -235,14 +267,7 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
                     const user = row.original;
                     return (
                         <Select
-                            data={Object.values(OrganizationMemberRole).map(
-                                (orgMemberRole) => ({
-                                    value: orgMemberRole,
-                                    label: capitalize(
-                                        orgMemberRole.replace('_', ' '),
-                                    ),
-                                }),
-                            )}
+                            data={organizationRoleOptions}
                             onChange={(newRole: string | null) => {
                                 if (newRole) {
                                     updateUserRole.mutate({
@@ -251,7 +276,8 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
                                     });
                                 }
                             }}
-                            value={user.role}
+                            value={user.roleUuid ?? user.role}
+                            disabled={organizationRolesQuery.isLoading}
                             w={180}
                             size="xs"
                         />
@@ -347,6 +373,8 @@ const UsersTable: FC<UsersTableProps> = ({ onInviteClick }) => {
         inviteSuccessFor,
         isGroupManagementEnabled,
         updateUserRole,
+        organizationRoleOptions,
+        organizationRolesQuery.isLoading,
         activeUser.data?.userUuid,
         flatData.length,
         canInvite,

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -1,6 +1,7 @@
 import { formatDate, type RoleWithScopes } from '@lightdash/common';
 import {
     ActionIcon,
+    Badge,
     Box,
     Menu,
     Paper,
@@ -22,7 +23,7 @@ const TableRow: FC<{
     onClickEdit: (role: RoleWithScopes) => void;
     onClickDelete: (role: RoleWithScopes) => void;
 }> = ({ role, onClickDelete }) => {
-    const { name, description, createdAt } = role;
+    const { name, description, level, createdAt } = role;
     const { ref: nameRef, isTruncated: isNameTruncated } =
         useIsTruncated<HTMLDivElement>();
     const { ref: descriptionRef, isTruncated: isDescriptionTruncated } =
@@ -56,6 +57,11 @@ const TableRow: FC<{
                         </Text>
                     </Box>
                 </Tooltip>
+            </Table.Td>
+            <Table.Td>
+                <Badge variant="light" color="gray">
+                    {level === 'organization' ? 'Organization' : 'Project'}
+                </Badge>
             </Table.Td>
             <Table.Td>{createdAt ? formatDate(createdAt) : '-'}</Table.Td>
             <Table.Td w="1%">
@@ -137,6 +143,7 @@ export const CustomRolesTable: FC<TableProps> = ({
                         <Table.Tr>
                             <Table.Th>Name</Table.Th>
                             <Table.Th>Description</Table.Th>
+                            <Table.Th>Level</Table.Th>
                             <Table.Th>Created</Table.Th>
                             <Table.Th></Table.Th>
                         </Table.Tr>

--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
@@ -1,4 +1,15 @@
-import { Box, Button, Flex, Stack, Textarea, TextInput } from '@mantine-8/core';
+import { isScopeAssignableAtLevel, type RoleLevel } from '@lightdash/common';
+import {
+    Box,
+    Button,
+    Flex,
+    Input,
+    SegmentedControl,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+} from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -12,11 +23,13 @@ type Props = {
     initialValues: {
         name: string;
         description: string;
+        level: RoleLevel;
         scopes: string[];
     };
     onSubmit: (values: {
         name: string;
         description: string;
+        level: RoleLevel;
         scopes: string[];
     }) => void;
     isWorking: boolean;
@@ -42,6 +55,7 @@ export const RoleBuilder: FC<Props> = ({
         initialValues: {
             name: initialValues.name,
             description: initialValues.description,
+            level: initialValues.level,
             scopes: initialScopesObject,
         },
         validate: {
@@ -58,9 +72,30 @@ export const RoleBuilder: FC<Props> = ({
         onSubmit({
             name: values.name,
             description: values.description,
+            level: values.level,
             scopes: scopeNames,
         });
     });
+
+    const handleLevelChange = (value: string) => {
+        const level = value as RoleLevel;
+        const scopes = Object.entries(form.values.scopes).reduce<
+            Record<string, boolean>
+        >(
+            (acc, [scopeName, isSelected]) => ({
+                ...acc,
+                [scopeName]:
+                    isSelected && isScopeAssignableAtLevel(scopeName, level),
+            }),
+            {},
+        );
+
+        form.setValues({
+            ...form.values,
+            level,
+            scopes,
+        });
+    };
 
     return (
         <form onSubmit={handleSubmit} className={styles.container}>
@@ -82,12 +117,38 @@ export const RoleBuilder: FC<Props> = ({
                                 disabled={isWorking}
                                 {...form.getInputProps('description')}
                             />
+                            <Stack gap="two">
+                                <Input.Label>Level</Input.Label>
+                                <SegmentedControl
+                                    data={[
+                                        {
+                                            value: 'project',
+                                            label: 'Project',
+                                        },
+                                        {
+                                            value: 'organization',
+                                            label: 'Organization',
+                                        },
+                                    ]}
+                                    disabled={isWorking || mode === 'edit'}
+                                    value={form.values.level}
+                                    onChange={handleLevelChange}
+                                />
+                                {mode === 'edit' && (
+                                    <Text fz="xs" c="dimmed">
+                                        Level can't be changed after creation.
+                                    </Text>
+                                )}
+                            </Stack>
                         </Stack>
                     </SettingsCard>
 
                     <SettingsCard className={styles.permissionsCard}>
                         <Box className={styles.permissionsContent}>
-                            <ScopeSelector form={form} />
+                            <ScopeSelector
+                                form={form}
+                                level={form.values.level}
+                            />
                         </Box>
                         <Flex
                             justify="flex-end"

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -1,3 +1,4 @@
+import { type RoleLevel } from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -33,9 +34,8 @@ import styles from './ScopeSelector.module.css';
 
 type ScopeSelectorProps = {
     form: UseFormReturnType<RoleFormValues>;
+    level: RoleLevel;
 };
-
-const ALL_GROUPED_SCOPES = getScopesByGroup(true);
 
 const GroupListItem: FC<{
     group: GroupedScopes;
@@ -156,16 +156,21 @@ const ScopePanel: FC<{
     );
 };
 
-export const ScopeSelector: FC<ScopeSelectorProps> = ({ form }) => {
+export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [debouncedSearchTerm] = useDebouncedValue(searchTerm, 300);
     const [selectedGroup, setSelectedGroup] = useState<GroupedScopes | null>(
         null,
     );
 
+    const allGroupedScopes = useMemo(
+        () => getScopesByGroup(true, level),
+        [level],
+    );
+
     const filteredScopes = useMemo(
-        () => filterScopes(ALL_GROUPED_SCOPES, debouncedSearchTerm),
-        [debouncedSearchTerm],
+        () => filterScopes(allGroupedScopes, debouncedSearchTerm),
+        [allGroupedScopes, debouncedSearchTerm],
     );
 
     const effectiveSelectedGroup = useMemo(() => {
@@ -180,20 +185,33 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form }) => {
         return filteredScopes[0] || null;
     }, [selectedGroup, filteredScopes]);
 
-    const totalScopes = ALL_GROUPED_SCOPES.reduce(
+    const totalScopes = allGroupedScopes.reduce(
         (acc, group) => acc + group.scopes.length,
         0,
     );
 
-    const selectedCount = Object.values(form.values.scopes || {}).filter(
-        (isSelected) => isSelected,
+    const visibleScopeNames = useMemo(
+        () =>
+            new Set<string>(
+                allGroupedScopes.flatMap((group) =>
+                    group.scopes.map((scope) => scope.name),
+                ),
+            ),
+        [allGroupedScopes],
+    );
+
+    const selectedCount = Object.entries(form.values.scopes || {}).filter(
+        ([scopeName, isSelected]) =>
+            isSelected && visibleScopeNames.has(scopeName),
     ).length;
 
     const handleClickClearScopes = () => {
         const clearedScopes = Object.keys(form.values.scopes || {}).reduce(
             (acc, scope) => ({
                 ...acc,
-                [scope]: false,
+                [scope]: visibleScopeNames.has(scope)
+                    ? false
+                    : form.values.scopes[scope],
             }),
             {},
         );
@@ -201,15 +219,15 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form }) => {
     };
 
     const handleClickSelectAllScopes = () => {
-        const allScopesObject = ALL_GROUPED_SCOPES.flatMap(
-            (group) => group.scopes,
-        ).reduce(
-            (acc, scope) => ({
-                ...acc,
-                [scope.name]: true,
-            }),
-            {},
-        );
+        const allScopesObject = allGroupedScopes
+            .flatMap((group) => group.scopes)
+            .reduce(
+                (acc, scope) => ({
+                    ...acc,
+                    [scope.name]: true,
+                }),
+                { ...form.values.scopes },
+            );
         form.setFieldValue('scopes', allScopesObject);
     };
 

--- a/packages/frontend/src/ee/features/customRoles/components/types.ts
+++ b/packages/frontend/src/ee/features/customRoles/components/types.ts
@@ -1,5 +1,8 @@
+import { type RoleLevel } from '@lightdash/common';
+
 export type RoleFormValues = {
     name: string;
     description: string;
+    level: RoleLevel;
     scopes: Record<string, boolean>;
 };

--- a/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
+++ b/packages/frontend/src/ee/features/customRoles/utils/scopeUtils.ts
@@ -1,4 +1,10 @@
-import { getScopes, ScopeGroup, type Scope } from '@lightdash/common';
+import {
+    getScopes,
+    isScopeAssignableAtLevel,
+    ScopeGroup,
+    type RoleLevel,
+    type Scope,
+} from '@lightdash/common';
 import startCase from 'lodash/startCase';
 
 const GROUP_DISPLAY_NAMES: Record<ScopeGroup, string> = {
@@ -17,10 +23,18 @@ export type GroupedScopes = {
     scopes: Scope[];
 };
 
-export const getScopesByGroup = (isEnterprise = false): GroupedScopes[] => {
+export const getScopesByGroup = (
+    isEnterprise = false,
+    level?: RoleLevel,
+): GroupedScopes[] => {
     const allScopes = getScopes({ isEnterprise });
+    const assignableScopes = level
+        ? allScopes.filter((scope) =>
+              isScopeAssignableAtLevel(scope.name, level),
+          )
+        : allScopes;
 
-    const grouped = allScopes.reduce(
+    const grouped = assignableScopes.reduce(
         (acc, scope) => {
             if (!acc[scope.group]) {
                 acc[scope.group] = [];

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsCreateModal.tsx
@@ -2,6 +2,7 @@ import {
     CommercialFeatureFlags,
     ServiceAccountScope,
     type ProjectMemberRole,
+    type RoleLevel,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -95,35 +96,53 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
     const isCustomRolesEnabled =
         health?.isCustomRolesEnabled || customRolesFlag?.enabled;
 
-    const customRoleOptions = useMemo(
-        () =>
-            isCustomRolesEnabled
-                ? (listRoles.data ?? [])
-                      .map((role) => ({
-                          value: `role:${role.roleUuid}`,
-                          label: role.name,
-                      }))
-                      .sort((a, b) =>
-                          a.label.localeCompare(b.label, undefined, {
-                              sensitivity: 'base',
-                          }),
-                      )
-                : [],
-        [listRoles.data, isCustomRolesEnabled],
-    );
-
-    const roleOptions = useMemo(() => {
-        const groups: {
-            group: string;
-            items: { value: string; label: string }[];
-        }[] = [
-            { group: 'Organization system roles', items: SYSTEM_ROLE_OPTIONS },
-        ];
-        if (customRoleOptions.length > 0) {
-            groups.push({ group: 'Custom roles', items: customRoleOptions });
+    const customRoleOptions = useMemo(() => {
+        if (!isCustomRolesEnabled) {
+            return {
+                organization: [],
+                project: [],
+            };
         }
-        return groups;
-    }, [customRoleOptions]);
+
+        const buildOptions = (level: RoleLevel) =>
+            (listRoles.data ?? [])
+                .filter((role) => role.level === level)
+                .map((role) => ({
+                    value: `role:${role.roleUuid}`,
+                    label: role.name,
+                }))
+                .sort((a, b) =>
+                    a.label.localeCompare(b.label, undefined, {
+                        sensitivity: 'base',
+                    }),
+                );
+
+        return {
+            organization: buildOptions('organization'),
+            project: buildOptions('project'),
+        };
+    }, [listRoles.data, isCustomRolesEnabled]);
+
+    const organizationCustomRoleOptions = customRoleOptions.organization;
+    const projectCustomRoleOptions = customRoleOptions.project;
+
+    const roleOptions = useMemo(
+        () => [
+            {
+                group: 'Organization system roles',
+                items: SYSTEM_ROLE_OPTIONS,
+            },
+            ...(organizationCustomRoleOptions.length > 0
+                ? [
+                      {
+                          group: 'Custom roles',
+                          items: organizationCustomRoleOptions,
+                      },
+                  ]
+                : []),
+        ],
+        [organizationCustomRoleOptions],
+    );
 
     // Per-row role picker for project mode. Same grouped shape as the
     // org-mode role select so the dropdown visually matches and custom
@@ -133,11 +152,14 @@ export const ServiceAccountsCreateModal: FC<Props> = ({
             group: string;
             items: { value: string; label: string }[];
         }[] = [{ group: 'System roles', items: SYSTEM_PROJECT_ROLE_OPTIONS }];
-        if (customRoleOptions.length > 0) {
-            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        if (projectCustomRoleOptions.length > 0) {
+            groups.push({
+                group: 'Custom roles',
+                items: projectCustomRoleOptions,
+            });
         }
         return groups;
-    }, [customRoleOptions]);
+    }, [projectCustomRoleOptions]);
 
     const form = useForm({
         initialValues: {

--- a/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
+++ b/packages/frontend/src/ee/features/serviceAccounts/ServiceAccountsEditModal.tsx
@@ -1,6 +1,7 @@
 import {
     ServiceAccountScope,
     type ProjectMemberRole,
+    type RoleLevel,
     type ServiceAccountProjectGrant,
     type ServiceAccountScope as ServiceAccountScopeType,
     type ServiceAccountWithProjectAccessCount,
@@ -116,9 +117,10 @@ const grantsToRows = (grants: ServiceAccountProjectGrant[]): ProjectRoleRow[] =>
 // showing that role even if the flag is off.
 const useCustomRoleOptions = () => {
     const { listRoles } = useCustomRoles();
-    const options = useMemo(
-        () =>
+    const options = useMemo(() => {
+        const buildOptions = (level: RoleLevel) =>
             (listRoles.data ?? [])
+                .filter((role) => role.level === level)
                 .map((role) => ({
                     value: `role:${role.roleUuid}`,
                     label: role.name,
@@ -127,9 +129,13 @@ const useCustomRoleOptions = () => {
                     a.label.localeCompare(b.label, undefined, {
                         sensitivity: 'base',
                     }),
-                ),
-        [listRoles.data],
-    );
+                );
+
+        return {
+            organization: buildOptions('organization'),
+            project: buildOptions('project'),
+        };
+    }, [listRoles.data]);
     return { options, isLoading: listRoles.isLoading };
 };
 
@@ -146,6 +152,8 @@ const EditForm: FC<{
     const { data: projects = [] } = useProjects();
     const { options: customRoleOptions, isLoading: rolesLoading } =
         useCustomRoleOptions();
+    const organizationCustomRoleOptions = customRoleOptions.organization;
+    const projectCustomRoleOptions = customRoleOptions.project;
 
     const initialScope: ScopeMode = isProjectScoped(serviceAccount)
         ? 'project'
@@ -158,22 +166,28 @@ const EditForm: FC<{
         }[] = [
             { group: 'Organization system roles', items: SYSTEM_ROLE_OPTIONS },
         ];
-        if (customRoleOptions.length > 0) {
-            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        if (organizationCustomRoleOptions.length > 0) {
+            groups.push({
+                group: 'Custom roles',
+                items: organizationCustomRoleOptions,
+            });
         }
         return groups;
-    }, [customRoleOptions]);
+    }, [organizationCustomRoleOptions]);
 
     const projectRoleOptions = useMemo(() => {
         const groups: {
             group: string;
             items: { value: string; label: string }[];
         }[] = [{ group: 'System roles', items: SYSTEM_PROJECT_ROLE_OPTIONS }];
-        if (customRoleOptions.length > 0) {
-            groups.push({ group: 'Custom roles', items: customRoleOptions });
+        if (projectCustomRoleOptions.length > 0) {
+            groups.push({
+                group: 'Custom roles',
+                items: projectCustomRoleOptions,
+            });
         }
         return groups;
-    }, [customRoleOptions]);
+    }, [projectCustomRoleOptions]);
 
     const form = useForm({
         initialValues: {

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoleCreate.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoleCreate.tsx
@@ -1,3 +1,4 @@
+import { type RoleLevel } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
 import { useNavigate } from 'react-router';
 import PageBreadcrumbs from '../../../components/common/PageBreadcrumbs';
@@ -11,11 +12,13 @@ export const CustomRoleCreate = () => {
     const handleCreateRole = async (values: {
         name: string;
         description: string;
+        level: RoleLevel;
         scopes: string[];
     }) => {
         await createRole.mutateAsync({
             name: values.name,
             description: values.description || undefined,
+            level: values.level,
             scopes: values.scopes,
         });
         void navigate('/generalSettings/customRoles');
@@ -24,6 +27,7 @@ export const CustomRoleCreate = () => {
     const initialValues = {
         name: '',
         description: '',
+        level: 'project' as const,
         scopes: [],
     };
 

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoleEdit.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoleEdit.tsx
@@ -1,3 +1,4 @@
+import { type RoleLevel } from '@lightdash/common';
 import { Center, Loader, Stack } from '@mantine-8/core';
 import { useNavigate, useParams } from 'react-router';
 import PageBreadcrumbs from '../../../components/common/PageBreadcrumbs';
@@ -16,6 +17,7 @@ export const CustomRoleEdit = () => {
     const handleUpdateRole = async (values: {
         name: string;
         description: string;
+        level: RoleLevel;
         scopes: string[];
     }) => {
         if (!roleId || !role) return;
@@ -76,6 +78,7 @@ export const CustomRoleEdit = () => {
                 initialValues={{
                     name: role.name,
                     description: role.description || '',
+                    level: role.level,
                     scopes: role.scopes || [],
                 }}
                 onSubmit={handleUpdateRole}

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.module.css
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.module.css
@@ -1,0 +1,81 @@
+.tabsList {
+    gap: 0.5rem;
+}
+
+.tab {
+    font-weight: 500;
+    font-size: 0.875rem;
+    padding: 0.375rem 0.875rem;
+    transition: all 150ms ease;
+    border-radius: var(--mantine-radius-md);
+    border: 1px solid
+        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-4));
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-ldDark-7)
+    );
+}
+
+.tab:hover {
+    border-color: light-dark(
+        var(--mantine-color-ldGray-4),
+        var(--mantine-color-ldDark-3)
+    );
+    background-color: light-dark(
+        var(--mantine-color-ldGray-0),
+        var(--mantine-color-ldDark-5)
+    );
+}
+
+.tab[data-active='true'] {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
+    );
+    border-color: light-dark(
+        var(--mantine-color-ldGray-9),
+        var(--mantine-color-ldDark-4)
+    );
+    color: light-dark(var(--mantine-color-white), var(--mantine-color-white));
+}
+
+.tab[data-active='true']:hover {
+    background-color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
+    );
+    border-color: light-dark(
+        var(--mantine-color-ldGray-8),
+        var(--mantine-color-ldDark-3)
+    );
+}
+
+.tabBadge {
+    height: 1.25rem;
+    padding-inline: 0.4375rem;
+    font-size: 0.75rem;
+    color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-1)
+    );
+    background-color: light-dark(
+        var(--mantine-color-ldGray-1),
+        var(--mantine-color-ldDark-5)
+    );
+}
+
+.tab[data-active='true'] .tabBadge {
+    color: light-dark(var(--mantine-color-white), var(--mantine-color-white));
+    background-color: light-dark(
+        var(--mantine-color-ldGray-7),
+        var(--mantine-color-ldDark-3)
+    );
+}
+
+.panel {
+    padding-top: 1rem;
+}

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -1,6 +1,6 @@
-import { type RoleWithScopes } from '@lightdash/common';
-import { Group, Stack } from '@mantine-8/core';
-import { IconIdBadge2 } from '@tabler/icons-react';
+import { type RoleLevel, type RoleWithScopes } from '@lightdash/common';
+import { Badge, Group, Stack, Tabs, Text } from '@mantine-8/core';
+import { IconBuilding, IconFolder, IconIdBadge2 } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { EmptyState } from '../../../components/common/EmptyState';
@@ -11,12 +11,14 @@ import { AddRoleButton } from '../../features/customRoles/components/AddRoleButt
 import { CustomRolesTable } from '../../features/customRoles/CustomRolesTable';
 import { DuplicateRoleModal } from '../../features/customRoles/DuplicateRoleModal';
 import { useCustomRoles } from '../../features/customRoles/useCustomRoles';
+import classes from './CustomRoles.module.css';
 
 export const CustomRoles = () => {
     const navigate = useNavigate();
     const { listRoles, deleteRole, getAllRoles, duplicateRole } =
         useCustomRoles();
     const [isDuplicateModalOpen, setIsDuplicateModalOpen] = useState(false);
+    const [level, setLevel] = useState<RoleLevel>('project');
 
     const handleEditRole = (role: RoleWithScopes) => {
         void navigate(`/generalSettings/customRoles/${role.roleUuid}`);
@@ -49,11 +51,36 @@ export const CustomRoles = () => {
         [listRoles.data],
     );
 
+    const projectRoles = useMemo(
+        () => sortedRoles.filter((role) => role.level === 'project'),
+        [sortedRoles],
+    );
+    const organizationRoles = useMemo(
+        () => sortedRoles.filter((role) => role.level === 'organization'),
+        [sortedRoles],
+    );
+
     if (listRoles.isLoading) {
         return <PageSpinner />;
     }
 
     const hasRoles = sortedRoles.length > 0;
+
+    const renderRolesTable = (roles: RoleWithScopes[], level: RoleLevel) =>
+        roles.length > 0 ? (
+            <CustomRolesTable
+                roles={roles}
+                onDelete={handleDeleteRole}
+                onEdit={handleEditRole}
+                isDeleting={deleteRole.isLoading}
+            />
+        ) : (
+            <Text c="dimmed" fz="sm">
+                {level === 'organization'
+                    ? 'No organization-level roles yet.'
+                    : 'No project-level roles yet.'}
+            </Text>
+        );
 
     return (
         <Stack mb="lg" gap="md">
@@ -75,14 +102,78 @@ export const CustomRoles = () => {
             </Group>
 
             {hasRoles ? (
-                <>
-                    <CustomRolesTable
-                        roles={sortedRoles}
-                        onDelete={handleDeleteRole}
-                        onEdit={handleEditRole}
-                        isDeleting={deleteRole.isLoading}
-                    />
-                </>
+                <Stack gap="md">
+                    <Text c="dimmed" fz="sm">
+                        Roles you create here can be assigned to users, groups
+                        and service accounts
+                    </Text>
+
+                    <Tabs
+                        keepMounted={false}
+                        value={level}
+                        onChange={(value) => setLevel(value as RoleLevel)}
+                        variant="pills"
+                        classNames={{
+                            list: classes.tabsList,
+                            tab: classes.tab,
+                            panel: classes.panel,
+                        }}
+                    >
+                        <Tabs.List>
+                            <Tabs.Tab
+                                value="project"
+                                leftSection={
+                                    <MantineIcon icon={IconFolder} size="sm" />
+                                }
+                            >
+                                <Group gap="xs" wrap="nowrap">
+                                    <Text span inherit>
+                                        Project
+                                    </Text>
+                                    <Badge
+                                        className={classes.tabBadge}
+                                        variant="light"
+                                        radius="sm"
+                                    >
+                                        {projectRoles.length}
+                                    </Badge>
+                                </Group>
+                            </Tabs.Tab>
+                            <Tabs.Tab
+                                value="organization"
+                                leftSection={
+                                    <MantineIcon
+                                        icon={IconBuilding}
+                                        size="sm"
+                                    />
+                                }
+                            >
+                                <Group gap="xs" wrap="nowrap">
+                                    <Text span inherit>
+                                        Organization
+                                    </Text>
+                                    <Badge
+                                        className={classes.tabBadge}
+                                        variant="light"
+                                        radius="sm"
+                                    >
+                                        {organizationRoles.length}
+                                    </Badge>
+                                </Group>
+                            </Tabs.Tab>
+                        </Tabs.List>
+
+                        <Tabs.Panel value="project">
+                            {renderRolesTable(projectRoles, 'project')}
+                        </Tabs.Panel>
+                        <Tabs.Panel value="organization">
+                            {renderRolesTable(
+                                organizationRoles,
+                                'organization',
+                            )}
+                        </Tabs.Panel>
+                    </Tabs>
+                </Stack>
             ) : (
                 <EmptyState
                     icon={

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -163,7 +163,10 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         const customRoles: { value: string; label: string }[] = [];
 
         organizationRoles.forEach(
-            (role: Pick<Role, 'roleUuid' | 'name' | 'ownerType'>) => {
+            (role: Pick<Role, 'roleUuid' | 'name' | 'ownerType' | 'level'>) => {
+                if (role.ownerType === 'user' && role.level !== 'project') {
+                    return;
+                }
                 const item = { value: role.roleUuid, label: role.name };
                 if (role.ownerType === 'system') {
                     systemRoles.push(item);


### PR DESCRIPTION
## Summary

PR 3 of 3 for [PROD-8195](https://linear.app/lightdash/issue/PROD-8195). The UI for org/project custom roles: a level toggle on the role builder with a level-filtered scope picker, and role dropdowns that offer the right roles per surface. Gated by the existing `CustomRoles` flag.

Stacks on PR2 ([#24589](https://github.com/lightdash/lightdash/pull/24589), open in this series), which added the `level` column, the `roleUuid` mapper fix, and the org-assignment service path.

Closes: [PROD-8396](https://linear.app/lightdash/issue/PROD-8396)

## Changes (frontend only)

- **Role builder** (`RoleBuilder`): a project | organization segmented control with a "Level" label; `ScopeSelector` filters offered scopes to the chosen level via the shared `isScopeAssignableAtLevel`. Read-only on edit ("Level can't be changed after creation"), since level is immutable.
- **Org members dropdown** (`UsersTable`): offers system roles + org-level custom roles.
- **Project access dropdowns** (`ProjectAccess`, `ProjectGroupAccess`): filter out org-level roles (symmetric).
- **Custom roles list** (`CustomRoles`): Project | Organization tab filter (Project default), matching the Project Access tab styling, with per-level empty states; level badge in the table.
- Service-account create/edit modals + `CustomRoleCreate/Edit` use the shared `RoleLevel` type.

## Roles list

```
[ Project (8) ]  Organization        ← Project default, first
─────────────────────────────────────
Name             Level        Created
Analyst          Project      …
Content Editor   Project      …
```

Switching to Organization shows org-level roles only; each tab has its own empty state.

## Test plan

- [x] `pnpm -F frontend typecheck:fast` — no new errors (only the pre-existing, `main`-also-failing `aiCopilot/ThreadPreviewSidebar.test.tsx`)
- [x] `pnpm -F frontend` oxlint on changed files — 0 warnings/errors
- [x] Manual: builder toggle filters scopes; level disabled on edit; org roles appear in the org-members picker and are absent from project access; list tab filter + badge render
- [ ] Screenshots to follow on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)