### PR TITLE
feat(ai-reviews): polish remediation workspace & reviews board

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -886,16 +886,14 @@ const AiAgentAdminReviewItemsTable = ({
                 ),
                 Cell: ({ row }) =>
                     isExampleReviewItem(row.original.uuid) ? (
-                        <Box data-tour="reviews-create-pr">
-                            <Button
-                                size="compact-xs"
-                                radius="md"
-                                variant="default"
-                                disabled
-                            >
-                                Create PR
-                            </Button>
-                        </Box>
+                        <Button
+                            size="compact-xs"
+                            radius="md"
+                            variant="default"
+                            disabled
+                        >
+                            Create PR
+                        </Button>
                     ) : (
                         <ReviewItemActions reviewItem={row.original} />
                     ),
@@ -1197,12 +1195,9 @@ const AiAgentAdminReviewItemsTable = ({
             }
 
             const reviewItem = row.original;
-            // Anchor the tour to the first row so it spotlights the whole finding.
-            const rowAnchor =
-                row.index === 0 ? { 'data-tour': 'reviews-row' } : {};
 
             if (isExampleReviewItem(reviewItem.uuid)) {
-                return { className: styles.exampleRow, ...rowAnchor };
+                return { className: styles.exampleRow };
             }
 
             const isSelected = selectedReviewItemUuid === reviewItem.uuid;
@@ -1225,7 +1220,6 @@ const AiAgentAdminReviewItemsTable = ({
                               reviewItemUuid: reviewItem.uuid,
                           })
                     : undefined,
-                ...rowAnchor,
             };
         },
         renderTopToolbar: ({ table: tableInstance }) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -188,7 +188,6 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                                 maw={260}
                             >
                                 <Button
-                                    data-tour="reviews-create-pr"
                                     size={buttonSize}
                                     radius="md"
                                     variant="default"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -36,6 +36,17 @@
     text-align: left;
     cursor: pointer;
 }
