### PR TITLE
fix: escape user-attribute values when compiling warehouse SQL

### DIFF
--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -4,6 +4,7 @@ import {
     NotFoundError,
     OpenIdIdentityIssuerType,
     OrganizationMemberRole,
+    ParameterError,
     ProjectMemberRole,
     SessionUser,
 } from '@lightdash/common';
@@ -61,6 +62,7 @@ const userModel = {
     findServiceAccountByUserUuid: jest.fn(async () => undefined),
     joinOrg: jest.fn(async () => sessionUser),
     hasUsers: jest.fn(async () => false),
+    updateUser: jest.fn(async () => sessionUser),
 };
 
 const openIdIdentityModel = {
@@ -194,6 +196,26 @@ describe('UserService', () => {
                 serviceAccountDescription: 'CI preview',
             });
             expect(account.user.id).toBe('userUuid');
+        });
+    });
+
+    describe('updateUser', () => {
+        test('should reject an invalid email before persisting', async () => {
+            await expect(
+                userService.updateUser(sessionUser, {
+                    email: "x' OR '1'='1@evil.com",
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(userModel.updateUser).not.toHaveBeenCalled();
+        });
+
+        test('should persist a valid email', async () => {
+            await userService.updateUser(sessionUser, {
+                firstName: 'firstName',
+                lastName: 'lastName',
+                email: sessionUser.email!,
+            });
+            expect(userModel.updateUser).toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -49,6 +49,7 @@ import {
     UpdateUserArgs,
     UpsertUserWarehouseCredentials,
     UserAllowedOrganization,
+    validateEmail,
     validateOrganizationEmailDomains,
     validateOrganizationNameOrThrow,
     WarehouseTypes,
@@ -1426,6 +1427,10 @@ export class UserService extends BaseService {
         data: Partial<UpdateUserArgs>,
     ): Promise<LightdashUser> {
         const emailChanged = data.email && user.email !== data.email;
+
+        if (data.email !== undefined && !validateEmail(data.email)) {
+            throw new ParameterError(`Invalid email: ${data.email}`);
+        }
 
         if (
             data.timezone !== undefined &&

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -91,6 +91,7 @@ import {
     getJoinType,
     isInflationProofMetric,
     replaceUserAttributesAsStrings,
+    replaceUserAttributesInSqlTable,
     replaceUserAttributesRaw,
     sortDayOfWeekName,
     sortMonthName,
@@ -1917,7 +1918,7 @@ export class MetricQueryBuilder {
             intrinsicUserAttributes,
             userAttributes = {},
         } = this.args;
-        const baseTable = replaceUserAttributesRaw(
+        const baseTable = replaceUserAttributesInSqlTable(
             explore.tables[explore.baseTable].sqlTable,
             intrinsicUserAttributes,
             userAttributes,
@@ -1980,7 +1981,7 @@ export class MetricQueryBuilder {
         const joinSQL = explore.joinedTables
             .filter((join) => joinedTables.has(join.table) || join.always)
             .map((join) => {
-                const joinTable = replaceUserAttributesRaw(
+                const joinTable = replaceUserAttributesInSqlTable(
                     explore.tables[join.table].sqlTable,
                     intrinsicUserAttributes,
                     userAttributes,
@@ -2407,7 +2408,7 @@ export class MetricQueryBuilder {
                  * - Only join keys table and metrics table
                  * - No filters needed
                  */
-                const joinTable = replaceUserAttributesRaw(
+                const joinTable = replaceUserAttributesInSqlTable(
                     table.sqlTable,
                     intrinsicUserAttributes,
                     userAttributes,
@@ -2564,7 +2565,7 @@ export class MetricQueryBuilder {
                          * - Only join keys table and metrics table
                          * - No filters needed
                          */
-                        const popJoinTable = replaceUserAttributesRaw(
+                        const popJoinTable = replaceUserAttributesInSqlTable(
                             table.sqlTable,
                             intrinsicUserAttributes,
                             userAttributes,

--- a/packages/backend/src/utils/QueryBuilder/utils.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.test.ts
@@ -37,6 +37,7 @@ import {
     getCustomSqlDimensionSql,
     getJoinedTables,
     replaceUserAttributesAsStrings,
+    replaceUserAttributesInSqlTable,
     sortDayOfWeekName,
     sortMonthName,
 } from './utils';
@@ -210,6 +211,71 @@ describe('replaceUserAttributes', () => {
                 warehouseClientMock,
             ),
         ).toEqual('(\'mock@lightdash.com\' = "mock@lightdash.com")');
+    });
+
+    it('should escape single quotes in a user attribute value to prevent SQL injection', () => {
+        expect(
+            replaceUserAttributesAsStrings(
+                'email = ${lightdash.attribute.region}',
+                INTRINSIC_USER_ATTRIBUTES,
+                { region: ["x' OR '1'='1"] },
+                warehouseClientMock,
+            ),
+        ).toEqual("(email = 'x'' OR ''1''=''1')");
+    });
+
+    it('should escape an intrinsic email value containing quotes and comments', () => {
+        expect(
+            replaceUserAttributesAsStrings(
+                'customer_email = ${lightdash.user.email}',
+                { email: "x'/**/OR/**/1=1/**/--@evil.com" },
+                {},
+                warehouseClientMock,
+            ),
+        ).toEqual("(customer_email = 'x''OR1=1')");
+    });
+
+    it('should escape every value in a multi-value user attribute', () => {
+        expect(
+            replaceUserAttributesAsStrings(
+                'region IN (${lightdash.attribute.region})',
+                INTRINSIC_USER_ATTRIBUTES,
+                { region: ['EU', "x'; DROP TABLE users; --"] },
+                warehouseClientMock,
+            ),
+        ).toEqual("(region IN ('EU', 'x''; DROP TABLE users; '))");
+    });
+});
+
+describe('replaceUserAttributesInSqlTable', () => {
+    it('should interpolate an identifier-safe user attribute into a table reference', () => {
+        expect(
+            replaceUserAttributesInSqlTable(
+                'analytics_${lightdash.attribute.tenant}.orders',
+                INTRINSIC_USER_ATTRIBUTES,
+                { tenant: ['acme'] },
+            ),
+        ).toEqual('analytics_acme.orders');
+    });
+
+    it('should throw when a user attribute value is not identifier-safe', () => {
+        expect(() =>
+            replaceUserAttributesInSqlTable(
+                'analytics_${lightdash.attribute.tenant}.orders',
+                INTRINSIC_USER_ATTRIBUTES,
+                { tenant: ['acme JOIN secrets s ON 1=1 --'] },
+            ),
+        ).toThrow(ForbiddenError);
+    });
+
+    it('should not run validation when the table references no user attributes', () => {
+        expect(
+            replaceUserAttributesInSqlTable(
+                'analytics.orders',
+                INTRINSIC_USER_ATTRIBUTES,
+                { tenant: ["x'; DROP TABLE users; --"] },
+            ),
+        ).toEqual('analytics.orders');
     });
 });
 

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -164,10 +164,12 @@ export const replaceLightdashValues = (
         // ! This is only for error messages so we can reuse the same function for user attributes and parameters
         replacementName = 'user attribute',
         cast,
+        escapeString,
     }: {
         throwOnMissing?: boolean;
         replacementName?: 'user attribute' | 'parameter';
         cast?: 'DATE';
+        escapeString?: (value: string) => string;
     } = {},
 ): {
     replacedSql: string;
@@ -213,19 +215,23 @@ export const replaceLightdashValues = (
                 );
             }
 
+            const escape = escapeString ?? ((value: string) => value);
+
             let valueString: string;
             if (isArray(attributeValues)) {
                 valueString = attributeValues
                     .map((attributeValue) =>
                         typeof attributeValue === 'number'
                             ? String(attributeValue)
-                            : `${quoteChar}${attributeValue}${quoteChar}`,
+                            : `${quoteChar}${escape(attributeValue)}${quoteChar}`,
                     )
                     .join(', ');
             } else if (typeof attributeValues === 'number') {
                 valueString = String(attributeValues);
             } else {
-                const quotedValue = `${quoteChar}${attributeValues}${quoteChar}`;
+                const quotedValue = `${quoteChar}${escape(
+                    attributeValues,
+                )}${quoteChar}`;
                 valueString =
                     cast === 'DATE'
                         ? `CAST(${quotedValue} AS DATE)`
@@ -251,6 +257,7 @@ export const replaceUserAttributes = (
     userAttributes: UserAttributeValueMap,
     quoteChar: string,
     wrapChar: string,
+    escapeString: (value: string) => string,
 ): string => {
     // Replace user attributes in the SQL filter
     const { replacedSql: replacedSqlFilter } = replaceLightdashValues(
@@ -259,6 +266,7 @@ export const replaceUserAttributes = (
         userAttributes,
         quoteChar,
         wrapChar,
+        { escapeString },
     );
 
     // Replace intrinsic user attributes in the SQL filter
@@ -268,6 +276,7 @@ export const replaceUserAttributes = (
         intrinsicUserAttributes,
         quoteChar,
         wrapChar,
+        { escapeString },
     );
 
     return replacedSql;
@@ -286,6 +295,7 @@ export const replaceUserAttributesAsStrings = (
         userAttributes,
         warehouseSqlBuilder.getStringQuoteChar(),
         opts?.noWrap ? '' : '(',
+        warehouseSqlBuilder.escapeString.bind(warehouseSqlBuilder),
     );
 
 export const replaceUserAttributesRaw = (
@@ -293,7 +303,43 @@ export const replaceUserAttributesRaw = (
     intrinsicUserAttributes: IntrinsicUserAttributes,
     userAttributes: UserAttributeValueMap,
 ) =>
-    replaceUserAttributes(sql, intrinsicUserAttributes, userAttributes, '', '');
+    // Raw replacement relies on a downstream compiler (e.g. the filter compiler)
+    // to quote/escape the value, so it is not escaped here.
+    replaceUserAttributes(
+        sql,
+        intrinsicUserAttributes,
+        userAttributes,
+        '',
+        '',
+        (value) => value,
+    );
+
+// A table-reference position (FROM/JOIN) cannot be quoted as a string literal,
+// so escaping is not enough to neutralise a malicious value. Restrict it to
+// identifier-safe characters and reject anything that could break out into
+// structural SQL.
+const assertSafeSqlIdentifierValue = (value: string): string => {
+    if (!/^[A-Za-z0-9_.-]*$/.test(value)) {
+        throw new ForbiddenError(
+            `User attribute value "${value}" contains characters that are not allowed in a table reference`,
+        );
+    }
+    return value;
+};
+
+export const replaceUserAttributesInSqlTable = (
+    sql: string,
+    intrinsicUserAttributes: IntrinsicUserAttributes,
+    userAttributes: UserAttributeValueMap,
+) =>
+    replaceUserAttributes(
+        sql,
+        intrinsicUserAttributes,
+        userAttributes,
+        '',
+        '',
+        assertSafeSqlIdentifierValue,
+    );
 
 export const assertValidDimensionRequiredAttribute = (
     dimension: CompiledDimension,
@@ -617,7 +663,7 @@ export const getCustomBinDimensionSql = ({
                     adapterType,
                     startOfWeek,
                 });
-                const baseTable = replaceUserAttributesRaw(
+                const baseTable = replaceUserAttributesInSqlTable(
                     explore.tables[customDimension.table].sqlTable,
                     intrinsicUserAttributes,
                     userAttributes,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8409

### Description:

User-attribute and intrinsic values (e.g. `${lightdash.user.email}`, `${ld.attributes.X}`) were substituted into warehouse SQL without escaping, unlike the parameter path which already escapes via the warehouse client. This routes those values through the warehouse client's `escapeString` in the string-literal substitution path, threading the escape as a required hook through `replaceUserAttributes` (the raw filter path stays identity since the filter compiler escapes downstream). Table-reference (`FROM`/`JOIN`) substitutions now go through a new `replaceUserAttributesInSqlTable` wrapper that allow-lists identifier-safe values, and the email format is now validated on user self-update (`PATCH /user/me`). Adds unit tests covering escaping, the table-reference allow-list, and email validation.