### PR TITLE
feat(scheduler): cap concurrent deliveries per org (PROD-7866)

### DIFF
--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -178,7 +178,6 @@ export class ClientRepository
                     analytics: this.context.lightdashAnalytics,
                     schedulerModel: this.models.getSchedulerModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
-                    organizationModel: this.models.getOrganizationModel(),
                 }),
         );
     }

--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -177,6 +177,8 @@ export class ClientRepository
                     lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     schedulerModel: this.models.getSchedulerModel(),
+                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    organizationModel: this.models.getOrganizationModel(),
                 }),
         );
     }

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -834,7 +834,6 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     schedulerModel: models.getSchedulerModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
-                    organizationModel: models.getOrganizationModel(),
                 }),
             slackClient: ({ context, models, repository }) =>
                 new CommercialSlackClient({

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -833,6 +833,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
                     schedulerModel: models.getSchedulerModel(),
+                    featureFlagModel: models.getFeatureFlagModel(),
+                    organizationModel: models.getOrganizationModel(),
                 }),
             slackClient: ({ context, models, repository }) =>
                 new CommercialSlackClient({

--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -6,7 +6,6 @@ import {
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { type LightdashConfig } from '../config/parseConfig';
 import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
-import { OrganizationModel } from '../models/OrganizationModel';
 import { SchedulerModel } from '../models/SchedulerModel';
 import { getOrgDeliveryQueueName, SchedulerClient } from './SchedulerClient';
 
@@ -19,13 +18,8 @@ jest.mock('graphile-worker', () => ({
 }));
 
 const ORG_UUID = 'org-1';
-const ORG_NAME = 'Org One';
 
-const makeClient = (
-    allowMultiOrgs: boolean,
-    get: jest.Mock,
-    orgGet: jest.Mock = jest.fn().mockResolvedValue({ name: ORG_NAME }),
-) =>
+const makeClient = (allowMultiOrgs: boolean, get: jest.Mock) =>
     new SchedulerClient({
         lightdashConfig: {
             allowMultiOrgs,
@@ -36,7 +30,6 @@ const makeClient = (
             logSchedulerJob: jest.fn().mockResolvedValue(undefined),
         } as unknown as SchedulerModel,
         featureFlagModel: { get } as unknown as FeatureFlagModel,
-        organizationModel: { get: orgGet } as unknown as OrganizationModel,
     });
 
 const scheduler = {
@@ -85,12 +78,11 @@ describe('SchedulerClient per-org delivery queue', () => {
                 (call) => call[3] === getOrgDeliveryQueueName(ORG_UUID),
             ),
         ).toBe(true);
-        // Flag evaluated per-org with the resolved organization name.
+        // Flag evaluated per-org for the scheduler's user + organization.
         expect(get).toHaveBeenCalledWith({
             user: {
                 userUuid: 'user-1',
                 organizationUuid: ORG_UUID,
-                organizationName: ORG_NAME,
             },
             featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
         });
@@ -119,10 +111,9 @@ describe('SchedulerClient per-org delivery queue', () => {
         );
     });
 
-    it('skips the org + flag lookups entirely on single-tenant instances', async () => {
+    it('skips the flag lookup entirely on single-tenant instances', async () => {
         const get = jest.fn();
-        const orgGet = jest.fn();
-        const client = makeClient(false, get, orgGet);
+        const client = makeClient(false, get);
         const addJob = jest
             .spyOn(client, 'addScheduledDeliveryJob')
             .mockResolvedValue({ jobId: 'j1', date: new Date() });
@@ -134,7 +125,6 @@ describe('SchedulerClient per-org delivery queue', () => {
             startingDateTime,
         );
 
-        expect(orgGet).not.toHaveBeenCalled();
         expect(get).not.toHaveBeenCalled();
         expect(addJob).toHaveBeenCalled();
         expect(addJob.mock.calls.every((call) => call[3] === undefined)).toBe(

--- a/packages/backend/src/scheduler/SchedulerClient.test.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.test.ts
@@ -1,0 +1,144 @@
+import {
+    FeatureFlags,
+    SchedulerAndTargets,
+    TraceTaskBase,
+} from '@lightdash/common';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import { type LightdashConfig } from '../config/parseConfig';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationModel } from '../models/OrganizationModel';
+import { SchedulerModel } from '../models/SchedulerModel';
+import { getOrgDeliveryQueueName, SchedulerClient } from './SchedulerClient';
+
+// The constructor eagerly calls makeWorkerUtils() to connect to graphile-worker;
+// stub it so we can construct the client without a database.
+jest.mock('graphile-worker', () => ({
+    makeWorkerUtils: jest
+        .fn()
+        .mockResolvedValue({ addJob: jest.fn(), withPgClient: jest.fn() }),
+}));
+
+const ORG_UUID = 'org-1';
+const ORG_NAME = 'Org One';
+
+const makeClient = (
+    allowMultiOrgs: boolean,
+    get: jest.Mock,
+    orgGet: jest.Mock = jest.fn().mockResolvedValue({ name: ORG_NAME }),
+) =>
+    new SchedulerClient({
+        lightdashConfig: {
+            allowMultiOrgs,
+            database: { connectionUri: 'postgres://noop' },
+        } as unknown as LightdashConfig,
+        analytics: { track: jest.fn() } as unknown as LightdashAnalytics,
+        schedulerModel: {
+            logSchedulerJob: jest.fn().mockResolvedValue(undefined),
+        } as unknown as SchedulerModel,
+        featureFlagModel: { get } as unknown as FeatureFlagModel,
+        organizationModel: { get: orgGet } as unknown as OrganizationModel,
+    });
+
+const scheduler = {
+    schedulerUuid: 'sched-1',
+    name: 'test',
+    cron: '0 * * * *', // hourly → 24 jobs for the test day
+    timezone: 'UTC',
+    enabled: true,
+    createdBy: 'user-1',
+    format: 'csv',
+    targets: [],
+} as unknown as SchedulerAndTargets;
+
+const traceProperties: TraceTaskBase = {
+    organizationUuid: ORG_UUID,
+    projectUuid: 'proj-1',
+    userUuid: 'user-1',
+};
+
+// A fixed start-of-day so getDailyDatesFromCron deterministically yields jobs.
+const startingDateTime = new Date(2023, 0, 1);
+
+describe('SchedulerClient per-org delivery queue', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('routes recurring deliveries into a per-org queue when multi-org + flag are on', async () => {
+        const get = jest.fn().mockResolvedValue({
+            id: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+            enabled: true,
+        });
+        const client = makeClient(true, get);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(addJob).toHaveBeenCalled();
+        expect(
+            addJob.mock.calls.every(
+                (call) => call[3] === getOrgDeliveryQueueName(ORG_UUID),
+            ),
+        ).toBe(true);
+        // Flag evaluated per-org with the resolved organization name.
+        expect(get).toHaveBeenCalledWith({
+            user: {
+                userUuid: 'user-1',
+                organizationUuid: ORG_UUID,
+                organizationName: ORG_NAME,
+            },
+            featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+        });
+    });
+
+    it('does not set a queue when the flag is off', async () => {
+        const get = jest.fn().mockResolvedValue({
+            id: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+            enabled: false,
+        });
+        const client = makeClient(true, get);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(addJob).toHaveBeenCalled();
+        expect(addJob.mock.calls.every((call) => call[3] === undefined)).toBe(
+            true,
+        );
+    });
+
+    it('skips the org + flag lookups entirely on single-tenant instances', async () => {
+        const get = jest.fn();
+        const orgGet = jest.fn();
+        const client = makeClient(false, get, orgGet);
+        const addJob = jest
+            .spyOn(client, 'addScheduledDeliveryJob')
+            .mockResolvedValue({ jobId: 'j1', date: new Date() });
+
+        await client.generateDailyJobsForScheduler(
+            scheduler,
+            traceProperties,
+            'UTC',
+            startingDateTime,
+        );
+
+        expect(orgGet).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
+        expect(addJob).toHaveBeenCalled();
+        expect(addJob.mock.calls.every((call) => call[3] === undefined)).toBe(
+            true,
+        );
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -65,7 +65,6 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
 import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
-import { OrganizationModel } from '../models/OrganizationModel';
 import { SchedulerModel } from '../models/SchedulerModel';
 
 type SchedulerClientArguments = {
@@ -73,7 +72,6 @@ type SchedulerClientArguments = {
     analytics: LightdashAnalytics;
     schedulerModel: SchedulerModel;
     featureFlagModel: FeatureFlagModel;
-    organizationModel: OrganizationModel;
 };
 
 const SCHEDULED_JOB_MAX_ATTEMPTS = 1;
@@ -130,8 +128,6 @@ export class SchedulerClient {
 
     featureFlagModel: FeatureFlagModel;
 
-    organizationModel: OrganizationModel;
-
     private static STUCK_JOB_WINDOW = 1.5;
 
     constructor({
@@ -139,13 +135,11 @@ export class SchedulerClient {
         analytics,
         schedulerModel,
         featureFlagModel,
-        organizationModel,
     }: SchedulerClientArguments) {
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.schedulerModel = schedulerModel;
         this.featureFlagModel = featureFlagModel;
-        this.organizationModel = organizationModel;
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
         })
@@ -895,10 +889,8 @@ export class SchedulerClient {
     ): Promise<string | undefined> {
         if (!this.lightdashConfig.allowMultiOrgs) return undefined;
         const { organizationUuid, userUuid } = traceProperties;
-        const { name: organizationName } =
-            await this.organizationModel.get(organizationUuid);
         const { enabled } = await this.featureFlagModel.get({
-            user: { userUuid, organizationUuid, organizationName },
+            user: { userUuid, organizationUuid },
             featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
         });
         return enabled ? getOrgDeliveryQueueName(organizationUuid) : undefined;

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -5,6 +5,7 @@ import {
     CreateSchedulerTarget,
     EmailBatchNotificationPayload,
     EmailNotificationPayload,
+    FeatureFlags,
     getSchedulerTargetUuid,
     getSchedulerUuid,
     GoogleChatBatchNotificationPayload,
@@ -63,15 +64,25 @@ import { nanoid } from 'nanoid';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
+import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
+import { OrganizationModel } from '../models/OrganizationModel';
 import { SchedulerModel } from '../models/SchedulerModel';
 
 type SchedulerClientArguments = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
     schedulerModel: SchedulerModel;
+    featureFlagModel: FeatureFlagModel;
+    organizationModel: OrganizationModel;
 };
 
 const SCHEDULED_JOB_MAX_ATTEMPTS = 1;
+
+// Name of the per-org graphile named queue that serializes an organization's
+// recurring scheduled deliveries. One queue per org → at most one delivery
+// render runs at a time for that org, so it can't starve the worker pool.
+export const getOrgDeliveryQueueName = (organizationUuid: string): string =>
+    `delivery:${organizationUuid}`;
 
 type SchedulablePreAggregate = Omit<
     PreAggregateSchedulerDetails,
@@ -117,16 +128,24 @@ export class SchedulerClient {
 
     schedulerModel: SchedulerModel;
 
+    featureFlagModel: FeatureFlagModel;
+
+    organizationModel: OrganizationModel;
+
     private static STUCK_JOB_WINDOW = 1.5;
 
     constructor({
         lightdashConfig,
         analytics,
         schedulerModel,
+        featureFlagModel,
+        organizationModel,
     }: SchedulerClientArguments) {
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
         this.schedulerModel = schedulerModel;
+        this.featureFlagModel = featureFlagModel;
+        this.organizationModel = organizationModel;
         this.graphileUtils = makeWorkerUtils({
             connectionString: lightdashConfig.database.connectionUri,
         })
@@ -211,6 +230,7 @@ export class SchedulerClient {
         priority: JobPriority,
         maxAttempts: number = SCHEDULED_JOB_MAX_ATTEMPTS,
         explicitJobKey?: string,
+        queueName?: string,
     ) {
         const messageId = nanoid();
         const jobId = await Sentry.startSpan(
@@ -264,6 +284,9 @@ export class SchedulerClient {
                         // JobKeyMode is by default (replace) which means that if the job already exists it will be replaced if having the same key, which is what we want here - https://worker.graphile.org/docs/job-key
                         // Having this we can remove the duplicate jobs deletion logic
                         ...(jobKey && { jobKey }),
+                        // Named queue makes jobs run serially per queue (graphile-worker).
+                        // Used to cap concurrent deliveries per org.
+                        ...(queueName && { queueName }),
                     },
                 );
 
@@ -415,6 +438,7 @@ export class SchedulerClient {
         date: Date,
         scheduler: ScheduledDeliveryPayload,
         schedulerUuid: string | undefined, // This detects if a scheduled delivery is to be sent "now"
+        queueName?: string, // When set, jobs run serially in this named queue (per-org delivery cap)
     ) {
         const graphileClient = await this.graphileUtils;
 
@@ -447,6 +471,8 @@ export class SchedulerClient {
             date,
             JobPriority.LOW,
             maxAttempts,
+            undefined,
+            queueName,
         );
         await this.schedulerModel.logSchedulerJob({
             task: SCHEDULER_TASKS.HANDLE_SCHEDULED_DELIVERY,
@@ -856,6 +882,28 @@ export class SchedulerClient {
         };
     }
 
+    /**
+     * On multi-org (shared-tenant) instances with the per-org delivery queue flag
+     * enabled for the org, recurring deliveries are routed into a per-org graphile
+     * named queue so they run serially and can't occupy every worker. Returns the
+     * queue name, or undefined to keep the default (fully parallel) behavior.
+     * Gated cheaply by allowMultiOrgs first to avoid a flag lookup on single-tenant
+     * instances.
+     */
+    private async resolveDeliveryQueueName(
+        traceProperties: TraceTaskBase,
+    ): Promise<string | undefined> {
+        if (!this.lightdashConfig.allowMultiOrgs) return undefined;
+        const { organizationUuid, userUuid } = traceProperties;
+        const { name: organizationName } =
+            await this.organizationModel.get(organizationUuid);
+        const { enabled } = await this.featureFlagModel.get({
+            user: { userUuid, organizationUuid, organizationName },
+            featureFlagId: FeatureFlags.ScheduledDeliveryPerOrgQueue,
+        });
+        return enabled ? getOrgDeliveryQueueName(organizationUuid) : undefined;
+    }
+
     async generateDailyJobsForScheduler(
         scheduler: SchedulerAndTargets,
         traceProperties: TraceTaskBase,
@@ -875,6 +923,9 @@ export class SchedulerClient {
             startingDateTime,
         );
 
+        // Evaluate the per-org queue gate once; the org is constant across all dates.
+        const queueName = await this.resolveDeliveryQueueName(traceProperties);
+
         try {
             const promises = dates.map((date: Date) =>
                 this.addScheduledDeliveryJob(
@@ -884,6 +935,7 @@ export class SchedulerClient {
                         ...traceProperties,
                     },
                     scheduler.schedulerUuid,
+                    queueName,
                 ),
             );
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -51,6 +51,15 @@ export enum FeatureFlags {
     GoogleChatEnabled = 'google-chat-enabled',
 
     /**
+     * On multi-org (shared-tenant) instances, route an organization's recurring
+     * scheduled deliveries into a per-org graphile-worker named queue
+     * (`delivery:<organizationUuid>`) so they run serially and a single org can't
+     * occupy every worker / crash the headless browser pool. Default off; enable
+     * per-org for gradual rollout.
+     */
+    ScheduledDeliveryPerOrgQueue = 'scheduled-delivery-per-org-queue',
+
+    /**
      * Enable admin user impersonation. When disabled, impersonation
      * actions are blocked and active sessions are cleared.
      */


### PR DESCRIPTION
## What
On multi-org (shared-tenant) instances, route an org's recurring scheduled deliveries into a per-org graphile named queue (`delivery:<organizationUuid>`) so they run **serially** — a single org can no longer occupy every worker and crash the headless-browser pool / backend.

## Why
A single org programmatically created **thousands** of scheduled deliveries on the same cron; at the cron tick they saturated every worker and took down deliveries for all tenants on the shared instance. graphile named queues process one job at a time per queue, so keying the queue on the org caps that org's concurrent delivery renders at 1.

## How
- New `scheduled-delivery-per-org-queue` feature flag — **default off**; enable per-org for gradual rollout. Only evaluated on multi-org instances (`allowMultiOrgs`), so single-tenant installs pay nothing.
- `queueName` threaded through `addJob` / `addScheduledDeliveryJob`, resolved once in `generateDailyJobsForScheduler` (the chokepoint for all recurring schedules). Manual "Send now" is unaffected.

## Provenance
This is @IrakliJani's work from the closed #23631 (PROD-7866), picked up from the support handover. Rebased onto current main (the branch was ~950 commits behind) and adapted to one upstream change: `FeatureFlagModel.get`'s `user` arg no longer accepts `organizationName`, so the obsolete `OrganizationModel` lookup that existed only to supply it has been dropped — the flag now evaluates from `userUuid` + `organizationUuid` alone (one fewer DB lookup per scheduler generation).

## Rollout
Default off (an unregistered flag resolves to disabled — no migration needed).
- **Instance-wide:** `LIGHTDASH_ENABLE_FEATURE_FLAGS=scheduled-delivery-per-org-queue`
- **Per-org (gradual):** a `feature_flags` row + a per-org `feature_flag_overrides` row
- **Kill switch:** `LIGHTDASH_DISABLE_FEATURE_FLAGS=scheduled-delivery-per-org-queue`
- Initial target: the EU shared-tenant cloud instance.

## Test plan
- `SchedulerClient.test.ts` (3 cases): multi-org + flag on → `delivery:<org>`; flag off → no queue; single-tenant → flag never evaluated. ✅
- Backend typecheck + lint clean.
- Manual live integration test (local, `ALLOW_MULTIPLE_ORGS=true` + flag on):
  - recurring delivery → jobs carry `queue_name=delivery:<org>` and a `graphile_worker.job_queues` row is created (the serialization gate) ✅
  - default config (flag off / single-tenant) → `queue_name` NULL, prod path unchanged ✅
  - "Send now" → NULL queue, manual path unaffected ✅
  - two schedulers in the same org → both share the one per-org queue (org-level serialization) ✅

Closes PROD-7866
https://linear.app/lightdash/issue/PROD-7866/limit-concurrent-deliveries-per-org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mo1nMfGmmwnHKXKP7kHQNy
