### PR TITLE
feat(apps): polish data app template picker

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -1,21 +1,71 @@
 .wrapper {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: stretch;
     justify-content: center;
-    gap: var(--mantine-spacing-md);
-    padding: var(--mantine-spacing-xl);
-    margin: auto;
-    max-width: 560px;
-    min-height: 100%;
+    gap: var(--mantine-spacing-lg);
+    padding: 40px;
+    /* Extra top room for the window-chrome dots. */
+    padding-top: 48px;
+    max-width: 760px;
     width: 100%;
+    /* Shared height + transition name with the compose card so picking a
+       template morphs the card smoothly (no height jump). */
+    height: min(600px, calc(100vh - 140px));
+    view-transition-name: app-composer;
     box-sizing: border-box;
     container-type: inline-size;
+    border-radius: var(--mantine-radius-lg);
+    border: 1px solid;
+
+    @mixin light {
+        background-color: var(--mantine-color-white);
+        border-color: var(--mantine-color-ldGray-2);
+        box-shadow:
+            0 1px 2px alpha(var(--mantine-color-black), 0.04),
+            0 12px 32px -12px alpha(var(--mantine-color-black), 0.12);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-7);
+        border-color: var(--mantine-color-dark-4);
+        box-shadow:
+            0 1px 2px alpha(var(--mantine-color-black), 0.2),
+            0 16px 40px -12px alpha(var(--mantine-color-black), 0.5);
+    }
+}
+
+/* Three traffic-light dots, echoing the data-app (window) icon. */
+.wrapper::before {
+    content: '';
+    position: absolute;
+    top: 18px;
+    left: 22px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-3);
+        box-shadow:
+            14px 0 0 var(--mantine-color-ldGray-3),
+            28px 0 0 var(--mantine-color-ldGray-3);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-3);
+        box-shadow:
+            14px 0 0 var(--mantine-color-dark-3),
+            28px 0 0 var(--mantine-color-dark-3);
+    }
 }
 
 .heading {
     text-align: center;
     margin-bottom: var(--mantine-spacing-xs);
+}
+
+.headingTitle {
+    letter-spacing: -0.02em;
 }
 
 .templateGrid {
@@ -24,8 +74,8 @@
 
 .card {
     position: relative;
-    padding: var(--mantine-spacing-md);
-    padding-right: calc(var(--mantine-spacing-md) + 24px);
+    padding: var(--mantine-spacing-lg);
+    padding-right: calc(var(--mantine-spacing-lg) + 20px);
     border: 1px solid var(--mantine-color-default-border);
     transition:
         border-color 120ms ease,
@@ -37,14 +87,22 @@
     color: inherit;
     cursor: pointer;
 
-    &:hover {
-        border-color: var(--mantine-color-blue-5);
+    @mixin light {
+        background-color: var(--mantine-color-white);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+    }
 
+    &:hover {
         @mixin light {
-            background-color: var(--mantine-color-ldGray-1);
+            border-color: var(--mantine-color-ldGray-4);
+            background-color: var(--mantine-color-ldGray-0);
+            box-shadow: 0 2px 8px -2px alpha(var(--mantine-color-black), 0.08);
         }
         @mixin dark {
-            background-color: var(--mantine-color-ldDark-4);
+            border-color: var(--mantine-color-dark-3);
+            background-color: var(--mantine-color-dark-5);
         }
     }
 
@@ -81,6 +139,17 @@
             0 0 0 1px var(--mantine-color-blue-5),
             0 10px 26px alpha(var(--mantine-color-blue-9), 0.28);
     }
+
+    &:hover {
+        @mixin light {
+            background-color: var(--mantine-color-blue-0);
+            border-color: var(--mantine-color-blue-6);
+        }
+        @mixin dark {
+            background-color: alpha(var(--mantine-color-blue-9), 0.18);
+            border-color: var(--mantine-color-blue-5);
+        }
+    }
 }
 
 .cardIcon {
@@ -114,13 +183,13 @@
 
 .themeRow {
     border-top: 1px solid;
-    padding-top: var(--mantine-spacing-md);
+    padding-top: var(--mantine-spacing-lg);
 
     @mixin light {
         border-color: var(--mantine-color-ldGray-2);
     }
     @mixin dark {
-        border-color: var(--mantine-color-ldDark-4);
+        border-color: var(--mantine-color-dark-4);
     }
 }
 
@@ -132,9 +201,10 @@
     margin-top: calc(var(--mantine-spacing-xs) * -1);
 }
 
-@container (max-width: 339px) {
+@container (max-width: 439px) {
     .themeRow {
-        justify-content: center;
+        flex-direction: column;
+        align-items: stretch;
     }
 
     .themeCopy {

--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -2,14 +2,15 @@
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    justify-content: center;
     gap: var(--mantine-spacing-md);
     padding: var(--mantine-spacing-xl);
-    /* Anchor toward the top instead of vertically centering — keeps the
-     * "Build a data app" headline above the fold and gives the picker
-     * areas more breathing room than the input bar below. */
-    margin: var(--mantine-spacing-xl) auto auto;
+    margin: auto;
     max-width: 560px;
+    min-height: 100%;
     width: 100%;
+    box-sizing: border-box;
+    container-type: inline-size;
 }
 
 .heading {
@@ -17,12 +18,20 @@
     margin-bottom: var(--mantine-spacing-xs);
 }
 
+.templateGrid {
+    width: 100%;
+}
+
 .card {
+    position: relative;
     padding: var(--mantine-spacing-md);
+    padding-right: calc(var(--mantine-spacing-md) + 24px);
     border: 1px solid var(--mantine-color-default-border);
     transition:
         border-color 120ms ease,
-        background-color 120ms ease;
+        background-color 120ms ease,
+        box-shadow 120ms ease,
+        transform 120ms ease;
     text-align: left;
     font: inherit;
     color: inherit;
@@ -38,16 +47,39 @@
             background-color: var(--mantine-color-ldDark-4);
         }
     }
+
+    &:focus-visible {
+        outline: none;
+
+        @mixin light {
+            border-color: var(--mantine-color-blue-6);
+            box-shadow: 0 0 0 3px var(--mantine-color-blue-1);
+        }
+        @mixin dark {
+            border-color: var(--mantine-color-blue-5);
+            box-shadow: 0 0 0 3px alpha(var(--mantine-color-blue-9), 0.35);
+        }
+    }
+
+    &:active {
+        transform: translateY(1px);
+    }
 }
 
 .cardSelected {
-    border-color: var(--mantine-color-blue-5);
+    border-color: var(--mantine-color-blue-6);
 
     @mixin light {
-        background-color: var(--mantine-color-ldGray-1);
+        background-color: var(--mantine-color-blue-0);
+        box-shadow:
+            0 0 0 1px var(--mantine-color-blue-6),
+            0 10px 26px alpha(var(--mantine-color-blue-6), 0.12);
     }
     @mixin dark {
-        background-color: var(--mantine-color-ldDark-4);
+        background-color: alpha(var(--mantine-color-blue-9), 0.18);
+        box-shadow:
+            0 0 0 1px var(--mantine-color-blue-5),
+            0 10px 26px alpha(var(--mantine-color-blue-9), 0.28);
     }
 }
 
@@ -55,6 +87,58 @@
     flex-shrink: 0;
 }
 