+/* Onboarding sample cards: muted, and their action stays visible (no hover)
+   so the tour spotlight always lands on something. */
+.cardExample {
+    opacity: 0.85;
+}
+.cardExample .cardBody {
+    cursor: default;
+}
+.cardExample .startAction {
+    opacity: 1;
+}
 .cardFooter {
     display: flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -99,4 +99,34 @@ describe('ReviewKanbanBoard', () => {
         // resolved item → done lane; getIssueTitle falls back to item.title
         expect(screen.getByText('All done')).toBeInTheDocument();
     });
+
+    it('injects inert, anchored example cards while the tour is open', () => {
+        const { container } = renderWithProviders(
+            <ReviewKanbanBoard
+                onReviewItemSelect={vi.fn()}
+                showOnboardingExamples
+            />,
+        );
+
+        // Example cards replace the real data and carry the board anchors.
+        expect(container.querySelector('[data-tour="reviews-card"]')).not.toBe(
+            null,
+        );
+        expect(container.querySelector('[data-tour="reviews-pr"]')).not.toBe(
+            null,
+        );
+        expect(
+            container.querySelector('[data-tour="reviews-workspace"]'),
+        ).not.toBe(null);
+        expect(
+            container.querySelector('[data-tour="reviews-in-progress"]'),
+        ).not.toBe(null);
+
+        // Example items are clearly labelled and their Start action is disabled.
+        expect(screen.getAllByText('Example').length).toBeGreaterThan(0);
+        const startButton = container.querySelector(
+            '[data-tour="reviews-pr"]',
+        ) as HTMLButtonElement | null;
+        expect(startButton?.disabled).toBe(true);
+    });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -222,8 +222,10 @@ export const ReviewKanbanBoard: FC<Props> = ({
     }, [projects]);
 
     const allItems = useMemo<AiAgentReviewItemSummary[]>(() => {
-        if (showOnboardingExamples && (!data || data.length === 0)) {
-            return EXAMPLE_REVIEW_ITEMS as AiAgentReviewItemSummary[];
+        // Tie the examples to the tour being open (not to emptiness) so the same
+        // cards get highlighted every run, even on a populated board.
+        if (showOnboardingExamples) {
+            return EXAMPLE_REVIEW_ITEMS;
         }
         return data ?? [];
     }, [data, showOnboardingExamples]);
@@ -532,7 +534,15 @@ export const ReviewKanbanBoard: FC<Props> = ({
                             const hasMore = all.length > VISIBLE_PER_LANE;
 
                             return (
-                                <Box key={lane.id} className={styles.lane}>
+                                <Box
+                                    key={lane.id}
+                                    className={styles.lane}
+                                    data-tour={
+                                        lane.id === 'in_progress'
+                                            ? 'reviews-in-progress'
+                                            : undefined
+                                    }
+                                >
                                     <Group gap={8} px={4} pb="xs">
                                         <Box
                                             w={8}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -24,6 +24,7 @@ import {
     useUpdateAiAgentReviewItemStatus,
 } from '../../hooks/useAiAgentAdmin';
 import { AiAgentIcon } from '../AiAgentIcon';
+import { isExampleReviewItem } from './onboarding';
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
 import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
 import {
@@ -82,6 +83,8 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
     const startKind = getStartWritebackKind(item);
     const isRetry = isWritebackRetry(item);
 
+    const isExample = isExampleReviewItem(item.uuid);
+
     const remediation = item.remediation;
     const hasWorkspace = Boolean(remediation);
     const workspaceHref = `/generalSettings/ai/reviews/${encodeURIComponent(
@@ -91,7 +94,10 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
 
     return (
         <Box
-            className={`${styles.card}${isSelected ? ` ${styles.cardSelected}` : ''}`}
+            data-tour={isExample ? 'reviews-card' : undefined}
+            className={`${styles.card}${isSelected ? ` ${styles.cardSelected}` : ''}${
+                isExample ? ` ${styles.cardExample}` : ''
+            }`}
         >
             <Box
                 className={styles.cardBody}
@@ -113,6 +119,17 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                         wrap="nowrap"
                     >
                         <Stack gap={2} style={{ minWidth: 0 }}>
+                            {isExample && (
+                                <Badge
+                                    size="xs"
+                                    radius="sm"
+                                    variant="default"
+                                    color="gray"
+                                    w="fit-content"
+                                >
+                                    Example
+                                </Badge>
+                            )}
                             <Text fz="sm" fw={550} lineClamp={2}>
                                 {title}
                             </Text>
@@ -137,8 +154,8 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     <Badge
                                         size="sm"
                                         radius="sm"
-                                        variant="light"
-                                        color="orange"
+                                        variant="default"
+                                        color="gray"
                                     >
                                         {item.findingCount}×
                                     </Badge>
@@ -181,20 +198,22 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                             />
                         </Group>
 
-                        <ReviewAssigneeMenu
-                            projectUuid={
-                                item.projectUuid ??
-                                item.latestFinding?.projectUuid ??
-                                null
-                            }
-                            fingerprint={item.fingerprint}
-                            assignedToUserUuid={item.assignedToUserUuid}
-                            className={
-                                item.assignedToUserUuid
-                                    ? undefined
-                                    : styles.assigneeUnassigned
-                            }
-                        />
+                        {!isExample && (
+                            <ReviewAssigneeMenu
+                                projectUuid={
+                                    item.projectUuid ??
+                                    item.latestFinding?.projectUuid ??
+                                    null
+                                }
+                                fingerprint={item.fingerprint}
+                                assignedToUserUuid={item.assignedToUserUuid}
+                                className={
+                                    item.assignedToUserUuid
+                                        ? undefined
+                                        : styles.assigneeUnassigned
+                                }
+                            />
+                        )}
                     </Group>
                 </Stack>
             </Box>
@@ -220,6 +239,17 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                             </Text>
                         </Group>
                     </Box>
+                ) : isExample ? (
+                    <Box
+                        data-tour="reviews-workspace"
+                        className={styles.cardFooter}
+                    >
+                        <Group gap={6} align="center">
+                            <MantineIcon icon={IconLayoutColumns} size={13} />
+                            <Text fz="xs">Open workspace</Text>
+                        </Group>
+                        <MantineIcon icon={IconArrowUpRight} size={14} />
+                    </Box>
                 ) : (
                     <Box
                         component={Link}
@@ -237,41 +267,54 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                     </Box>
                 ))}
 
-            {startKind !== null && (
-                <Button
-                    size="compact-xs"
-                    radius="md"
-                    variant="filled"
-                    leftSection={
-                        <MantineIcon
-                            icon={isRetry ? IconRefresh : IconBolt}
-                            size={12}
-                        />
-                    }
-                    loading={createWriteback.isLoading}
-                    className={styles.startAction}
-                    onPointerDown={(e: React.PointerEvent) =>
-                        e.stopPropagation()
-                    }
-                    onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        updateStatus.mutate({
-                            fingerprint: item.fingerprint,
-                            body: {
-                                status: 'in_progress',
-                                dismissedReason: null,
-                            },
-                        });
-                        if (startKind === 'modal') {
-                            setPreviewOpen(true);
-                        } else {
-                            createWriteback.mutate(item.fingerprint);
+            {startKind !== null &&
+                (isExample ? (
+                    <Button
+                        data-tour="reviews-pr"
+                        size="compact-xs"
+                        radius="md"
+                        variant="filled"
+                        disabled
+                        leftSection={<MantineIcon icon={IconBolt} size={12} />}
+                        className={styles.startAction}
+                    >
+                        Start fix
+                    </Button>
+                ) : (
+                    <Button
+                        size="compact-xs"
+                        radius="md"
+                        variant="filled"
+                        leftSection={
+                            <MantineIcon
+                                icon={isRetry ? IconRefresh : IconBolt}
+                                size={12}
+                            />
                         }
-                    }}
-                >
-                    {isRetry ? 'Retry fix' : 'Start fix'}
-                </Button>
-            )}
+                        loading={createWriteback.isLoading}
+                        className={styles.startAction}
+                        onPointerDown={(e: React.PointerEvent) =>
+                            e.stopPropagation()
+                        }
+                        onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            updateStatus.mutate({
+                                fingerprint: item.fingerprint,
+                                body: {
+                                    status: 'in_progress',
+                                    dismissedReason: null,
+                                },
+                            });
+                            if (startKind === 'modal') {
+                                setPreviewOpen(true);
+                            } else {
+                                createWriteback.mutate(item.fingerprint);
+                            }
+                        }}
+                    >
+                        {isRetry ? 'Retry fix' : 'Start fix'}
+                    </Button>
+                ))}
 
             {startKind === 'modal' && (
                 <ProjectContextWritebackModal

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
@@ -1,0 +1,103 @@
+import { type AiAgentReviewItemPrDiff } from '@lightdash/common';
+import {
+    Center,
+    Loader,
+    Paper,
+    Stack,
+    Text,
+    useComputedColorScheme,
+} from '@mantine-8/core';
+import {
+    MultiFileDiff,
+    Virtualizer,
+    WorkerPoolContextProvider,
+} from '@pierre/diffs/react';
+import { type CSSProperties, type FC } from 'react';
+import {
+    PIERRE_HIGHLIGHTER_OPTIONS,
+    PIERRE_POOL_OPTIONS,
+} from './pierreDiffConfig';
+
+type Props = {
+    diff: AiAgentReviewItemPrDiff | undefined;
+    isLoading: boolean;
+    maxHeight?: string;
+};
+
+export const ReviewPrDiffContent: FC<Props> = ({
+    diff,
+    isLoading,
+    maxHeight = '70vh',
+}) => {
+    const colorScheme = useComputedColorScheme('light');
+
+    // Pierre's <Virtualizer> IS the scroll viewport its virtualizer tracks —
+    // each file gets its own so off-screen rows render as you scroll.
+    const viewportStyle = {
+        maxHeight,
+        overflow: 'auto',
+        colorScheme,
+        '--diffs-font-size': '11px',
+        '--diffs-line-height': '17px',
+    } as CSSProperties;
+
+    if (isLoading || !diff) {
+        return (
+            <Center py="xl">
+                <Loader size="md" color="gray" />
+            </Center>
+        );
+    }
+
+    return (
+        <WorkerPoolContextProvider
+            poolOptions={PIERRE_POOL_OPTIONS}
+            highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
+        >
+            <Stack gap="md">
+                {diff.truncated && (
+                    <Text fz="xs" c="dimmed">
+                        Showing the first {diff.files.length} changed files —
+                        open the PR for the full change set.
+                    </Text>
+                )}
+                {diff.files.map((file) => (
+                    <Paper
+                        key={file.path}
+                        withBorder
+                        radius="md"
+                        style={{ overflow: 'hidden' }}
+                    >
+                        <Virtualizer style={viewportStyle}>
+                            <MultiFileDiff
+                                oldFile={{
+                                    name: file.path,
+                                    contents: file.before,
+                                }}
+                                newFile={{
+                                    name: file.path,
+                                    contents: file.after,
+                                }}
+                                // color-scheme must sit on the diff host
+                                // itself to override its `:host` default.
+                                style={{ colorScheme }}
+                                renderHeaderMetadata={() => (
+                                    <Text fz="xs" c="ldGray.6">
+                                        +{file.additions} −{file.deletions}
+                                    </Text>
+                                )}
+                                options={{
+                                    diffStyle: 'split',
+                                    theme:
+                                        colorScheme === 'dark'
+                                            ? 'pierre-dark'
+                                            : 'pierre-light',
+                                }}
+                            />
+                        </Virtualizer>
+                    </Paper>
+                ))}
+            </Stack>
+        </WorkerPoolContextProvider>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffModal.tsx
@@ -1,24 +1,8 @@
 import { type AiAgentReviewItemPrDiff } from '@lightdash/common';
-import {
-    Center,
-    Loader,
-    Paper,
-    Stack,
-    Text,
-    useComputedColorScheme,
-} from '@mantine-8/core';
-import {
-    MultiFileDiff,
-    Virtualizer,
-    WorkerPoolContextProvider,
-} from '@pierre/diffs/react';
 import { IconGitPullRequest } from '@tabler/icons-react';
-import { type CSSProperties, type FC } from 'react';
+import { type FC } from 'react';
 import MantineModal from '../../../../../components/common/MantineModal';
-import {
-    PIERRE_HIGHLIGHTER_OPTIONS,
-    PIERRE_POOL_OPTIONS,
-} from './pierreDiffConfig';
+import { ReviewPrDiffContent } from './ReviewPrDiffContent';
 
 type Props = {
     opened: boolean;
@@ -32,83 +16,14 @@ export const ReviewPrDiffModal: FC<Props> = ({
     onClose,
     diff,
     isLoading,
-}) => {
-    const colorScheme = useComputedColorScheme('light');
-
-    // Pierre's <Virtualizer> IS the scroll viewport its virtualizer tracks —
-    // each file gets its own so off-screen rows render as you scroll.
-    const viewportStyle = {
-        maxHeight: '70vh',
-        overflow: 'auto',
-        colorScheme,
-        '--diffs-font-size': '11px',
-        '--diffs-line-height': '17px',
-    } as CSSProperties;
-
-    return (
-        <MantineModal
-            opened={opened}
-            onClose={onClose}
-            title="Pull request changes"
-            icon={IconGitPullRequest}
-            size="80vw"
-        >
-            {isLoading || !diff ? (
-                <Center py="xl">
-                    <Loader size="md" color="gray" />
-                </Center>
-            ) : (
-                <WorkerPoolContextProvider
-                    poolOptions={PIERRE_POOL_OPTIONS}
-                    highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
-                >
-                    <Stack gap="md">
-                        {diff.truncated && (
-                            <Text fz="xs" c="dimmed">
-                                Showing the first {diff.files.length} changed
-                                files — open the PR for the full change set.
-                            </Text>
-                        )}
-                        {diff.files.map((file) => (
-                            <Paper
-                                key={file.path}
-                                withBorder
-                                radius="md"
-                                style={{ overflow: 'hidden' }}
-                            >
-                                <Virtualizer style={viewportStyle}>
-                                    <MultiFileDiff
-                                        oldFile={{
-                                            name: file.path,
-                                            contents: file.before,
-                                        }}
-                                        newFile={{
-                                            name: file.path,
-                                            contents: file.after,
-                                        }}
-                                        // color-scheme must sit on the diff host
-                                        // itself to override its `:host` default.
-                                        style={{ colorScheme }}
-                                        renderHeaderMetadata={() => (
-                                            <Text fz="xs" c="ldGray.6">
-                                                +{file.additions} −
-                                                {file.deletions}
-                                            </Text>
-                                        )}
-                                        options={{
-                                            diffStyle: 'split',
-                                            theme:
-                                                colorScheme === 'dark'
-                                                    ? 'pierre-dark'
-                                                    : 'pierre-light',
-                                        }}
-                                    />
-                                </Virtualizer>
-                            </Paper>
-                        ))}
-                    </Stack>
-                </WorkerPoolContextProvider>
-            )}
-        </MantineModal>
-    );
-};
+}) => (
+    <MantineModal
+        opened={opened}
+        onClose={onClose}
+        title="Pull request changes"
+        icon={IconGitPullRequest}
+        size="80vw"
+    >
+        <ReviewPrDiffContent diff={diff} isLoading={isLoading} />
+    </MantineModal>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
@@ -26,13 +26,33 @@
     flex: 1 1 0;
 }
 
-/* Tie the Test pane to the preview environment with the preview-banner blue. */
-.panePreview {
-    border-top: 2px solid var(--mantine-color-blue-6);
-}
-
 .connector {
     flex: 0 0 auto;
     align-self: center;
     color: var(--mantine-color-dimmed);
+}
+
+.testHeader {
+    background-color: light-dark(
+        var(--mantine-color-blue-0),
+        color-mix(in srgb, var(--mantine-color-blue-6) 22%, transparent)
+    );
+}
+
+.drawerBody {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.diffHeader {
+    display: block;
+    width: 100%;
+    padding: var(--mantine-spacing-sm);
+    border-radius: var(--mantine-radius-md);
+}
+
+.diffHeader:hover {
+    background-color: var(--mantine-color-default-hover);
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
@@ -17,26 +17,21 @@
     overflow-y: auto;
 }
 
-/* Build is the primary pane (you act here); Test is the narrower verification rail. */
-.paneBuild {
-    flex: 1.4 1 0;
-}
-
-.paneTest {
-    flex: 1 1 0;
-}
-
-.connector {
-    flex: 0 0 auto;
-    align-self: center;
-    color: var(--mantine-color-dimmed);
-}
-
 .testHeader {
     background-color: light-dark(
         var(--mantine-color-blue-0),
         color-mix(in srgb, var(--mantine-color-blue-6) 22%, transparent)
     );
+}
+
+.drawerInner {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
+}
+
+.drawerOverlay {
+    top: var(--drawer-top-offset, 0);
+    height: calc(100% - var(--drawer-top-offset, 0));
 }
 
 .drawerBody {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.module.css
@@ -24,6 +24,19 @@
     );
 }
 
+.drawerHeader {
+    background: linear-gradient(
+        180deg,
+        light-dark(
+            var(--mantine-color-blue-0),
+            color-mix(in srgb, var(--mantine-color-blue-6) 16%, transparent)
+        ),
+        light-dark(var(--mantine-color-white), var(--mantine-color-dark-7))
+    );
+    border-bottom: 1px solid
+        light-dark(var(--mantine-color-blue-1), var(--mantine-color-dark-4));
+}
+
 .drawerInner {
     top: var(--drawer-top-offset, 0);
     height: calc(100% - var(--drawer-top-offset, 0));

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -1,6 +1,8 @@
+import { ProjectType } from '@lightdash/common';
 import {
     Box,
     Button,
+    CloseButton,
     Collapse,
     Divider,
     Drawer,
@@ -8,7 +10,6 @@ import {
     Group,
     Loader,
     Paper,
-    SegmentedControl,
     Stack,
     Text,
     ThemeIcon,
@@ -29,8 +30,15 @@ import { useMemo } from 'react';
 import { useParams } from 'react-router';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
+import {
+    BANNER_HEIGHT,
+    NAVBAR_HEIGHT,
+} from '../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../components/common/PageBreadcrumbs';
+import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
+import { useProject } from '../../../../../hooks/useProject';
 import { useProjects } from '../../../../../hooks/useProjects';
+import { useImpersonation } from '../../../../../hooks/user/useImpersonation';
 import {
     useAiAgentAdminAgents,
     useAiAgentAdminReviewItem,
@@ -54,6 +62,15 @@ const WORKSPACE_HEIGHT = 'calc(100vh - 170px)';
 
 export const ReviewRemediationWorkspace = () => {
     const { fingerprint } = useParams<{ fingerprint: string }>();
+
+    // The drawer is anchored below the fixed navbar (and the preview/impersonation
+    // banner when one is showing), so its header isn't hidden under them.
+    const { activeProjectUuid } = useActiveProjectUuid();
+    const { data: activeProject } = useProject(activeProjectUuid);
+    const { isImpersonating } = useImpersonation();
+    const hasBanner =
+        activeProject?.type === ProjectType.PREVIEW || isImpersonating;
+    const drawerTopOffset = NAVBAR_HEIGHT + (hasBanner ? BANNER_HEIGHT : 0);
 
     const { data: reviewItem, isLoading: isItemLoading } =
         useAiAgentAdminReviewItem(fingerprint ?? '', {
@@ -124,8 +141,8 @@ export const ReviewRemediationWorkspace = () => {
     // and not stale (the fix changed since it was last tested).
     const isVerified = hasVerification && !activity?.verdictStale;
 
-    // Layout d folds the Test + Retest buttons into a single pill that opens the
-    // test drawer. It mirrors testBadge, with a "Test the fix" CTA fallback when
+    // A single header pill that opens the test drawer, in place of separate Test
+    // and Retest buttons. It mirrors testBadge, with a "Test the fix" CTA when
     // nothing has run yet. It stays a loud (filled) CTA while there's something
     // to verify, and calms to a light status once a verdict is in — so the
     // emphasis hands off to the black Resolve button at the right moment.
@@ -203,14 +220,6 @@ export const ReviewRemediationWorkspace = () => {
         </Group>
     );
 
-    const stepIcon = (n: number) => (
-        <ThemeIcon size="sm" radius="xl" variant="default">
-            <Text fz="xs" fw={600} c="dimmed">
-                {n}
-            </Text>
-        </ThemeIcon>
-    );
-
     const buildPane = (className: string) => (
         <Paper withBorder className={className}>
             <Group justify="space-between" p="sm" wrap="nowrap">
@@ -259,7 +268,53 @@ export const ReviewRemediationWorkspace = () => {
         </Paper>
     );
 
-    const testPane = (className: string, showRetest = true) => (
+    const retestButton = (
+        <Button
+            size="compact-sm"
+            variant={activity?.verdictStale ? 'filled' : 'light'}
+            color="yellow"
+            disabled={!canRetest}
+            loading={retest.isLoading}
+            leftSection={<MantineIcon icon={IconRefresh} size={16} />}
+            onClick={() => fingerprint && retest.mutate({ fingerprint })}
+        >
+            Retest
+        </Button>
+    );
+
+    // The verification conversation (or the live waiting state). Shared by the
+    // inline deterministic-fix pane and the test drawer's scroll container.
+    const testThreadBody = (
+        <div className={classes.paneBody}>
+            {hasTestThread &&
+            remediation.previewProjectUuid &&
+            remediation.previewAgentUuid &&
+            remediation.previewThreadUuid ? (
+                <WorkspaceThreadPane
+                    projectUuid={remediation.previewProjectUuid}
+                    agentUuid={remediation.previewAgentUuid}
+                    agentName={testAgent?.name ?? 'Verification'}
+                    threadUuid={remediation.previewThreadUuid}
+                    interactive={false}
+                />
+            ) : (
+                <Stack align="center" mt="xl" gap="xs">
+                    {isLive && <Loader size="sm" />}
+                    <Text c="dimmed" fz="sm" ta="center" maw={320}>
+                        {activity?.liveState === 'writeback'
+                            ? 'Waiting for the pull request to open…'
+                            : activity?.liveState === 'compiling'
+                              ? 'Building the preview environment…'
+                              : activity?.liveState === 'verifying'
+                                ? 'Running verification in the preview…'
+                                : 'The verdict appears here once the preview is ready.'}
+                    </Text>
+                </Stack>
+            )}
+        </div>
+    );
+
+    const testPane = (className: string) => (
         <Paper withBorder className={className}>
             <Group
                 justify="space-between"
@@ -270,13 +325,11 @@ export const ReviewRemediationWorkspace = () => {
                 <Group gap="xs" wrap="nowrap" miw={0}>
                     <ThemeIcon
                         size="sm"
-                        radius="xl"
+                        radius="md"
                         variant="light"
                         color="blue"
                     >
-                        <Text fz="xs" fw={600} c="blue">
-                            2
-                        </Text>
+                        <MantineIcon icon={IconFlask} size={14} />
                     </ThemeIcon>
                     <Text fw={600} fz="sm">
                         Test the fix
@@ -286,56 +339,10 @@ export const ReviewRemediationWorkspace = () => {
                     </Text>
                     {testBadge && renderBadge(testBadge)}
                 </Group>
-                {showRetest && (
-                    <Group gap="xs" wrap="nowrap">
-                        <Button
-                            size="compact-xs"
-                            variant={
-                                activity?.verdictStale ? 'filled' : 'light'
-                            }
-                            color="yellow"
-                            disabled={!canRetest}
-                            loading={retest.isLoading}
-                            leftSection={
-                                <MantineIcon icon={IconRefresh} size={16} />
-                            }
-                            onClick={() =>
-                                fingerprint && retest.mutate({ fingerprint })
-                            }
-                        >
-                            Retest
-                        </Button>
-                    </Group>
-                )}
+                {retestButton}
             </Group>
             <Divider />
-            <div className={classes.paneBody}>
-                {hasTestThread &&
-                remediation.previewProjectUuid &&
-                remediation.previewAgentUuid &&
-                remediation.previewThreadUuid ? (
-                    <WorkspaceThreadPane
-                        projectUuid={remediation.previewProjectUuid}
-                        agentUuid={remediation.previewAgentUuid}
-                        agentName={testAgent?.name ?? 'Verification'}
-                        threadUuid={remediation.previewThreadUuid}
-                        interactive={false}
-                    />
-                ) : (
-                    <Stack align="center" mt="xl" gap="xs">
-                        {isLive && <Loader size="sm" />}
-                        <Text c="dimmed" fz="sm" ta="center" maw={320}>
-                            {activity?.liveState === 'writeback'
-                                ? 'Waiting for the pull request to open…'
-                                : activity?.liveState === 'compiling'
-                                  ? 'Building the preview environment…'
-                                  : activity?.liveState === 'verifying'
-                                    ? 'Running verification in the preview…'
-                                    : 'The verdict appears here once the preview is ready.'}
-                        </Text>
-                    </Stack>
-                )}
-            </div>
+            {testThreadBody}
         </Paper>
     );
 
@@ -366,7 +373,7 @@ export const ReviewRemediationWorkspace = () => {
                     />
                 </Group>
                 <Group gap="xs" wrap="nowrap">
-                    {reviewItem.linkedPrUrl && layout !== 'd' && (
+                    {reviewItem.linkedPrUrl && !hasBuildThread && (
                         <Button
                             component="a"
                             href={reviewItem.linkedPrUrl}
@@ -390,7 +397,7 @@ export const ReviewRemediationWorkspace = () => {
                             View PR
                         </Button>
                     )}
-                    {layout === 'd' && hasBuildThread && (
+                    {hasBuildThread && (
                         <Button
                             size="xs"
                             color={verdictPill.color}
@@ -439,45 +446,9 @@ export const ReviewRemediationWorkspace = () => {
                 </Group>
             </Group>
 
-            {hasBuildThread && layout === 'd' ? (
+            {hasBuildThread ? (
                 <Flex className={classes.panes} h={WORKSPACE_HEIGHT}>
                     {buildPane(`${classes.pane}`)}
-                </Flex>
-            ) : hasBuildThread && layout === 'b' ? (
-                <Flex
-                    direction="column"
-                    gap="sm"
-                    className={classes.panes}
-                    h={WORKSPACE_HEIGHT}
-                >
-                    {buildPane(`${classes.pane}`)}
-                    {testPane(`${classes.pane}`)}
-                </Flex>
-            ) : hasBuildThread && layout === 'c' ? (
-                <Stack gap="sm" h={WORKSPACE_HEIGHT}>
-                    <SegmentedControl
-                        value={activeTab}
-                        onChange={(value) =>
-                            setActiveTab(value as 'build' | 'test')
-                        }
-                        data={[
-                            { label: '1 · Build the fix', value: 'build' },
-                            { label: '2 · Test the fix', value: 'test' },
-                        ]}
-                    />
-                    {activeTab === 'build'
-                        ? buildPane(`${classes.pane}`)
-                        : testPane(`${classes.pane}`)}
-                </Stack>
-            ) : hasBuildThread ? (
-                <Flex gap="sm" className={classes.panes} h={WORKSPACE_HEIGHT}>
-                    {buildPane(`${classes.pane} ${classes.paneBuild}`)}
-
-                    <Flex className={classes.connector}>
-                        <MantineIcon icon={IconArrowRight} size={24} />
-                    </Flex>
-
-                    {testPane(`${classes.pane} ${classes.paneTest}`)}
                 </Flex>
             ) : (
                 <Flex
@@ -488,12 +459,22 @@ export const ReviewRemediationWorkspace = () => {
                 >
                     <Paper withBorder p="sm">
                         <Group gap="xs" wrap="nowrap" miw={0}>
-                            {stepIcon(1)}
+                            <ThemeIcon
+                                size="sm"
+                                radius="md"
+                                variant="light"
+                                color="gray"
+                            >
+                                <MantineIcon
+                                    icon={IconGitPullRequest}
+                                    size={14}
+                                />
+                            </ThemeIcon>
                             <Text fw={600} fz="sm">
                                 Deterministic fix
                             </Text>
                             <Text fz="xs" c="dimmed" truncate>
-                                · Project context — written without a build
+                                · Project context, written without a build
                                 conversation
                             </Text>
                         </Group>
@@ -552,9 +533,55 @@ export const ReviewRemediationWorkspace = () => {
                 size="xl"
                 padding={0}
                 withCloseButton={false}
-                classNames={{ body: classes.drawerBody }}
+                classNames={{
+                    inner: classes.drawerInner,
+                    overlay: classes.drawerOverlay,
+                    body: classes.drawerBody,
+                }}
+                __vars={{ '--drawer-top-offset': `${drawerTopOffset}px` }}
             >
-                {testPane(`${classes.pane}`, true)}
+                <Box p="md" className={classes.testHeader}>
+                    <Group
+                        justify="space-between"
+                        align="flex-start"
+                        wrap="nowrap"
+                    >
+                        <Group gap="sm" wrap="nowrap" miw={0}>
+                            <ThemeIcon
+                                size="lg"
+                                radius="md"
+                                variant="light"
+                                color="blue"
+                            >
+                                <MantineIcon icon={IconFlask} size={20} />
+                            </ThemeIcon>
+                            <Box miw={0}>
+                                <Group gap="xs" wrap="nowrap" miw={0}>
+                                    <Text fw={600} fz="sm">
+                                        Test the fix
+                                    </Text>
+                                    {testBadge && renderBadge(testBadge)}
+                                </Group>
+                                <Text fz="xs" c="dimmed" truncate>
+                                    Preview environment · {previewProjectName}
+                                </Text>
+                            </Box>
+                        </Group>
+                        <CloseButton onClick={testDrawerHandlers.close} />
+                    </Group>
+                    <Text fz="sm" c="dimmed" mt="sm">
+                        We spun up a throwaway copy of your project with this
+                        fix applied. {testAgent?.name ?? 'Your agent'} re-runs
+                        the original question against it, so you can see whether
+                        the answer is right now before you merge. Nothing here
+                        touches production.
+                    </Text>
+                    <Group justify="flex-end" mt="sm">
+                        {retestButton}
+                    </Group>
+                </Box>
+                <Divider />
+                {testThreadBody}
             </Drawer>
 
             <MarkResolvedModal

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -278,7 +278,7 @@ export const ReviewRemediationWorkspace = () => {
             leftSection={<MantineIcon icon={IconRefresh} size={16} />}
             onClick={() => fingerprint && retest.mutate({ fingerprint })}
         >
-            Retest
+            Test again
         </Button>
     );
 
@@ -540,7 +540,7 @@ export const ReviewRemediationWorkspace = () => {
                 }}
                 __vars={{ '--drawer-top-offset': `${drawerTopOffset}px` }}
             >
-                <Box p="md" className={classes.testHeader}>
+                <Box p="md" className={classes.drawerHeader}>
                     <Group
                         justify="space-between"
                         align="flex-start"
@@ -550,14 +550,14 @@ export const ReviewRemediationWorkspace = () => {
                             <ThemeIcon
                                 size="lg"
                                 radius="md"
-                                variant="light"
+                                variant="white"
                                 color="blue"
                             >
                                 <MantineIcon icon={IconFlask} size={20} />
                             </ThemeIcon>
                             <Box miw={0}>
                                 <Group gap="xs" wrap="nowrap" miw={0}>
-                                    <Text fw={600} fz="sm">
+                                    <Text fw={700} fz="md">
                                         Test the fix
                                     </Text>
                                     {testBadge && renderBadge(testBadge)}
@@ -570,17 +570,28 @@ export const ReviewRemediationWorkspace = () => {
                         <CloseButton onClick={testDrawerHandlers.close} />
                     </Group>
                     <Text fz="sm" c="dimmed" mt="sm">
-                        We spun up a throwaway copy of your project with this
-                        fix applied. {testAgent?.name ?? 'Your agent'} re-runs
-                        the original question against it, so you can see whether
-                        the answer is right now before you merge. Nothing here
-                        touches production.
+                        We spun up a{' '}
+                        <Text span fw={600} c="bright" fz="inherit">
+                            throwaway copy
+                        </Text>{' '}
+                        of your project with this fix applied.{' '}
+                        <Text span fw={600} c="bright" fz="inherit">
+                            {testAgent?.name ?? 'Your agent'}
+                        </Text>{' '}
+                        re-runs the original question against it, so you can see
+                        whether the answer is right{' '}
+                        <Text span fw={600} c="bright" fz="inherit">
+                            before you merge
+                        </Text>
+                        .{' '}
+                        <Text span fw={600} c="bright" fz="inherit">
+                            Nothing here touches production.
+                        </Text>
                     </Text>
                     <Group justify="flex-end" mt="sm">
                         {retestButton}
                     </Group>
                 </Box>
-                <Divider />
                 {testThreadBody}
             </Drawer>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -1,21 +1,27 @@
 import {
-    Badge,
+    Box,
     Button,
+    Collapse,
     Divider,
+    Drawer,
     Flex,
     Group,
     Loader,
     Paper,
+    SegmentedControl,
     Stack,
     Text,
     ThemeIcon,
+    UnstyledButton,
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
-    IconArrowRight,
+    IconAlertTriangle,
+    IconChevronDown,
+    IconChevronRight,
     IconCircleCheck,
     IconExternalLink,
-    IconFileDiff,
+    IconFlask,
     IconGitPullRequest,
     IconRefresh,
 } from '@tabler/icons-react';
@@ -38,7 +44,7 @@ import {
     reviewRootCauseColors,
     reviewRootCauseLabels,
 } from './reviewItemDetails';
-import { ReviewPrDiffModal } from './ReviewPrDiffModal';
+import { ReviewPrDiffContent } from './ReviewPrDiffContent';
 import classes from './ReviewRemediationWorkspace.module.css';
 import { WorkspaceThreadPane } from './WorkspaceThreadPane';
 
@@ -74,6 +80,7 @@ export const ReviewRemediationWorkspace = () => {
     });
     const [diffOpen, diffHandlers] = useDisclosure(false);
     const [resolveOpen, resolveHandlers] = useDisclosure(false);
+    const [testDrawerOpen, testDrawerHandlers] = useDisclosure(false);
 
     const retest = useRetestAiAgentReviewRemediation();
 
@@ -112,6 +119,34 @@ export const ReviewRemediationWorkspace = () => {
         activity?.liveState === 'writeback'
             ? { label: 'Opening PR', color: 'blue', loading: true }
             : null;
+
+    // A verdict is trustworthy enough to encourage resolving only once it's in
+    // and not stale (the fix changed since it was last tested).
+    const isVerified = hasVerification && !activity?.verdictStale;
+
+    // Layout d folds the Test + Retest buttons into a single pill that opens the
+    // test drawer. It mirrors testBadge, with a "Test the fix" CTA fallback when
+    // nothing has run yet. It stays a loud (filled) CTA while there's something
+    // to verify, and calms to a light status once a verdict is in — so the
+    // emphasis hands off to the black Resolve button at the right moment.
+    const verdictPill = useMemo(() => {
+        const base = testBadge ?? {
+            label: 'Test the fix',
+            color: 'blue',
+            loading: false,
+        };
+        const icon =
+            base.color === 'green'
+                ? IconCircleCheck
+                : base.color === 'red'
+                  ? IconAlertTriangle
+                  : base.color === 'yellow'
+                    ? IconRefresh
+                    : IconFlask;
+        const variant: 'light' | 'filled' =
+            base.color === 'green' ? 'light' : 'filled';
+        return { ...base, icon, variant };
+    }, [testBadge]);
 
     if (isItemLoading) {
         return (
@@ -153,34 +188,96 @@ export const ReviewRemediationWorkspace = () => {
     const previewProjectName =
         projectName(remediation.previewProjectUuid) ?? 'Preview environment';
 
-    const renderBadge = (badge: PaneBadge) => (
-        <Badge
-            size="sm"
-            variant="light"
-            color={badge.color}
-            leftSection={
-                badge.loading ? (
-                    <Loader size={9} color={badge.color} />
-                ) : undefined
-            }
-        >
-            {badge.label}
-        </Badge>
+    const renderBadge = (badge: PaneBadge, onColor = false) => (
+        <Group gap={6} wrap="nowrap" align="center">
+            {badge.loading && (
+                <Loader size={10} color={onColor ? 'white' : 'gray'} />
+            )}
+            <Text
+                fz="xs"
+                fw={500}
+                c={onColor ? 'white' : badge.color === 'red' ? 'red' : 'dimmed'}
+            >
+                {badge.label}
+            </Text>
+        </Group>
     );
 
-    const stepIcon = (n: number, color: string) => (
-        <ThemeIcon size="sm" radius="xl" variant="filled" color={color}>
-            <Text fz="xs" fw={700}>
+    const stepIcon = (n: number) => (
+        <ThemeIcon size="sm" radius="xl" variant="default">
+            <Text fz="xs" fw={600} c="dimmed">
                 {n}
             </Text>
         </ThemeIcon>
     );
 
-    const testPane = (className: string) => (
+    const buildPane = (className: string) => (
         <Paper withBorder className={className}>
             <Group justify="space-between" p="sm" wrap="nowrap">
                 <Group gap="xs" wrap="nowrap" miw={0}>
-                    {stepIcon(2, 'blue')}
+                    <ThemeIcon
+                        size="sm"
+                        radius="md"
+                        variant="light"
+                        color="gray"
+                    >
+                        <MantineIcon icon={IconGitPullRequest} size={14} />
+                    </ThemeIcon>
+                    <Text fw={600} fz="sm">
+                        Build the fix
+                    </Text>
+                    {buildProjectName && (
+                        <Text fz="xs" c="dimmed" truncate maw={150}>
+                            · {buildProjectName}
+                        </Text>
+                    )}
+                    {buildBadge && renderBadge(buildBadge)}
+                </Group>
+                {buildAgent && (
+                    <AgentNamePill
+                        name={buildAgent.name}
+                        imageUrl={buildAgent.imageUrl ?? null}
+                        variant="inline"
+                    />
+                )}
+            </Group>
+            <Divider />
+            {buildBadge && activity?.liveMessage && (
+                <Text fz="xs" c="dimmed" px="sm" py={4} truncate>
+                    {activity.liveMessage}
+                </Text>
+            )}
+            <div className={classes.paneBody}>
+                <WorkspaceThreadPane
+                    projectUuid={remediation.sourceProjectUuid}
+                    agentUuid={remediation.sourceAgentUuid}
+                    agentName={buildAgent?.name ?? 'Build fix'}
+                    threadUuid={remediation.workThreadUuid!}
+                    interactive
+                />
+            </div>
+        </Paper>
+    );
+
+    const testPane = (className: string, showRetest = true) => (
+        <Paper withBorder className={className}>
+            <Group
+                justify="space-between"
+                p="sm"
+                wrap="nowrap"
+                className={classes.testHeader}
+            >
+                <Group gap="xs" wrap="nowrap" miw={0}>
+                    <ThemeIcon
+                        size="sm"
+                        radius="xl"
+                        variant="light"
+                        color="blue"
+                    >
+                        <Text fz="xs" fw={600} c="blue">
+                            2
+                        </Text>
+                    </ThemeIcon>
                     <Text fw={600} fz="sm">
                         Test the fix
                     </Text>
@@ -189,30 +286,27 @@ export const ReviewRemediationWorkspace = () => {
                     </Text>
                     {testBadge && renderBadge(testBadge)}
                 </Group>
-                <Group gap="xs" wrap="nowrap">
-                    {hasTestThread && testAgent && (
-                        <AgentNamePill
-                            name={testAgent.name}
-                            imageUrl={testAgent.imageUrl ?? null}
-                            variant="inline"
-                        />
-                    )}
-                    <Button
-                        size="compact-xs"
-                        variant={activity?.verdictStale ? 'filled' : 'light'}
-                        color="yellow"
-                        disabled={!canRetest}
-                        loading={retest.isLoading}
-                        leftSection={
-                            <MantineIcon icon={IconRefresh} size={16} />
-                        }
-                        onClick={() =>
-                            fingerprint && retest.mutate({ fingerprint })
-                        }
-                    >
-                        Retest
-                    </Button>
-                </Group>
+                {showRetest && (
+                    <Group gap="xs" wrap="nowrap">
+                        <Button
+                            size="compact-xs"
+                            variant={
+                                activity?.verdictStale ? 'filled' : 'light'
+                            }
+                            color="yellow"
+                            disabled={!canRetest}
+                            loading={retest.isLoading}
+                            leftSection={
+                                <MantineIcon icon={IconRefresh} size={16} />
+                            }
+                            onClick={() =>
+                                fingerprint && retest.mutate({ fingerprint })
+                            }
+                        >
+                            Retest
+                        </Button>
+                    </Group>
+                )}
             </Group>
             <Divider />
             <div className={classes.paneBody}>
@@ -272,22 +366,7 @@ export const ReviewRemediationWorkspace = () => {
                     />
                 </Group>
                 <Group gap="xs" wrap="nowrap">
-                    {reviewItem.linkedPrUrl && (
-                        <Button
-                            variant="default"
-                            size="xs"
-                            leftSection={
-                                <MantineIcon icon={IconFileDiff} size={18} />
-                            }
-                            onClick={diffHandlers.open}
-                        >
-                            View changes
-                            {prDiff.data
-                                ? ` (${prDiff.data.files.length})`
-                                : ''}
-                        </Button>
-                    )}
-                    {reviewItem.linkedPrUrl && (
+                    {reviewItem.linkedPrUrl && layout !== 'd' && (
                         <Button
                             component="a"
                             href={reviewItem.linkedPrUrl}
@@ -311,10 +390,44 @@ export const ReviewRemediationWorkspace = () => {
                             View PR
                         </Button>
                     )}
+                    {layout === 'd' && hasBuildThread && (
+                        <Button
+                            size="xs"
+                            color={verdictPill.color}
+                            variant={verdictPill.variant}
+                            onClick={testDrawerHandlers.open}
+                            leftSection={
+                                verdictPill.loading ? (
+                                    <Loader
+                                        size={14}
+                                        color={
+                                            verdictPill.variant === 'filled'
+                                                ? 'white'
+                                                : verdictPill.color
+                                        }
+                                    />
+                                ) : (
+                                    <MantineIcon
+                                        icon={verdictPill.icon}
+                                        size={16}
+                                    />
+                                )
+                            }
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconChevronRight}
+                                    size={14}
+                                />
+                            }
+                        >
+                            {verdictPill.label}
+                        </Button>
+                    )}
                     {reviewItem.status !== 'resolved' && (
                         <Button
-                            color="green"
+                            color="dark"
                             size="xs"
+                            variant={isVerified ? 'filled' : 'default'}
                             leftSection={
                                 <MantineIcon icon={IconCircleCheck} size={18} />
                             }
@@ -326,57 +439,45 @@ export const ReviewRemediationWorkspace = () => {
                 </Group>
             </Group>
 
-            {hasBuildThread ? (
+            {hasBuildThread && layout === 'd' ? (
+                <Flex className={classes.panes} h={WORKSPACE_HEIGHT}>
+                    {buildPane(`${classes.pane}`)}
+                </Flex>
+            ) : hasBuildThread && layout === 'b' ? (
+                <Flex
+                    direction="column"
+                    gap="sm"
+                    className={classes.panes}
+                    h={WORKSPACE_HEIGHT}
+                >
+                    {buildPane(`${classes.pane}`)}
+                    {testPane(`${classes.pane}`)}
+                </Flex>
+            ) : hasBuildThread && layout === 'c' ? (
+                <Stack gap="sm" h={WORKSPACE_HEIGHT}>
+                    <SegmentedControl
+                        value={activeTab}
+                        onChange={(value) =>
+                            setActiveTab(value as 'build' | 'test')
+                        }
+                        data={[
+                            { label: '1 · Build the fix', value: 'build' },
+                            { label: '2 · Test the fix', value: 'test' },
+                        ]}
+                    />
+                    {activeTab === 'build'
+                        ? buildPane(`${classes.pane}`)
+                        : testPane(`${classes.pane}`)}
+                </Stack>
+            ) : hasBuildThread ? (
                 <Flex gap="sm" className={classes.panes} h={WORKSPACE_HEIGHT}>
-                    <Paper
-                        withBorder
-                        className={`${classes.pane} ${classes.paneBuild}`}
-                    >
-                        <Group justify="space-between" p="sm" wrap="nowrap">
-                            <Group gap="xs" wrap="nowrap" miw={0}>
-                                {stepIcon(1, 'indigo')}
-                                <Text fw={600} fz="sm">
-                                    Build the fix
-                                </Text>
-                                {buildProjectName && (
-                                    <Text fz="xs" c="dimmed" truncate maw={150}>
-                                        · {buildProjectName}
-                                    </Text>
-                                )}
-                                {buildBadge && renderBadge(buildBadge)}
-                            </Group>
-                            {buildAgent && (
-                                <AgentNamePill
-                                    name={buildAgent.name}
-                                    imageUrl={buildAgent.imageUrl ?? null}
-                                    variant="inline"
-                                />
-                            )}
-                        </Group>
-                        <Divider />
-                        {buildBadge && activity?.liveMessage && (
-                            <Text fz="xs" c="dimmed" px="sm" py={4} truncate>
-                                {activity.liveMessage}
-                            </Text>
-                        )}
-                        <div className={classes.paneBody}>
-                            <WorkspaceThreadPane
-                                projectUuid={remediation.sourceProjectUuid}
-                                agentUuid={remediation.sourceAgentUuid}
-                                agentName={buildAgent?.name ?? 'Build fix'}
-                                threadUuid={remediation.workThreadUuid!}
-                                interactive
-                            />
-                        </div>
-                    </Paper>
+                    {buildPane(`${classes.pane} ${classes.paneBuild}`)}
 
                     <Flex className={classes.connector}>
                         <MantineIcon icon={IconArrowRight} size={24} />
                     </Flex>
 
-                    {testPane(
-                        `${classes.pane} ${classes.paneTest} ${classes.panePreview}`,
-                    )}
+                    {testPane(`${classes.pane} ${classes.paneTest}`)}
                 </Flex>
             ) : (
                 <Flex
@@ -386,45 +487,75 @@ export const ReviewRemediationWorkspace = () => {
                     h={WORKSPACE_HEIGHT}
                 >
                     <Paper withBorder p="sm">
-                        <Group justify="space-between" wrap="nowrap">
-                            <Group gap="xs" wrap="nowrap" miw={0}>
-                                {stepIcon(1, 'indigo')}
-                                <Text fw={600} fz="sm">
-                                    Deterministic fix
-                                </Text>
-                                <Text fz="xs" c="dimmed" truncate>
-                                    · Project context — written without a build
-                                    conversation
-                                </Text>
-                            </Group>
-                            {reviewItem.linkedPrUrl && (
-                                <Button
-                                    variant="subtle"
-                                    color="gray"
-                                    size="compact-xs"
-                                    leftSection={
-                                        <MantineIcon
-                                            icon={IconFileDiff}
-                                            size={16}
-                                        />
-                                    }
-                                    onClick={diffHandlers.open}
-                                >
-                                    View the change
-                                </Button>
-                            )}
+                        <Group gap="xs" wrap="nowrap" miw={0}>
+                            {stepIcon(1)}
+                            <Text fw={600} fz="sm">
+                                Deterministic fix
+                            </Text>
+                            <Text fz="xs" c="dimmed" truncate>
+                                · Project context — written without a build
+                                conversation
+                            </Text>
                         </Group>
                     </Paper>
-                    {testPane(`${classes.pane} ${classes.panePreview}`)}
+                    {testPane(`${classes.pane}`)}
                 </Flex>
             )}
 
-            <ReviewPrDiffModal
-                opened={diffOpen}
-                onClose={diffHandlers.close}
-                diff={prDiff.data}
-                isLoading={prDiff.isLoading}
-            />
+            {reviewItem.linkedPrUrl && (
+                <Paper withBorder radius="md">
+                    <UnstyledButton
+                        className={classes.diffHeader}
+                        onClick={diffHandlers.toggle}
+                    >
+                        <Group gap="xs" wrap="nowrap">
+                            <MantineIcon
+                                icon={
+                                    diffOpen
+                                        ? IconChevronDown
+                                        : IconChevronRight
+                                }
+                                color="dimmed"
+                            />
+                            <Text fw={600} fz="sm">
+                                Changes
+                            </Text>
+                            {prDiff.data && (
+                                <Text fz="xs" c="dimmed">
+                                    {prDiff.data.files.length}{' '}
+                                    {prDiff.data.files.length === 1
+                                        ? 'file'
+                                        : 'files'}
+                                </Text>
+                            )}
+                        </Group>
+                    </UnstyledButton>
+                    <Collapse in={diffOpen}>
+                        <Divider />
+                        <Box p="sm">
+                            {diffOpen && (
+                                <ReviewPrDiffContent
+                                    diff={prDiff.data}
+                                    isLoading={prDiff.isLoading}
+                                    maxHeight="420px"
+                                />
+                            )}
+                        </Box>
+                    </Collapse>
+                </Paper>
+            )}
+
+            <Drawer
+                opened={testDrawerOpen}
+                onClose={testDrawerHandlers.close}
+                position="right"
+                size="xl"
+                padding={0}
+                withCloseButton={false}
+                classNames={{ body: classes.drawerBody }}
+            >
+                {testPane(`${classes.pane}`, true)}
+            </Drawer>
 
             <MarkResolvedModal
                 opened={resolveOpen}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.test.tsx
@@ -4,13 +4,13 @@ import { renderWithProviders } from '../../../../../../testing/testUtils';
 import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
 
 describe('ReviewsLoopDiagram', () => {
-    it('renders the four steps and the feedback line', () => {
+    it('renders the four lifecycle steps and the feedback line', () => {
         renderWithProviders(<ReviewsLoopDiagram />);
 
-        expect(screen.getByText('Finding')).toBeInTheDocument();
         expect(screen.getByText('Pull request')).toBeInTheDocument();
-        expect(screen.getByText('dbt compile')).toBeInTheDocument();
-        expect(screen.getByText('Future answers')).toBeInTheDocument();
+        expect(screen.getByText('Workspace')).toBeInTheDocument();
+        expect(screen.getByText('Build and verify')).toBeInTheDocument();
+        expect(screen.getByText('Merge')).toBeInTheDocument();
         expect(screen.getByText(/The agent picks this up/)).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/ReviewsLoopDiagram.tsx
@@ -1,10 +1,10 @@
 import { Box, Text } from '@mantine-8/core';
 import {
-    IconBulb,
-    IconCheck,
+    IconChecks,
     IconChevronRight,
     IconGitMerge,
-    IconRefresh,
+    IconGitPullRequest,
+    IconLayoutColumns,
     IconReload,
     type Icon as TablerIcon,
 } from '@tabler/icons-react';
@@ -19,20 +19,28 @@ type Step = {
 };
 
 const STEPS: Step[] = [
-    { icon: IconCheck, title: 'Finding', subtitle: 'you say yes' },
     {
-        icon: IconGitMerge,
+        icon: IconGitPullRequest,
         title: 'Pull request',
         subtitle: 'opens in your repo',
     },
-    { icon: IconRefresh, title: 'dbt compile', subtitle: 'your context loads' },
-    { icon: IconBulb, title: 'Future answers', subtitle: 'the agent knows it' },
+    {
+        icon: IconLayoutColumns,
+        title: 'Workspace',
+        subtitle: 'follow the fix',
+    },
+    {
+        icon: IconChecks,
+        title: 'Build and verify',
+        subtitle: 'in a preview',
+    },
+    { icon: IconGitMerge, title: 'Merge', subtitle: 'the fix is live' },
 ];
 
 /**
- * Explains, at a glance, that accepting a Reviews suggestion teaches the agent:
- * Finding → Pull request → dbt compile → Future answers, plus the feedback loop.
- * Used in the first-visit tour's final step and the project-context help popover.
+ * Walks the fix lifecycle at a glance: Pull request, Workspace, Build and
+ * verify, then Merge (the payoff), plus the feedback loop. Used in the
+ * first-visit tour's final step.
  */
 export const ReviewsLoopDiagram: FC = () => (
     <Box className={styles.diagram}>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -1,8 +1,12 @@
-import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import {
+    type AiAgentReviewItemSummary,
+    type AiAgentReviewRemediation,
+    PullRequestProvider,
+} from '@lightdash/common';
 
-// Sample rows shown while the onboarding tour runs so admins see what findings
-// look like, aligned to the real columns. Identified by a sentinel uuid prefix
-// so the cells can render them inert (no live PR, no status menu, no thread).
+// Sample cards shown while the onboarding tour runs so admins see what the
+// board looks like across the lifecycle. Identified by a sentinel uuid prefix
+// so the card can render them inert (no live PR, no workspace, no thread).
 const EXAMPLE_REVIEW_ITEM_PREFIX = 'example:';
 
 export const isExampleReviewItem = (uuid: string): boolean =>
@@ -11,10 +15,11 @@ export const isExampleReviewItem = (uuid: string): boolean =>
 const EXAMPLE_SEEN_AT = new Date();
 
 const makeExampleReviewItem = (
-    overrides: Pick<
-        AiAgentReviewItemSummary,
-        'uuid' | 'title' | 'description' | 'primaryRootCause' | 'ownerType'
-    >,
+    overrides: Partial<AiAgentReviewItemSummary> &
+        Pick<
+            AiAgentReviewItemSummary,
+            'uuid' | 'title' | 'description' | 'primaryRootCause' | 'ownerType'
+        >,
 ): AiAgentReviewItemSummary => ({
     fingerprint: overrides.uuid,
     organizationUuid: '',
@@ -48,21 +53,75 @@ const makeExampleReviewItem = (
     ...overrides,
 });
 
+const makeExampleRemediation = (
+    fingerprint: string,
+    status: AiAgentReviewRemediation['status'],
+): AiAgentReviewRemediation => ({
+    uuid: `${fingerprint}:remediation`,
+    fingerprint,
+    organizationUuid: '',
+    sourceFindingUuid: `${fingerprint}:finding`,
+    sourcePromptUuid: `${fingerprint}:prompt`,
+    sourceThreadUuid: `${fingerprint}:thread`,
+    sourceProjectUuid: `${fingerprint}:project`,
+    sourceAgentUuid: `${fingerprint}:agent`,
+    workThreadUuid: `${fingerprint}:work-thread`,
+    pullRequestUuid: `${fingerprint}:pr`,
+    linkedPrUrl: 'https://github.com/example/dbt-project/pull/1234',
+    previewProjectUuid: `${fingerprint}:preview-project`,
+    previewAgentUuid: `${fingerprint}:preview-agent`,
+    previewThreadUuid: `${fingerprint}:preview-thread`,
+    status,
+    errorMessage: null,
+    retryPrompt: null,
+    createdByUserUuid: null,
+    resolvedByUserUuid: null,
+    resolvedAt: null,
+    createdAt: EXAMPLE_SEEN_AT,
+    updatedAt: EXAMPLE_SEEN_AT,
+});
+
 export const EXAMPLE_REVIEW_ITEMS: AiAgentReviewItemSummary[] = [
+    // To Do — eligible, so the card shows the Start button the tour points at.
     makeExampleReviewItem({
-        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}semantic-layer`,
+        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}todo`,
         title: 'No metric for weekly active users',
         description:
             'Someone asked for weekly active users. There was no metric for it, so the agent estimated.',
         primaryRootCause: 'semantic_layer',
         ownerType: 'semantic_layer_owner',
+        writebackEligible: true,
+        writebackEligibility: {
+            eligible: true,
+            reason: null,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'semantic_layer',
+        },
     }),
+    // In Progress — a PR is open and the workspace is ready to follow the fix.
     makeExampleReviewItem({
-        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}project-context`,
+        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}in-progress`,
         title: 'Agent didn’t know what “active user” means',
         description:
             'Someone asked for active users. The agent guessed instead of using your definition.',
         primaryRootCause: 'project_context',
         ownerType: 'unknown',
+        status: 'in_progress',
+        linkedPrUrl: 'https://github.com/example/dbt-project/pull/1234',
+        remediation: makeExampleRemediation(
+            `${EXAMPLE_REVIEW_ITEM_PREFIX}in-progress`,
+            'preview_ready',
+        ),
+    }),
+    // Done — merged, so the card lands in the Done lane.
+    makeExampleReviewItem({
+        uuid: `${EXAMPLE_REVIEW_ITEM_PREFIX}done`,
+        title: 'Revenue excluded refunds',
+        description:
+            'Someone asked for revenue. The agent left out refunds, so the number was too high.',
+        primaryRootCause: 'semantic_layer',
+        ownerType: 'semantic_layer_owner',
+        status: 'resolved',
+        linkedPrUrl: 'https://github.com/example/dbt-project/pull/1230',
     }),
 ];

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
@@ -2,22 +2,32 @@ import { Stack, Text } from '@mantine-8/core';
 import { type GuidedTourStep } from '../../../../../../components/common/GuidedTour';
 import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
 
-// First-visit tour for the Reviews page. All step copy lives here.
+// First-visit tour for the Reviews board. All step copy lives here.
 export const REVIEWS_TOUR_STEPS: GuidedTourStep[] = [
     {
         target: '[data-tour="reviews-intro"]',
         title: 'Start here',
-        body: 'These are answers your agents probably got wrong. We group them by what caused them, so you can see what is worth your time.',
+        body: 'These are answers your agents probably got wrong. We group them by what caused them, and you work them left to right.',
     },
     {
-        target: '[data-tour="reviews-row"]',
-        title: 'Each row is a finding',
-        body: 'One answer your agent likely got wrong, tagged by its cause. Click the row to open the full review details and thread context. Semantic layer and Project context are the two kinds you can usually fix from here.',
+        target: '[data-tour="reviews-card"]',
+        title: 'Each card is one finding',
+        body: 'Click a card to inspect the thread and the suggested fix. Semantic layer and Project context are the kinds you can usually fix from here.',
     },
     {
-        target: '[data-tour="reviews-create-pr"]',
-        title: 'Fix it right here',
-        body: 'When something is fixable, this button opens a pull request. Merge it and the fix reaches your agent.',
+        target: '[data-tour="reviews-pr"]',
+        title: 'Open a pull request',
+        body: 'When a fix is ready, Start opens a pull request in your repo. The card moves to In Progress and tracks the PR.',
+    },
+    {
+        target: '[data-tour="reviews-workspace"]',
+        title: 'Follow the fix',
+        body: 'Open the workspace to watch the fix come together and pick up where it left off.',
+    },
+    {
+        target: '[data-tour="reviews-in-progress"]',
+        title: 'Build and verify',
+        body: 'In the workspace the fix builds in a throwaway preview, then your agent re-answers the original question to check it actually worked.',
     },
     {
         target: null,
@@ -25,8 +35,8 @@ export const REVIEWS_TOUR_STEPS: GuidedTourStep[] = [
         body: (
             <Stack gap="sm">
                 <Text fz="sm" c="dimmed">
-                    Merging the PR adds the fix to your project. The agent uses
-                    it on its next answer:
+                    Merge and the card lands in Done. The agent uses the fix on
+                    its next answer:
                 </Text>
                 <ReviewsLoopDiagram />
             </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -52,18 +52,22 @@ export const AiReviewsSettingsPage = () => {
 
     const isSidebarOpen = selectedReviewItem !== null;
 
-    // While the tour is running, the table always shows sample rows so it
-    // highlights the same findings every time. Closing it flips to real data.
+    // While the tour runs, the board always shows the same sample cards so the
+    // spotlights land every time. Closing it flips back to real data.
     const {
         isOpen: isTourOpen,
         startTour,
         closeTour,
-    } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v1' });
+    } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v2' });
 
     const [view, setView] = useLocalStorage<'board' | 'table'>({
         key: 'ld.aiReviews.view',
         defaultValue: 'board',
     });
+
+    // The board-oriented tour anchors only resolve on the board, so force it
+    // while the tour runs (render-time only — the user's stored view is kept).
+    const effectiveView = isTourOpen ? 'board' : view;
 
     const updateReviewSearchParams = (
         reviewItem: AiAgentAdminReviewItemPreviewTarget | null,
@@ -113,7 +117,7 @@ export const AiReviewsSettingsPage = () => {
                     <Group gap="xs">
                         <SegmentedControl
                             size="xs"
-                            value={view}
+                            value={effectiveView}
                             onChange={(value) =>
                                 setView(value as 'board' | 'table')
                             }
@@ -169,7 +173,7 @@ export const AiReviewsSettingsPage = () => {
 
             {settings?.aiAgentsVisible === false && <AiFeaturesDisabledAlert />}
 
-            {view === 'board' ? (
+            {effectiveView === 'board' ? (
                 <ReviewKanbanBoard
                     selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
                     onReviewItemSelect={handleReviewItemSelect}
@@ -179,7 +183,6 @@ export const AiReviewsSettingsPage = () => {
                 <AiAgentAdminReviewItemsTable
                     selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
                     onReviewItemSelect={handleReviewItemSelect}
-                    showOnboardingExamples={isTourOpen}
                 />
             )}
 


### PR DESCRIPTION
## What

Two connected pieces of polish on the AI reviews experience: a board-oriented onboarding tour, and a settled design for the remediation workspace (the old `?layout=a/b/c/d` exploration is gone — there is now one layout).

### Reviews board — onboarding tour
- Replaced the old table-oriented first-run tour with a **board-oriented** one that walks the lifecycle: open a PR, follow the fix in the workspace, build & verify in a preview, merge.
- Deterministic example cards (`example:` sentinel) span the lifecycle (To Do / In Progress / Done) so the spotlights always land on the same, inert, clearly-labelled cards — shown whenever the tour is open, board only.
- The board is forced while the tour runs (render-time only; the user's stored view is preserved), `storageKey` bumped to `v2`.
- Upgraded the loop diagram to the 4-stage flow (Pull request → Workspace → Build and verify → Merge) and removed the dead table tour anchors.

### Remediation workspace — one settled layout
- The `?layout=a/b/c/d` experiment is removed. The workspace is now a **full-width build pane**, with verification in an on-demand drawer.
- The Test + Retest header buttons collapse into a **single verdict pill** that opens the test drawer. It is a loud (filled) CTA while a fix still needs verifying, and calms to a light status once a verdict lands — handing emphasis to the black **Resolve** button (which only fills once the verdict is in and not stale).
- The **test drawer** gets a proper header explaining the preview environment and what verification does, a scroll container, and is anchored below the navbar (and the preview/impersonation banner when shown) so its header is never hidden.
- Visual pass carried over from the earlier exploration: neutral panes (single hairline border), status-as-text instead of loud badges, and the PR diff in an inline collapsible "Changes" panel (shared `ReviewPrDiffContent` so modal and inline use one implementation).

## Behaviour / compatibility
- No backend or API changes — frontend only.
- The deterministic (project-context, no build thread) case keeps its inline test pane and "View PR" header button; the verdict pill is specific to the build-thread workspace.
- Existing remediations are unaffected; this only changes how the workspace and board render.

## Verification
- `pnpm -F frontend typecheck:fast` and oxlint clean on the touched files; board/diagram/table unit tests pass, plus new board-tour coverage (example cards render inert and carry the tour anchors).
- Recommend a quick light/dark pass on a live remediation finding before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)