### PR TITLE
feat(pivot): graduate pivot-column-sort flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -158,16 +158,6 @@ export enum FeatureFlags {
     LockDashboardFilters = 'lock-dashboard-filters',
 
     /**
-     * Enable the new pivot-column-sort UI: per-pivot-column sort menu on
-     * pivot table headers, sort-direction indicators, and the pinned
-     * pivot-column entries in the Sort popover. Backend support
-     * (per-metric anchor CTE, pivot_values persistence) is always on;
-     * this flag only gates the UI/UX so we can validate with design
-     * partners before announcing GA.
-     */
-    PivotColumnSort = 'pivot-column-sort',
-
-    /**
      * Gate the "Schedule delivery" entry point for data apps. Disabled by
      * default while the screenshot pipeline is producing blank pages in
      * production. Enable per-org once the underlying rendering issue is

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -6,7 +6,6 @@ import {
     getHiddenTableFields,
     getPivotConfig,
     NotFoundError,
-    FeatureFlags,
     type ApiErrorDetail,
     type ChartConfig,
     type ChartType,
@@ -48,7 +47,6 @@ import { uploadGsheet } from '../../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useExplore } from '../../../hooks/useExplore';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
@@ -94,11 +92,6 @@ const VisualizationCard: FC<Props> = memo((props) => {
     const savedChart = useExplorerSelector(selectSavedChart);
 
     const sorts = useExplorerSelector(selectSorts);
-
-    const { data: pivotColumnSortFlag } = useServerFeatureFlag(
-        FeatureFlags.PivotColumnSort,
-    );
-    const isPivotColumnSortEnabled = pivotColumnSortFlag?.enabled ?? false;
 
     const projectUuid = savedChart?.projectUuid || fallBackUUid;
     const stagedColorPaletteUuid = useExplorerSelector(
@@ -363,13 +356,12 @@ const VisualizationCard: FC<Props> = memo((props) => {
                     headerElement={
                         isOpen && (
                             <>
-                                {isPivotColumnSortEnabled &&
-                                    sorts.length > 0 && (
-                                        <SortButton
-                                            sorts={sorts}
-                                            isEditMode={isEditMode}
-                                        />
-                                    )}
+                                {sorts.length > 0 && (
+                                    <SortButton
+                                        sorts={sorts}
+                                        isEditMode={isEditMode}
+                                    />
+                                )}
                                 <VisualizationWarning
                                     dirtyPivotConfiguration={
                                         dirtyPivotConfiguration

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -1,4 +1,3 @@
-import { FeatureFlags } from '@lightdash/common';
 import { Box, Button, Flex, Text } from '@mantine/core';
 import { noop } from '@mantine/utils';
 import { IconAlertCircle, IconRefresh, IconTable } from '@tabler/icons-react';
@@ -7,7 +6,6 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
-import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { computeLimitedRowCount, sliceRows } from '../../utils/sliceRows';
 import LoadingChart from '../common/LoadingChart';
 import PivotTable from '../common/PivotTable';
@@ -56,11 +54,6 @@ const SimpleTable: FC<SimpleTableProps> = ({
         isEditMode,
         parameters,
     } = useVisualizationContext();
-
-    const { data: pivotColumnSortFlag } = useServerFeatureFlag(
-        FeatureFlags.PivotColumnSort,
-    );
-    const isPivotColumnSortEnabled = pivotColumnSortFlag?.enabled ?? false;
 
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -310,11 +303,9 @@ const SimpleTable: FC<SimpleTableProps> = ({
             >
                 {pivotTableData.data && resultsData?.hasFetchedAllRows ? (
                     <>
-                        {/* Dashboard mode has no explorer store — use plain
-                         * table. Gated behind PivotColumnSort flag so we can
-                         * validate the new sort UX with design partners before
-                         * GA. */}
-                        {isDashboard || !isPivotColumnSortEnabled ? (
+                        {/* Dashboard mode has no explorer store — use the plain
+                         * table; the explorer uses the sort-enabled variant. */}
+                        {isDashboard ? (
                             <PivotTable
                                 className={className}
                                 data={pivotTableData.data}


### PR DESCRIPTION
## What & why

Graduates the `pivot-column-sort` feature flag to GA by removing the frontend flag gate, so the pivot-column sort UI ships to everyone:

- per-pivot-column sort menu on table headers
- sort-direction indicators
- pinned pivot-column entries in the Sort popover
- the "Sorted by" badge in the results card

Backend support (per-metric anchor CTE, `pivot_values` persistence) is already always-on — this only removes the UI gating in `SimpleTable` and `VisualizationCard`, plus the `PivotColumnSort` enum member.

First of a 3-PR stack graduating the pivot-tables flags (`pivot-column-sort` → `hide-pivot-dimensions` → `pivot-row-grouping`).

Closes: PROD-8437