### PR TITLE
feat: add org AI model defaults

### DIFF
--- a/packages/backend/src/ee/database/entities/ai.ts
+++ b/packages/backend/src/ee/database/entities/ai.ts
@@ -1,4 +1,7 @@
-import { type AiChartRuntimeOverrides } from '@lightdash/common';
+import {
+    type AiAgentModelConfig,
+    type AiChartRuntimeOverrides,
+} from '@lightdash/common';
 import { Knex } from 'knex';
 
 export const AiThreadTableName = 'ai_thread';
@@ -371,6 +374,7 @@ export type DbAiOrganizationSettings = {
     ai_agents_visible: boolean;
     ai_agent_reviews_enabled: boolean;
     mcp_content_writes_enabled: boolean;
+    default_ai_agent_model_config: AiAgentModelConfig | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -381,7 +385,9 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
         Partial<
             Pick<
                 DbAiOrganizationSettings,
-                'ai_agent_reviews_enabled' | 'mcp_content_writes_enabled'
+                | 'ai_agent_reviews_enabled'
+                | 'mcp_content_writes_enabled'
+                | 'default_ai_agent_model_config'
             >
         >,
     Partial<
@@ -390,6 +396,7 @@ export type AiOrganizationSettingsTable = Knex.CompositeTableType<
             | 'ai_agents_visible'
             | 'ai_agent_reviews_enabled'
             | 'mcp_content_writes_enabled'
+            | 'default_ai_agent_model_config'
         >
     >
 >;

--- a/packages/backend/src/ee/database/migrations/20260623120000_add_default_ai_agent_model_config_to_ai_organization_settings.ts
+++ b/packages/backend/src/ee/database/migrations/20260623120000_add_default_ai_agent_model_config_to_ai_organization_settings.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const aiOrganizationSettings = 'ai_organization_settings';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.jsonb('default_ai_agent_model_config').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(aiOrganizationSettings, (table) => {
+        table.dropColumn('default_ai_agent_model_config');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -4334,6 +4334,7 @@ export class AiAgentModel {
                     ai_thread_uuid: data.threadUuid,
                     created_by_user_uuid: data.createdByUserUuid,
                     prompt: data.prompt,
+                    model_config: data.modelConfig,
                 })
                 .returning('ai_prompt_uuid');
 

--- a/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
+++ b/packages/backend/src/ee/models/AiOrganizationSettingsModel.ts
@@ -31,6 +31,7 @@ export class AiOrganizationSettingsModel {
             aiAgentsVisible: db.ai_agents_visible,
             aiAgentReviewsEnabled: db.ai_agent_reviews_enabled,
             mcpContentWritesEnabled: db.mcp_content_writes_enabled,
+            defaultAiAgentModelConfig: db.default_ai_agent_model_config,
         };
     }
 
@@ -69,6 +70,7 @@ export class AiOrganizationSettingsModel {
                 ai_agents_visible: data.aiAgentsVisible,
                 ai_agent_reviews_enabled: data.aiAgentReviewsEnabled,
                 mcp_content_writes_enabled: data.mcpContentWritesEnabled,
+                default_ai_agent_model_config: data.defaultAiAgentModelConfig,
             })
             .returning('*');
 
