### PR TITLE
fix(navbar): truncate long project names in top navigation

### DIFF
--- a/packages/frontend/src/components/NavBar/PreviewBanner.module.css
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.module.css
@@ -1,3 +1,11 @@
 .banner {
     z-index: var(--mantine-z-index-app);
 }
+
+.backLink {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/NavBar/PreviewBanner.module.css
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.module.css
@@ -8,4 +8,5 @@
     gap: 4px;
     flex-shrink: 0;
     white-space: nowrap;
+    font-family: inherit;
 }

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -47,8 +47,8 @@ export const PreviewBanner: FC<{
             <Group gap="xs" wrap="nowrap" miw={0}>
                 <MantineIcon icon={IconTool} color="white" size="sm" />
                 <Text c="white" fw={500} fz="xs" truncate>
-                    This is a preview environment. Any changes you make here will
-                    not affect production.
+                    This is a preview environment. Any changes you make here
+                    will not affect production.
                     {expiresAt && formatExpirationSuffix(expiresAt)}
                 </Text>
                 {upstreamProject && (

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -1,6 +1,8 @@
-import { Center, Text } from '@mantine-8/core';
-import { IconTool } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { Anchor, Center, Group, Text } from '@mantine-8/core';
+import { IconArrowLeft, IconTool } from '@tabler/icons-react';
+import { useCallback, type FC } from 'react';
+import { useNavigate } from 'react-router';
+import { useUpdateActiveProjectMutation } from '../../hooks/useActiveProject';
 import MantineIcon from '../common/MantineIcon';
 import { BANNER_HEIGHT } from '../common/Page/constants';
 import classes from './PreviewBanner.module.css';
@@ -18,23 +20,56 @@ const formatExpirationSuffix = (expiresAt: Date): string => {
     return ` Expires in ${diffDays} days (${formatted}).`;
 };
 
-export const PreviewBanner: FC<{ expiresAt: Date | null }> = ({
-    expiresAt,
-}) => (
-    <Center
-        id="preview-banner"
-        pos="fixed"
-        top={0}
-        w="100%"
-        h={BANNER_HEIGHT}
-        bg="blue.6"
-        className={classes.banner}
-    >
-        <MantineIcon icon={IconTool} color="white" size="sm" />
-        <Text c="white" fw={500} fz="xs" mx={4}>
-            This is a preview environment. Any changes you make here will not
-            affect production.
-            {expiresAt && formatExpirationSuffix(expiresAt)}
-        </Text>
-    </Center>
-);
+export const PreviewBanner: FC<{
+    expiresAt: Date | null;
+    upstreamProject: { projectUuid: string; name: string } | null;
+}> = ({ expiresAt, upstreamProject }) => {
+    const navigate = useNavigate();
+    const { mutate: setActiveProject } = useUpdateActiveProjectMutation();
+
+    const handleBackToUpstream = useCallback(() => {
+        if (!upstreamProject) return;
+        setActiveProject(upstreamProject.projectUuid);
+        void navigate(`/projects/${upstreamProject.projectUuid}/home`);
+    }, [navigate, setActiveProject, upstreamProject]);
+
+    return (
+        <Center
+            id="preview-banner"
+            pos="fixed"
+            top={0}
+            w="100%"
+            h={BANNER_HEIGHT}
+            bg="blue.6"
+            className={classes.banner}
+            px="md"
+        >
+            <Group gap="xs" wrap="nowrap" miw={0}>
+                <MantineIcon icon={IconTool} color="white" size="sm" />
+                <Text c="white" fw={500} fz="xs" truncate>
+                    This is a preview environment. Any changes you make here will
+                    not affect production.
+                    {expiresAt && formatExpirationSuffix(expiresAt)}
+                </Text>
+                {upstreamProject && (
+                    <Anchor
+                        component="button"
+                        type="button"
+                        onClick={handleBackToUpstream}
+                        c="white"
+                        fz="xs"
+                        fw={600}
+                        underline="always"
+                        className={classes.backLink}
+                    >
+                        <MantineIcon icon={IconArrowLeft} size="sm" />
+                        <Text span>back to</Text>
+                        <Text span truncate maw={200}>
+                            {upstreamProject.name}
+                        </Text>
+                    </Anchor>
+                )}
+            </Group>
+        </Center>
+    );
+};

--- a/packages/frontend/src/components/NavBar/PreviewBanner.tsx
+++ b/packages/frontend/src/components/NavBar/PreviewBanner.tsx
@@ -63,9 +63,8 @@ export const PreviewBanner: FC<{
                         className={classes.backLink}
                     >
                         <MantineIcon icon={IconArrowLeft} size="sm" />
-                        <Text span>back to</Text>
-                        <Text span truncate maw={200}>
-                            {upstreamProject.name}
+                        <Text span fz="xs" fw={600} truncate maw={200}>
+                            back to {upstreamProject.name}
                         </Text>
                     </Anchor>
                 )}

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
@@ -21,6 +21,12 @@
     }
 }
 
