### PR TITLE
perf(pivot): collapse final-stage total_columns into a single pass

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -169,7 +169,6 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('group_by_query AS (');
             expect(result).toContain('pivot_query AS (');
             expect(result).toContain('filtered_rows AS (');
-            expect(result).toContain('total_columns AS (');
 
             // Should include row_index and column_index metadata
             expect(result.toLowerCase()).toContain(
@@ -183,9 +182,25 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('WHERE "row_index" <= 100');
             expect(result).toContain('"column_index" <= 100');
 
-            // Should join with total_columns for metadata
-            expect(result).toContain('CROSS JOIN total_columns t');
-            expect(result).toContain('t.total_columns');
+            // total_columns is computed in a single pass over filtered_rows via
+            // the stacked-window count-distinct idiom.
+            expect(replaceWhitespace(result)).toContain(
+                'ROW_NUMBER() OVER (PARTITION BY "event_type") AS "__grp_rn" FROM filtered_rows f',
+            );
+            expect(replaceWhitespace(result)).toContain(
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
+            );
+
+            // The base pivot data is referenced exactly once (Tier B: was 2×).
+            expect(result.match(/FROM pivot_query\b/g)).toHaveLength(1);
+
+            // The __grp_rn helper must not leak into the final projection.
+            const finalSelect = result.slice(result.indexOf('\nSELECT '));
+            const finalProjection = finalSelect.slice(
+                0,
+                finalSelect.indexOf(' FROM ('),
+            );
+            expect(finalProjection).not.toContain('__grp_rn');
         });
 
         test('Should handle multiple group by columns', () => {
@@ -683,9 +698,10 @@ describe('PivotQueryBuilder', () => {
             // pivot_query should compute rankings inline with DENSE_RANK
             expect(result).toContain('DENSE_RANK() OVER');
 
-            // Downstream CTEs should reference pivot_query directly
+            // filtered_rows references pivot_query directly — and it's the only
+            // reference (Tier B single-pass: the base data is scanned once).
             expect(result).toContain('FROM pivot_query WHERE "row_index"');
-            expect(result).toContain('FROM pivot_query p CROSS JOIN');
+            expect(result.match(/FROM pivot_query\b/g)).toHaveLength(1);
         });
 
         test('Pinned sort: pivotValues swaps WHERE col_idx = 1 for a value match on the pinned column', () => {
@@ -1824,12 +1840,12 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(
                 'SELECT "category", "date" FROM original_query group by "category", "date"',
             );
-            // Should calculate total_columns via a top-level distinct_groups CTE
+            // Should calculate total_columns in a single pass over filtered_rows
             expect(replaceWhitespace(result)).toContain(
-                'distinct_groups AS (SELECT DISTINCT "category" FROM filtered_rows)',
+                'ROW_NUMBER() OVER (PARTITION BY "category") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
-                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
             );
         });
 
@@ -3323,7 +3339,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // total_columns should multiply by 2 (the visible TCs), not 3 (TCs + implicit metric)
-            expect(result).toContain('COUNT(*) * 2 AS total_columns');
+            expect(result).toContain(
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () * 2 AS total_columns',
+            );
         });
 
         test('Edge case: TC referencing a dimension (not a metric) via pivot_index', () => {
@@ -3832,9 +3850,11 @@ SELECT * FROM group_by_query LIMIT 50`);
             }
 
             // total_columns should count only 1 display value column (tc1), not 6
-            expect(result).toContain('COUNT(*) AS total_columns');
-            expect(result).not.toContain('COUNT(*) * 5');
-            expect(result).not.toContain('COUNT(*) * 6');
+            expect(result).toContain(
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
+            );
+            expect(result).not.toContain('OVER () * 5');
+            expect(result).not.toContain('OVER () * 6');
         });
 
         test('Should produce identical SQL when no pivot TCs exist in itemsMap', () => {
@@ -4897,17 +4917,15 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
         });
 
-        test('total_columns CTE counts via nested DISTINCT subquery, never via COUNT(DISTINCT CONCAT(...)) (#19767)', () => {
+        test('total_columns counts distinct groups via PARTITION BY raw columns, never via COUNT(DISTINCT CONCAT(...)) (#19767)', () => {
             // https://github.com/lightdash/lightdash/issues/19767 / PROD-2762
             // Repro: pivot a chart whose groupBy mixes types (e.g. a
             // TIMESTAMP column AND a STRING column) on Redshift. The bug
             // emitted `COUNT(DISTINCT CONCAT('col1', "col1", '-', 'col2',
             // "col2"))` for total_columns, which Redshift refused because
             // CONCAT across mixed types fails type checking.
-            // Expectation: total_columns is computed via
-            // `SELECT COUNT(*) FROM (SELECT DISTINCT col1, col2 FROM
-            // filtered_rows) AS distinct_groups` — warehouse-agnostic, no
-            // CONCAT, no DISTINCT-CONCAT.
+            // Expectation: the single-pass count PARTITIONs by the raw groupBy
+            // columns (no CONCAT, no DISTINCT-CONCAT) — warehouse-agnostic.
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -4931,15 +4949,13 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // Distinct-groups CTE shape — both groupBy refs appear in the
-            // SELECT DISTINCT list of the top-level distinct_groups CTE, and
-            // total_columns counts over it directly (no CONCAT, no
-            // DISTINCT-CONCAT).
+            // Single-pass shape: both groupBy refs are the raw PARTITION BY keys
+            // and total_columns sums the per-group first-row markers.
             expect(replaceWhitespace(result)).toContain(
-                'distinct_groups AS (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows)',
+                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
-                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
             );
 
             // Negative: the bugged Redshift-incompatible form must not
@@ -4948,11 +4964,12 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).not.toContain('COUNT(DISTINCT concat(');
         });
 
-        test('total_columns counts via a top-level distinct_groups CTE, never a subquery nesting filtered_rows', () => {
-            // distinct_groups is its own top-level CTE so both references are
-            // direct CTE -> CTE (distinct_groups -> filtered_rows,
-            // total_columns -> distinct_groups), rather than nesting a subquery
-            // that references filtered_rows inside a later CTE.
+        test('Tier B: the base pivot data (filtered_rows) is referenced exactly once', () => {
+            // Tier B (PROD-8440): the final assembly used to reference the
+            // pivot subtree twice (filtered_rows -> distinct_groups ->
+            // total_columns AND the final CROSS JOIN), doubling the base scan on
+            // CTE-inlining engines (Trino/Athena/Spark). Now total_columns is a
+            // single-pass window over filtered_rows, referenced once.
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -4976,22 +4993,20 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // distinct_groups is a top-level CTE referencing filtered_rows directly.
-            expect(replaceWhitespace(result)).toContain(
-                'distinct_groups AS (SELECT DISTINCT "order_date_year", "payment_method" FROM filtered_rows)',
-            );
-            // total_columns counts over the distinct_groups CTE directly.
-            expect(replaceWhitespace(result)).toContain(
-                'total_columns AS (SELECT COUNT(*) AS total_columns FROM distinct_groups)',
-            );
+            // filtered_rows and pivot_query are each referenced exactly once
+            // (single-pass): the base data is scanned once instead of twice.
+            expect(result.match(/FROM filtered_rows\b/g)).toHaveLength(1);
+            expect(result.match(/FROM pivot_query\b/g)).toHaveLength(1);
 
-            // Negative: filtered_rows must never be referenced from inside a
-            // subquery within another CTE definition.
-            expect(result).not.toContain(
-                'FROM filtered_rows) AS distinct_groups',
+            // With multiple pivot columns the count PARTITIONs by the full tuple,
+            // so each distinct (order_date_year, payment_method) combination is
+            // counted once.
+            expect(replaceWhitespace(result)).toContain(
+                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
             );
-            // And no COUNT(DISTINCT CONCAT(...)).
-            expect(result).not.toContain('COUNT(DISTINCT CONCAT(');
+            expect(replaceWhitespace(result)).toContain(
+                'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
+            );
         });
 
         test('Metric sort: pivot_query/row_ranking/column_ranking alias every carried column to a bare name (ClickHouse #23711)', () => {
@@ -5049,9 +5064,10 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'row_ranking AS (SELECT DISTINCT g."order_date" AS "order_date", DENSE_RANK()',
             );
 
-            // The downstream CTEs reference the bare names the aliases expose.
+            // The downstream single-pass count references the bare name the
+            // aliases expose (PARTITION BY "status").
             expect(result).toContain(
-                'distinct_groups AS (SELECT DISTINCT "status" FROM filtered_rows)',
+                'ROW_NUMBER() OVER (PARTITION BY "status") AS "__grp_rn" FROM filtered_rows f',
             );
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -358,49 +358,37 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates the distinct_groups CTE body: the unique pivot-column
-     * combinations from the filtered rows. Kept as a standalone CTE so the
-     * reference to filteredRowsTable is a direct CTE -> CTE reference.
-     * @param groupByColumns - Columns that are being pivoted
-     * @param filteredRowsTable - Name of the CTE containing filtered rows
-     * @returns SQL selecting distinct pivot-column combinations
+     * Returns the ordered, quoted column names exposed by filtered_rows (i.e.
+     * the pivot output columns), so the final single-pass total_columns SELECT
+     * can project them explicitly and drop the __grp_rn helper. Order mirrors
+     * getPivotQuerySQL (+ pivot table calculations) so the output schema is
+     * identical to the previous `SELECT p.*` form.
      */
-    private getDistinctGroupsSQL(
-        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
-        filteredRowsTable: string,
-    ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
-        // SELECT DISTINCT counts unique combinations without type casting,
-        // which works across all warehouses.
-        const columnRefs = groupByColumns
-            .map((col) => `${q}${col.reference}${q}`)
-            .join(', ');
-
-        return `SELECT DISTINCT ${columnRefs} FROM ${filteredRowsTable}`;
-    }
-
-    /**
-     * Generates query that counts total distinct column combinations for pivot.
-     * @param valuesColumns - Value columns to multiply count by (only when metricsAsRows is false)
-     * @param distinctGroupsTable - Name of the CTE containing distinct pivot-column combinations
-     * @returns SQL query for counting total columns
-     */
-    private getTotalColumnsSQL(
+    private getPivotOutputColumns(
+        indexColumns: ReturnType<typeof normalizeIndexColumns>,
         valuesColumns: PivotConfiguration['valuesColumns'],
-        distinctGroupsTable: string,
-    ): string {
-        // Fallback to 1 when no valuesColumns to ensure at least one column per distinct group
-        // This maintains consistent pivot behavior even when only grouping without aggregations
-        const valuesCount = valuesColumns?.length || 1;
-
-        // When metricsAsRows is true, metrics become rows (not columns),
-        // so we don't multiply by valuesCount
-        const shouldMultiplyByValues =
-            !this.pivotConfiguration.metricsAsRows && valuesCount > 1;
-        const multiplier = shouldMultiplyByValues ? ` * ${valuesCount}` : '';
-
-        return `SELECT COUNT(*)${multiplier} AS total_columns FROM ${distinctGroupsTable}`;
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+        passthroughDimensions: PivotConfiguration['passthroughDimensions'],
+    ): string[] {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+        const names = [
+            ...indexColumns.map((col) => col.reference),
+            ...groupByColumns.map((col) => col.reference),
+            ...(passthroughDimensions || []).map((col) => col.reference),
+            ...(valuesColumns ?? []).map((col) =>
+                PivotQueryBuilder.getValueColumnFieldName(
+                    col.reference,
+                    col.aggregation,
+                ),
+            ),
+            ...this.implicitMetricReferences,
+            'row_index',
+            'column_index',
+            ...Object.values(this.pivotTableCalculations).map(
+                (tc) => `${tc.name}_any`,
+            ),
+        ];
+        return [...new Set(names)].map((name) => `${q}${name}${q}`);
     }
 
     /**
@@ -1321,8 +1309,9 @@ export class PivotQueryBuilder {
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
-        // Alias to bare names so filtered_rows/distinct_groups can resolve them
-        // (ClickHouse exposes multi-join CTE columns only under the `g.` qualifier).
+        // Alias to bare names so filtered_rows and the count subquery can
+        // resolve them (ClickHouse exposes multi-join CTE columns only under
+        // the `g.` qualifier).
         const selectReferences = [
             ...indexColumns.map(
                 (col) =>
@@ -1652,7 +1641,7 @@ export class PivotQueryBuilder {
             passthroughDimensions,
         );
 
-        let maxColumnsPerValueColumnSql = '';
+        let columnIndexFilterSql = '';
 
         if (columnLimit) {
             const maxColumnsPerValueColumn =
@@ -1662,18 +1651,8 @@ export class PivotQueryBuilder {
                     this.pivotConfiguration.metricsAsRows,
                 );
 
-            // Keep leading space to avoid SQL syntax errors
-            maxColumnsPerValueColumnSql = ` and p.${q}column_index${q} <= ${maxColumnsPerValueColumn}`;
+            columnIndexFilterSql = ` WHERE ${q}column_index${q} <= ${maxColumnsPerValueColumn}`;
         }
-
-        const distinctGroupsQuery = this.getDistinctGroupsSQL(
-            groupByColumns,
-            'filtered_rows',
-        );
-        const totalColumnsQuery = this.getTotalColumnsSQL(
-            valuesColumns,
-            'distinct_groups',
-        );
 
         // Build CTEs in correct dependency order:
         // 1. original_query, group_by_query (base data)
@@ -1681,7 +1660,7 @@ export class PivotQueryBuilder {
         // 3. column_ranking, anchor_column (for metric-based row sorting - identifies first pivot column)
         // 4. row anchor CTEs (uses anchor_column to get metric value at first column only)
         // 5. row_ranking (when precomputed rankings are used)
-        // 6. pivot_query, filtered_rows, distinct_groups, total_columns
+        // 6. pivot_query, filtered_rows
         // 7. pivot_table_calculations (if there are any pivot table calculations)
         const ctes = [
             `original_query AS (${userSql})`,
@@ -1694,7 +1673,7 @@ export class PivotQueryBuilder {
             `pivot_query AS (${pivotQuery})`,
         ];
 
-        // Reference the appropriate table for filtered_rows and final select
+        // Reference the appropriate table for filtered_rows
         let pivotTableRef = 'pivot_query';
 
         // Add pivot table calculations CTE if there are any
@@ -1706,11 +1685,32 @@ export class PivotQueryBuilder {
 
         ctes.push(
             `filtered_rows AS (SELECT * FROM ${pivotTableRef} WHERE ${q}row_index${q} <= ${rowLimit})`,
-            `distinct_groups AS (${distinctGroupsQuery})`,
-            `total_columns AS (${totalColumnsQuery})`,
         );
 
-        const finalSelect = `SELECT p.*, t.total_columns FROM ${pivotTableRef} p CROSS JOIN total_columns t WHERE p.${q}row_index${q} <= ${rowLimit}${maxColumnsPerValueColumnSql} order by p.${q}row_index${q}, p.${q}column_index${q}`;
+        // total_columns is the distinct groupBy-combination count (× valuesCount
+        // unless metricsAsRows). Computed in a single pass over filtered_rows so
+        // the base data is referenced once. DISTINCT inside a window function
+        // isn't portable, so use the stacked-window count-distinct idiom and
+        // count before the column_index filter (matching the old CTEs).
+        const valuesCount = valuesColumns?.length || 1;
+        const shouldMultiplyByValues =
+            !this.pivotConfiguration.metricsAsRows && valuesCount > 1;
+        const totalColumnsMultiplier = shouldMultiplyByValues
+            ? ` * ${valuesCount}`
+            : '';
+
+        const groupByPartition = groupByColumns
+            .map((col) => `${q}${col.reference}${q}`)
+            .join(', ');
+
+        const outputColumns = this.getPivotOutputColumns(
+            indexColumns,
+            valuesColumnsWithoutPivotTableCalculations,
+            groupByColumns,
+            passthroughDimensions,
+        ).join(', ');
+
+        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
 
         return PivotQueryBuilder.assembleSqlParts([
             PivotQueryBuilder.buildCtesSQL(ctes),


### PR DESCRIPTION
Closes: PROD-8440
Relates: #24388

### Description:

Part of the effort to keep pivoted charts under Trino's `query.max-stage-count` limit (parent: PROD-8338 / #24388). This change is warehouse-agnostic — it helps **every** pivot chart (including the common dimension-sort case) and can ship independently.

**Problem.** In `getFullPivotSQL` the final assembly referenced the pivot subtree **twice**:
- once via `filtered_rows → distinct_groups → total_columns`, and
- again in the final `SELECT … CROSS JOIN total_columns`.

CTE-inlining engines (Trino/Athena/Spark) don't materialize CTEs — they re-expand the whole `pivot_query` subtree at every reference. So the base scan ran **2×** and the tail roughly doubled the stage count it contributed, pushing complex pivots over the 150-stage limit.

**Change.** Compute `total_columns` as a single-pass window over the row-limited data, deleting the `distinct_groups` and `total_columns` CTEs and the `CROSS JOIN`. Since `COUNT(DISTINCT …) OVER ()` isn't portable, it uses the stacked-window count-distinct idiom: `ROW_NUMBER() OVER (PARTITION BY <groupBy>)` to mark one row per distinct pivot-column combination, then `SUM(CASE WHEN __grp_rn = 1 THEN 1 ELSE 0 END) OVER ()`.

**Reference-count reduction.** The base pivot data is now referenced **once instead of twice** — `FROM pivot_query` and `FROM filtered_rows` each appear exactly 1× (asserted in tests). On CTE-inlining engines this halves the base-scan re-evaluation and removes the tail's duplicate stage contribution; on warehouses that materialize CTEs it's cost-neutral.

**Preserved exactly:** the `total_columns` value (the `× valuesCount` multiplier, `metricsAsRows` rule, and counting **before** the `column_index` filter), the final output schema/column order, the `row_index`/`column_index` filters and `ORDER BY`, and the `__grp_rn` helper never leaks into the output.

**Verification.** Updated `PivotQueryBuilder.test.ts` (single-reference assertions, single-pass shape, multi-pivot `PARTITION BY`) plus end-to-end API runs across sorting modes, `metricsAsRows`, and pivot/value-column counts — every cell, row/column ordering, and all pivot metadata matched an independent flat group-by oracle.

test-frontend