### PR TITLE
feat(data-apps): trace generation with Claude Code OTEL (GLITCH-521)

### DIFF
--- a/docker/dev-configs/jaeger-ui.json
+++ b/docker/dev-configs/jaeger-ui.json
@@ -1,0 +1,5 @@
+{
+    "themes": {
+        "enabled": true
+    }
+}

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -73,6 +73,10 @@ services:
         restart: always
         environment:
             - COLLECTOR_OTLP_ENABLED=true
+            # Enables the dark/light theme toggle in the Jaeger UI
+            - QUERY_UI_CONFIG=/etc/jaeger/ui-config.json
+        volumes:
+            - ./dev-configs/jaeger-ui.json:/etc/jaeger/ui-config.json
         ports:
             - '16686:16686' # Jaeger UI
             - '4317:4317' # OTLP gRPC receiver

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -68,6 +68,16 @@ services:
             - '--storage.tsdb.retention.time=200h'
             - '--web.enable-lifecycle'
 
+    jaeger:
+        image: jaegertracing/all-in-one:latest
+        restart: always
+        environment:
+            - COLLECTOR_OTLP_ENABLED=true
+        ports:
+            - '16686:16686' # Jaeger UI
+            - '4317:4317' # OTLP gRPC receiver
+            - '4318:4318' # OTLP HTTP receiver
+
     mailpit:
         image: axllent/mailpit:latest
         restart: unless-stopped

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -833,7 +833,7 @@ What each span type carries, and the question it answers:
 
 | Span                     | Key attributes                                                                       | Answers                                                            |
 | ------------------------ | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `DataApp.generate`       | app / version / org / project / user uuid, install id                                | Who generated this, and how long the whole pipeline took          |
+| `DataApp.generate`       | app / version / org / project / user uuid, `is_iteration`                             | Who generated this, and how long the whole pipeline took          |
 | `claude_code.interaction`| session id, identity (`user.email`, `user.account_uuid`, `organization.id`)          | Overall agent-loop duration                                       |
 | `claude_code.llm_request`| model, `ttft_ms`, `duration_ms`, input / output / cache tokens, `stop_reason`        | Per-call latency and context-window size                          |
 | `claude_code.tool`       | `tool_name`, `duration_ms`, `result_tokens`                                          | Per-tool timing                                                   |
@@ -848,8 +848,8 @@ works for the headless mode data apps run in.)
 
 The parent span is created with `wrapSentryTransaction('DataApp.generate', ...)` around the
 generation pipeline in `AppGenerateService.ts`, tagged with the app, version, org, project, and user
-uuids plus the instance `installId` for attribution. The `traceparent` is read from the active span
-context by `getOtelTraceHeaders()` in `packages/backend/src/tracing/tracing.ts`.
+uuids plus `is_iteration` for attribution. The `traceparent` is read from the active span context by
+`getOtelTraceHeaders()` in `packages/backend/src/tracing/tracing.ts`.
 
 One non-obvious wrinkle lives in `getOtelTraceHeaders`: `@sentry/node` registers its own
 (`sentry-trace`) propagator as the OTel global, so a plain `propagation.inject` never emits a W3C
@@ -872,9 +872,9 @@ on, it sets:
   `TRACEPARENT`.
 - `OTEL_TRACES_EXPORT_INTERVAL=1000`. Generations are short-lived and the CLI flushes on clean exit;
   a low interval makes spans land before the sandbox is paused or torn down.
-- `OTEL_RESOURCE_ATTRIBUTES` carrying `service.name=lightdash-data-app` plus the same app / org /
-  project / user uuids and install id as the parent span, so the sandbox spans are attributable on
-  their own.
+- `OTEL_RESOURCE_ATTRIBUTES` carrying `service.name=lightdash-data-app` plus the app / version / org
+  / project / user uuids and the instance install id (`lightdash.install_id`, from
+  `LIGHTDASH_INSTALL_ID`), so the sandbox spans are attributable on their own.
 - `OTEL_LOG_USER_PROMPTS=1` and `OTEL_LOG_TOOL_DETAILS=1`. Data apps opt into capturing the prompt
   and tool inputs/results because the generation PII surface is bounded (metadata-only schema plus
   the prompt, no warehouse-query tool, real rows only via opt-in sample data). Raw API bodies
@@ -923,8 +923,13 @@ LIGHTDASH_OTEL_TRACES_ENABLED=true                 # Master switch (backend + sa
 OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318  # OTLP collector (GCP collector in prod, local Jaeger in dev)
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf           # Defaults to http/protobuf
 OTEL_EXPORTER_OTLP_HEADERS=...                       # Optional auth headers for the collector