+/* Allow the button label (and its flex children) to shrink so the project
+   name truncates with an ellipsis instead of being cropped. */
+.targetButtonLabel {
+    min-width: 0;
+}
+
 .breadcrumbSeparator {
     flex-shrink: 0;
 }

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -101,21 +101,34 @@ const SwitcherLabel: FC<{
 
     if (!upstreamProjectName) {
         return (
-            <Group gap={6} wrap="nowrap">
-                <Text truncate fw={500} fz="xs">
-                    {activeProjectName}
-                </Text>
+            <Group gap={6} wrap="nowrap" miw={0}>
+                <Tooltip
+                    withinPortal
+                    label={activeProjectName}
+                    disabled={!isTruncated}
+                >
+                    <Text
+                        ref={truncatedRef}
+                        truncate
+                        fw={500}
+                        fz="xs"
+                        className={classes.previewName}
+                    >
+                        {activeProjectName}
+                    </Text>
+                </Tooltip>
                 <MantineIcon
                     icon={IconChevronDown}
                     size="sm"
                     color="ldGray.6"
+                    className={classes.breadcrumbSeparator}
                 />
             </Group>
         );
     }
 
     return (
-        <Group gap={4} wrap="nowrap">
+        <Group gap={4} wrap="nowrap" miw={0}>
             <Text
                 fw={500}
                 fz="xs"
@@ -592,6 +605,7 @@ const ProjectSwitcher = () => {
                         variant="default"
                         size="xs"
                         className={classes.targetButton}
+                        classNames={{ label: classes.targetButtonLabel }}
                     >
                         <SwitcherLabel
                             activeProjectName={

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -70,6 +70,10 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const { data: project } = useProject(activeProjectUuid);
 
     const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
+    const upstreamProjectUuid = isCurrentProjectPreview
+        ? project?.upstreamProjectUuid
+        : undefined;
+    const { data: upstreamProject } = useProject(upstreamProjectUuid);
     const { isImpersonating } = useImpersonation();
     const { data: organizationAccess } = useOrganizationAccess();
 
@@ -101,7 +105,17 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
                 {isImpersonating ? (
                     <ImpersonationBanner />
                 ) : isCurrentProjectPreview ? (
-                    <PreviewBanner expiresAt={project?.expiresAt ?? null} />
+                    <PreviewBanner
+                        expiresAt={project?.expiresAt ?? null}
+                        upstreamProject={
+                            upstreamProject
+                                ? {
+                                      projectUuid: upstreamProject.projectUuid,
+                                      name: upstreamProject.name,
+                                  }
+                                : null
+                        }
+                    />
                 ) : (
                     organizationAccess && (
                         <TrialWarningBanner access={organizationAccess} />


### PR DESCRIPTION
Long preview/project names in the new project switcher were cropped without an ellipsis, and the preview banner had no way back to the main project.

**Changes**
- Project switcher button label now truncates with an ellipsis (`…`) instead of cropping. The fix lets the Mantine `Button` label and its flex children shrink (`min-width: 0`) so the existing `truncate` actually engages; a tooltip shows the full name on hover when truncated. Applies to both the plain project name and the `upstream › preview` breadcrumb.
- Added a "back to **&lt;main project&gt;**" link to the blue preview banner that switches the active project back to the upstream project and navigates to its home.

Verification was limited to typecheck + lint (no browser available in the sandbox).