### PR TITLE
feat(ai-writeback): track token usage and cost on completion

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1439,6 +1439,18 @@ export type AiWritebackCompletedEvent = BaseTrack & {
         hasChanges: boolean;
         prCreated: boolean;
         totalDurationMs: number;
+        // AI usage/spend for the run, parsed from the agent's stream-json
+        // `result` event (mirrors data apps' data_app.version.completed). Null
+        // when the agent crashed before emitting a result. Field names match
+        // ClaudeGenerationUsage so spend dashboards can union both features.
+        costUsd: number | null;
+        inputTokens: number | null;
+        outputTokens: number | null;
+        cacheReadInputTokens: number | null;
+        cacheCreationInputTokens: number | null;
+        numTurns: number | null;
+        // Time (ms) spent in LLM API calls — the rest is local tool execution.
+        durationApiMs: number | null;
     };
 };
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -86,6 +86,7 @@ import type {
     AdoptedPullRequest,
     AiWritebackRunArgs,
     AiWritebackSource,
+    AiWritebackUsage,
     AppliedChanges,
     CloneTarget,
     GitInstallation,
@@ -1260,6 +1261,7 @@ export class AiWritebackService extends BaseService {
                     exitCode: agent.exitCode,
                     hasChanges,
                     prCreated: false,
+                    usage: agent.usage,
                 });
                 const crashPrUrl =
                     turn.existingRow?.pr_url ?? adoptedPr?.prUrl ?? null;