-OTEL_SDK_DISABLED=false
+OTEL_SDK_DISABLED=false                             # Must not be 'true' (kill switch)
+OTEL_TRACES_EXPORTER=otlp                           # Must not be 'none' (kill switch)
 ```
+
+Enablement is gated on all three of `LIGHTDASH_OTEL_TRACES_ENABLED === 'true'`,
+`OTEL_SDK_DISABLED !== 'true'`, and `OTEL_TRACES_EXPORTER !== 'none'` (see `parseConfig.ts`); the
+last two default to off/unset, so setting the master switch is normally enough.
 
 `appRuntime.otel` (in `parseConfig.ts`) is structurally a subset of this and is passed straight to
 `buildClaudeCodeTelemetryEnv`; its `enabled` mirrors the backend tracer's `otelTracingEnabled()`.

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -798,6 +798,148 @@ During a generation, for every linked connection that has a saved sample, the pi
 
 ---
 
+## Observability (distributed tracing)
+
+Every generation emits a single distributed trace that spans two services: the backend that
+orchestrates the pipeline and the `claude` CLI running inside the E2B sandbox. The goal is one
+waterfall per generation, with per-LLM-request and per-tool timing, token counts, and model
+attribution, all attributable to the user, app, org, and project that triggered it.
+
+It is built on Claude Code's native OpenTelemetry export. When telemetry is enabled, the CLI emits
+its own trace (an agent-loop root span with a child span per LLM request and per tool call) and
+ships it over OTLP to a collector. The backend wraps the whole generation in a parent span and hands
+its trace context to the sandbox, so the CLI's spans nest underneath instead of starting a fresh
+trace.
+
+### The trace shape
+
+One trace, two services:
+
+```
+[lightdash]            DataApp.generate                ← backend parent span (root)
+[lightdash-data-app]   └─ claude_code.interaction      ← Claude Code agent loop
+[lightdash-data-app]      ├─ claude_code.llm_request   ← one per model call
+[lightdash-data-app]      ├─ claude_code.tool          ← one per tool call
+[lightdash-data-app]      │  ├─ claude_code.tool.blocked_on_user
+[lightdash-data-app]      │  └─ claude_code.tool.execution
+[lightdash-data-app]      └─ claude_code.llm_request
+```
+
+The backend service reports as `lightdash` (or `OTEL_SERVICE_NAME`); the sandbox sets its own
+`service.name` to `lightdash-data-app` via resource attributes, so the two halves are
+distinguishable inside one trace.
+
+What each span type carries, and the question it answers:
+
+| Span                     | Key attributes                                                                       | Answers                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `DataApp.generate`       | app / version / org / project / user uuid, install id                                | Who generated this, and how long the whole pipeline took          |
+| `claude_code.interaction`| session id, identity (`user.email`, `user.account_uuid`, `organization.id`)          | Overall agent-loop duration                                       |
+| `claude_code.llm_request`| model, `ttft_ms`, `duration_ms`, input / output / cache tokens, `stop_reason`        | Per-call latency and context-window size                          |
+| `claude_code.tool`       | `tool_name`, `duration_ms`, `result_tokens`                                          | Per-tool timing                                                   |
+
+### How the trace is stitched (TRACEPARENT)
+
+The backend creates the parent span and passes its W3C `traceparent` into the sandbox as the
+`TRACEPARENT` env var. Claude Code's non-interactive (`-p` / stream-json) mode honors an inbound
+`TRACEPARENT`, so its root `claude_code.interaction` span becomes a child of the backend span
+instead of opening a new trace. (Interactive sessions deliberately ignore it, which is why this only
+works for the headless mode data apps run in.)
+
+The parent span is created with `wrapSentryTransaction('DataApp.generate', ...)` around the
+generation pipeline in `AppGenerateService.ts`, tagged with the app, version, org, project, and user
+uuids plus the instance `installId` for attribution. The `traceparent` is read from the active span
+context by `getOtelTraceHeaders()` in `packages/backend/src/tracing/tracing.ts`.
+
+One non-obvious wrinkle lives in `getOtelTraceHeaders`: `@sentry/node` registers its own
+(`sentry-trace`) propagator as the OTel global, so a plain `propagation.inject` never emits a W3C
+`traceparent`. Without one, the sandbox gets no `TRACEPARENT` and Claude Code fragments every
+operation into its own trace. So `getOtelTraceHeaders` falls back to deriving the header directly
+from the active span context (`00-<traceId>-<spanId>-<flags>`) when the global propagator omits it.
+
+### What the sandbox exports
+
+`buildClaudeCodeTelemetryEnv` (`claudeCodeEnv.ts`) builds the OTEL env injected into the sandbox. It
+returns an empty object (no telemetry) unless tracing is enabled and an endpoint is configured. When
+on, it sets:
+
+- `CLAUDE_CODE_ENABLE_TELEMETRY=1` and `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1`. The beta flag is what
+  unlocks the trace signal (token and tool span attributes); without it Claude Code emits metrics
+  only.
+- `OTEL_TRACES_EXPORTER=otlp`, with `OTEL_METRICS_EXPORTER` and `OTEL_LOGS_EXPORTER` set to `none`.
+  The sandbox is traces-only.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` / `_PROTOCOL` / `_HEADERS` from config, plus the parent's
+  `TRACEPARENT`.
+- `OTEL_TRACES_EXPORT_INTERVAL=1000`. Generations are short-lived and the CLI flushes on clean exit;
+  a low interval makes spans land before the sandbox is paused or torn down.
+- `OTEL_RESOURCE_ATTRIBUTES` carrying `service.name=lightdash-data-app` plus the same app / org /
+  project / user uuids and install id as the parent span, so the sandbox spans are attributable on
+  their own.
+- `OTEL_LOG_USER_PROMPTS=1` and `OTEL_LOG_TOOL_DETAILS=1`. Data apps opt into capturing the prompt
+  and tool inputs/results because the generation PII surface is bounded (metadata-only schema plus
+  the prompt, no warehouse-query tool, real rows only via opt-in sample data). Raw API bodies
+  (`OTEL_LOG_RAW_API_BODIES`) stay off. See the caveat below: these flags feed Claude Code's
+  log-events signal, not span attributes.
+
+### Sandbox egress
+
+The E2B sandbox firewall denies all outbound traffic except an allowlist (see
+[LLM provider](#llm-provider-anthropic-vs-bedrock)). When OTEL export is on, `claudeCodeAllowedHosts`
+adds the OTLP collector's host to that allowlist, otherwise the exporter's POSTs are dropped
+silently. A malformed endpoint leaves the allowlist unchanged rather than opening an invalid host.
+
+### Cost and payloads are not on the spans
+
+Two things the trace deliberately does not carry:
+
+- **Cost.** Claude Code reports cost USD as a metric (`claude_code.cost.usage`), not a span
+  attribute, and the sandbox runs with metrics export off. Cost continues to come from the stdout
+  `total_cost_usd` the pipeline already parses (`ClaudeStreamProcessor`). The per-request token
+  attributes on `llm_request` spans cover context-window size and any downstream token-based pricing.
+- **Prompts and tool details.** `OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_DETAILS` populate Claude
+  Code's OTEL log-events signal, not trace span attributes. With `OTEL_LOGS_EXPORTER=none` and a
+  traces-only backend they never appear. Capturing them needs a logs-ingesting backend and
+  `OTEL_LOGS_EXPORTER=otlp`, a separate decision because the PII surface for logs is wider.
+
+### Generation runs in the scheduler, not the API
+
+Easy to get wrong, so worth calling out: the pipeline runs as a Graphile Worker job
+(`appGeneratePipeline`) in the **scheduler** process, not in the API process that served the create
+request. The `DataApp.generate` parent span is therefore created and exported by the scheduler. For
+the parent to reach the collector (and the trace to render as one rooted waterfall rather than a
+headless tree of orphaned sandbox spans), the **scheduler process** must have OTLP tracing enabled
+(`LIGHTDASH_OTEL_TRACES_ENABLED=true`) and a reachable `OTEL_EXPORTER_OTLP_ENDPOINT`. If only the API
+has it, the sandbox still emits a valid `TRACEPARENT` (the active span context is enough on its own),
+and the children nest under a parent id that was never exported, so the trace renders parent-less in
+the trace UI.
+
+### Configuration
+
+The data-app sandbox reuses the same OTLP config as the backend's own tracer
+(`src/tracing/tracing.ts`), so both halves land in the same place:
+
+```
+LIGHTDASH_OTEL_TRACES_ENABLED=true                 # Master switch (backend + sandbox traces)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318  # OTLP collector (GCP collector in prod, local Jaeger in dev)
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf           # Defaults to http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS=...                       # Optional auth headers for the collector
+OTEL_SDK_DISABLED=false
+```
+
+`appRuntime.otel` (in `parseConfig.ts`) is structurally a subset of this and is passed straight to
+`buildClaudeCodeTelemetryEnv`; its `enabled` mirrors the backend tracer's `otelTracingEnabled()`.
+
+### Local verification (Jaeger)
+
+`docker/docker-compose.infra.yml` includes a local Jaeger (`jaegertracing/all-in-one`, OTLP on
+:4317 / :4318, UI on :16686) as the dev trace target. Spotlight is not usable for OTLP (it only
+parses Sentry envelopes). Because the E2B sandbox runs in the cloud and cannot reach `localhost`, the
+dev `OTEL_EXPORTER_OTLP_ENDPOINT` is a tunnel to the local Jaeger, while the backend posts to it
+directly. Open the Jaeger UI, filter by the `lightdash-data-app` service, and inspect the
+`claude_code.*` tree under its `DataApp.generate` parent.
+
+---
+
 ## Frontend Architecture
 
 ### Pages
@@ -892,7 +1034,8 @@ S3 credentials are configured through the existing `S3_*` environment variables 
 | File                                                                        | Purpose                                                                                      |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts` | Core pipeline: sandbox, Claude, build, S3, DB                                                |
-| `packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts`      | Builds the `claude` CLI env + firewall allowlist for the Anthropic / Bedrock provider switch |
+| `packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts`      | Builds the `claude` CLI env (provider switch + OTEL telemetry env) and the firewall allowlist |
+| `packages/backend/src/tracing/tracing.ts`                                   | Backend OTLP trace exporter + the `getOtelTraceHeaders` helper that derives the `TRACEPARENT` injected into the sandbox |
 | `packages/backend/src/ee/controllers/appGenerateController.ts`              | TSOA REST controllers                                                                        |
 | `packages/backend/src/models/AppModel.ts`                                   | Data access layer for apps and versions                                                      |
 | `packages/backend/src/routers/appPreviewRouter.ts`                          | Express router serving built artifacts from S3                                               |

--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -872,6 +872,8 @@ on, it sets:
   `TRACEPARENT`.
 - `OTEL_TRACES_EXPORT_INTERVAL=1000`. Generations are short-lived and the CLI flushes on clean exit;
   a low interval makes spans land before the sandbox is paused or torn down.
+- `OTEL_EXPORTER_OTLP_TIMEOUT=3000`. Caps each exporter HTTP call so an unreachable or slow collector
+  can't add flush latency to sandbox teardown.
 - `OTEL_RESOURCE_ATTRIBUTES` carrying `service.name=lightdash-data-app` plus the app / version / org
   / project / user uuids and the instance install id (`lightdash.install_id`, from
   `LIGHTDASH_INSTALL_ID`), so the sandbox spans are attributable on their own.
@@ -887,6 +889,21 @@ The E2B sandbox firewall denies all outbound traffic except an allowlist (see
 [LLM provider](#llm-provider-anthropic-vs-bedrock)). When OTEL export is on, `claudeCodeAllowedHosts`
 adds the OTLP collector's host to that allowlist, otherwise the exporter's POSTs are dropped
 silently. A malformed endpoint leaves the allowlist unchanged rather than opening an invalid host.
+
+### Failsafe behavior
+
+Tracing is a side channel and must never break a generation. The wiring degrades safely:
+
+- **OTEL disabled, or no endpoint configured.** `buildClaudeCodeTelemetryEnv` returns an empty
+  object and `getOtelTraceHeaders` returns nothing, so the sandbox runs with the plain env and the
+  firewall allowlist is unchanged. This is the default and a pure no-op.
+- **Malformed endpoint.** Treated as disabled by both the telemetry env and the firewall allowlist
+  (they share the same URL parse), so no unusable exporter config is injected into the sandbox.
+- **Unreachable / slow collector.** The exporter's failures are non-fatal to the CLI; the export
+  interval plus `OTEL_EXPORTER_OTLP_TIMEOUT` bound any added latency at teardown.
+- **Telemetry setup throws.** Building the telemetry env (including reading the trace header) is
+  wrapped in a try/catch in `AppGenerateService`; on any error it logs a warning and proceeds with
+  the plain env, so a misconfigured tracer can never abort the generation.
 
 ### Cost and payloads are not on the spans
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -370,6 +370,12 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bTemplateTag: '',
         e2bAiWritebackTemplateName: 'lightdash-ai-writeback',
         e2bAiWritebackTemplateTag: '',
+        otel: {
+            enabled: false,
+            endpoint: null,
+            protocol: 'http/protobuf',
+            headers: null,
+        },
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1569,6 +1569,20 @@ export type AppRuntimeConfig = {
      */
     e2bAiWritebackTemplateName: string;
     e2bAiWritebackTemplateTag: string;
+    /**
+     * OpenTelemetry export for data-app generation. When enabled with an
+     * endpoint, Claude Code's native OTEL tracing is turned on inside the
+     * sandbox and pointed at this OTLP collector; the collector host is added
+     * to the sandbox egress allowlist. The data-app generation gets a backend
+     * parent span and the sandbox `claude_code.*` spans nest under it via an
+     * injected TRACEPARENT. Off unless an endpoint is configured.
+     */
+    otel: {
+        enabled: boolean;
+        endpoint: string | null;
+        protocol: string;
+        headers: string | null;
+    };
 };
 
 export type IntercomConfig = {
@@ -1793,6 +1807,20 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             'lightdash-ai-writeback',
         e2bAiWritebackTemplateTag:
             process.env.E2B_AI_WRITEBACK_TEMPLATE_TAG ?? (VERSION as string),
+        // Reuses the shared OTEL trace-export config (same flag + collector as
+        // the backend's own OTLP exporter in src/tracing/tracing.ts) so the
+        // data-app sandbox traces land in the same place and stitch into one
+        // trace. Enablement mirrors that module's otelTracingEnabled().
+        otel: {
+            enabled:
+                process.env.LIGHTDASH_OTEL_TRACES_ENABLED === 'true' &&
+                process.env.OTEL_SDK_DISABLED !== 'true' &&
+                process.env.OTEL_TRACES_EXPORTER !== 'none',
+            endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || null,
+            protocol:
+                process.env.OTEL_EXPORTER_OTLP_PROTOCOL || 'http/protobuf',
+            headers: process.env.OTEL_EXPORTER_OTLP_HEADERS || null,
+        },
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2581,30 +2581,46 @@ export class AppGenerateService extends BaseService {
                     // sandbox and nest its spans under this backend parent via
                     // the active trace context's W3C TRACEPARENT, so the whole
                     // generation is one cross-service trace. No-op when OTEL
-                    // tracing is off.
-                    const installId = process.env.LIGHTDASH_INSTALL_ID;
-                    const claudeCodeEnvWithTelemetry = {
-                        ...claudeCodeEnv,
-                        ...buildClaudeCodeTelemetryEnv(
-                            this.lightdashConfig.appRuntime.otel,
-                            {
-                                traceparent:
-                                    getOtelTraceHeaders().traceparent ?? null,
-                                resourceAttributes: {
-                                    'service.name': 'lightdash-data-app',
-                                    'data_app.app_uuid': appUuid,
-                                    'data_app.version': String(version),
-                                    'organization.uuid':
-                                        payload.organizationUuid,
-                                    'project.uuid': projectUuid,
-                                    'user.uuid': payload.userUuid,
-                                    ...(installId
-                                        ? { 'lightdash.install_id': installId }
-                                        : {}),
+                    // tracing is off. Telemetry is a side channel: if anything
+                    // about its setup fails (misconfigured OTEL, propagator
+                    // error), fall back to the plain env and generate without
+                    // tracing rather than failing the generation.
+                    let claudeCodeEnvWithTelemetry = claudeCodeEnv;
+                    try {
+                        const installId = process.env.LIGHTDASH_INSTALL_ID;
+                        claudeCodeEnvWithTelemetry = {
+                            ...claudeCodeEnv,
+                            ...buildClaudeCodeTelemetryEnv(
+                                this.lightdashConfig.appRuntime.otel,
+                                {
+                                    traceparent:
+                                        getOtelTraceHeaders().traceparent ??
+                                        null,
+                                    resourceAttributes: {
+                                        'service.name': 'lightdash-data-app',
+                                        'data_app.app_uuid': appUuid,
+                                        'data_app.version': String(version),
+                                        'organization.uuid':
+                                            payload.organizationUuid,
+                                        'project.uuid': projectUuid,
+                                        'user.uuid': payload.userUuid,
+                                        ...(installId
+                                            ? {
+                                                  'lightdash.install_id':
+                                                      installId,
+                                              }
+                                            : {}),
+                                    },
                                 },
-                            },
-                        ),
-                    };
+                            ),
+                        };
+                    } catch (e) {
+                        this.logger.warn(
+                            `App ${appUuid}: OTEL telemetry setup failed; continuing without sandbox tracing: ${getErrorMessage(
+                                e,
+                            )}`,
+                        );
+                    }
                     await this.runPipelineStages(
                         sandbox,
                         payload,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2579,8 +2579,9 @@ export class AppGenerateService extends BaseService {
                 async () => {
                     // Turn on Claude Code's native OTEL tracing inside the
                     // sandbox and nest its spans under this backend parent via
-                    // the active trace context's TRACEPARENT (shared with the
-                    // backend's OTLP exporter). No-op when OTEL tracing is off.
+                    // the active trace context's W3C TRACEPARENT, so the whole
+                    // generation is one cross-service trace. No-op when OTEL
+                    // tracing is off.
                     const installId = process.env.LIGHTDASH_INSTALL_ID;
                     const claudeCodeEnvWithTelemetry = {
                         ...claudeCodeEnv,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -79,6 +79,8 @@ import type { ProjectService } from '../../../services/ProjectService/ProjectSer
 import type { PromoteService } from '../../../services/PromoteService/PromoteService';
 import type { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
 import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
+import { getOtelTraceHeaders } from '../../../tracing/tracing';
+import { wrapSentryTransaction } from '../../../utils';
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
@@ -89,6 +91,7 @@ import {
 } from './claudeCliFailure';
 import {
     buildClaudeCodeEnv,
+    buildClaudeCodeTelemetryEnv,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
 } from './claudeCodeEnv';
@@ -994,6 +997,7 @@ export class AppGenerateService extends BaseService {
             network: {
                 allowOut: claudeCodeAllowedHosts(
                     this.lightdashConfig.ai.copilot,
+                    this.lightdashConfig.appRuntime.otel,
                 ),
                 denyOut: [ALL_TRAFFIC],
             },
@@ -2562,18 +2566,58 @@ export class AppGenerateService extends BaseService {
         }, HEARTBEAT_INTERVAL_MS);
 
         try {
-            await this.runPipelineStages(
-                sandbox,
-                payload,
-                s3Client,
-                bucket,
-                durations,
-                overallStart,
-                currentStatus,
-                wasResumed,
-                claudeCodeEnv,
-                imageIds,
-                chartReferences,
+            await wrapSentryTransaction(
+                'DataApp.generate',
+                {
+                    'data_app.app_uuid': appUuid,
+                    'data_app.version': version,
+                    'organization.uuid': payload.organizationUuid,
+                    'project.uuid': projectUuid,
+                    'user.uuid': payload.userUuid,
+                    'data_app.is_iteration': isIteration,
+                },
+                async () => {
+                    // Turn on Claude Code's native OTEL tracing inside the
+                    // sandbox and nest its spans under this backend parent via
+                    // the active trace context's TRACEPARENT (shared with the
+                    // backend's OTLP exporter). No-op when OTEL tracing is off.
+                    const installId = process.env.LIGHTDASH_INSTALL_ID;
+                    const claudeCodeEnvWithTelemetry = {
+                        ...claudeCodeEnv,
+                        ...buildClaudeCodeTelemetryEnv(
+                            this.lightdashConfig.appRuntime.otel,
+                            {
+                                traceparent:
+                                    getOtelTraceHeaders().traceparent ?? null,
+                                resourceAttributes: {
+                                    'service.name': 'lightdash-data-app',
+                                    'data_app.app_uuid': appUuid,
+                                    'data_app.version': String(version),
+                                    'organization.uuid':
+                                        payload.organizationUuid,
+                                    'project.uuid': projectUuid,
+                                    'user.uuid': payload.userUuid,
+                                    ...(installId
+                                        ? { 'lightdash.install_id': installId }
+                                        : {}),
+                                },
+                            },
+                        ),
+                    };
+                    await this.runPipelineStages(
+                        sandbox,
+                        payload,
+                        s3Client,
+                        bucket,
+                        durations,
+                        overallStart,
+                        currentStatus,
+                        wasResumed,
+                        claudeCodeEnvWithTelemetry,
+                        imageIds,
+                        chartReferences,
+                    );
+                },
             );
         } finally {
             clearInterval(heartbeat);

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
@@ -1,7 +1,9 @@
 import {
     buildClaudeCodeEnv,
+    buildClaudeCodeTelemetryEnv,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
+    type ClaudeCodeOtelConfig,
 } from './claudeCodeEnv';
 
 describe('buildClaudeCodeEnv', () => {
@@ -161,13 +163,144 @@ describe('describeClaudeCodeEnv', () => {
     });
 });
 
+describe('buildClaudeCodeTelemetryEnv', () => {
+    const enabledOtel: ClaudeCodeOtelConfig = {
+        enabled: true,
+        endpoint: 'http://collector.internal:4318',
+        protocol: 'http/protobuf',
+        headers: null,
+    };
+
+    test('returns no env when disabled', () => {
+        expect(
+            buildClaudeCodeTelemetryEnv(
+                { ...enabledOtel, enabled: false },
+                { traceparent: '00-abc-def-01', resourceAttributes: {} },
+            ),
+        ).toEqual({});
+    });
+
+    test('returns no env when enabled but no endpoint is set', () => {
+        expect(
+            buildClaudeCodeTelemetryEnv(
+                { ...enabledOtel, endpoint: null },
+                { traceparent: '00-abc-def-01', resourceAttributes: {} },
+            ),
+        ).toEqual({});
+    });
+
+    test('enables Claude Code tracing and points it at the collector', () => {
+        const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
+            traceparent: null,
+            resourceAttributes: {},
+        });
+
+        expect(env).toEqual({
+            CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+            CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: '1',
+            OTEL_TRACES_EXPORTER: 'otlp',
+            OTEL_METRICS_EXPORTER: 'none',
+            OTEL_LOGS_EXPORTER: 'none',
+            OTEL_LOG_USER_PROMPTS: '1',
+            OTEL_LOG_TOOL_DETAILS: '1',
+            OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
+            OTEL_EXPORTER_OTLP_ENDPOINT: 'http://collector.internal:4318',
+            OTEL_TRACES_EXPORT_INTERVAL: '1000',
+        });
+    });
+
+    test('captures prompts + tool details but not raw API bodies', () => {
+        const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
+            traceparent: null,
+            resourceAttributes: {},
+        });
+
+        expect(env.OTEL_LOG_USER_PROMPTS).toBe('1');
+        expect(env.OTEL_LOG_TOOL_DETAILS).toBe('1');
+        expect(env).not.toHaveProperty('OTEL_LOG_RAW_API_BODIES');
+    });
+
+    test('includes TRACEPARENT, headers and serialized resource attributes when provided', () => {
+        const env = buildClaudeCodeTelemetryEnv(
+            { ...enabledOtel, headers: 'authorization=Bearer token' },
+            {
+                traceparent:
+                    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+                resourceAttributes: {
+                    'service.name': 'lightdash-data-app',
+                    'data_app.app_uuid': 'app-1',
+                    'organization.uuid': 'org-1',
+                },
+            },
+        );
+
+        expect(env.TRACEPARENT).toBe(
+            '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+        );
+        expect(env.OTEL_EXPORTER_OTLP_HEADERS).toBe(
+            'authorization=Bearer token',
+        );
+        expect(env.OTEL_RESOURCE_ATTRIBUTES).toBe(
+            'service.name=lightdash-data-app,data_app.app_uuid=app-1,organization.uuid=org-1',
+        );
+    });
+
+    test('skips resource-attribute values that would corrupt the list or are empty', () => {
+        const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
+            traceparent: null,
+            resourceAttributes: {
+                good: 'value',
+                empty: '',
+                withComma: 'a,b',
+                withEquals: 'a=b',
+            },
+        });
+
+        expect(env.OTEL_RESOURCE_ATTRIBUTES).toBe('good=value');
+    });
+});
+
 describe('claudeCodeAllowedHosts', () => {
+    const enabledOtel: ClaudeCodeOtelConfig = {
+        enabled: true,
+        endpoint: 'http://collector.internal:4318',
+        protocol: 'http/protobuf',
+        headers: null,
+    };
+
     test('allows only api.anthropic.com when not using Bedrock', () => {
         expect(
             claudeCodeAllowedHosts({
                 defaultProvider: 'openai',
                 providers: {},
             }),
+        ).toEqual(['api.anthropic.com']);
+    });
+
+    test('appends the OTLP collector host when OTEL is enabled', () => {
+        expect(
+            claudeCodeAllowedHosts(
+                { defaultProvider: 'openai', providers: {} },
+                enabledOtel,
+            ),
+        ).toEqual(['api.anthropic.com', 'collector.internal']);
+    });
+
+    test('does NOT append a collector host when OTEL is disabled', () => {
+        expect(
+            claudeCodeAllowedHosts(
+                { defaultProvider: 'openai', providers: {} },
+                { ...enabledOtel, enabled: false },
+            ),
+        ).toEqual(['api.anthropic.com']);
+    });
+
+    test('ignores a malformed OTLP endpoint rather than opening an invalid host', () => {
+        expect(
+            claudeCodeAllowedHosts(
+                { defaultProvider: 'openai', providers: {} },
+                { ...enabledOtel, endpoint: 'not a url' },
+            ),
         ).toEqual(['api.anthropic.com']);
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
@@ -189,6 +189,15 @@ describe('buildClaudeCodeTelemetryEnv', () => {
         ).toEqual({});
     });
 
+    test('returns no env when the endpoint is not a parseable URL', () => {
+        expect(
+            buildClaudeCodeTelemetryEnv(
+                { ...enabledOtel, endpoint: 'not a url' },
+                { traceparent: '00-abc-def-01', resourceAttributes: {} },
+            ),
+        ).toEqual({});
+    });
+
     test('enables Claude Code tracing and points it at the collector', () => {
         const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
             traceparent: null,
@@ -206,6 +215,7 @@ describe('buildClaudeCodeTelemetryEnv', () => {
             OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
             OTEL_EXPORTER_OTLP_ENDPOINT: 'http://collector.internal:4318',
             OTEL_TRACES_EXPORT_INTERVAL: '1000',
+            OTEL_EXPORTER_OTLP_TIMEOUT: '3000',
         });
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
@@ -140,14 +140,30 @@ const serializeResourceAttributes = (
         .join(',');
 
 /**
+ * Returns the host of an OTLP endpoint, or null when it is not a parseable URL.
+ * Shared so the telemetry env and the firewall allowlist agree on what counts as
+ * a usable endpoint — a malformed one is treated as no endpoint by both.
+ */
+const otelEndpointHost = (endpoint: string): string | null => {
+    try {
+        return new URL(endpoint).hostname || null;
+    } catch {
+        return null;
+    }
+};
+
+/**
  * Builds the OpenTelemetry env that turns on Claude Code's native tracing inside
  * the sandbox and exports it to the configured OTLP collector. Returns an empty
- * object (no telemetry) when disabled or no endpoint is set. Data apps opt INTO
- * prompt + tool-detail capture (`OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_DETAILS`)
- * since the generation PII surface is bounded — metadata-only schema + prompt, no
- * warehouse rows except opt-in sample data. Raw API bodies stay off. Cost is not
- * exported here (it is a metric, not a span attribute) — it stays on the stdout
- * passthrough; the metrics exporter is off so the sandbox is traces-only.
+ * object (no telemetry) when disabled, no endpoint is set, or the endpoint is not
+ * a parseable URL — a broken endpoint can never be exported to (the firewall
+ * allowlist rejects it too), so we leave the sandbox env clean rather than
+ * injecting an unusable exporter config. Data apps opt INTO prompt + tool-detail
+ * capture (`OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_DETAILS`) since the generation
+ * PII surface is bounded — metadata-only schema + prompt, no warehouse rows
+ * except opt-in sample data. Raw API bodies stay off. Cost is not exported here
+ * (it is a metric, not a span attribute) — it stays on the stdout passthrough;
+ * the metrics exporter is off so the sandbox is traces-only.
  */
 export const buildClaudeCodeTelemetryEnv = (
     otel: ClaudeCodeOtelConfig,
@@ -156,7 +172,7 @@ export const buildClaudeCodeTelemetryEnv = (
         resourceAttributes: Record<string, string>;
     },
 ): Record<string, string> => {
-    if (!otel.enabled || !otel.endpoint) {
+    if (!otel.enabled || !otel.endpoint || !otelEndpointHost(otel.endpoint)) {
         return {};
     }
     const resourceAttributes = serializeResourceAttributes(
@@ -176,6 +192,9 @@ export const buildClaudeCodeTelemetryEnv = (
         OTEL_EXPORTER_OTLP_ENDPOINT: otel.endpoint,
         // Short-lived runs: flush fast so spans land before sandbox teardown.
         OTEL_TRACES_EXPORT_INTERVAL: '1000',
+        // Cap each exporter HTTP call so an unreachable or slow collector can't
+        // add flush latency to sandbox teardown.
+        OTEL_EXPORTER_OTLP_TIMEOUT: '3000',
         ...(otel.headers ? { OTEL_EXPORTER_OTLP_HEADERS: otel.headers } : {}),
         ...(options.traceparent ? { TRACEPARENT: options.traceparent } : {}),
         ...(resourceAttributes
@@ -205,15 +224,11 @@ export const claudeCodeAllowedHosts = (
           ];
 
     if (otel?.enabled && otel.endpoint) {
-        try {
-            const host = new URL(otel.endpoint).hostname;
-            if (host) {
-                return [...llmHosts, host];
-            }
-        } catch {
-            // Malformed endpoint — leave the allowlist unchanged rather than
-            // opening an invalid host. The exporter will simply fail to reach
-            // an unconfigured collector.
+        // Malformed endpoint → host is null, allowlist left unchanged rather
+        // than opening an invalid host.
+        const host = otelEndpointHost(otel.endpoint);
+        if (host) {
+            return [...llmHosts, host];
         }
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
@@ -28,6 +28,19 @@ export type ClaudeCodeProviderConfig = {
 };
 
 /**
+ * The OpenTelemetry export config for the data-app sandbox. Structurally a
+ * subset of `lightdashConfig.appRuntime.otel`, so it can be passed straight
+ * through. When `enabled` with an `endpoint`, Claude Code's native OTEL tracing
+ * is turned on inside the sandbox and pointed at the OTLP collector.
+ */
+export type ClaudeCodeOtelConfig = {
+    enabled: boolean;
+    endpoint: string | null;
+    protocol: string;
+    headers: string | null;
+};
+
+/**
  * Resolves the Bedrock config the data-apps pipeline should use:
  * - not on Bedrock (`AI_DEFAULT_PROVIDER` ≠ bedrock) → null (use the Anthropic API)
  * - on Bedrock with credentials + region → the config
@@ -113,20 +126,96 @@ export const describeClaudeCodeEnv = (env: Record<string, string>): string => {
 };
 
 /**
+ * Serializes resource attributes into the `OTEL_RESOURCE_ATTRIBUTES` format
+ * (comma-separated `key=value`). Values containing `,` or `=` would corrupt the
+ * list, and empty values add nothing, so both are skipped defensively. Our
+ * attribution values (uuids, install id) are safe.
+ */
+const serializeResourceAttributes = (
+    attributes: Record<string, string>,
+): string =>
+    Object.entries(attributes)
+        .filter(([, value]) => value !== '' && !/[,=]/.test(value))
+        .map(([key, value]) => `${key}=${value}`)
+        .join(',');
+
+/**
+ * Builds the OpenTelemetry env that turns on Claude Code's native tracing inside
+ * the sandbox and exports it to the configured OTLP collector. Returns an empty
+ * object (no telemetry) when disabled or no endpoint is set. Data apps opt INTO
+ * prompt + tool-detail capture (`OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_DETAILS`)
+ * since the generation PII surface is bounded — metadata-only schema + prompt, no
+ * warehouse rows except opt-in sample data. Raw API bodies stay off. Cost is not
+ * exported here (it is a metric, not a span attribute) — it stays on the stdout
+ * passthrough; the metrics exporter is off so the sandbox is traces-only.
+ */
+export const buildClaudeCodeTelemetryEnv = (
+    otel: ClaudeCodeOtelConfig,
+    options: {
+        traceparent: string | null;
+        resourceAttributes: Record<string, string>;
+    },
+): Record<string, string> => {
+    if (!otel.enabled || !otel.endpoint) {
+        return {};
+    }
+    const resourceAttributes = serializeResourceAttributes(
+        options.resourceAttributes,
+    );
+    return {
+        CLAUDE_CODE_ENABLE_TELEMETRY: '1',
+        CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: '1',
+        OTEL_TRACES_EXPORTER: 'otlp',
+        OTEL_METRICS_EXPORTER: 'none',
+        OTEL_LOGS_EXPORTER: 'none',
+        // Capture the prompt + tool details on the data-app spans (opt-in,
+        // bounded PII surface). Raw API bodies stay off.
+        OTEL_LOG_USER_PROMPTS: '1',
+        OTEL_LOG_TOOL_DETAILS: '1',
+        OTEL_EXPORTER_OTLP_PROTOCOL: otel.protocol,
+        OTEL_EXPORTER_OTLP_ENDPOINT: otel.endpoint,
+        // Short-lived runs: flush fast so spans land before sandbox teardown.
+        OTEL_TRACES_EXPORT_INTERVAL: '1000',
+        ...(otel.headers ? { OTEL_EXPORTER_OTLP_HEADERS: otel.headers } : {}),
+        ...(options.traceparent ? { TRACEPARENT: options.traceparent } : {}),
+        ...(resourceAttributes
+            ? { OTEL_RESOURCE_ATTRIBUTES: resourceAttributes }
+            : {}),
+    };
+};
+
+/**
  * The egress allowlist for the E2B sandbox firewall. Data apps deny all
  * outbound traffic except the LLM endpoint, so this must follow the same
  * provider switch as the env: the Bedrock runtime + control-plane hosts for
- * the region in Bedrock mode, otherwise the Anthropic API host.
+ * the region in Bedrock mode, otherwise the Anthropic API host. When OTEL
+ * export is enabled, the OTLP collector host is also allowed so the exporter's
+ * POSTs are not blocked.
  */
 export const claudeCodeAllowedHosts = (
     copilot: ClaudeCodeProviderConfig,
+    otel?: ClaudeCodeOtelConfig,
 ): string[] => {
     const bedrock = resolveBedrockConfig(copilot);
-    if (!bedrock) {
-        return ['api.anthropic.com'];
+    const llmHosts = !bedrock
+        ? ['api.anthropic.com']
+        : [
+              `bedrock-runtime.${bedrock.region}.amazonaws.com`,
+              `bedrock.${bedrock.region}.amazonaws.com`,
+          ];
+
+    if (otel?.enabled && otel.endpoint) {
+        try {
+            const host = new URL(otel.endpoint).hostname;
+            if (host) {
+                return [...llmHosts, host];
+            }
+        } catch {
+            // Malformed endpoint — leave the allowlist unchanged rather than
+            // opening an invalid host. The exporter will simply fail to reach
+            // an unconfigured collector.
+        }
     }
-    return [
-        `bedrock-runtime.${bedrock.region}.amazonaws.com`,
-        `bedrock.${bedrock.region}.amazonaws.com`,
-    ];
+
+    return llmHosts;
 };

--- a/packages/backend/src/tracing/tracing.ts
+++ b/packages/backend/src/tracing/tracing.ts
@@ -5,6 +5,7 @@ import type {
 } from '@opentelemetry/api';
 import {
     context,
+    isSpanContextValid,
     propagation,
     SpanStatusCode,
     trace,
@@ -138,6 +139,20 @@ export const getOtelTraceHeaders = (): OtelTraceHeaders => {
 
     const carrier: Record<string, string> = {};
     propagation.inject(context.active(), carrier);
+
+    // When @sentry/node is initialized it registers its own (sentry-trace)
+    // propagator as the OTel global, so `propagation.inject` above never emits a
+    // W3C `traceparent`. Derive it from the active span context directly so
+    // downstream OTLP consumers (e.g. Claude Code in the data-app sandbox) get a
+    // valid header to nest under.
+    if (!carrier.traceparent) {
+        const spanContext = trace.getSpanContext(context.active());
+        if (spanContext && isSpanContextValid(spanContext)) {
+            // sampled flag = lowest bit of traceFlags; `% 2` avoids no-bitwise.
+            const sampledFlag = spanContext.traceFlags % 2 === 1 ? '01' : '00';
+            carrier.traceparent = `00-${spanContext.traceId}-${spanContext.spanId}-${sampledFlag}`;
+        }
+    }
 
     return {
         traceparent: carrier.traceparent ?? carrier['sentry-trace'],


### PR DESCRIPTION
## What

Traces each data-app generation with Claude Code's native OpenTelemetry export, producing a per-build span waterfall (one span per LLM request and per tool call, with timing and tokens).

- **Backend parent span** — `runPipeline` wraps the generation in a `DataApp.generate` span via `wrapSentryTransaction`, which (after the stacked PR below) also emits an OTLP span through the shared tracer. Tagged with user / org / project / app uuid + install id.
- **Sandbox telemetry** — the e2b sandbox gets Claude Code OTEL turned on (`CLAUDE_CODE_ENABLE_TELEMETRY` + enhanced-telemetry beta) plus the active trace's `TRACEPARENT`, so the `claude_code.*` spans nest under the backend parent. Attribution is passed as OTEL resource attributes.
- **Payload capture** — data apps opt into prompt + tool-detail capture (`OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_DETAILS`) for richer AI debugging; the generation PII surface is bounded (metadata-only schema + prompt, no warehouse rows except opt-in sample data). Raw API bodies (`OTEL_LOG_RAW_API_BODIES`) stay off.
- **Egress** — the OTLP collector host is added to the sandbox firewall allowlist when tracing is enabled.
- **Config** — reuses the shared `LIGHTDASH_OTEL_TRACES_ENABLED` + `OTEL_EXPORTER_OTLP_ENDPOINT` (no data-app-specific OTEL env vars).
- **Local harness** — adds a `jaeger` service to `docker-compose.infra.yml` for verifying traces locally.

## Why

Gives per-tool timing, overall speed, context-window size (tokens per request), prompts/tool detail for debugging, and attribution by user/org/app. Cost stays on the existing stdout passthrough (it is an OTEL metric, not a span attribute).

## Verification

Verified end-to-end against a real e2b generation: the full `claude_code.*` waterfall lands nested under the backend `DataApp.generate` span, with token counts, per-tool timing, and the attribution attributes. Backend typecheck and unit tests pass.

## Notes

Stacked on #24579 (shared OTLP trace export) — the base of this PR is that branch.

Closes: GLITCH-521