@@ -85,6 +87,7 @@ export class AiOrganizationSettingsModel {
                 | 'ai_agents_visible'
                 | 'ai_agent_reviews_enabled'
                 | 'mcp_content_writes_enabled'
+                | 'default_ai_agent_model_config'
             >
         > = {};
         if (data.aiAgentsVisible !== undefined) {
@@ -96,6 +99,10 @@ export class AiOrganizationSettingsModel {
         if (data.mcpContentWritesEnabled !== undefined) {
             updateData.mcp_content_writes_enabled =
                 data.mcpContentWritesEnabled;
+        }
+        if (data.defaultAiAgentModelConfig !== undefined) {
+            updateData.default_ai_agent_model_config =
+                data.defaultAiAgentModelConfig;
         }
         if (Object.keys(updateData).length === 0) {
             return this.getByOrganizationUuid(organizationUuid);
@@ -131,6 +138,7 @@ export class AiOrganizationSettingsModel {
             aiAgentsVisible: data.aiAgentsVisible ?? true,
             aiAgentReviewsEnabled: data.aiAgentReviewsEnabled ?? false,
             mcpContentWritesEnabled: data.mcpContentWritesEnabled ?? true,
+            defaultAiAgentModelConfig: data.defaultAiAgentModelConfig ?? null,
         });
     }
 

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -325,6 +325,7 @@ describe('AiAgentReviewClassifierService', () => {
             aiAgentsVisible: true,
             aiAgentReviewsEnabled: true,
             mcpContentWritesEnabled: true,
+            defaultAiAgentModelConfig: null,
         });
         model.createRun.mockResolvedValue(makeRun());
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
@@ -379,6 +380,7 @@ describe('AiAgentReviewClassifierService', () => {
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
                 mcpContentWritesEnabled: true,
+                defaultAiAgentModelConfig: null,
             },
         );
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -93,6 +93,7 @@ import {
     UserAttributeValueMap,
     validateAgentSuggestion,
     type AgentSuggestionTool,
+    type AiAgentModelConfig,
     type AiPromptContextInput,
     type SessionUser,
     type SuggestionValidationCatalog,
@@ -7696,6 +7697,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         prompt: string;
         promptSlackTs: string;
         agentUuid: string | null;
+        modelConfig?: AiAgentModelConfig | null;
         threadMessages?: Array<
             Required<Pick<MessageElement, 'text' | 'user' | 'ts'>>
         >;
@@ -7722,13 +7724,22 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 );
         }
 
+        const user = await this.userModel.getUserDetailsByUuid(data.userUuid);
+        if (user.organizationUuid === undefined) {
+            throw new Error('Organization not found');
+        }
+
+        const aiOrganizationSettings = data.modelConfig
+            ? undefined
+            : await this.aiOrganizationSettingsService.getSettings(
+                  user as SessionUser,
+              );
+        const modelConfig =
+            data.modelConfig ??
+            aiOrganizationSettings?.defaultAiAgentModelConfig ??
+            undefined;
+
         if (!threadUuid) {
-            const user = await this.userModel.getUserDetailsByUuid(
-                data.userUuid,
-            );
-            if (user.organizationUuid === undefined) {
-                throw new Error('Organization not found');
-            }
             createdThread = true;
             threadUuid = await this.aiAgentModel.createSlackThread({
                 organizationUuid: user.organizationUuid,
@@ -7759,12 +7770,12 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             threadUuid,
             createdByUserUuid: data.userUuid,
             prompt: AiAgentService.stripSlackMentions(data.prompt),
+            modelConfig,
             slackUserId: data.slackUserId,
             slackChannelId: data.slackChannelId,
             promptSlackTs: data.promptSlackTs,
         });
 
-        const user = await this.userModel.getUserDetailsByUuid(data.userUuid);
         if (user.organizationUuid) {
             this.analytics.track<AiAgentPromptCreatedEvent>({
                 event: 'ai_agent_prompt.created',

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -6,6 +6,7 @@ import {
     ForbiddenError,
     LightdashUser,
     UpdateAiOrganizationSettings,
+    type AiModelOption,
     type SessionUser,
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -13,6 +14,8 @@ import { OrganizationModel } from '../../models/OrganizationModel';
 import { BaseService } from '../../services/BaseService';
 import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
+import { getAvailableModels, getDefaultModel } from './ai/models';
+import { matchesPreset } from './ai/models/presets';
 
 type AiOrganizationSettingsServiceDependencies = {
     aiOrganizationSettingsModel: AiOrganizationSettingsModel;
@@ -67,6 +70,23 @@ export class AiOrganizationSettingsService extends BaseService {
             featureFlagId: CommercialFeatureFlags.AiCopilot,
         });
         return isCopilotEnabled.enabled;
+    }
+
+    private getDefaultModelOptions(): AiModelOption[] {
+        const defaultModel = getDefaultModel(this.lightdashConfig.ai.copilot);
+
+        return getAvailableModels(this.lightdashConfig.ai.copilot).map(
+            (preset) => ({
+                name: preset.name,
+                displayName: preset.displayName,
+                description: preset.description,
+                provider: preset.provider,
+                default:
+                    preset.provider === defaultModel.provider &&
+                    matchesPreset(preset, defaultModel.name),
+                supportsReasoning: preset.supportsReasoning,
+            }),
+        );
     }
 
     /**
@@ -128,6 +148,8 @@ export class AiOrganizationSettingsService extends BaseService {
                 aiAgentsVisible: true,
                 aiAgentReviewsEnabled: false,
                 mcpContentWritesEnabled: true,
+                defaultAiAgentModelConfig: null,
+                defaultAiAgentModelOptions: this.getDefaultModelOptions(),
                 isTrial: isTrialEligible,
             };
         }
@@ -136,6 +158,7 @@ export class AiOrganizationSettingsService extends BaseService {
             ...settings,
             isTrial: isTrialEligible,
             isCopilotEnabled,
+            defaultAiAgentModelOptions: this.getDefaultModelOptions(),
         };
     }
 

--- a/packages/common/src/ee/AiAgent/adminTypes.ts
+++ b/packages/common/src/ee/AiAgent/adminTypes.ts
@@ -3,7 +3,9 @@ import type {
     AiAgentSummary,
     AiAgentThreadSummary,
     AiAgentUser,
+    AiModelOption,
 } from './index';
+import type { AiAgentModelConfig } from './requestTypes';
 
 export type AiAgentAdminFilters = {
     projectUuids?: string[];
@@ -72,6 +74,7 @@ export type ApiAiAgentAdminPromptActivityResponse = ApiSuccess<
 export type ComputedAiOrganizationSettings = {
     isCopilotEnabled: boolean;
     isTrial: boolean;
+    defaultAiAgentModelOptions: AiModelOption[];
 };
 
 // AI Organization Settings Types
@@ -80,6 +83,7 @@ export type AiOrganizationSettings = {
     aiAgentsVisible: boolean;
     aiAgentReviewsEnabled: boolean;
     mcpContentWritesEnabled: boolean;
+    defaultAiAgentModelConfig: AiAgentModelConfig | null;
 };
 
 export type CreateAiOrganizationSettings = AiOrganizationSettings;

--- a/packages/common/src/ee/AiAgent/index.ts
+++ b/packages/common/src/ee/AiAgent/index.ts
@@ -17,6 +17,7 @@ import type {
 } from '../..';
 import { type AiEvalRunResultAssessment } from './aiEvalAssessment';
 import {
+    type AiAgentModelConfig,
     type AiPromptContext,
     type AiPromptContextInput,
     type AiPromptTokenUsage,
@@ -272,11 +273,7 @@ export type AiAgentMessageAssistant = {
 
     artifacts: AiAgentMessageAssistantArtifact[] | null;
     referencedArtifacts: AiAgentMessageAssistantArtifact[] | null;
-    modelConfig: {
-        modelName: string;
-        modelProvider: string;
-        reasoning?: boolean;
-    } | null;
+    modelConfig: AiAgentModelConfig | null;
     tokenUsage: AiPromptTokenUsage | null;
 };
 
@@ -482,11 +479,7 @@ export type ApiAiAgentThreadPullRequestResponse =
 export type ApiAiAgentThreadCreateRequest = {
     prompt?: string;
     context?: AiPromptContextInput;
-    modelConfig?: {
-        modelName: string;
-        modelProvider: string;
-        reasoning?: boolean;
-    };
+    modelConfig?: AiAgentModelConfig;
 };
 
 export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
@@ -494,11 +487,7 @@ export type ApiAiAgentThreadCreateResponse = ApiSuccess<AiAgentThreadSummary>;
 export type ApiAiAgentThreadMessageCreateRequest = {
     prompt: string;
     context?: AiPromptContextInput;
-    modelConfig?: {
-        modelName: string;
-        modelProvider: string;
-        reasoning?: boolean;
-    };
+    modelConfig?: AiAgentModelConfig;
     /**
      * Inject the prompt as a hidden turn — the agent responds to it, but the UI
      * does not render the user bubble. Used by the post-merge content-migration

--- a/packages/common/src/ee/AiAgent/requestTypes.ts
+++ b/packages/common/src/ee/AiAgent/requestTypes.ts
@@ -13,6 +13,12 @@ import {
     type AiAgentRootCause,
 } from './aiAgentReviewClassifierTypes';
 
+export type AiAgentModelConfig = {
+    modelName: string;
+    modelProvider: string;
+    reasoning?: boolean;
+};
+
 /**
  * Runtime state captured at pin time for a chart context. When a user pins a
  * chart from a dashboard view, these are the dashboard-level overrides that
@@ -68,11 +74,7 @@ export type AiPrompt = {
     response: string | null;
     errorMessage: string | null;
     humanScore: number | null;
-    modelConfig: {
-        modelName: string;
-        modelProvider: string;
-        reasoning?: boolean;
-    } | null;
+    modelConfig: AiAgentModelConfig | null;
 };
 
 export type SlackPrompt = AiPrompt & {
@@ -94,6 +96,7 @@ export type CreateSlackPrompt = {
     threadUuid: string;
     createdByUserUuid: string;
     prompt: string;
+    modelConfig?: AiAgentModelConfig;
     slackUserId: string;
     slackChannelId: string;
     promptSlackTs: string;
@@ -229,11 +232,7 @@ export type CreateWebAppPrompt = {
     createdByUserUuid: string;
     prompt: string;
     context?: AiPromptContextInput;
-    modelConfig?: {
-        modelName: string;
-        modelProvider: string;
-        reasoning?: boolean;
-    };
+    modelConfig?: AiAgentModelConfig;
     /** Inject as a hidden turn (agent responds, UI hides the user bubble). */
     hidden?: boolean;
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -5,17 +5,26 @@ import {
     Divider,
     Group,
     Loader,
+    Select,
     Stack,
     Switch,
     Text,
     Title,
 } from '@mantine-8/core';
 import { IconSparkles } from '@tabler/icons-react';
+import { useMemo } from 'react';
 import { Link } from 'react-router';
 import { BetaBadge } from '../../../../../../components/common/BetaBadge';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import { getModelKey } from '../../../../../../components/common/ModelSelector/utils';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { SettingsCard } from '../../../../../../components/common/Settings/SettingsCard';
+import {
+    getAiAgentModelConfig,
+    getConfiguredModelOption,
+    getModelOptionByKey,
+    getSystemDefaultModelOption,
+} from '../../../hooks/useAiAgentModelSelection';
 import {
     useAiOrganizationSettings,
     useUpdateAiOrganizationSettings,
@@ -37,6 +46,24 @@ export const AiGeneralSettingsPage = () => {
     const isRouterLoading = aiRouterQuery.isInitialLoading;
     const { mutate: upsertRouter, isLoading: isUpdatingRouter } =
         useUpsertAiRouterConfig();
+    const defaultModelConfig = settings?.defaultAiAgentModelConfig ?? null;
+    const defaultModelOptions = settings?.defaultAiAgentModelOptions;
+    const selectedDefaultModel = useMemo(
+        () => getConfiguredModelOption(defaultModelOptions, defaultModelConfig),
+        [defaultModelConfig, defaultModelOptions],
+    );
+    const selectedDefaultModelKey = selectedDefaultModel
+        ? getModelKey(selectedDefaultModel)
+        : null;
+    const systemDefaultModel = useMemo(
+        () => getSystemDefaultModelOption(defaultModelOptions),
+        [defaultModelOptions],
+    );
+    const systemDefaultModelLabel = systemDefaultModel
+        ? `System default: ${systemDefaultModel.displayName}`
+        : 'System default';
+    const showReasoningDefault =
+        selectedDefaultModel?.supportsReasoning === true;
 
     return (
         <Stack mb="lg" gap="md">
@@ -53,6 +80,106 @@ export const AiGeneralSettingsPage = () => {
                 </Group>
             ) : (
                 <>
+                    <SettingsCard>
+                        <Stack gap="md">
+                            <Group
+                                justify="space-between"
+                                wrap="nowrap"
+                                align="flex-start"
+                                gap="md"
+                            >
+                                <Box maw={620}>
+                                    <Title order={5} mb={4}>
+                                        Default AI model
+                                    </Title>
+                                    <Text c="dimmed" fz="xs">
+                                        Choose the model and reasoning default
+                                        for new AI agent chats. Users can still
+                                        change it in each chat.
+                                    </Text>
+                                </Box>
+                                <Select
+                                    w={260}
+                                    size="xs"
+                                    value={selectedDefaultModelKey}
+                                    disabled={
+                                        isUpdatingSettings ||
+                                        !defaultModelOptions?.length
+                                    }
+                                    placeholder={systemDefaultModelLabel}
+                                    clearable
+                                    data={(defaultModelOptions ?? []).map(
+                                        (model) => ({
+                                            value: getModelKey(model),
+                                            label: model.displayName,
+                                        }),
+                                    )}
+                                    onChange={(modelKey) => {
+                                        const model = getModelOptionByKey(
+                                            defaultModelOptions,
+                                            modelKey,
+                                        );
+                                        updateSettings({
+                                            defaultAiAgentModelConfig:
+                                                getAiAgentModelConfig(
+                                                    model,
+                                                    defaultModelConfig?.reasoning ??
+                                                        false,
+                                                ) ?? null,
+                                        });
+                                    }}
+                                />
+                            </Group>
+
+                            {showReasoningDefault && (
+                                <>
+                                    <Divider />
+                                    <Group
+                                        justify="space-between"
+                                        wrap="nowrap"
+                                        align="flex-start"
+                                        gap="md"
+                                    >
+                                        <Box maw={620}>
+                                            <Title order={6} mb={4}>
+                                                High reasoning by default
+                                            </Title>
+                                            <Text c="dimmed" fz="xs">
+                                                Start new chats with high
+                                                reasoning enabled for the
+                                                selected model.
+                                            </Text>
+                                        </Box>
+                                        <Switch
+                                            size="md"
+                                            checked={
+                                                defaultModelConfig?.reasoning ===
+                                                true
+                                            }
+                                            disabled={isUpdatingSettings}
+                                            onChange={(event) => {
+                                                if (!selectedDefaultModel)
+                                                    return;
+                                                updateSettings({
+                                                    defaultAiAgentModelConfig: {
+                                                        ...defaultModelConfig,
+                                                        modelName:
+                                                            selectedDefaultModel.name,
+                                                        modelProvider:
+                                                            selectedDefaultModel.provider,
+                                                        reasoning:
+                                                            event.currentTarget
+                                                                .checked,
+                                                    },
+                                                });
+                                            }}
+                                        />
+                                    </Group>
+                                </>
+                            )}
+                        </Stack>
+                    </SettingsCard>
+
                     <SettingsCard>
                         <Group
                             justify="space-between"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/LauncherPanel.tsx
@@ -24,6 +24,7 @@ import {
 import { createPath, useLocation, useNavigate } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import useApp from '../../../../../providers/App/useApp';
+import { useAiAgentModelSelection } from '../../hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../hooks/useAiAgentSqlModeAvailable';
 import { usePendingThreadRefetch } from '../../hooks/usePendingThreadRefetch';
 import { usePinnedContext } from '../../hooks/usePinnedContext';
@@ -147,6 +148,18 @@ const NewThreadPanel: FC<{
     // the per-thread slice entry once the thread is created.
     const [sqlMode, setSqlMode] = useState(false);
     const [composerSeed, setComposerSeed] = useState<string | null>(null);
+    const {
+        extendedThinking,
+        handleExtendedThinkingChange,
+        handleSelectedModelKeyChange,
+        modelConfig,
+        modelOptions,
+        selectedModelKey,
+        showExtendedThinking,
+    } = useAiAgentModelSelection({
+        projectUuid,
+        agentUuid: concreteAgent?.uuid,
+    });
     const dispatchToStore = useAiAgentStoreDispatch();
     const handleToolResult = useCallback(
         (toolResult: AiAgentToolResult) => {
@@ -210,10 +223,11 @@ const NewThreadPanel: FC<{
                 context,
                 optimisticContext,
                 enableSqlMode: sqlModeAvailable && sqlMode,
+                modelConfig,
                 toolHints,
             });
         },
-        [createAgentThread, sqlMode, sqlModeAvailable],
+        [createAgentThread, modelConfig, sqlMode, sqlModeAvailable],
     );
 
     const {
@@ -320,6 +334,17 @@ const NewThreadPanel: FC<{
                     sqlMode={sqlModeAvailable ? sqlMode : undefined}
                     onSqlModeChange={sqlModeAvailable ? setSqlMode : undefined}
                     contentMentionPriorityItems={contentMentionItems}
+                    models={modelOptions}
+                    selectedModelId={selectedModelKey}
+                    onModelChange={handleSelectedModelKeyChange}
+                    extendedThinking={
+                        showExtendedThinking ? extendedThinking : undefined
+                    }
+                    onExtendedThinkingChange={
+                        showExtendedThinking
+                            ? handleExtendedThinkingChange
+                            : undefined
+                    }
                 />
             </div>
         </div>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentModelSelection.ts
@@ -1,0 +1,178 @@
+import type { AiAgentModelConfig, AiModelOption } from '@lightdash/common';
+import { useCallback, useMemo, useReducer } from 'react';
+import { getModelKey } from '../../../../components/common/ModelSelector/utils';
+import { useAiOrganizationSettings } from './useAiOrganizationSettings';
+import { useModelOptions } from './useModelOptions';
+
+export const getModelOptionByKey = (
+    modelOptions: AiModelOption[] | undefined,
+    modelKey: string | null,
+) => modelOptions?.find((model) => getModelKey(model) === modelKey);
+
+export const getConfiguredModelOption = (
+    modelOptions: AiModelOption[] | undefined,
+    modelConfig: AiAgentModelConfig | null | undefined,
+) =>
+    modelOptions?.find(
+        (model) =>
+            model.name === modelConfig?.modelName &&
+            model.provider === modelConfig?.modelProvider,
+    );
+
+export const getSystemDefaultModelOption = (
+    modelOptions: AiModelOption[] | undefined,
+) => modelOptions?.find((model) => model.default);
+
+const getDefaultModelSelection = (
+    modelOptions: AiModelOption[] | undefined,
+    modelConfig: AiAgentModelConfig | null | undefined,
+) => {
+    const configuredModel = getConfiguredModelOption(modelOptions, modelConfig);
+    const model = configuredModel ?? getSystemDefaultModelOption(modelOptions);
+
+    if (!model) return undefined;
+
+    return {
+        model,
+        extendedThinking:
+            configuredModel?.supportsReasoning === true &&
+            modelConfig?.reasoning === true,
+    };
+};
+
+export const getAiAgentModelConfig = (
+    model: AiModelOption | undefined,
+    extendedThinking: boolean,
+): AiAgentModelConfig | undefined =>
+    model
+        ? {
+              modelName: model.name,
+              modelProvider: model.provider,
+              reasoning: model.supportsReasoning ? extendedThinking : undefined,
+          }
+        : undefined;
+
+type UseAiAgentModelSelectionProps = {
+    agentUuid: string | undefined;
+    projectUuid: string | undefined;
+    organizationSettingsEnabled?: boolean;
+};
+
+type ModelSelectionState = {
+    extendedThinking: boolean | null;
+    selectedModelKey: string | null;
+};
+
+type ModelSelectionAction =
+    | { type: 'setExtendedThinking'; extendedThinking: boolean }
+    | {
+          type: 'setModel';
+          modelKey: string;
+          supportsReasoning: boolean;
+          extendedThinking: boolean;
+      };
+
+const modelSelectionReducer = (
+    state: ModelSelectionState,
+    action: ModelSelectionAction,
+): ModelSelectionState => {
+    switch (action.type) {
+        case 'setExtendedThinking':
+            return {
+                ...state,
+                extendedThinking: action.extendedThinking,
+            };
+        case 'setModel':
+            return {
+                selectedModelKey: action.modelKey,
+                extendedThinking: action.supportsReasoning
+                    ? action.extendedThinking
+                    : false,
+            };
+    }
+};
+
+export const useAiAgentModelSelection = ({
+    agentUuid,
+    projectUuid,
+    organizationSettingsEnabled = true,
+}: UseAiAgentModelSelectionProps) => {
+    const { data: modelOptions } = useModelOptions({ projectUuid, agentUuid });
+    const {
+        data: aiOrganizationSettings,
+        isFetched: isAiOrganizationSettingsFetched,
+    } = useAiOrganizationSettings({
+        enabled: organizationSettingsEnabled,
+    });
+    const [{ extendedThinking, selectedModelKey }, dispatch] = useReducer(
+        modelSelectionReducer,
+        {
+            extendedThinking: null,
+            selectedModelKey: null,
+        },
+    );
+    const defaultModelConfig =
+        aiOrganizationSettings?.defaultAiAgentModelConfig;
+    const isDefaultModelConfigReady =
+        !organizationSettingsEnabled || isAiOrganizationSettingsFetched;
+    const defaultModelSelection = useMemo(
+        () =>
+            modelOptions && isDefaultModelConfigReady
+                ? getDefaultModelSelection(modelOptions, defaultModelConfig)
+                : undefined,
+        [defaultModelConfig, isDefaultModelConfigReady, modelOptions],
+    );
+    const effectiveSelectedModelKey =
+        selectedModelKey ??
+        (defaultModelSelection?.model
+            ? getModelKey(defaultModelSelection.model)
+            : null);
+    const effectiveExtendedThinking =
+        extendedThinking ?? defaultModelSelection?.extendedThinking ?? false;
+
+    const selectedModel = useMemo(
+        () => getModelOptionByKey(modelOptions, effectiveSelectedModelKey),
+        [effectiveSelectedModelKey, modelOptions],
+    );
+
+    const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+
+    const handleSelectedModelKeyChange = useCallback(
+        (modelKey: string) => {
+            const model = getModelOptionByKey(modelOptions, modelKey);
+            dispatch({
+                type: 'setModel',
+                modelKey,
+                supportsReasoning: model?.supportsReasoning ?? false,
+                extendedThinking: effectiveExtendedThinking,
+            });
+        },
+        [effectiveExtendedThinking, modelOptions],
+    );
+
+    const handleExtendedThinkingChange = useCallback(
+        (extendedThinkingValue: boolean) => {
+            dispatch({
+                type: 'setExtendedThinking',
+                extendedThinking: extendedThinkingValue,
+            });
+        },
+        [],
+    );
+
+    const modelConfig = useMemo(
+        () => getAiAgentModelConfig(selectedModel, effectiveExtendedThinking),
+        [effectiveExtendedThinking, selectedModel],
+    );
+
+    return {
+        extendedThinking: effectiveExtendedThinking,
+        handleExtendedThinkingChange,
+        handleSelectedModelKeyChange,
+        modelConfig,
+        modelOptions,
+        selectedModel,
+        selectedModelKey: effectiveSelectedModelKey,
+        showExtendedThinking,
+    };
+};

--- a/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsRouterPage.tsx
@@ -30,7 +30,6 @@ import {
 } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { useProject } from '../../../hooks/useProject';
 import { AutoModeSidebar } from '../../features/aiCopilot/components/AiAgentPageLayout/AgentSidebar';
 import { AiAgentPageLayout } from '../../features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout';
@@ -43,10 +42,10 @@ import { getPromptContextItemKey } from '../../features/aiCopilot/components/Cha
 import { ChatElementsUtils } from '../../features/aiCopilot/components/ChatElements/utils';
 import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
+import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentPermission } from '../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentRouterFlow } from '../../features/aiCopilot/hooks/useAiAgentRouterFlow';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
-import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -77,15 +76,7 @@ const AgentsRouterPage = () => {
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
     const placeholderAgentUuid = agents?.[0]?.uuid;
-    const { data: modelOptions } = useModelOptions({
-        projectUuid,
-        agentUuid: placeholderAgentUuid,
-    });
 
-    const [selectedModelKey, setSelectedModelKey] = useState<string | null>(
-        null,
-    );
-    const [extendedThinking, setExtendedThinking] = useState(false);
     const [sqlMode, setSqlMode] = useState(false);
     const sqlModeAvailable = useAiAgentSqlModeAvailable(projectUuid);
     const chartUuid = searchParams.get('chartUuid');
@@ -102,32 +93,18 @@ const AgentsRouterPage = () => {
         dashboardUuidOrSlug: dashboardUuid,
     });
 
-    const handleSelectedModelKeyChange = useCallback(
-        (modelKey: string) => {
-            setSelectedModelKey(modelKey);
-            const model = modelOptions?.find(
-                (m) => getModelKey(m) === modelKey,
-            );
-            if (model && !model.supportsReasoning) {
-                setExtendedThinking(false);
-            }
-        },
-        [modelOptions],
-    );
-
-    useEffect(() => {
-        if (modelOptions && !selectedModelKey) {
-            const defaultModel = modelOptions.find((m) => m.default);
-            if (defaultModel) {
-                handleSelectedModelKeyChange(getModelKey(defaultModel));
-            }
-        }
-    }, [modelOptions, selectedModelKey, handleSelectedModelKeyChange]);
-
-    const selectedModel = modelOptions?.find(
-        (m) => getModelKey(m) === selectedModelKey,
-    );
-    const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+    const {
+        extendedThinking,
+        handleExtendedThinkingChange,
+        handleSelectedModelKeyChange,
+        modelConfig,
+        modelOptions,
+        selectedModelKey,
+        showExtendedThinking,
+    } = useAiAgentModelSelection({
+        projectUuid,
+        agentUuid: placeholderAgentUuid,
+    });
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
 
@@ -152,15 +129,7 @@ const AgentsRouterPage = () => {
                 optimisticContext: args.optimisticContext,
                 prompt: args.message,
                 toolHints: args.toolHints,
-                modelConfig: selectedModel
-                    ? {
-                          modelName: selectedModel.name,
-                          modelProvider: selectedModel.provider,
-                          reasoning: showExtendedThinking
-                              ? extendedThinking
-                              : undefined,
-                      }
-                    : undefined,
+                modelConfig,
             });
             dispatch(
                 setThreadSqlMode({
@@ -170,15 +139,7 @@ const AgentsRouterPage = () => {
             );
             return thread;
         },
-        [
-            createThread,
-            dispatch,
-            extendedThinking,
-            selectedModel,
-            showExtendedThinking,
-            sqlMode,
-            sqlModeAvailable,
-        ],
+        [createThread, dispatch, modelConfig, sqlMode, sqlModeAvailable],
     );
 
     const handleRouteError = useCallback(
@@ -382,7 +343,7 @@ const AgentsRouterPage = () => {
                             }
                             onExtendedThinkingChange={
                                 showExtendedThinking
-                                    ? setExtendedThinking
+                                    ? handleExtendedThinkingChange
                                     : undefined
                             }
                             sqlMode={sqlModeAvailable ? sqlMode : undefined}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -11,18 +11,10 @@ import {
     Title,
 } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
+import { useCallback, useRef, useState, type FC } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { LightdashUserAvatar } from '../../../components/Avatar';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { getModelKey } from '../../../components/common/ModelSelector/utils';
 import { AiAgentNewThreadMcpConnections } from '../../features/aiCopilot/components/AiAgentNewThreadMcpConnections';
 import { AgentChatInput } from '../../features/aiCopilot/components/ChatElements/AgentChatInput';
 import {
@@ -36,8 +28,8 @@ import { usePendingPrompt } from '../../features/aiCopilot/components/PendingPro
 import { PinnedContextCard } from '../../features/aiCopilot/components/PinnedContextCard/PinnedContextCard';
 import { SuggestedQuestions } from '../../features/aiCopilot/components/SuggestedQuestions/SuggestedQuestions';
 import { isEmbedAiAgentRoute } from '../../features/aiCopilot/hooks/aiAgentRouting';
+import { useAiAgentModelSelection } from '../../features/aiCopilot/hooks/useAiAgentModelSelection';
 import { useAiAgentSqlModeAvailable } from '../../features/aiCopilot/hooks/useAiAgentSqlModeAvailable';
-import { useModelOptions } from '../../features/aiCopilot/hooks/useModelOptions';
 import { usePinnedContext } from '../../features/aiCopilot/hooks/usePinnedContext';
 import {
     useCreateAgentThreadMutation,
@@ -119,42 +111,20 @@ const AiAgentNewThreadPage: FC = () => {
         projectUuid,
         agentUuid,
     );
-    const { data: modelOptions } = useModelOptions({ projectUuid, agentUuid });
 
-    const [selectedModelKey, setSelectedModelKey] = useState<string | null>(
-        null,
-    );
-    const [extendedThinking, setExtendedThinking] = useState(false);
-
-    const handleSelectedModelKeyChange = useCallback(
-        (modelKey: string) => {
-            setSelectedModelKey(modelKey);
-            const model = modelOptions?.find(
-                (m) => getModelKey(m) === modelKey,
-            );
-            if (model && !model.supportsReasoning) {
-                setExtendedThinking(false);
-            }
-        },
-        [modelOptions, setExtendedThinking],
-    );
-
-    // Initialize to default model when data loads
-    useEffect(() => {
-        if (modelOptions && !selectedModelKey) {
-            const defaultModel = modelOptions.find((m) => m.default);
-            if (defaultModel) {
-                handleSelectedModelKeyChange(getModelKey(defaultModel));
-            }
-        }
-    }, [modelOptions, selectedModelKey, handleSelectedModelKeyChange]);
-
-    // Only enable extended thinking toggle when selected model supports reasoning
-    const selectedModel = useMemo(
-        () => modelOptions?.find((m) => getModelKey(m) === selectedModelKey),
-        [modelOptions, selectedModelKey],
-    );
-    const showExtendedThinking = selectedModel?.supportsReasoning ?? false;
+    const {
+        extendedThinking,
+        handleExtendedThinkingChange,
+        handleSelectedModelKeyChange,
+        modelConfig,
+        modelOptions,
+        selectedModelKey,
+        showExtendedThinking,
+    } = useAiAgentModelSelection({
+        projectUuid,
+        agentUuid,
+        organizationSettingsEnabled: !isEmbed,
+    });
 
     const { pendingPrompt, setPendingPrompt } = usePendingPrompt();
     const [composerSeedKey, setComposerSeedKey] = useState(0);
@@ -196,15 +166,7 @@ const AiAgentNewThreadPage: FC = () => {
                 optimisticContext: mergedOptimisticContext,
                 enableSqlMode: sqlModeAvailable && sqlMode,
                 toolHints,
-                modelConfig: selectedModel
-                    ? {
-                          modelName: selectedModel.name,
-                          modelProvider: selectedModel.provider,
-                          reasoning: showExtendedThinking
-                              ? extendedThinking
-                              : undefined,
-                      }
-                    : undefined,
+                modelConfig,
             });
         },
         [
@@ -215,9 +177,7 @@ const AiAgentNewThreadPage: FC = () => {
             previewItems,
             sqlModeAvailable,
             sqlMode,
-            selectedModel,
-            showExtendedThinking,
-            extendedThinking,
+            modelConfig,
             isPinnedContextReady,
         ],
     );
@@ -357,7 +317,7 @@ const AiAgentNewThreadPage: FC = () => {
                         }
                         onExtendedThinkingChange={
                             showExtendedThinking
-                                ? setExtendedThinking
+                                ? handleExtendedThinkingChange
                                 : undefined
                         }
                         sqlMode={sqlModeAvailable ? sqlMode : undefined}


### PR DESCRIPTION
## Summary
- Add org-level default AI agent model config on ai_organization_settings
- Expose model options/default config through AI org settings
- Apply org defaults to new AI agent chats while preserving per-chat overrides and thread continuation behavior

## Tests
- pnpm -F @lightdash/common typecheck:fast
- pnpm -F backend typecheck:fast
- pnpm -F frontend typecheck:fast (fails on unrelated matcher typing errors in ThreadPreviewSidebar.test.tsx and PinnedReviewEntityCard.test.tsx)
- pnpm -F @lightdash/common format
- pnpm -F backend format
- pnpm -F frontend format
- pnpm -F backend test -- AiAgentReviewClassifierService.test.ts AiOrganizationSettingsService.test.ts

Closes: PROD-6758