### PR TITLE
feat(data-apps): add gcp auth mode for sandbox OTEL export

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -868,10 +868,15 @@ on, it sets:
   only.
 - `OTEL_TRACES_EXPORTER=otlp`, with `OTEL_METRICS_EXPORTER` and `OTEL_LOGS_EXPORTER` set to `none`.
   The sandbox is traces-only.
-- `OTEL_EXPORTER_OTLP_ENDPOINT` / `_PROTOCOL` / `_HEADERS` from config, plus the parent's
-  `TRACEPARENT`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` / `_PROTOCOL` / `_HEADERS`, plus the parent's `TRACEPARENT`. The
+  endpoint and headers are **resolved per auth mode** (see [Auth strategy](#auth-strategy-data_app_otel_auth)
+  below), not always the raw config values.
 - `OTEL_TRACES_EXPORT_INTERVAL=1000`. Generations are short-lived and the CLI flushes on clean exit;
   a low interval makes spans land before the sandbox is paused or torn down.
+- `OTEL_EXPORTER_OTLP_TIMEOUT=3000`. Bounds each export attempt so an unreachable endpoint adds at
+  most ~3s of flush latency at exit rather than the ~10s default. Telemetry is a non-fatal side
+  channel throughout: a wrong/unreachable endpoint, a misconfig, or a token-mint failure drops traces
+  but never the generation.
 - `OTEL_RESOURCE_ATTRIBUTES` carrying `service.name=lightdash-data-app` plus the same app / org /
   project / user uuids and install id as the parent span, so the sandbox spans are attributable on
   their own.
@@ -881,12 +886,39 @@ on, it sets:
   (`OTEL_LOG_RAW_API_BODIES`) stay off. See the caveat below: these flags feed Claude Code's
   log-events signal, not span attributes.
 
+### Auth strategy (`DATA_APP_OTEL_AUTH`)
+
+The OTLP endpoint and auth headers for the sandbox are chosen by a config-selected strategy, so the
+destination is a deployment decision and self-hosted installs are never coupled to a specific
+provider:
+
+- **`static` (default).** The sandbox uses the configured `OTEL_EXPORTER_OTLP_ENDPOINT` +
+  `OTEL_EXPORTER_OTLP_HEADERS` verbatim (your own collector, your own token / mTLS, etc.). No
+  provider-specific code runs. This is what a self-hosted deployment uses to point at its own
+  collector, and it's identical to the backend tracer's destination.
+- **`gcp`.** The sandbox endpoint is forced to GCP's public OTLP endpoint
+  (`https://telemetry.googleapis.com`), **independent of** the backend tracer's own
+  `OTEL_EXPORTER_OTLP_ENDPOINT`, and the headers are minted **per generation**: the backend uses
+  Application Default Credentials (Workload Identity) to mint a short-lived access token and injects
+  `Authorization: Bearer <token>` + `X-Goog-User-Project`. The deployment's identity must hold a
+  trace-write role; the project for `X-Goog-User-Project` comes from ADC unless `DATA_APP_OTEL_GCP_PROJECT`
+  overrides it. Minting happens at sandbox-execute time (not config-parse time), so the token is
+  always fresh regardless of process age or deploy cadence.
+
+The split matters: in `gcp` mode the sandbox goes straight to GCP while the backend tracer keeps its
+own (e.g. in-cluster collector) endpoint, so both halves must target the **same GCP project's Cloud
+Trace** for the parent and children to stitch by trace id. The header minting lives in
+`dataAppOtelAuth.ts` (`resolveDataAppOtelHeaders`) and the endpoint resolution in `claudeCodeEnv.ts`
+(`resolveDataAppOtelEndpoint`); both default to `static`, so the GCP path never runs unless a
+deployment opts in.
+
 ### Sandbox egress
 
 The E2B sandbox firewall denies all outbound traffic except an allowlist (see
 [LLM provider](#llm-provider-anthropic-vs-bedrock)). When OTEL export is on, `claudeCodeAllowedHosts`
-adds the OTLP collector's host to that allowlist, otherwise the exporter's POSTs are dropped
-silently. A malformed endpoint leaves the allowlist unchanged rather than opening an invalid host.
+adds the **resolved** endpoint's host to that allowlist (the configured collector in `static` mode,
+`telemetry.googleapis.com` in `gcp` mode), otherwise the exporter's POSTs are dropped silently. A
+malformed endpoint leaves the allowlist unchanged rather than opening an invalid host.
 
 ### Cost and payloads are not on the spans
 
@@ -915,19 +947,25 @@ the trace UI.
 
 ### Configuration
 
-The data-app sandbox reuses the same OTLP config as the backend's own tracer
-(`src/tracing/tracing.ts`), so both halves land in the same place:
+In `static` mode the data-app sandbox reuses the same OTLP config as the backend's own tracer
+(`src/tracing/tracing.ts`):
 
 ```
 LIGHTDASH_OTEL_TRACES_ENABLED=true                 # Master switch (backend + sandbox traces)
-OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318  # OTLP collector (GCP collector in prod, local Jaeger in dev)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318  # OTLP collector (local Jaeger in dev)
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf           # Defaults to http/protobuf
-OTEL_EXPORTER_OTLP_HEADERS=...                       # Optional auth headers for the collector
+OTEL_EXPORTER_OTLP_HEADERS=...                       # Optional auth headers (static mode)
 OTEL_SDK_DISABLED=false
+DATA_APP_OTEL_AUTH=static                            # 'static' (default) or 'gcp'
+DATA_APP_OTEL_GCP_PROJECT=...                        # Optional X-Goog-User-Project override (gcp mode; else ADC)
 ```
 
-`appRuntime.otel` (in `parseConfig.ts`) is structurally a subset of this and is passed straight to
-`buildClaudeCodeTelemetryEnv`; its `enabled` mirrors the backend tracer's `otelTracingEnabled()`.
+In `gcp` mode (`DATA_APP_OTEL_AUTH=gcp`) the sandbox endpoint is forced to `telemetry.googleapis.com`
+and the headers are minted from Workload Identity (see [Auth strategy](#auth-strategy-data_app_otel_auth)),
+so the sandbox no longer follows `OTEL_EXPORTER_OTLP_ENDPOINT` — only the backend tracer does.
+
+`appRuntime.otel` (in `parseConfig.ts`) carries `enabled`, `auth`, `endpoint`, `protocol`, `headers`,
+and `gcpProject`; its `enabled` mirrors the backend tracer's `otelTracingEnabled()`.
 
 ### Local verification (Jaeger)
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -372,9 +372,11 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bAiWritebackTemplateTag: '',
         otel: {
             enabled: false,
+            auth: 'static',
             endpoint: null,
             protocol: 'http/protobuf',
             headers: null,
+            gcpProject: null,
         },
     },
     enabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1579,9 +1579,11 @@ export type AppRuntimeConfig = {
      */
     otel: {
         enabled: boolean;
+        auth: 'static' | 'gcp';
         endpoint: string | null;
         protocol: string;
         headers: string | null;
+        gcpProject: string | null;
     };
 };
 
@@ -1816,10 +1818,17 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
                 process.env.LIGHTDASH_OTEL_TRACES_ENABLED === 'true' &&
                 process.env.OTEL_SDK_DISABLED !== 'true' &&
                 process.env.OTEL_TRACES_EXPORTER !== 'none',
+            // 'gcp' mints a short-lived Workload-Identity token per generation
+            // and exports the sandbox traces straight to telemetry.googleapis.com.
+            // Default 'static' keeps the generic endpoint+headers passthrough, so
+            // self-hosted installs never run the GCP path.
+            auth: process.env.DATA_APP_OTEL_AUTH === 'gcp' ? 'gcp' : 'static',
             endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || null,
             protocol:
                 process.env.OTEL_EXPORTER_OTLP_PROTOCOL || 'http/protobuf',
             headers: process.env.OTEL_EXPORTER_OTLP_HEADERS || null,
+            // X-Goog-User-Project for the GCP path; falls back to the ADC project.
+            gcpProject: process.env.DATA_APP_OTEL_GCP_PROJECT || null,
         },
     };
 };

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -94,6 +94,7 @@ import {
     buildClaudeCodeTelemetryEnv,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
+    resolveDataAppOtelEndpoint,
 } from './claudeCodeEnv';
 import {
     addClaudeUsage,
@@ -101,6 +102,7 @@ import {
     ZERO_CLAUDE_USAGE,
     type ClaudeGenerationUsage,
 } from './ClaudeStreamProcessor';
+import { resolveDataAppOtelHeaders } from './dataAppOtelAuth';
 import {
     copyDesignIntoSandbox,
     type DesignSandboxCopyResult,
@@ -2583,27 +2585,43 @@ export class AppGenerateService extends BaseService {
                     // generation is one cross-service trace. No-op when OTEL
                     // tracing is off.
                     const installId = process.env.LIGHTDASH_INSTALL_ID;
+                    const otelConfig = this.lightdashConfig.appRuntime.otel;
+                    // Resolve the sandbox endpoint + headers at execute time. In
+                    // 'gcp' mode the headers carry a freshly-minted Workload-Identity
+                    // token (short-lived, per generation) and the endpoint is GCP's
+                    // public OTLP endpoint; in 'static' mode both are the configured
+                    // values. Telemetry is a non-fatal side channel: any failure
+                    // (e.g. a token mint error) drops traces but never the run.
+                    let telemetryEnv: Record<string, string> = {};
+                    try {
+                        telemetryEnv = buildClaudeCodeTelemetryEnv(otelConfig, {
+                            traceparent:
+                                getOtelTraceHeaders().traceparent ?? null,
+                            endpoint: resolveDataAppOtelEndpoint(otelConfig),
+                            headers:
+                                await resolveDataAppOtelHeaders(otelConfig),
+                            resourceAttributes: {
+                                'service.name': 'lightdash-data-app',
+                                'data_app.app_uuid': appUuid,
+                                'data_app.version': String(version),
+                                'organization.uuid': payload.organizationUuid,
+                                'project.uuid': projectUuid,
+                                'user.uuid': payload.userUuid,
+                                ...(installId
+                                    ? { 'lightdash.install_id': installId }
+                                    : {}),
+                            },
+                        });
+                    } catch (e) {
+                        this.logger.warn(
+                            `App ${appUuid}: OTEL telemetry setup failed, continuing without traces: ${getErrorMessage(
+                                e,
+                            )}`,
+                        );
+                    }
                     const claudeCodeEnvWithTelemetry = {
                         ...claudeCodeEnv,
-                        ...buildClaudeCodeTelemetryEnv(
-                            this.lightdashConfig.appRuntime.otel,
-                            {
-                                traceparent:
-                                    getOtelTraceHeaders().traceparent ?? null,
-                                resourceAttributes: {
-                                    'service.name': 'lightdash-data-app',
-                                    'data_app.app_uuid': appUuid,
-                                    'data_app.version': String(version),
-                                    'organization.uuid':
-                                        payload.organizationUuid,
-                                    'project.uuid': projectUuid,
-                                    'user.uuid': payload.userUuid,
-                                    ...(installId
-                                        ? { 'lightdash.install_id': installId }
-                                        : {}),
-                                },
-                            },
-                        ),
+                        ...telemetryEnv,
                     };
                     await this.runPipelineStages(
                         sandbox,

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.test.ts
@@ -3,6 +3,8 @@ import {
     buildClaudeCodeTelemetryEnv,
     claudeCodeAllowedHosts,
     describeClaudeCodeEnv,
+    GCP_TELEMETRY_ENDPOINT,
+    resolveDataAppOtelEndpoint,
     type ClaudeCodeOtelConfig,
 } from './claudeCodeEnv';
 
@@ -163,36 +165,69 @@ describe('describeClaudeCodeEnv', () => {
     });
 });
 
+const staticOtel: ClaudeCodeOtelConfig = {
+    enabled: true,
+    auth: 'static',
+    endpoint: 'http://collector.internal:4318',
+    protocol: 'http/protobuf',
+    headers: null,
+    gcpProject: null,
+};
+
+describe('resolveDataAppOtelEndpoint', () => {
+    test('returns null when disabled', () => {
+        expect(
+            resolveDataAppOtelEndpoint({ ...staticOtel, enabled: false }),
+        ).toBeNull();
+    });
+
+    test('returns the configured endpoint in static mode', () => {
+        expect(resolveDataAppOtelEndpoint(staticOtel)).toBe(
+            'http://collector.internal:4318',
+        );
+    });
+
+    test('returns GCPs public endpoint in gcp mode, ignoring the configured one', () => {
+        expect(resolveDataAppOtelEndpoint({ ...staticOtel, auth: 'gcp' })).toBe(
+            GCP_TELEMETRY_ENDPOINT,
+        );
+    });
+});
+
 describe('buildClaudeCodeTelemetryEnv', () => {
-    const enabledOtel: ClaudeCodeOtelConfig = {
-        enabled: true,
-        endpoint: 'http://collector.internal:4318',
-        protocol: 'http/protobuf',
-        headers: null,
-    };
+    const enabledOtel = staticOtel;
 
     test('returns no env when disabled', () => {
         expect(
             buildClaudeCodeTelemetryEnv(
                 { ...enabledOtel, enabled: false },
-                { traceparent: '00-abc-def-01', resourceAttributes: {} },
+                {
+                    traceparent: '00-abc-def-01',
+                    resourceAttributes: {},
+                    endpoint: 'http://collector.internal:4318',
+                    headers: null,
+                },
             ),
         ).toEqual({});
     });
 
-    test('returns no env when enabled but no endpoint is set', () => {
+    test('returns no env when no resolved endpoint is set', () => {
         expect(
-            buildClaudeCodeTelemetryEnv(
-                { ...enabledOtel, endpoint: null },
-                { traceparent: '00-abc-def-01', resourceAttributes: {} },
-            ),
+            buildClaudeCodeTelemetryEnv(enabledOtel, {
+                traceparent: '00-abc-def-01',
+                resourceAttributes: {},
+                endpoint: null,
+                headers: null,
+            }),
         ).toEqual({});
     });
 
-    test('enables Claude Code tracing and points it at the collector', () => {
+    test('enables Claude Code tracing and points it at the resolved endpoint', () => {
         const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
             traceparent: null,
             resourceAttributes: {},
+            endpoint: 'http://collector.internal:4318',
+            headers: null,
         });
 
         expect(env).toEqual({
@@ -206,6 +241,7 @@ describe('buildClaudeCodeTelemetryEnv', () => {
             OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
             OTEL_EXPORTER_OTLP_ENDPOINT: 'http://collector.internal:4318',
             OTEL_TRACES_EXPORT_INTERVAL: '1000',
+            OTEL_EXPORTER_OTLP_TIMEOUT: '3000',
         });
     });
 
@@ -213,6 +249,8 @@ describe('buildClaudeCodeTelemetryEnv', () => {
         const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
             traceparent: null,
             resourceAttributes: {},
+            endpoint: 'http://collector.internal:4318',
+            headers: null,
         });
 
         expect(env.OTEL_LOG_USER_PROMPTS).toBe('1');
@@ -220,25 +258,26 @@ describe('buildClaudeCodeTelemetryEnv', () => {
         expect(env).not.toHaveProperty('OTEL_LOG_RAW_API_BODIES');
     });
 
-    test('includes TRACEPARENT, headers and serialized resource attributes when provided', () => {
-        const env = buildClaudeCodeTelemetryEnv(
-            { ...enabledOtel, headers: 'authorization=Bearer token' },
-            {
-                traceparent:
-                    '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
-                resourceAttributes: {
-                    'service.name': 'lightdash-data-app',
-                    'data_app.app_uuid': 'app-1',
-                    'organization.uuid': 'org-1',
-                },
+    test('includes the resolved (e.g. minted) headers + TRACEPARENT + resource attributes', () => {
+        const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
+            traceparent:
+                '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+            endpoint: GCP_TELEMETRY_ENDPOINT,
+            headers:
+                'Authorization=Bearer minted-token,X-Goog-User-Project=proj',
+            resourceAttributes: {
+                'service.name': 'lightdash-data-app',
+                'data_app.app_uuid': 'app-1',
+                'organization.uuid': 'org-1',
             },
-        );
+        });
 
+        expect(env.OTEL_EXPORTER_OTLP_ENDPOINT).toBe(GCP_TELEMETRY_ENDPOINT);
         expect(env.TRACEPARENT).toBe(
             '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
         );
         expect(env.OTEL_EXPORTER_OTLP_HEADERS).toBe(
-            'authorization=Bearer token',
+            'Authorization=Bearer minted-token,X-Goog-User-Project=proj',
         );
         expect(env.OTEL_RESOURCE_ATTRIBUTES).toBe(
             'service.name=lightdash-data-app,data_app.app_uuid=app-1,organization.uuid=org-1',
@@ -248,6 +287,8 @@ describe('buildClaudeCodeTelemetryEnv', () => {
     test('skips resource-attribute values that would corrupt the list or are empty', () => {
         const env = buildClaudeCodeTelemetryEnv(enabledOtel, {
             traceparent: null,
+            endpoint: 'http://collector.internal:4318',
+            headers: null,
             resourceAttributes: {
                 good: 'value',
                 empty: '',
@@ -261,12 +302,7 @@ describe('buildClaudeCodeTelemetryEnv', () => {
 });
 
 describe('claudeCodeAllowedHosts', () => {
-    const enabledOtel: ClaudeCodeOtelConfig = {
-        enabled: true,
-        endpoint: 'http://collector.internal:4318',
-        protocol: 'http/protobuf',
-        headers: null,
-    };
+    const enabledOtel = staticOtel;
 
     test('allows only api.anthropic.com when not using Bedrock', () => {
         expect(
@@ -284,6 +320,15 @@ describe('claudeCodeAllowedHosts', () => {
                 enabledOtel,
             ),
         ).toEqual(['api.anthropic.com', 'collector.internal']);
+    });
+
+    test('appends the GCP telemetry host (not the configured endpoint) in gcp mode', () => {
+        expect(
+            claudeCodeAllowedHosts(
+                { defaultProvider: 'openai', providers: {} },
+                { ...enabledOtel, auth: 'gcp' },
+            ),
+        ).toEqual(['api.anthropic.com', 'telemetry.googleapis.com']);
     });
 
     test('does NOT append a collector host when OTEL is disabled', () => {

--- a/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/claudeCodeEnv.ts
@@ -35,9 +35,31 @@ export type ClaudeCodeProviderConfig = {
  */
 export type ClaudeCodeOtelConfig = {
     enabled: boolean;
+    auth: 'static' | 'gcp';
     endpoint: string | null;
     protocol: string;
     headers: string | null;
+    gcpProject: string | null;
+};
+
+// GCP's public OTLP ingestion endpoint, used by the 'gcp' auth mode. Global; the
+// exporter appends /v1/traces and the project comes from the token +
+// X-Goog-User-Project header.
+export const GCP_TELEMETRY_ENDPOINT = 'https://telemetry.googleapis.com';
+
+/**
+ * The effective OTLP endpoint for the data-app sandbox. In 'gcp' mode this is
+ * GCP's public endpoint (independent of the backend's own
+ * OTEL_EXPORTER_OTLP_ENDPOINT, which stays the in-cluster collector); otherwise
+ * the configured endpoint. Null when telemetry is disabled.
+ */
+export const resolveDataAppOtelEndpoint = (
+    otel: ClaudeCodeOtelConfig,
+): string | null => {
+    if (!otel.enabled) {
+        return null;
+    }
+    return otel.auth === 'gcp' ? GCP_TELEMETRY_ENDPOINT : otel.endpoint;
 };
 
 /**
@@ -154,9 +176,14 @@ export const buildClaudeCodeTelemetryEnv = (
     options: {
         traceparent: string | null;
         resourceAttributes: Record<string, string>;
+        // The effective endpoint + headers, resolved by the caller (the 'gcp'
+        // auth mode overrides both: endpoint -> telemetry.googleapis.com, headers
+        // -> a freshly-minted Workload-Identity token).
+        endpoint: string | null;
+        headers: string | null;
     },
 ): Record<string, string> => {
-    if (!otel.enabled || !otel.endpoint) {
+    if (!otel.enabled || !options.endpoint) {
         return {};
     }
     const resourceAttributes = serializeResourceAttributes(
@@ -173,10 +200,15 @@ export const buildClaudeCodeTelemetryEnv = (
         OTEL_LOG_USER_PROMPTS: '1',
         OTEL_LOG_TOOL_DETAILS: '1',
         OTEL_EXPORTER_OTLP_PROTOCOL: otel.protocol,
-        OTEL_EXPORTER_OTLP_ENDPOINT: otel.endpoint,
+        OTEL_EXPORTER_OTLP_ENDPOINT: options.endpoint,
         // Short-lived runs: flush fast so spans land before sandbox teardown.
         OTEL_TRACES_EXPORT_INTERVAL: '1000',
-        ...(otel.headers ? { OTEL_EXPORTER_OTLP_HEADERS: otel.headers } : {}),
+        // Bound each export attempt so an unreachable endpoint adds minimal flush
+        // latency at exit rather than the ~10s default.
+        OTEL_EXPORTER_OTLP_TIMEOUT: '3000',
+        ...(options.headers
+            ? { OTEL_EXPORTER_OTLP_HEADERS: options.headers }
+            : {}),
         ...(options.traceparent ? { TRACEPARENT: options.traceparent } : {}),
         ...(resourceAttributes
             ? { OTEL_RESOURCE_ATTRIBUTES: resourceAttributes }
@@ -204,9 +236,10 @@ export const claudeCodeAllowedHosts = (
               `bedrock.${bedrock.region}.amazonaws.com`,
           ];
 
-    if (otel?.enabled && otel.endpoint) {
+    const otelEndpoint = otel ? resolveDataAppOtelEndpoint(otel) : null;
+    if (otelEndpoint) {
         try {
-            const host = new URL(otel.endpoint).hostname;
+            const host = new URL(otelEndpoint).hostname;
             if (host) {
                 return [...llmHosts, host];
             }

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppOtelAuth.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppOtelAuth.test.ts
@@ -1,0 +1,85 @@
+import type { ClaudeCodeOtelConfig } from './claudeCodeEnv';
+import { resolveDataAppOtelHeaders } from './dataAppOtelAuth';
+
+const getAccessToken = jest.fn();
+const getProjectId = jest.fn();
+const getClient = jest.fn();
+
+jest.mock('googleapis', () => ({
+    google: {
+        auth: {
+            GoogleAuth: jest.fn().mockImplementation(() => ({
+                getClient: () => getClient(),
+                getProjectId: () => getProjectId(),
+            })),
+        },
+    },
+}));
+
+const gcpOtel: ClaudeCodeOtelConfig = {
+    enabled: true,
+    auth: 'gcp',
+    endpoint: null,
+    protocol: 'http/protobuf',
+    headers: null,
+    gcpProject: null,
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    getClient.mockResolvedValue({
+        getAccessToken: () => getAccessToken(),
+    });
+    getAccessToken.mockResolvedValue({ token: 'wi-token' });
+    getProjectId.mockResolvedValue('adc-project');
+});
+
+describe('resolveDataAppOtelHeaders', () => {
+    test('returns null when telemetry is disabled', async () => {
+        await expect(
+            resolveDataAppOtelHeaders({ ...gcpOtel, enabled: false }),
+        ).resolves.toBeNull();
+    });
+
+    test('static mode returns the configured headers verbatim', async () => {
+        await expect(
+            resolveDataAppOtelHeaders({
+                ...gcpOtel,
+                auth: 'static',
+                headers: 'Authorization=Bearer my-static-token',
+            }),
+        ).resolves.toBe('Authorization=Bearer my-static-token');
+    });
+
+    test('static mode returns null when no headers are configured', async () => {
+        await expect(
+            resolveDataAppOtelHeaders({ ...gcpOtel, auth: 'static' }),
+        ).resolves.toBeNull();
+    });
+
+    test('gcp mode mints a WI token and derives the project from ADC', async () => {
+        await expect(resolveDataAppOtelHeaders(gcpOtel)).resolves.toBe(
+            'Authorization=Bearer wi-token,X-Goog-User-Project=adc-project',
+        );
+        expect(getProjectId).toHaveBeenCalled();
+    });
+
+    test('gcp mode uses the configured project override instead of ADC', async () => {
+        await expect(
+            resolveDataAppOtelHeaders({
+                ...gcpOtel,
+                gcpProject: 'override-project',
+            }),
+        ).resolves.toBe(
+            'Authorization=Bearer wi-token,X-Goog-User-Project=override-project',
+        );
+        expect(getProjectId).not.toHaveBeenCalled();
+    });
+
+    test('throws when no token is minted (caller treats telemetry as non-fatal)', async () => {
+        getAccessToken.mockResolvedValue({ token: null });
+        await expect(resolveDataAppOtelHeaders(gcpOtel)).rejects.toThrow(
+            'Failed to mint a GCP access token',
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AppGenerateService/dataAppOtelAuth.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/dataAppOtelAuth.ts
@@ -1,0 +1,51 @@
+import { google } from 'googleapis';
+import type { ClaudeCodeOtelConfig } from './claudeCodeEnv';
+
+// Least-privilege scope for writing traces. If telemetry.googleapis.com ever
+// rejects it, widen to https://www.googleapis.com/auth/cloud-platform (the SA's
+// IAM role still bounds what the token can actually do).
+const GCP_TRACE_SCOPE = 'https://www.googleapis.com/auth/trace.append';
+
+/**
+ * Mints a short-lived GCP access token via Application Default Credentials and
+ * returns it as the `OTEL_EXPORTER_OTLP_HEADERS` value for the data-app sandbox.
+ * The deployment's identity (e.g. a Workload-Identity service account) must be
+ * granted trace-write permission. `X-Goog-User-Project` is derived from ADC
+ * unless `gcpProject` overrides it.
+ *
+ * Only reached in `gcp` auth mode (default is `static`), so non-GCP installs
+ * never run any of this.
+ */
+const mintGcpOtelHeaders = async (
+    otel: ClaudeCodeOtelConfig,
+): Promise<string> => {
+    const auth = new google.auth.GoogleAuth({ scopes: [GCP_TRACE_SCOPE] });
+    const client = await auth.getClient();
+
+    const { token } = await client.getAccessToken();
+    if (!token) {
+        throw new Error('Failed to mint a GCP access token for OTEL export');
+    }
+
+    const project = otel.gcpProject ?? (await auth.getProjectId());
+
+    return `Authorization=Bearer ${token},X-Goog-User-Project=${project}`;
+};
+
+/**
+ * Resolves the `OTEL_EXPORTER_OTLP_HEADERS` value for the data-app sandbox.
+ * - `gcp`: mints a short-lived WI token (above).
+ * - `static` (default): the configured headers, verbatim.
+ * Returns null when telemetry is disabled.
+ */
+export const resolveDataAppOtelHeaders = async (
+    otel: ClaudeCodeOtelConfig,
+): Promise<string | null> => {
+    if (!otel.enabled) {
+        return null;
+    }
+    if (otel.auth === 'gcp') {
+        return mintGcpOtelHeaders(otel);
+    }
+    return otel.headers;
+};


### PR DESCRIPTION
## What

Adds a `DATA_APP_OTEL_AUTH` config that selects how the data-app sandbox authenticates its OTLP trace export.

- **`static`** (default) — uses the configured `OTEL_EXPORTER_OTLP_ENDPOINT` + `OTEL_EXPORTER_OTLP_HEADERS` as-is. Self-hosted installs are unchanged and never run the GCP path.
- **`gcp`** — mints a short-lived Application Default Credentials (Workload Identity) token per generation and exports straight to `telemetry.googleapis.com`, independent of the backend tracer's own endpoint.

The token is minted at sandbox-execute time so it's always fresh regardless of process age. The export timeout is bounded and telemetry stays non-fatal — a mint or endpoint failure drops traces, never the generation.

## Why

A deployment's OTLP collector can be on an internal address the e2b sandbox (off-cluster) can't reach. `gcp` mode lets the sandbox export directly to GCP's public OTLP endpoint with a per-generation token, while the default `static` path keeps the generic behaviour for self-hosted.

## Notes

- Stacked on #24591.
- GLITCH-521