+.cardContent {
+    min-width: 0;
+}
+
+.card[data-selected='true'] .cardIcon {
+    @mixin light {
+        background-color: var(--mantine-color-blue-1);
+        color: var(--mantine-color-blue-7);
+    }
+    @mixin dark {
+        background-color: alpha(var(--mantine-color-blue-8), 0.4);
+        color: var(--mantine-color-blue-3);
+    }
+}
+
 .cardTitle {
     line-height: 1.2;
+}
+
+.selectedIndicator {
+    position: absolute;
+    top: var(--mantine-spacing-sm);
+    right: var(--mantine-spacing-sm);
+}
+
+.themeRow {
+    border-top: 1px solid;
+    padding-top: var(--mantine-spacing-md);
+
+    @mixin light {
+        border-color: var(--mantine-color-ldGray-2);
+    }
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.themeCopy {
+    min-width: 0;
+}
+
+.nextHint {
+    margin-top: calc(var(--mantine-spacing-xs) * -1);
+}
+
+@container (max-width: 339px) {
+    .themeRow {
+        justify-content: center;
+    }
+
+    .themeCopy {
+        text-align: center;
+        width: 100%;
+    }
 }

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -34,14 +34,14 @@ const AppTemplatePicker: FC<Props> = ({
     // because clicking a card no longer advances the wizard — the user
     // confirms with the "Let's go!" button after also picking a theme.
     const [highlighted, setHighlighted] = useState<DataAppTemplate | null>(
-        null,
+        'dashboard',
     );
 
     return (
         <div className={classes.wrapper}>
-            <Stack gap={4} className={classes.heading}>
-                <Text fw={600} size="lg">
-                    Build a data app
+            <Stack gap={6} className={classes.heading}>
+                <Text fw={700} fz={28} className={classes.headingTitle}>
+                    Build a Data App
                 </Text>
                 <Text size="sm" c="dimmed">
                     Pick a starting point. You can refine the prompt next.
@@ -49,8 +49,8 @@ const AppTemplatePicker: FC<Props> = ({
             </Stack>
             <SimpleGrid
                 type="container"
-                cols={{ base: 1, '340px': 2 }}
-                spacing="sm"
+                cols={{ base: 1, '420px': 2 }}
+                spacing="md"
                 className={classes.templateGrid}
             >
                 {TEMPLATES.map((template) => {
@@ -133,7 +133,7 @@ const AppTemplatePicker: FC<Props> = ({
                         if (highlighted !== null) onSelect(highlighted);
                     }}
                 >
-                    Build a data app
+                    Let's go!
                 </Button>
             </Group>
             <Text size="xs" c="dimmed" ta="center" className={classes.nextHint}>

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -7,6 +7,7 @@ import {
     Text,
     ThemeIcon,
 } from '@mantine-8/core';
+import { IconCheck } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
 import { ThemePicker } from '../organizationDesigns/components/ThemePicker';
@@ -43,14 +44,14 @@ const AppTemplatePicker: FC<Props> = ({
                     Build a data app
                 </Text>
                 <Text size="sm" c="dimmed">
-                    Pick a starting point - you can customize the prompt before
-                    generating.
+                    Pick a starting point. You can refine the prompt next.
                 </Text>
             </Stack>
             <SimpleGrid
                 type="container"
                 cols={{ base: 1, '340px': 2 }}
                 spacing="sm"
+                className={classes.templateGrid}
             >
                 {TEMPLATES.map((template) => {
                     const Icon = template.icon;
@@ -66,6 +67,7 @@ const AppTemplatePicker: FC<Props> = ({
                             onClick={() => setHighlighted(template.id)}
                             radius="md"
                             aria-pressed={isSelected}
+                            data-selected={isSelected ? 'true' : undefined}
                         >
                             <Group gap="sm" wrap="nowrap" align="flex-start">
                                 <ThemeIcon
@@ -77,7 +79,7 @@ const AppTemplatePicker: FC<Props> = ({
                                 >
                                     <Icon size={20} />
                                 </ThemeIcon>
-                                <Stack gap={2}>
+                                <Stack gap={2} className={classes.cardContent}>
                                     <Text
                                         fw={600}
                                         size="sm"
@@ -89,27 +91,41 @@ const AppTemplatePicker: FC<Props> = ({
                                         {template.description}
                                     </Text>
                                 </Stack>
+                                {isSelected && (
+                                    <ThemeIcon
+                                        size={20}
+                                        radius="xl"
+                                        color="blue"
+                                        className={classes.selectedIndicator}
+                                    >
+                                        <IconCheck size={12} stroke={3} />
+                                    </ThemeIcon>
+                                )}
                             </Group>
                         </PolymorphicPaperButton>
                     );
                 })}
             </SimpleGrid>
-            <Stack gap={4} className={classes.heading}>
-                <Text fw={600} size="lg" mt="lg">
-                    Choose a theme
-                </Text>
-                <Text size="sm" c="dimmed">
-                    Your app will follow the design guidelines defined in your
-                    theme.
-                </Text>
-            </Stack>
-            <Group justify="center">
+            <Group
+                justify="space-between"
+                align="center"
+                gap="sm"
+                className={classes.themeRow}
+            >
+                <Stack gap={2} className={classes.themeCopy}>
+                    <Text size="xs" fw={600} c="dimmed" tt="uppercase">
+                        Theme
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        Optional styling guide for the generated app.
+                    </Text>
+                </Stack>
                 <ThemePicker
                     value={selectedThemeUuid}
                     onChange={onThemeChange}
                 />
             </Group>
-            <Group justify="flex-end" mt="xl">
+            <Group justify="center" mt="xs">
                 <Button
                     size="md"
                     disabled={highlighted === null}
@@ -117,9 +133,12 @@ const AppTemplatePicker: FC<Props> = ({
                         if (highlighted !== null) onSelect(highlighted);
                     }}
                 >
-                    Let's go!
+                    Build a data app
                 </Button>
             </Group>
+            <Text size="xs" c="dimmed" ta="center" className={classes.nextHint}>
+                Next: describe what you want to build.
+            </Text>
         </div>
     );
 };

--- a/packages/frontend/src/features/apps/templates.ts
+++ b/packages/frontend/src/features/apps/templates.ts
@@ -2,8 +2,8 @@ import { type DataAppTemplate } from '@lightdash/common';
 import {
     IconFileText,
     IconLayoutDashboard,
+    IconPencil,
     IconPresentation,
-    IconSparkles,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
 
@@ -37,9 +37,9 @@ export const TEMPLATES: TemplateDefinition[] = [
     },
     {
         id: 'custom',
-        title: 'Custom',
+        title: 'From scratch',
         description: 'Start from scratch and describe whatever you want.',
-        icon: IconSparkles,
+        icon: IconPencil,
     },
 ];
 

--- a/packages/frontend/src/features/organizationDesigns/components/ThemePicker.module.css
+++ b/packages/frontend/src/features/organizationDesigns/components/ThemePicker.module.css
@@ -1,6 +1,7 @@
 .dropdown {
     min-width: 260px;
     max-width: 360px;
+    font-family: var(--mantine-font-family);
 }
 
 /* Mantine Button forces white-space:nowrap on its label, which defeats
@@ -8,6 +9,7 @@
  * description can break onto up to 3 lines. */
 .triggerWrap {
     white-space: normal;
+    font-family: var(--mantine-font-family);
 }
 
 .option {
@@ -16,19 +18,25 @@
     width: 100%;
     padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
     text-align: left;
+    font-family: var(--mantine-font-family);
     transition: background-color 80ms ease;
 }
 
 .option:hover {
-    background-color: var(--mantine-color-gray-1);
+    background-color: var(--mantine-color-default-hover);
 }
 
 .option[aria-pressed='true'] {
-    background-color: var(--mantine-color-gray-0);
+    @mixin light {
+        background-color: var(--mantine-color-gray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+    }
 }
 
 .footer {
-    border-top: 1px solid var(--mantine-color-gray-2);
+    border-top: 1px solid var(--mantine-color-default-border);
 }
 
 .manageLink {

--- a/packages/frontend/src/features/organizationDesigns/components/ThemePicker.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/ThemePicker.tsx
@@ -53,7 +53,7 @@ export const ThemePicker: FC<Props> = ({
         <Button
             variant="default"
             size="xs"
-            radius="sm"
+            radius="md"
             color="gray"
             miw={200}
             h="auto"

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -20,10 +20,65 @@
     min-width: 300px;
 }
 
+/* Template-pick stage: the picker owns the full viewport, centered both
+   axes. No split panel / empty preview pane until a template is chosen. */
+.pickerLayout {
+    height: calc(100vh - 50px);
+    overflow-y: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-8);
+    }
+}
+
+:global(body:has(#preview-banner)) .pickerLayout,
+:global(body:has(#impersonation-banner)) .pickerLayout {
+    height: calc(100vh - 50px - 35px);
+}
+
+/* Compose stage: the chat panel becomes a centered card on the muted
+   backdrop, then morphs into the split sidebar (see .chatPanel's
+   view-transition-name) on first submit. */
+.composeLayout {
+    height: calc(100vh - 50px);
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    padding: var(--mantine-spacing-xl);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-8);
+    }
+}
+
+/* The compose Panel fills the group; center the (height-capped) card
+   inside it so it doesn't stretch to the full viewport height. */
+.chatPanelOuterCompose {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+:global(body:has(#preview-banner)) .composeLayout,
+:global(body:has(#impersonation-banner)) .composeLayout {
+    height: calc(100vh - 50px - 35px);
+}
+
 .chatPanel {
     display: flex;
     flex-direction: column;
     height: 100%;
+    view-transition-name: app-composer;
 
     @mixin light {
         background-color: var(--mantine-color-white);
@@ -31,6 +86,66 @@
     @mixin dark {
         background-color: var(--mantine-color-dark-7);
     }
+}
+
+/* Cute springy expand when the centered composer morphs into the split
+   sidebar (and the preview panel slides in). */
+:global(::view-transition-group(app-composer)) {
+    animation-duration: 460ms;
+    animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+:global(::view-transition-old(app-composer)),
+:global(::view-transition-new(app-composer)) {
+    animation-duration: 460ms;
+    animation-timing-function: cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.composeHeading {
+    text-align: center;
+    align-items: center;
+    padding: var(--mantine-spacing-md) var(--mantine-spacing-xl) 0;
+}
+
+.composeTitle {
+    letter-spacing: -0.02em;
+}
+
+.chatPanelCompose {
+    position: relative;
+    max-width: 760px;
+    width: 100%;
+    margin: 0 auto;
+    /* Shared height with the template picker so the View Transition between
+       them only morphs width/position — no jarring height jump. */
+    height: min(600px, calc(100vh - 140px));
+    border-radius: var(--mantine-radius-lg);
+    border: 1px solid;
+    overflow: hidden;
+    /* Reserve room for the window-chrome dots / back button row. */
+    padding-top: 4px;
+
+    @mixin light {
+        border-color: var(--mantine-color-ldGray-2);
+        box-shadow:
+            0 1px 2px alpha(var(--mantine-color-black), 0.04),
+            0 12px 32px -12px alpha(var(--mantine-color-black), 0.12);
+    }
+    @mixin dark {
+        border-color: var(--mantine-color-dark-4);
+        box-shadow:
+            0 1px 2px alpha(var(--mantine-color-black), 0.2),
+            0 16px 40px -12px alpha(var(--mantine-color-black), 0.5);
+    }
+}
+
+/* Top row of the compose card — the back button sits where the picker's
+   window-chrome dots are, replacing them on this stage. */
+.composeBackBar {
+    display: flex;
+    align-items: center;
+    min-height: 36px;
+    padding: 8px 12px 0 12px;
 }
 
 .chatMessages {

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -26,7 +26,6 @@ import {
     Stack,
     Text,
     Textarea,
-    ThemeIcon,
     Title,
     Tooltip,
 } from '@mantine-8/core';
@@ -34,6 +33,7 @@ import {
     IconAppsOff,
     IconAppWindow,
     IconCheck,
+    IconArrowLeft,
     IconArrowUp,
     IconCopy,
     IconDatabase,
@@ -49,7 +49,6 @@ import {
     IconPlayerStop,
     IconRefresh,
     IconRestore,
-    IconSparkles,
     IconTrash,
     IconPlugConnected,
     IconX,
@@ -65,6 +64,7 @@ import {
     useState,
     type FC,
 } from 'react';
+import { flushSync } from 'react-dom';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import {
     Link,
@@ -154,6 +154,22 @@ function parseElementRefLabel(label: string): ElementRef | null {
         );
     if (!m) return null;
     return { tag: m[1] ?? '', text: m[2] ?? '', loc: m[3] ?? '' };
+}
+
+// Run a layout-changing state update inside a native View Transition so the
+// browser cross-fades/morphs the before/after frames (used for the
+// centered-composer → split-sidebar handoff). flushSync forces React to
+// commit synchronously so the transition captures the new layout. Falls back
+// to a plain update where the API is unavailable.
+function withViewTransition(update: () => void): void {
+    const doc = document as Document & {
+        startViewTransition?: (cb: () => void) => unknown;
+    };
+    if (typeof doc.startViewTransition === 'function') {
+        doc.startViewTransition(() => flushSync(update));
+    } else {
+        update();
+    }
 }
 
 // ChatChart and ChatMessage are imported from `features/apps/utils/mergeChatMessages`
@@ -870,6 +886,25 @@ const AppGenerate: FC = () => {
         !isLoading &&
         wizardStage !== 'confirm';
 
+    // At the template-pick stage the picker takes over the whole viewport
+    // (centered, no split) — there's no app to preview yet, so the empty
+    // preview pane would just be dead space.
+    const showTemplatePicker =
+        isNewApp &&
+        wizardStage === 'pick' &&
+        messages.length === 0 &&
+        !isLoading;
+
+    // After a template is picked but before the first prompt is submitted, the
+    // composer takes over the whole viewport (centered, no split / empty
+    // preview) — mirroring the Ask AI new-thread compose view. On submit the
+    // layout morphs to the split sidebar via a native View Transition.
+    const composeMode =
+        isNewApp &&
+        wizardStage === 'confirm' &&
+        messages.length === 0 &&
+        !isLoading;
+
     // `hasNextPage` reflects the server's "more pages exist" signal, but we
     // accumulate versions across fetches in `versionCacheRef` — so even if the
     // server thinks more exist, we may already have them all. Versions are
@@ -1415,7 +1450,16 @@ const AppGenerate: FC = () => {
         if (!trimmed || isLoading || isSubmittingRef.current) return;
 
         isSubmittingRef.current = true;
-        setIsSubmitting(true);
+        // Morph the centered composer into the split sidebar layout. Only the
+        // first submit of a brand-new app crosses that layout boundary; later
+        // iterations are already in the split view and just re-render in place.
+        if (composeMode) {
+            withViewTransition(() => {
+                setIsSubmitting(true);
+            });
+        } else {
+            setIsSubmitting(true);
+        }
 
         try {
             // Send structured chart refs (uuid + per-chart sample-data opt-in).
@@ -1707,12 +1751,22 @@ const AppGenerate: FC = () => {
         // ask hand-rolled questions per template — the AI clarifier produces
         // those dynamically on submit.
         setSelectedTemplate(template);
-        setWizardStage('confirm');
+        withViewTransition(() => {
+            setWizardStage('confirm');
+        });
         promptEditorRef.current?.clear();
         setIsPromptEmpty(true);
         // Focus the editor so the user can immediately type. The setTimeout
         // gives the editor a tick to mount when the input area first appears.
         setTimeout(() => promptEditorRef.current?.focus(), 0);
+    };
+
+    // Return from the composer to the template picker, collapsing the card back
+    // via the same View Transition used on the way in.
+    const handleBackToTemplates = () => {
+        withViewTransition(() => {
+            setWizardStage('pick');
+        });
     };
 
     const handleCancel = () => {
@@ -1739,17 +1793,72 @@ const AppGenerate: FC = () => {
         );
     };
 
-    return (
-        <Box className={classes.layout}>
-            <PanelGroup direction="horizontal">
+    return showTemplatePicker ? (
+        <Box className={classes.pickerLayout}>
+            <AppTemplatePicker
+                onSelect={handleTemplateSelect}
+                selectedThemeUuid={selectedThemeUuid}
+                onThemeChange={handleThemeChange}
+            />
+        </Box>
+    ) : (
+        <Box className={composeMode ? classes.composeLayout : classes.layout}>
+            <PanelGroup
+                key={composeMode ? 'compose' : 'split'}
+                direction="horizontal"
+            >
                 {/* Chat Panel */}
                 <Panel
-                    defaultSize={30}
-                    minSize={22}
-                    maxSize={50}
-                    className={classes.chatPanelOuter}
+                    defaultSize={composeMode ? 100 : 30}
+                    minSize={composeMode ? 100 : 22}
+                    maxSize={composeMode ? 100 : 50}
+                    className={`${classes.chatPanelOuter}${
+                        composeMode ? ` ${classes.chatPanelOuterCompose}` : ''
+                    }`}
                 >
-                    <Box className={classes.chatPanel}>
+                    <Box
+                        className={`${classes.chatPanel}${
+                            composeMode ? ` ${classes.chatPanelCompose}` : ''
+                        }`}
+                    >
+                        {composeMode && (
+                            <Box className={classes.composeBackBar}>
+                                <Tooltip
+                                    label="Back to templates"
+                                    position="right"
+                                    withArrow
+                                >
+                                    <ActionIcon
+                                        variant="subtle"
+                                        color="gray"
+                                        radius="md"
+                                        onClick={handleBackToTemplates}
+                                        aria-label="Back to templates"
+                                    >
+                                        <MantineIcon
+                                            icon={IconArrowLeft}
+                                            size={18}
+                                        />
+                                    </ActionIcon>
+                                </Tooltip>
+                            </Box>
+                        )}
+                        {composeMode && (
+                            <Stack gap={6} className={classes.composeHeading}>
+                                <Text
+                                    fw={700}
+                                    fz={28}
+                                    className={classes.composeTitle}
+                                >
+                                    Build a Data App
+                                </Text>
+                                <Text size="sm" c="dimmed">
+                                    Describe what you want to build and I'll
+                                    generate a data app connected to your
+                                    project.
+                                </Text>
+                            </Stack>
+                        )}
                         <Box
                             ref={chatMessagesRef}
                             className={classes.chatMessages}
@@ -1777,32 +1886,20 @@ const AppGenerate: FC = () => {
                                 </Group>
                             )}
                             {messages.length === 0 && !isLoading ? (
-                                isNewApp && wizardStage === 'pick' ? (
-                                    <AppTemplatePicker
-                                        onSelect={handleTemplateSelect}
-                                        selectedThemeUuid={selectedThemeUuid}
-                                        onThemeChange={handleThemeChange}
-                                    />
-                                ) : (
-                                    <Box className={classes.emptyChat}>
-                                        <ThemeIcon
-                                            size="xl"
-                                            radius="xl"
-                                            variant="light"
-                                            color="gray"
+                                <Box className={classes.emptyChat}>
+                                    {!composeMode && (
+                                        <Text
+                                            size="sm"
+                                            c="dimmed"
+                                            maw={320}
+                                            ta="center"
                                         >
-                                            <IconSparkles size={24} />
-                                        </ThemeIcon>
-                                        <Text fw={600} size="lg">
-                                            Build a data app
-                                        </Text>
-                                        <Text size="sm" c="dimmed" maw={280}>
                                             Describe what you want to build and
                                             I'll generate a data app connected
                                             to your project.
                                         </Text>
-                                    </Box>
-                                )
+                                    )}
+                                </Box>
                             ) : (
                                 <>
                                     <Box
@@ -2594,377 +2691,395 @@ const AppGenerate: FC = () => {
                     </Box>
                 </Panel>
 
-                <PanelResizeHandle className={classes.resizeHandle} />
+                {!composeMode && (
+                    <PanelResizeHandle className={classes.resizeHandle} />
+                )}
 
                 {/* Preview Panel */}
-                <Panel minSize={40}>
-                    <Box className={classes.previewPanel}>
-                        {activeAppUuid && (
-                            <Box className={classes.previewHeader}>
-                                <Box className={classes.previewHeaderInfo}>
-                                    <Title order={6} fw={600} lineClamp={1}>
-                                        {appName || 'Untitled app'}
-                                    </Title>
-                                    {appDescription && (
-                                        <Text
-                                            size="xs"
-                                            c="dimmed"
-                                            lineClamp={1}
-                                        >
-                                            {appDescription}
-                                        </Text>
-                                    )}
-                                </Box>
-                                <Tooltip
-                                    label="Refresh preview to re-run queries"
-                                    withArrow
-                                    position="bottom"
-                                >
-                                    <ActionIcon
-                                        variant="subtle"
-                                        size="sm"
-                                        color="ldGray.6"
-                                        ml="auto"
-                                        disabled={!previewApp}
-                                        onClick={handleRefreshPreview}
-                                        aria-label="Refresh preview"
+                {!composeMode && (
+                    <Panel minSize={40}>
+                        <Box className={classes.previewPanel}>
+                            {activeAppUuid && (
+                                <Box className={classes.previewHeader}>
+                                    <Box className={classes.previewHeaderInfo}>
+                                        <Title order={6} fw={600} lineClamp={1}>
+                                            {appName || 'Untitled app'}
+                                        </Title>
+                                        {appDescription && (
+                                            <Text
+                                                size="xs"
+                                                c="dimmed"
+                                                lineClamp={1}
+                                            >
+                                                {appDescription}
+                                            </Text>
+                                        )}
+                                    </Box>
+                                    <Tooltip
+                                        label="Refresh preview to re-run queries"
+                                        withArrow
+                                        position="bottom"
                                     >
-                                        <MantineIcon
-                                            icon={IconRefresh}
-                                            size={16}
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                                <Menu
-                                    position="bottom-end"
-                                    shadow="md"
-                                    withinPortal
-                                    withArrow
-                                    arrowPosition="center"
-                                >
-                                    <Menu.Target>
                                         <ActionIcon
                                             variant="subtle"
                                             size="sm"
                                             color="ldGray.6"
-                                            aria-label="App actions"
+                                            ml="auto"
+                                            disabled={!previewApp}
+                                            onClick={handleRefreshPreview}
+                                            aria-label="Refresh preview"
                                         >
                                             <MantineIcon
-                                                icon={IconDots}
+                                                icon={IconRefresh}
                                                 size={16}
                                             />
                                         </ActionIcon>
-                                    </Menu.Target>
-                                    <Menu.Dropdown>
-                                        {previewApp && (
-                                            <Menu.Item
-                                                component={Link}
-                                                to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
-                                                target="_blank"
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconExternalLink}
-                                                        size={14}
-                                                    />
-                                                }
+                                    </Tooltip>
+                                    <Menu
+                                        position="bottom-end"
+                                        shadow="md"
+                                        withinPortal
+                                        withArrow
+                                        arrowPosition="center"
+                                    >
+                                        <Menu.Target>
+                                            <ActionIcon
+                                                variant="subtle"
+                                                size="sm"
+                                                color="ldGray.6"
+                                                aria-label="App actions"
                                             >
-                                                Preview latest
-                                            </Menu.Item>
-                                        )}
-                                        <Menu.Item
-                                            leftSection={
                                                 <MantineIcon
-                                                    icon={IconDatabase}
-                                                    size={14}
+                                                    icon={IconDots}
+                                                    size={16}
                                                 />
-                                            }
-                                            onClick={() =>
-                                                setQueriesPanelHidden(false)
-                                            }
-                                        >
-                                            View queries
-                                        </Menu.Item>
-                                        <Menu.Divider />
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconCopy}
-                                                    size={14}
-                                                />
-                                            }
-                                            disabled={
-                                                isDuplicating || !activeAppUuid
-                                            }
-                                            onClick={() => {
-                                                if (!activeAppUuid) return;
-                                                duplicateMutate(
-                                                    {
-                                                        projectUuid,
-                                                        appUuid: activeAppUuid,
-                                                    },
-                                                    {
-                                                        onSuccess: ({
-                                                            appUuid: newAppUuid,
-                                                        }) => {
-                                                            void navigate(
-                                                                `/projects/${projectUuid}/apps/${newAppUuid}`,
-                                                            );
-                                                        },
-                                                    },
-                                                );
-                                            }}
-                                        >
-                                            Duplicate
-                                        </Menu.Item>
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconPencil}
-                                                    size={14}
-                                                />
-                                            }
-                                            onClick={() =>
-                                                setIsUpdateModalOpen(true)
-                                            }
-                                        >
-                                            Rename
-                                        </Menu.Item>
-                                        <Menu.Item
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={
-                                                        appSpaceUuid
-                                                            ? IconFolderSymlink
-                                                            : IconFolderPlus
-                                                    }
-                                                    size={14}
-                                                />
-                                            }
-                                            onClick={() =>
-                                                setIsMoveToSpaceOpen(true)
-                                            }
-                                        >
-                                            {appSpaceUuid
-                                                ? 'Move to space'
-                                                : 'Add to space'}
-                                        </Menu.Item>
-                                        {isPreviewProject &&
-                                            latestReadyVersion && (
+                                            </ActionIcon>
+                                        </Menu.Target>
+                                        <Menu.Dropdown>
+                                            {previewApp && (
                                                 <Menu.Item
+                                                    component={Link}
+                                                    to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
+                                                    target="_blank"
                                                     leftSection={
                                                         <MantineIcon
                                                             icon={
-                                                                IconDatabaseExport
+                                                                IconExternalLink
                                                             }
                                                             size={14}
                                                         />
                                                     }
-                                                    disabled={!activeAppUuid}
-                                                    onClick={() =>
-                                                        setIsPromoteModalOpen(
-                                                            true,
-                                                        )
-                                                    }
                                                 >
-                                                    Promote
+                                                    Preview latest
                                                 </Menu.Item>
                                             )}
-                                        <Menu.Divider />
-                                        <Menu.Item
-                                            color="red"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconTrash}
-                                                    size={14}
-                                                />
-                                            }
-                                            onClick={() =>
-                                                setIsDeleteModalOpen(true)
-                                            }
-                                        >
-                                            Delete
-                                        </Menu.Item>
-                                    </Menu.Dropdown>
-                                </Menu>
-                            </Box>
-                        )}
-                        {isMoveToSpaceOpen && activeAppUuid && (
-                            <TransferItemsModal
-                                projectUuid={projectUuid}
-                                opened
-                                onClose={() => setIsMoveToSpaceOpen(false)}
-                                items={[
-                                    {
-                                        type: ResourceViewItemType.DATA_APP,
-                                        data: {
-                                            uuid: activeAppUuid,
-                                            name: appName,
-                                            description:
-                                                appDescription || undefined,
-                                            spaceUuid: appSpaceUuid,
-                                            createdByUserUuid:
-                                                appCreatedByUserUuid,
-                                            updatedAt: new Date(),
-                                            updatedByUser: null,
-                                            views: 0,
-                                            firstViewedAt: null,
-                                            latestVersionNumber: null,
-                                            latestVersionStatus: null,
-                                            pinnedListUuid: null,
-                                            pinnedListOrder: null,
-                                        },
-                                    },
-                                ]}
-                                isLoading={isMovingToSpace}
-                                onConfirm={async (targetSpaceUuid) => {
-                                    if (!targetSpaceUuid) return;
-                                    await contentAction({
-                                        action: {
-                                            type: 'move',
-                                            targetSpaceUuid,
-                                        },
-                                        item: {
-                                            uuid: activeAppUuid,
-                                            contentType: ContentType.DATA_APP,
-                                        },
-                                    });
-                                    await queryClient.invalidateQueries({
-                                        queryKey: [
-                                            'app',
-                                            projectUuid,
-                                            activeAppUuid,
-                                        ],
-                                    });
-                                    setIsMoveToSpaceOpen(false);
-                                }}
-                            />
-                        )}
-                        {isUpdateModalOpen && activeAppUuid && (
-                            <AppUpdateModal
-                                opened
-                                projectUuid={projectUuid}
-                                uuid={activeAppUuid}
-                                initialName={appName}
-                                initialDescription={appDescription}
-                                onClose={() => setIsUpdateModalOpen(false)}
-                                onConfirm={() => setIsUpdateModalOpen(false)}
-                            />
-                        )}
-                        {isPromoteModalOpen && activeAppUuid && (
-                            <PromoteAppModal
-                                projectUuid={projectUuid}
-                                appUuid={activeAppUuid}
-                                opened
-                                onClose={() => setIsPromoteModalOpen(false)}
-                            />
-                        )}
-                        {isDeleteModalOpen && activeAppUuid && (
-                            <AppDeleteModal
-                                opened
-                                projectUuid={projectUuid}
-                                uuid={activeAppUuid}
-                                name={appName}
-                                onClose={() => setIsDeleteModalOpen(false)}
-                                onConfirm={() => {
-                                    setIsDeleteModalOpen(false);
-                                    void navigate(
-                                        `/projects/${projectUuid}/apps/generate`,
-                                    );
-                                }}
-                            />
-                        )}
-                        {restoreTargetVersion !== null && activeAppUuid && (
-                            <MantineModal
-                                opened
-                                onClose={() => {
-                                    if (isRestoringVersion) return;
-                                    setRestoreTargetVersion(null);
-                                    resetRestoreVersion();
-                                }}
-                                title={`Restore version ${restoreTargetVersion}?`}
-                                icon={IconRestore}
-                                confirmLabel="Restore version"
-                                cancelDisabled={isRestoringVersion}
-                                confirmLoading={isRestoringVersion}
-                                onConfirm={() =>
-                                    restoreVersionMutate(
-                                        {
-                                            projectUuid,
-                                            appUuid: activeAppUuid,
-                                            version: restoreTargetVersion,
-                                        },
-                                        {
-                                            onSuccess: () => {
-                                                setRestoreTargetVersion(null);
-                                            },
-                                        },
-                                    )
-                                }
-                            >
-                                <Stack gap="sm">
-                                    <Text fz="sm">
-                                        This will create a new version on top of
-                                        the timeline that duplicates the
-                                        contents of version{' '}
-                                        {restoreTargetVersion}. Your next prompt
-                                        will iterate from there.
-                                    </Text>
-                                    {restoreVersionError && (
-                                        <Callout variant="danger">
-                                            {restoreVersionError.error
-                                                ?.message ??
-                                                'Failed to restore version.'}
-                                        </Callout>
-                                    )}
-                                </Stack>
-                            </MantineModal>
-                        )}
-
-                        <Box className={classes.previewContent}>
-                            {previewApp ? (
-                                <AppPreview
-                                    ref={previewRef}
-                                    projectUuid={projectUuid}
-                                    appUuid={previewApp.appUuid}
-                                    version={previewApp.version}
-                                    refreshKey={previewRefreshKey}
-                                    invalidateCache={invalidatePreviewCache}
-                                    onQueryEvent={handleQueryEvent}
-                                    inspectorEnabled={inspectorEnabled}
-                                    onElementSelected={handleElementSelected}
-                                    onInspectorAvailabilityChange={
-                                        setInspectorAvailable
-                                    }
-                                    onScreenshotAvailabilityChange={
-                                        setScreenshotAvailable
-                                    }
-                                    onInspectorCancelled={
-                                        handleInspectorCancelled
-                                    }
-                                />
-                            ) : (
-                                <Box className={classes.previewEmpty}>
-                                    <IconAppWindow size={48} stroke={1} />
-                                    <Text size="sm">
-                                        Your app preview will appear here
-                                    </Text>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconDatabase}
+                                                        size={14}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setQueriesPanelHidden(false)
+                                                }
+                                            >
+                                                View queries
+                                            </Menu.Item>
+                                            <Menu.Divider />
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconCopy}
+                                                        size={14}
+                                                    />
+                                                }
+                                                disabled={
+                                                    isDuplicating ||
+                                                    !activeAppUuid
+                                                }
+                                                onClick={() => {
+                                                    if (!activeAppUuid) return;
+                                                    duplicateMutate(
+                                                        {
+                                                            projectUuid,
+                                                            appUuid:
+                                                                activeAppUuid,
+                                                        },
+                                                        {
+                                                            onSuccess: ({
+                                                                appUuid:
+                                                                    newAppUuid,
+                                                            }) => {
+                                                                void navigate(
+                                                                    `/projects/${projectUuid}/apps/${newAppUuid}`,
+                                                                );
+                                                            },
+                                                        },
+                                                    );
+                                                }}
+                                            >
+                                                Duplicate
+                                            </Menu.Item>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconPencil}
+                                                        size={14}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setIsUpdateModalOpen(true)
+                                                }
+                                            >
+                                                Rename
+                                            </Menu.Item>
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={
+                                                            appSpaceUuid
+                                                                ? IconFolderSymlink
+                                                                : IconFolderPlus
+                                                        }
+                                                        size={14}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setIsMoveToSpaceOpen(true)
+                                                }
+                                            >
+                                                {appSpaceUuid
+                                                    ? 'Move to space'
+                                                    : 'Add to space'}
+                                            </Menu.Item>
+                                            {isPreviewProject &&
+                                                latestReadyVersion && (
+                                                    <Menu.Item
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconDatabaseExport
+                                                                }
+                                                                size={14}
+                                                            />
+                                                        }
+                                                        disabled={
+                                                            !activeAppUuid
+                                                        }
+                                                        onClick={() =>
+                                                            setIsPromoteModalOpen(
+                                                                true,
+                                                            )
+                                                        }
+                                                    >
+                                                        Promote
+                                                    </Menu.Item>
+                                                )}
+                                            <Menu.Divider />
+                                            <Menu.Item
+                                                color="red"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconTrash}
+                                                        size={14}
+                                                    />
+                                                }
+                                                onClick={() =>
+                                                    setIsDeleteModalOpen(true)
+                                                }
+                                            >
+                                                Delete
+                                            </Menu.Item>
+                                        </Menu.Dropdown>
+                                    </Menu>
                                 </Box>
                             )}
-                            {!queriesPanelHidden && (
-                                <QueryInspector
-                                    queries={trackedQueries}
-                                    projectUuid={projectUuid!}
-                                    onClear={clearQueries}
-                                    persistLogs={persistLogs}
-                                    onPersistLogsChange={setPersistLogs}
-                                    onDismiss={() =>
-                                        setQueriesPanelHidden(true)
+                            {isMoveToSpaceOpen && activeAppUuid && (
+                                <TransferItemsModal
+                                    projectUuid={projectUuid}
+                                    opened
+                                    onClose={() => setIsMoveToSpaceOpen(false)}
+                                    items={[
+                                        {
+                                            type: ResourceViewItemType.DATA_APP,
+                                            data: {
+                                                uuid: activeAppUuid,
+                                                name: appName,
+                                                description:
+                                                    appDescription || undefined,
+                                                spaceUuid: appSpaceUuid,
+                                                createdByUserUuid:
+                                                    appCreatedByUserUuid,
+                                                updatedAt: new Date(),
+                                                updatedByUser: null,
+                                                views: 0,
+                                                firstViewedAt: null,
+                                                latestVersionNumber: null,
+                                                latestVersionStatus: null,
+                                                pinnedListUuid: null,
+                                                pinnedListOrder: null,
+                                            },
+                                        },
+                                    ]}
+                                    isLoading={isMovingToSpace}
+                                    onConfirm={async (targetSpaceUuid) => {
+                                        if (!targetSpaceUuid) return;
+                                        await contentAction({
+                                            action: {
+                                                type: 'move',
+                                                targetSpaceUuid,
+                                            },
+                                            item: {
+                                                uuid: activeAppUuid,
+                                                contentType:
+                                                    ContentType.DATA_APP,
+                                            },
+                                        });
+                                        await queryClient.invalidateQueries({
+                                            queryKey: [
+                                                'app',
+                                                projectUuid,
+                                                activeAppUuid,
+                                            ],
+                                        });
+                                        setIsMoveToSpaceOpen(false);
+                                    }}
+                                />
+                            )}
+                            {isUpdateModalOpen && activeAppUuid && (
+                                <AppUpdateModal
+                                    opened
+                                    projectUuid={projectUuid}
+                                    uuid={activeAppUuid}
+                                    initialName={appName}
+                                    initialDescription={appDescription}
+                                    onClose={() => setIsUpdateModalOpen(false)}
+                                    onConfirm={() =>
+                                        setIsUpdateModalOpen(false)
                                     }
                                 />
                             )}
+                            {isPromoteModalOpen && activeAppUuid && (
+                                <PromoteAppModal
+                                    projectUuid={projectUuid}
+                                    appUuid={activeAppUuid}
+                                    opened
+                                    onClose={() => setIsPromoteModalOpen(false)}
+                                />
+                            )}
+                            {isDeleteModalOpen && activeAppUuid && (
+                                <AppDeleteModal
+                                    opened
+                                    projectUuid={projectUuid}
+                                    uuid={activeAppUuid}
+                                    name={appName}
+                                    onClose={() => setIsDeleteModalOpen(false)}
+                                    onConfirm={() => {
+                                        setIsDeleteModalOpen(false);
+                                        void navigate(
+                                            `/projects/${projectUuid}/apps/generate`,
+                                        );
+                                    }}
+                                />
+                            )}
+                            {restoreTargetVersion !== null && activeAppUuid && (
+                                <MantineModal
+                                    opened
+                                    onClose={() => {
+                                        if (isRestoringVersion) return;
+                                        setRestoreTargetVersion(null);
+                                        resetRestoreVersion();
+                                    }}
+                                    title={`Restore version ${restoreTargetVersion}?`}
+                                    icon={IconRestore}
+                                    confirmLabel="Restore version"
+                                    cancelDisabled={isRestoringVersion}
+                                    confirmLoading={isRestoringVersion}
+                                    onConfirm={() =>
+                                        restoreVersionMutate(
+                                            {
+                                                projectUuid,
+                                                appUuid: activeAppUuid,
+                                                version: restoreTargetVersion,
+                                            },
+                                            {
+                                                onSuccess: () => {
+                                                    setRestoreTargetVersion(
+                                                        null,
+                                                    );
+                                                },
+                                            },
+                                        )
+                                    }
+                                >
+                                    <Stack gap="sm">
+                                        <Text fz="sm">
+                                            This will create a new version on
+                                            top of the timeline that duplicates
+                                            the contents of version{' '}
+                                            {restoreTargetVersion}. Your next
+                                            prompt will iterate from there.
+                                        </Text>
+                                        {restoreVersionError && (
+                                            <Callout variant="danger">
+                                                {restoreVersionError.error
+                                                    ?.message ??
+                                                    'Failed to restore version.'}
+                                            </Callout>
+                                        )}
+                                    </Stack>
+                                </MantineModal>
+                            )}
+
+                            <Box className={classes.previewContent}>
+                                {previewApp ? (
+                                    <AppPreview
+                                        ref={previewRef}
+                                        projectUuid={projectUuid}
+                                        appUuid={previewApp.appUuid}
+                                        version={previewApp.version}
+                                        refreshKey={previewRefreshKey}
+                                        invalidateCache={invalidatePreviewCache}
+                                        onQueryEvent={handleQueryEvent}
+                                        inspectorEnabled={inspectorEnabled}
+                                        onElementSelected={
+                                            handleElementSelected
+                                        }
+                                        onInspectorAvailabilityChange={
+                                            setInspectorAvailable
+                                        }
+                                        onScreenshotAvailabilityChange={
+                                            setScreenshotAvailable
+                                        }
+                                        onInspectorCancelled={
+                                            handleInspectorCancelled
+                                        }
+                                    />
+                                ) : (
+                                    <Box className={classes.previewEmpty}>
+                                        <IconAppWindow size={48} stroke={1} />
+                                        <Text size="sm">
+                                            Your app preview will appear here
+                                        </Text>
+                                    </Box>
+                                )}
+                                {!queriesPanelHidden && (
+                                    <QueryInspector
+                                        queries={trackedQueries}
+                                        projectUuid={projectUuid!}
+                                        onClear={clearQueries}
+                                        persistLogs={persistLogs}
+                                        onPersistLogsChange={setPersistLogs}
+                                        onDismiss={() =>
+                                            setQueriesPanelHidden(true)
+                                        }
+                                    />
+                                )}
+                            </Box>
                         </Box>
-                    </Box>
-                </Panel>
+                    </Panel>
+                )}
             </PanelGroup>
         </Box>
     );


### PR DESCRIPTION
## Summary

- Center the first-run data app template picker inside the chat pane.
- Make selected templates feel more active with a stronger border, tinted icon, shadow, and check indicator.
- Demote theme selection into a quieter optional footer control and make the primary CTA `Build a data app`.

## Validation

- `git diff --check`
- `pnpm -F @lightdash/frontend linter src/features/apps/AppTemplatePicker.tsx` could not run because this worktree has no `node_modules` and `oxlint` is unavailable.
- `pnpm -F @lightdash/frontend formatter src/features/apps/AppTemplatePicker.tsx src/features/apps/AppTemplatePicker.module.css --check` could not run because this worktree has no `node_modules` and `oxfmt` is unavailable.