@@ -1300,6 +1302,7 @@ export class AiWritebackService extends BaseService {
                 exitCode: agent.exitCode,
                 hasChanges,
                 prCreated: applied.prCreated,
+                usage: agent.usage,
             });
 
             this.logger.info('AI writeback run completed', {
@@ -1493,14 +1496,26 @@ export class AiWritebackService extends BaseService {
                 exitCode: number;
                 hasChanges: boolean;
                 prCreated: boolean;
+                usage: AiWritebackUsage | null;
             }) =>
                 this.analytics.track({
                     event: 'ai_writeback.completed',
                     userId: user.userUuid,
                     properties: {
                         ...eventBase,
-                        ...props,
+                        exitCode: props.exitCode,
+                        hasChanges: props.hasChanges,
+                        prCreated: props.prCreated,
                         totalDurationMs: Date.now() - startedAt,
+                        costUsd: props.usage?.costUsd ?? null,
+                        inputTokens: props.usage?.inputTokens ?? null,
+                        outputTokens: props.usage?.outputTokens ?? null,
+                        cacheReadInputTokens:
+                            props.usage?.cacheReadInputTokens ?? null,
+                        cacheCreationInputTokens:
+                            props.usage?.cacheCreationInputTokens ?? null,
+                        numTurns: props.usage?.numTurns ?? null,
+                        durationApiMs: props.usage?.durationApiMs ?? null,
                     },
                 }),
             failed: (stage: AiWritebackFailureStage, error: unknown) =>
@@ -1719,7 +1734,11 @@ export class AiWritebackService extends BaseService {
         skillKey: WarehouseSkillKey | null;
         warehouseType: WarehouseTypes | null;
         dbtVersion: SupportedDbtVersions;
-    }): Promise<{ stdout: string; exitCode: number }> {
+    }): Promise<{
+        stdout: string;
+        exitCode: number;
+        usage: AiWritebackUsage | null;
+    }> {
         await sandbox.files.write(SYSTEM_PROMPT_PATH, systemPrompt);
         await sandbox.files.write(PROMPT_PATH, prompt);
 
@@ -1770,6 +1789,9 @@ export class AiWritebackService extends BaseService {
         // user-facing reply and the PR_TITLE/PR_DESCRIPTION blocks.
         let buffer = '';
         let assistantText = '';
+        // Token/turn/cost usage from the run's `result` event, captured so the
+        // caller can attach it to the `ai_writeback.completed` analytics event.
+        let agentUsage: AiWritebackUsage | null = null;
         const toolCounts: Record<string, number> = {};
 
         let stderrTail = '';
@@ -1790,6 +1812,16 @@ export class AiWritebackService extends BaseService {
                     interpreted.durationApiMs !== null
                         ? interpreted.durationMs - interpreted.durationApiMs
                         : null;
+                agentUsage = {
+                    costUsd: interpreted.costUsd,
+                    inputTokens: interpreted.inputTokens,
+                    outputTokens: interpreted.outputTokens,
+                    cacheReadInputTokens: interpreted.cacheReadInputTokens,
+                    cacheCreationInputTokens:
+                        interpreted.cacheCreationInputTokens,
+                    numTurns: interpreted.numTurns,
+                    durationApiMs: interpreted.durationApiMs,
+                };
                 this.logger.info(
                     `AI writeback agent run summary (wall=${
                         interpreted.durationMs ?? '?'
@@ -1797,6 +1829,10 @@ export class AiWritebackService extends BaseService {
                         localToolMs ?? '?'
                     }ms, turns=${interpreted.numTurns ?? '?'}, cost=$${
                         interpreted.costUsd ?? '?'
+                    }, in=${interpreted.inputTokens ?? '?'}, out=${
+                        interpreted.outputTokens ?? '?'
+                    }, cacheRead=${
+                        interpreted.cacheReadInputTokens ?? '?'
                     }, tools=${JSON.stringify(toolCounts)})`,
                     {
                         event: 'ai_writeback.run.summary',
@@ -1807,6 +1843,11 @@ export class AiWritebackService extends BaseService {
                         durationApiMs: interpreted.durationApiMs,
                         localToolMs,
                         numTurns: interpreted.numTurns,
+                        inputTokens: interpreted.inputTokens,
+                        outputTokens: interpreted.outputTokens,
+                        cacheReadInputTokens: interpreted.cacheReadInputTokens,
+                        cacheCreationInputTokens:
+                            interpreted.cacheCreationInputTokens,
                         warehouseType,
                         toolCounts,
                     },
@@ -2009,7 +2050,11 @@ export class AiWritebackService extends BaseService {
             );
         }
 
-        return { stdout: assistantText, exitCode: result.exitCode };
+        return {
+            stdout: assistantText,
+            exitCode: result.exitCode,
+            usage: agentUsage,
+        };
     }
 
     /**

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -158,17 +158,32 @@ export type AgentToolCall = {
  */
 export type AgentStreamEvent =
     | { type: 'assistant'; text: string | null; toolCalls: AgentToolCall[] }
-    | {
+    | ({
           type: 'result';
-          costUsd: number | null;
           /** Total agent wall-clock (ms) as reported by Claude Code. */
           durationMs: number | null;
-          /** Time (ms) spent in LLM API calls — the rest is local tool execution. */
-          durationApiMs: number | null;
-          /** Number of agent turns. */
-          numTurns: number | null;
-      }
+      } & AiWritebackUsage)
     | { type: 'ignored' };
+
+/**
+ * Token/turn/cost usage for one agent run, parsed from the stream-json `result`
+ * event (token counts nested under `usage.*`, the rest top-level). Mirrors the
+ * data-apps `ClaudeGenerationUsage` shape so both features report AI spend with
+ * the same field names. Nullable throughout: a run that crashes before the
+ * `result` event leaves these unknown rather than zero.
+ */
+export type AiWritebackUsage = {
+    /** Total run cost in USD as computed by the CLI from token usage. */
+    costUsd: number | null;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cacheReadInputTokens: number | null;
+    cacheCreationInputTokens: number | null;
+    /** Number of agent turns. */
+    numTurns: number | null;
+    /** Time (ms) spent in LLM API calls — the rest is local tool execution. */
+    durationApiMs: number | null;
+};
 
 /** Title/description/summary parsed out of the agent's final stdout. */
 export type PrMetadata = {

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -380,7 +380,7 @@ describe('interpretAgentEvent', () => {
         ).toEqual({ type: 'assistant', text: null, toolCalls: [] });
     });
 
-    it('reads the cost and timing from a result event', () => {
+    it('reads the cost, timing, and token usage from a result event', () => {
         expect(
             interpretAgentEvent({
                 type: 'result',
@@ -388,6 +388,12 @@ describe('interpretAgentEvent', () => {
                 duration_ms: 90000,
                 duration_api_ms: 30000,
                 num_turns: 7,
+                usage: {
+                    input_tokens: 12,
+                    output_tokens: 345,
+                    cache_read_input_tokens: 6789,
+                    cache_creation_input_tokens: 100,
+                },
             }),
         ).toEqual({
             type: 'result',
@@ -395,10 +401,14 @@ describe('interpretAgentEvent', () => {
             durationMs: 90000,
             durationApiMs: 30000,
             numTurns: 7,
+            inputTokens: 12,
+            outputTokens: 345,
+            cacheReadInputTokens: 6789,
+            cacheCreationInputTokens: 100,
         });
     });
 
-    it('defaults missing result timing fields to null', () => {
+    it('defaults missing result timing and token fields to null', () => {
         expect(
             interpretAgentEvent({ type: 'result', total_cost_usd: 0.42 }),
         ).toEqual({
@@ -407,6 +417,10 @@ describe('interpretAgentEvent', () => {
             durationMs: null,
             durationApiMs: null,
             numTurns: null,
+            inputTokens: null,
+            outputTokens: null,
+            cacheReadInputTokens: null,
+            cacheCreationInputTokens: null,
         });
     });
 

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -330,14 +330,27 @@ export const interpretAgentEvent = (event: unknown): AgentStreamEvent => {
         duration_ms?: number;
         duration_api_ms?: number;
         num_turns?: number;
+        // Token counts live nested under `usage` on the result event; the rest
+        // are top-level. Same shape data apps reads in ClaudeStreamProcessor.
+        usage?: {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_read_input_tokens?: number;
+            cache_creation_input_tokens?: number;
+        };
     };
     if (typed.type === 'result') {
+        const usage = typed.usage ?? {};
         return {
             type: 'result',
             costUsd: typed.total_cost_usd ?? null,
             durationMs: typed.duration_ms ?? null,
             durationApiMs: typed.duration_api_ms ?? null,
             numTurns: typed.num_turns ?? null,
+            inputTokens: usage.input_tokens ?? null,
+            outputTokens: usage.output_tokens ?? null,
+            cacheReadInputTokens: usage.cache_read_input_tokens ?? null,
+            cacheCreationInputTokens: usage.cache_creation_input_tokens ?? null,
         };
     }
     if (typed.type !== 'assistant') return { type: 'ignored' };


### PR DESCRIPTION
## What & why

The `ai_writeback.completed` analytics event recorded only timing and PR outcome, while data apps' `data_app.version.completed` already tracks full AI spend from the *same* Claude Code CLI. This adds the missing usage/token/cost dimensions to writeback so AI spend can be reported consistently across both AI features.

The token usage was already present in the agent's stream-json `result` event — data apps reads it in `ClaudeStreamProcessor`, but writeback's `interpretAgentEvent` only destructured cost/turns/duration and dropped the `usage.*` token block. This was a parsing gap, not a data-availability gap.

## Changes

- **`utils.ts`** — `interpretAgentEvent` now parses the nested `usage.{input,output,cache_read,cache_creation}_tokens` block from the `result` event.
- **`types.ts`** — new shared `AiWritebackUsage` type; `AgentStreamEvent` result variant widened.
- **`AiWritebackService.ts`** — usage captured from the run, returned from `runAgentInSandbox`, and forwarded into the `ai_writeback.completed` event at both call sites; run-summary log enriched with token counts.
- **`LightdashAnalytics.ts`** — `AiWritebackCompletedEvent` gains `costUsd`, `inputTokens`, `outputTokens`, `cacheReadInputTokens`, `cacheCreationInputTokens`, `numTurns`, `durationApiMs`. Field names match data apps' `ClaudeGenerationUsage` so spend dashboards can union both features.

Counts are nullable: a run that crashes before the `result` event leaves spend *unknown* rather than zero. No DB migration or API regeneration needed (analytics types aren't in controllers).

## Testing

- `pnpm -F backend typecheck:fast` ✓, eslint ✓
- Ran a real writeback end-to-end locally — opened a PR, exit 0, and the new fields populated: `cost=$0.123, in=7, out=686, cacheRead=151785, turns=5`. The `cacheRead`-dominated breakdown is exactly the signal this instrumentation is meant to surface (input tokens alone would have made the run look almost free).

## Follow-up (out of scope)

`ai_writeback.failed` is intentionally unchanged — a run that burns tokens then fails at the push/PR stage won't record that spend. Easy to add the same fields there if cost accounting needs to be airtight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)