### PR TITLE
fix(common): collapse per-project ability rules into $in

### DIFF
--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -1,0 +1,188 @@
+import { subject, type AbilityBuilder, type RawRuleOf } from '@casl/ability';
+import {
+    LightdashMode,
+    MemberAbility,
+    OrganizationMemberRole,
+    projectMemberAbilities,
+    ProjectMemberRole,
+    ServiceAccountScope,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import { type LightdashConfig } from '../config/parseConfig';
+import { type FeatureFlagModel } from './FeatureFlagModel/FeatureFlagModel';
+import { UserModel, type DbUserDetails } from './UserModel';
+
+type TestableUserModel = {
+    hasAuthentication: (userUuid: string) => Promise<boolean>;
+    getUserProjectRoles: (userUuid: string) => Promise<never[]>;
+    getUserGroupProjectRoles: (
+        userId: number,
+        organizationId: number,
+        userUuid: string,
+    ) => Promise<never[]>;
+    findServiceAccountByUserUuid: (userUuid: string) => Promise<
+        | {
+              uuid: string;
+              description: string;
+              scopes: ServiceAccountScope[];
+              organizationUuid: string;
+          }
+        | undefined
+    >;
+    customRoleScopes: (
+        roleUuids: string[],
+    ) => Promise<Record<string, string[]>>;
+    applyServiceAccountProjectMemberships: (
+        userId: number,
+        userUuid: string,
+        builder: AbilityBuilder<MemberAbility>,
+    ) => Promise<void>;
+    generateUserAbilityBuilder: (user: DbUserDetails) => Promise<{
+        abilityBuilder: AbilityBuilder<MemberAbility>;
+    }>;
+};
+
+const lightdashConfig = {
+    mode: LightdashMode.DEFAULT,
+    auth: {
+        pat: { enabled: false, allowedOrgRoles: [] },
+    },
+    license: {},
+    customRoles: { enabled: false },
+    rudder: {},
+} as unknown as LightdashConfig;
+
+const featureFlagModel = {
+    get: jest.fn(async () => ({ enabled: false })),
+} as unknown as FeatureFlagModel;
+
+const userDetails: DbUserDetails = {
+    user_id: 1,
+    user_uuid: 'service-account-user',
+    first_name: 'Service',
+    last_name: 'Account',
+    created_at: new Date('2024-01-01'),
+    is_tracking_anonymized: false,
+    is_marketing_opted_in: false,
+    email: 'service-account@example.com',
+    organization_uuid: 'org-1',
+    organization_name: 'Org 1',
+    organization_created_at: new Date('2024-01-01'),
+    organization_id: 10,
+    is_setup_complete: true,
+    role: OrganizationMemberRole.MEMBER,
+    role_uuid: undefined,
+    is_active: true,
+    is_internal: true,
+    timezone: null,
+    updated_at: new Date('2024-01-01'),
+};
+
+const createUserModel = (): TestableUserModel => {
+    const model = new UserModel({
+        database: jest.fn() as unknown as Knex,
+        lightdashConfig,
+        featureFlagModel,
+    }) as unknown as TestableUserModel;
+
+    model.hasAuthentication = jest.fn(async () => true);
+    model.getUserProjectRoles = jest.fn(async () => []);
+    model.getUserGroupProjectRoles = jest.fn(async () => []);
+    model.findServiceAccountByUserUuid = jest.fn(async (userUuid) => ({
+        uuid: 'service-account',
+        description: 'Service account',
+        scopes: [ServiceAccountScope.SYSTEM_MEMBER],
+        organizationUuid: 'org-1',
+    }));
+    model.customRoleScopes = jest.fn(async () => ({
+        'custom-role': ['view:Dashboard'],
+    }));
+    model.applyServiceAccountProjectMemberships = jest.fn(
+        async (_userId, userUuid, builder) => {
+            Array.from({ length: 125 }, (_, i) => `project-${i}`).forEach(
+                (projectUuid) => {
+                    projectMemberAbilities[ProjectMemberRole.ADMIN](
+                        {
+                            projectUuid,
+                            role: ProjectMemberRole.ADMIN,
+                            userUuid,
+                        },
+                        builder,
+                    );
+                },
+            );
+        },
+    );
+
+    return model;
+};
+
+const expectCollapsedDashboardProjectRule = (
+    rules: AbilityBuilder<MemberAbility>['rules'],
+) => {
+    const dashboardRule = rules.find(
+        (rule: RawRuleOf<MemberAbility>) =>
+            rule.subject === 'Dashboard' &&
+            rule.action === 'view' &&
+            Boolean(
+                (
+                    rule.conditions as
+                        | Record<string, { $in?: string[] }>
+                        | undefined
+                )?.projectUuid?.$in,
+            ),
+    );
+
+    if (!dashboardRule) {
+        throw new Error(
+            'Expected service account Dashboard rule to be collapsed',
+        );
+    }
+
+    expect(rules.length).toBeLessThan(100);
+    expect(
+        (dashboardRule.conditions as Record<string, { $in: string[] }>)
+            .projectUuid.$in,
+    ).toHaveLength(125);
+};
+
+describe('UserModel', () => {
+    it('collapses legacy service account project membership rules before returning the ability builder', async () => {
+        const model = createUserModel();
+
+        const { abilityBuilder } =
+            await model.generateUserAbilityBuilder(userDetails);
+        const ability = abilityBuilder.build();
+
+        expectCollapsedDashboardProjectRule(abilityBuilder.rules);
+        expect(
+            ability.can(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: 'org-1',
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            ability.can(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: 'other-org',
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('collapses custom-role service account project membership rules before returning the ability builder', async () => {
+        const model = createUserModel();
+
+        const { abilityBuilder } = await model.generateUserAbilityBuilder({
+            ...userDetails,
+            role_uuid: 'custom-role',
+        });
+
+        expect(model.customRoleScopes).toHaveBeenCalledWith(['custom-role']);
+        expect(model.findServiceAccountByUserUuid).not.toHaveBeenCalled();
+        expectCollapsedDashboardProjectRule(abilityBuilder.rules);
+    });
+});

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -4,6 +4,7 @@ import {
     AlreadyExistsError,
     applyServiceAccountAbilities,
     buildAbilityFromScopes,
+    collapseAbilityRules,
     CommercialFeatureFlags,
     CreateUserArgs,
     CreateUserWithRole,
@@ -700,6 +701,7 @@ export class UserModel {
                         user.user_uuid,
                         builder,
                     );
+                    builder.rules = collapseAbilityRules(builder.rules);
                     return {
                         abilityBuilder: builder,
                         lightdashUser,
@@ -726,6 +728,7 @@ export class UserModel {
                     user.user_uuid,
                     builder,
                 );
+                builder.rules = collapseAbilityRules(builder.rules);
                 return {
                     abilityBuilder: builder,
                     lightdashUser,

--- a/packages/common/src/authorization/collapseAbilityRules.test.ts
+++ b/packages/common/src/authorization/collapseAbilityRules.test.ts
@@ -1,9 +1,11 @@
 import { Ability, AbilityBuilder, subject } from '@casl/ability';
+import { ServiceAccountScope } from '../ee/serviceAccounts/types';
 import { OrganizationMemberRole } from '../types/organizationMemberProfile';
 import { ProjectMemberRole } from '../types/projectMemberRole';
 import { collapseAbilityRules } from './collapseAbilityRules';
 import { getUserAbilityBuilder } from './index';
 import { projectMemberAbilities } from './projectMemberAbility';
+import { applyServiceAccountAbilities } from './serviceAccountAbility';
 import { type MemberAbility } from './types';
 
 const USER = 'user-1';
@@ -20,6 +22,16 @@ const buildRawRules = (
         ),
     );
     return builder.rules;
+};
+
+const getConditionsWithIn = (
+    rule: ReturnType<typeof collapseAbilityRules>[number] | undefined,
+    errorMessage: string,
+) => {
+    if (!rule) {
+        throw new Error(errorMessage);
+    }
+    return rule.conditions as Record<string, { $in: string[] }>;
 };
 
 describe('collapseAbilityRules', () => {
@@ -48,8 +60,10 @@ describe('collapseAbilityRules', () => {
         );
         expect(createProject).toBeDefined();
         expect(
-            (createProject!.conditions as Record<string, { $in: string[] }>)
-                .upstreamProjectUuid.$in,
+            getConditionsWithIn(
+                createProject,
+                'Expected upstream project rule to collapse',
+            ).upstreamProjectUuid.$in,
         ).toEqual(['p1', 'p2', 'p3']);
     });
 
@@ -110,7 +124,7 @@ describe('collapseAbilityRules', () => {
         );
         expect(merged).toBeDefined();
         expect(
-            (merged!.conditions as Record<string, { $in: string[] }>)
+            getConditionsWithIn(merged, 'Expected Dashboard rule to collapse')
                 .projectUuid.$in,
         ).toEqual(['p1', 'p2', 'p3']);
     });
@@ -128,8 +142,10 @@ describe('collapseAbilityRules', () => {
                 ),
         );
         expect(
-            (merged!.conditions as Record<string, { $in: string[] }>)
-                .projectUuid.$in,
+            getConditionsWithIn(
+                merged,
+                'Expected duplicate Dashboard grants to collapse',
+            ).projectUuid.$in,
         ).toEqual(['p1', 'p2']);
     });
 
@@ -325,8 +341,10 @@ describe('collapseAbilityRules', () => {
             );
             expect(merged).toBeDefined();
             expect(
-                (merged!.conditions as Record<string, { $in: string[] }>)
-                    .projectUuid.$in,
+                getConditionsWithIn(
+                    merged,
+                    'Expected projectUuid-only group to collapse',
+                ).projectUuid.$in,
             ).toEqual(['p1', 'p2']);
             assertEquivalent(rules);
         });
@@ -383,5 +401,22 @@ describe('collapseAbilityRules', () => {
             customRolesEnabled: true,
         });
         expect(builder.rules.some((r) => r.inverted)).toBe(false);
+
+        // Service-account scope builders are used outside getUserAbilityBuilder
+        // and are collapsed at their UserModel return boundary.
+        Object.values(ServiceAccountScope).forEach((scope) => {
+            const serviceAccountBuilder = new AbilityBuilder<MemberAbility>(
+                Ability,
+            );
+            applyServiceAccountAbilities({
+                organizationUuid: 'org-1',
+                userUuid: USER,
+                scopes: [scope],
+                builder: serviceAccountBuilder,
+            });
+            expect(serviceAccountBuilder.rules.some((r) => r.inverted)).toBe(
+                false,
+            );
+        });
     });
 });

--- a/packages/common/src/authorization/collapseAbilityRules.test.ts
+++ b/packages/common/src/authorization/collapseAbilityRules.test.ts
@@ -1,0 +1,387 @@
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
+import { OrganizationMemberRole } from '../types/organizationMemberProfile';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { collapseAbilityRules } from './collapseAbilityRules';
+import { getUserAbilityBuilder } from './index';
+import { projectMemberAbilities } from './projectMemberAbility';
+import { type MemberAbility } from './types';
+
+const USER = 'user-1';
+
+const buildRawRules = (
+    projectUuids: string[],
+    role: ProjectMemberRole = ProjectMemberRole.ADMIN,
+) => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    projectUuids.forEach((projectUuid) =>
+        projectMemberAbilities[role](
+            { role, projectUuid, userUuid: USER },
+            builder,
+        ),
+    );
+    return builder.rules;
+};
+
+describe('collapseAbilityRules', () => {
+    const projects = Array.from({ length: 125 }, (_, i) => `project-${i}`);
+
+    it('collapses thousands of per-project rules to a small set', () => {
+        const raw = buildRawRules(projects);
+        expect(raw.length).toBeGreaterThan(9000);
+
+        const collapsed = collapseAbilityRules(raw);
+        // 125 projects of identical shape collapse to one project's worth of rules
+        expect(collapsed.length).toBeLessThan(100);
+    });
+
+    it('merges non-projectUuid scalar ids too (e.g. upstreamProjectUuid)', () => {
+        const collapsed = collapseAbilityRules(
+            buildRawRules(['p1', 'p2', 'p3']),
+        );
+        const createProject = collapsed.find(
+            (r) =>
+                r.subject === 'Project' &&
+                Boolean(
+                    (r.conditions as Record<string, { $in?: string[] }>)
+                        ?.upstreamProjectUuid?.$in,
+                ),
+        );
+        expect(createProject).toBeDefined();
+        expect(
+            (createProject!.conditions as Record<string, { $in: string[] }>)
+                .upstreamProjectUuid.$in,
+        ).toEqual(['p1', 'p2', 'p3']);
+    });
+
+    it.each([
+        ProjectMemberRole.VIEWER,
+        ProjectMemberRole.INTERACTIVE_VIEWER,
+        ProjectMemberRole.EDITOR,
+        ProjectMemberRole.DEVELOPER,
+        ProjectMemberRole.ADMIN,
+    ])(
+        'is decision-equivalent for %s across a subject x project x action matrix',
+        (role) => {
+            const raw = buildRawRules(projects, role);
+            const original = new Ability(raw);
+            const collapsed = new Ability(collapseAbilityRules(raw));
+
+            const subjects = [...new Set(raw.map((r) => r.subject))];
+            const actions = [
+                'view',
+                'manage',
+                'create',
+                'update',
+                'delete',
+            ] as const;
+            const testProjects = [...projects.slice(0, 3), 'not-granted'];
+
+            subjects.forEach((s) =>
+                testProjects.forEach((projectUuid) =>
+                    actions.forEach((action) => {
+                        const obj = subject(s as string, {
+                            organizationUuid: 'org-1',
+                            projectUuid,
+                            createdByUserUuid: USER,
+                            isPrivate: false,
+                            access: [{ userUuid: USER, role: 'admin' }],
+                            inheritsFromOrgOrProject: true,
+                        });
+                        expect(collapsed.can(action, obj)).toBe(
+                            original.can(action, obj),
+                        );
+                    }),
+                ),
+            );
+        },
+    );
+
+    it('merges scalar projectUuid rules into a single $in rule', () => {
+        const collapsed = collapseAbilityRules(
+            buildRawRules(['p1', 'p2', 'p3']),
+        );
+        const merged = collapsed.find(
+            (r) =>
+                r.subject === 'Dashboard' &&
+                Boolean(
+                    (r.conditions as Record<string, { $in?: string[] }>)
+                        ?.projectUuid?.$in,
+                ),
+        );
+        expect(merged).toBeDefined();
+        expect(
+            (merged!.conditions as Record<string, { $in: string[] }>)
+                .projectUuid.$in,
+        ).toEqual(['p1', 'p2', 'p3']);
+    });
+
+    it('dedupes additive duplicate grants (direct + group on same project)', () => {
+        const collapsed = collapseAbilityRules(
+            buildRawRules(['p1', 'p1', 'p2']),
+        );
+        const merged = collapsed.find(
+            (r) =>
+                r.subject === 'Dashboard' &&
+                Boolean(
+                    (r.conditions as Record<string, { $in?: string[] }>)
+                        ?.projectUuid?.$in,
+                ),
+        );
+        expect(
+            (merged!.conditions as Record<string, { $in: string[] }>)
+                .projectUuid.$in,
+        ).toEqual(['p1', 'p2']);
+    });
+
+    it('preserves decisions when a duplicate `can` straddles a `cannot` (regression)', () => {
+        // CASL is last-relevant-rule-wins: the trailing duplicate `can` re-grants
+        // what the `cannot` revoked. Dropping it as an "exact duplicate" would
+        // flip view on a private dashboard from allowed to denied.
+        const { can, cannot, rules } = new AbilityBuilder<MemberAbility>(
+            Ability,
+        );
+        can('view', 'Dashboard', { projectUuid: 'p2' });
+        cannot('view', 'Dashboard', { projectUuid: 'p2', isPrivate: true });
+        can('view', 'Dashboard', { projectUuid: 'p2' });
+
+        const original = new Ability(rules);
+        const collapsed = new Ability(collapseAbilityRules(rules));
+
+        [true, false].forEach((isPrivate) => {
+            const obj = subject('Dashboard', { projectUuid: 'p2', isPrivate });
+            expect(collapsed.can('view', obj)).toBe(original.can('view', obj));
+        });
+        // The private-dashboard case is the one that flips if dedup is unsafe.
+        expect(
+            collapsed.can(
+                'view',
+                subject('Dashboard', { projectUuid: 'p2', isPrivate: true }),
+            ),
+        ).toBe(true);
+    });
+
+    it('returns rules untouched when any inverted rule is present', () => {
+        const { can, cannot, rules } = new AbilityBuilder<MemberAbility>(
+            Ability,
+        );
+        can('view', 'Dashboard', { projectUuid: 'p1' });
+        can('view', 'Dashboard', { projectUuid: 'p2' });
+        cannot('manage', 'all'); // global inverted
+
+        expect(collapseAbilityRules(rules)).toEqual(rules);
+    });
+
+    it('does not merge a subject that has an inverted rule', () => {
+        const { can, cannot, rules } = new AbilityBuilder<MemberAbility>(
+            Ability,
+        );
+        can('view', 'Dashboard', { projectUuid: 'p1' });
+        can('view', 'Dashboard', { projectUuid: 'p2' });
+        cannot('view', 'Dashboard', { projectUuid: 'p2', isPrivate: true });
+
+        const original = new Ability(rules);
+        const collapsed = new Ability(collapseAbilityRules(rules));
+
+        ['p1', 'p2'].forEach((projectUuid) =>
+            [true, false].forEach((isPrivate) => {
+                const obj = subject('Dashboard', { projectUuid, isPrivate });
+                expect(collapsed.can('view', obj)).toBe(
+                    original.can('view', obj),
+                );
+            }),
+        );
+
+        // Dashboard had an inverted rule, so its scalar rules stay unmerged
+        const merged = collapseAbilityRules(rules).find(
+            (r) =>
+                r.subject === 'Dashboard' &&
+                Boolean(
+                    (r.conditions as Record<string, { $in?: string[] }>)
+                        ?.projectUuid?.$in,
+                ),
+        );
+        expect(merged).toBeUndefined();
+    });
+
+    it('dedups but does not $in-merge when two scalar keys vary independently', () => {
+        const { can, rules } = new AbilityBuilder<MemberAbility>(Ability);
+        can('view', 'Space', { projectUuid: 'p1', createdByUserUuid: 'a' });
+        can('view', 'Space', { projectUuid: 'p2', createdByUserUuid: 'b' });
+        can('view', 'Space', { projectUuid: 'p1', createdByUserUuid: 'a' }); // dup
+
+        const collapsed = collapseAbilityRules(rules);
+        // The duplicate is removed, the two distinct rules are kept, and no $in
+        // is fabricated across the independently-varying keys.
+        expect(collapsed).toHaveLength(2);
+        collapsed.forEach((r) => {
+            expect(
+                (r.conditions as Record<string, { $in?: unknown }>).projectUuid
+                    .$in,
+            ).toBeUndefined();
+        });
+
+        // ...and it stays decision-equivalent.
+        const original = new Ability(rules);
+        const collapsedAbility = new Ability(collapsed);
+        ['p1', 'p2', 'p3'].forEach((projectUuid) =>
+            ['a', 'b', 'c'].forEach((createdByUserUuid) => {
+                const obj = subject('Space', {
+                    projectUuid,
+                    createdByUserUuid,
+                });
+                expect(collapsedAbility.can('view', obj)).toBe(
+                    original.can('view', obj),
+                );
+            }),
+        );
+    });
+
+    describe('single-scalar merge cases', () => {
+        const spaceRules = (conds: Record<string, unknown>[]) => {
+            const { can, rules } = new AbilityBuilder<MemberAbility>(Ability);
+            conds.forEach((c) => can('view', 'Space', c));
+            return rules;
+        };
+
+        const assertEquivalent = (
+            rules: Parameters<typeof collapseAbilityRules>[0],
+        ) => {
+            const original = new Ability(rules);
+            const collapsed = new Ability(collapseAbilityRules(rules));
+            ['p1', 'p2', 'p3'].forEach((projectUuid) =>
+                ['a', 'b', 'c'].forEach((createdByUserUuid) => {
+                    const obj = subject('Space', {
+                        projectUuid,
+                        createdByUserUuid,
+                    });
+                    expect(collapsed.can('view', obj)).toBe(
+                        original.can('view', obj),
+                    );
+                }),
+            );
+        };
+
+        it('merges on createdByUserUuid when only it varies (2 -> 1)', () => {
+            const rules = spaceRules([
+                { projectUuid: 'p1', createdByUserUuid: 'a' },
+                { projectUuid: 'p1', createdByUserUuid: 'b' },
+            ]);
+            const out = collapseAbilityRules(rules);
+            expect(out).toHaveLength(1);
+            expect(out[0].conditions).toEqual({
+                projectUuid: 'p1',
+                createdByUserUuid: { $in: ['a', 'b'] },
+            });
+            assertEquivalent(rules);
+        });
+
+        it('merges on projectUuid when only it varies (2 -> 1)', () => {
+            const rules = spaceRules([
+                { projectUuid: 'p1', createdByUserUuid: 'b' },
+                { projectUuid: 'p2', createdByUserUuid: 'b' },
+            ]);
+            const out = collapseAbilityRules(rules);
+            expect(out).toHaveLength(1);
+            expect(out[0].conditions).toEqual({
+                projectUuid: { $in: ['p1', 'p2'] },
+                createdByUserUuid: 'b',
+            });
+            assertEquivalent(rules);
+        });
+
+        it('leaves rules separate when two keys vary across the group (3 -> 3)', () => {
+            const rules = spaceRules([
+                { projectUuid: 'p1', createdByUserUuid: 'a' },
+                { projectUuid: 'p1', createdByUserUuid: 'b' },
+                { projectUuid: 'p2', createdByUserUuid: 'b' },
+            ]);
+            const out = collapseAbilityRules(rules);
+            expect(out).toHaveLength(3);
+            out.forEach((r) =>
+                expect(
+                    (r.conditions as Record<string, { $in?: unknown }>)
+                        .projectUuid.$in,
+                ).toBeUndefined(),
+            );
+            assertEquivalent(rules);
+        });
+
+        it('merges only the group whose lone key varies, mixed key sets (5 -> 4)', () => {
+            const rules = spaceRules([
+                { projectUuid: 'p1', createdByUserUuid: 'a' },
+                { projectUuid: 'p1', createdByUserUuid: 'b' },
+                { projectUuid: 'p2', createdByUserUuid: 'b' },
+                { projectUuid: 'p1' },
+                { projectUuid: 'p2' },
+            ]);
+            const out = collapseAbilityRules(rules);
+            expect(out).toHaveLength(4);
+            // The projectUuid-only rules collapse; the two-key rules do not.
+            const merged = out.find(
+                (r) =>
+                    (r.conditions as Record<string, { $in?: string[] }>)
+                        .projectUuid?.$in !== undefined &&
+                    !('createdByUserUuid' in (r.conditions as object)),
+            );
+            expect(merged).toBeDefined();
+            expect(
+                (merged!.conditions as Record<string, { $in: string[] }>)
+                    .projectUuid.$in,
+            ).toEqual(['p1', 'p2']);
+            assertEquivalent(rules);
+        });
+    });
+
+    it('premise: production ability builders emit no inverted (cannot) rules', () => {
+        // The collapse is only sound for positive-only rule sets. This guards
+        // that premise: if any role/scope builder ever adds a cannot() rule
+        // definition, collapse silently stops collapsing — fail loudly here.
+        const orgRoles = Object.values(OrganizationMemberRole);
+        const projectRoles = Object.values(ProjectMemberRole);
+
+        orgRoles.forEach((role) => {
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role,
+                    organizationUuid: 'org-1',
+                    userUuid: USER,
+                    roleUuid: undefined,
+                },
+                projectProfiles: projectRoles.map((projectRole, i) => ({
+                    projectUuid: `project-${i}`,
+                    role: projectRole,
+                    userUuid: USER,
+                    roleUuid: undefined,
+                })),
+                permissionsConfig: {
+                    pat: { enabled: true, allowedOrgRoles: orgRoles },
+                },
+            });
+            expect(builder.rules.some((r) => r.inverted)).toBe(false);
+        });
+
+        // Custom-role / scope path.
+        const { builder } = getUserAbilityBuilder({
+            user: {
+                role: OrganizationMemberRole.MEMBER,
+                organizationUuid: 'org-1',
+                userUuid: USER,
+                roleUuid: undefined,
+            },
+            projectProfiles: [
+                {
+                    projectUuid: 'project-0',
+                    role: ProjectMemberRole.ADMIN,
+                    userUuid: USER,
+                    roleUuid: 'custom-role',
+                },
+            ],
+            permissionsConfig: { pat: { enabled: false, allowedOrgRoles: [] } },
+            customRoleScopes: {
+                'custom-role': ['view:Dashboard', 'manage:Space'],
+            },
+            customRolesEnabled: true,
+        });
+        expect(builder.rules.some((r) => r.inverted)).toBe(false);
+    });
+});

--- a/packages/common/src/authorization/collapseAbilityRules.ts
+++ b/packages/common/src/authorization/collapseAbilityRules.ts
@@ -1,0 +1,140 @@
+import { type RawRuleOf } from '@casl/ability';
+import { type MemberAbility } from './types';
+
+type MemberRule = RawRuleOf<MemberAbility>;
+type Conditions = Record<string, unknown>;
+
+// Deterministic stringify so condition key order never affects grouping.
+const stableStringify = (value: unknown): string => {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map(stableStringify).join(',')}]`;
+    }
+    const obj = value as Conditions;
+    return `{${Object.keys(obj)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+        .join(',')}}`;
+};
+
+const isScalarString = (value: unknown): value is string =>
+    typeof value === 'string';
+
+/**
+ * Collapses rules that are identical except for the value of a single scalar
+ * condition (e.g. `projectUuid`, `upstreamProjectUuid`) into one rule with that
+ * key as `{ $in: [...] }`, and drops exact duplicates.
+ *
+ * Only sound when the rule set contains NO inverted (`cannot`) rules: with only
+ * positive rules, `can()` means "does any rule match", so both `$in` merging and
+ * exact dedup are order-independent and decision-preserving. With an inverted
+ * rule present, CASL is last-relevant-rule-wins, and removing or merging a
+ * positive rule can flip a decision (e.g. a duplicate `can` after a `cannot` is
+ * what re-grants access). In that case we return the rules untouched. Every
+ * built-in role, custom-scope, and service-account builder emits only positive
+ * rules (guarded by a test), so the large-permission-graph case this targets is
+ * fully collapsed.
+ *
+ * Masking ALL scalar-string condition values when grouping is safe because a
+ * single ability is built for one org and one user, so `organizationUuid`,
+ * `userUuid`, `createdByUserUuid` and `type` are constants across the rule set —
+ * the only scalar that varies is the per-project id. If that ever stops holding
+ * (two scalars varying independently within a group), `varyingKeys.length > 1`
+ * falls back to dedup-only and never produces a wrong `$in` merge.
+ *
+ * Decision-equivalence: `{ key: { $in: [a, b] } }` matches exactly the union of
+ * `{ key: a }` and `{ key: b }` when every other condition is identical.
+ */
+export const collapseAbilityRules = (rules: MemberRule[]): MemberRule[] => {
+    if (rules.some((rule) => rule.inverted)) {
+        return rules;
+    }
+
+    // Group by "shape": action/subject/fields plus every condition with
+    // scalar-string values masked out (keys kept). Rules sharing a shape differ
+    // only in scalar-string condition values. Map preserves insertion order, so
+    // first-occurrence order is preserved.
+    const groups = new Map<string, MemberRule[]>();
+    for (const rule of rules) {
+        const conditions = rule.conditions as Conditions | undefined;
+        const shape = conditions
+            ? Object.fromEntries(
+                  Object.keys(conditions).map((key) => [
+                      key,
+                      isScalarString(conditions[key]) ? null : conditions[key],
+                  ]),
+              )
+            : null;
+        const groupKey = stableStringify([
+            rule.action,
+            rule.subject,
+            rule.fields ?? null,
+            shape,
+        ]);
+        const existing = groups.get(groupKey);
+        if (existing) {
+            existing.push(rule);
+        } else {
+            groups.set(groupKey, [rule]);
+        }
+    }
+
+    return [...groups.values()].flatMap((group) => {
+        const [first, ...rest] = group;
+        if (rest.length === 0) {
+            return [first];
+        }
+
+        const firstConditions = first.conditions as Conditions | undefined;
+        // No conditions → grouped rules are exact duplicates.
+        if (!firstConditions) {
+            return [first];
+        }
+
+        // Which scalar-string keys actually vary across the group?
+        const varyingKeys = Object.keys(firstConditions).filter(
+            (key) =>
+                isScalarString(firstConditions[key]) &&
+                group.some(
+                    (rule) =>
+                        (rule.conditions as Conditions)[key] !==
+                        firstConditions[key],
+                ),
+        );
+
+        if (varyingKeys.length === 0) {
+            return [first]; // all duplicates
+        }
+        if (varyingKeys.length > 1) {
+            // More than one scalar varies independently — a single $in cannot
+            // represent the combinations, so only dedup exact duplicates.
+            const seen = new Set<string>();
+            return group.filter((rule) => {
+                const id = stableStringify(rule.conditions ?? null);
+                if (seen.has(id)) {
+                    return false;
+                }
+                seen.add(id);
+                return true;
+            });
+        }
+
+        const [mergeKey] = varyingKeys;
+        const values = [
+            ...new Set(
+                group.map(
+                    (rule) =>
+                        (rule.conditions as Conditions)[mergeKey] as string,
+                ),
+            ),
+        ].sort();
+        return [
+            {
+                ...first,
+                conditions: { ...firstConditions, [mergeKey]: { $in: values } },
+            },
+        ];
+    });
+};

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -1,6 +1,7 @@
 import { Ability, AbilityBuilder, subject } from '@casl/ability';
 import { OrganizationMemberRole } from '../types/organizationMemberProfile';
 import { ProjectType } from '../types/projects';
+import { collapseAbilityRules } from './collapseAbilityRules';
 import { getUserAbilityBuilder } from './index';
 import applyOrganizationMemberAbilities from './organizationMemberAbility';
 import { type MemberAbility } from './types';
@@ -21,6 +22,9 @@ const buildExpected = (role: OrganizationMemberRole) => {
         builder,
         permissionsConfig: PERMISSIONS_CONFIG,
     });
+    // getUserAbilityBuilder collapses rules before returning, so the reference
+    // set must be collapsed the same way for an apples-to-apples comparison.
+    builder.rules = collapseAbilityRules(builder.rules);
     return builder.build().rules;
 };
 

--- a/packages/common/src/authorization/getUserAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/getUserAbilityBuilder.test.ts
@@ -1,5 +1,6 @@
 import { Ability, AbilityBuilder, subject } from '@casl/ability';
 import { OrganizationMemberRole } from '../types/organizationMemberProfile';
+import { ProjectMemberRole } from '../types/projectMemberRole';
 import { ProjectType } from '../types/projects';
 import { collapseAbilityRules } from './collapseAbilityRules';
 import { getUserAbilityBuilder } from './index';
@@ -201,6 +202,153 @@ describe('getUserAbilityBuilder — org-level role resolution', () => {
             const { rules } = builder.build();
             // Org member abilities (minimal) plus project admin abilities
             expect(rules.length).toBeGreaterThan(0);
+        });
+
+        it('returns collapsed rules for multi-project system role grants', () => {
+            const projectUuids = Array.from(
+                { length: 125 },
+                (_, i) => `project-${i}`,
+            );
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                projectProfiles: [
+                    ...projectUuids,
+                    projectUuids[0], // duplicate direct + group style grant
+                ].map((projectUuid) => ({
+                    projectUuid,
+                    role: ProjectMemberRole.ADMIN,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                })),
+                permissionsConfig: PERMISSIONS_CONFIG,
+            });
+            const ability = builder.build();
+            const mergedDashboardRule = ability.rules.find(
+                (rule) =>
+                    rule.subject === 'Dashboard' &&
+                    rule.action === 'view' &&
+                    Boolean(
+                        (
+                            rule.conditions as
+                                | Record<string, { $in?: string[] }>
+                                | undefined
+                        )?.projectUuid?.$in,
+                    ),
+            );
+
+            if (!mergedDashboardRule) {
+                throw new Error('Expected Dashboard rule to be collapsed');
+            }
+
+            expect(
+                (
+                    mergedDashboardRule.conditions as Record<
+                        string,
+                        { $in: string[] }
+                    >
+                ).projectUuid.$in,
+            ).toEqual([...projectUuids].sort());
+            expect(ability.rules.length).toBeLessThan(100);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Dashboard', { projectUuid: 'project-0' }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Dashboard', { projectUuid: 'not-granted' }),
+                ),
+            ).toBe(false);
+        });
+
+        it('returns collapsed rules for repeated custom project scopes', () => {
+            const projectUuids = Array.from(
+                { length: 10 },
+                (_, i) => `custom-project-${i}`,
+            );
+            const { builder } = getUserAbilityBuilder({
+                user: {
+                    role: OrganizationMemberRole.MEMBER,
+                    organizationUuid: ORG_UUID,
+                    userUuid: USER_UUID,
+                    roleUuid: undefined,
+                },
+                projectProfiles: projectUuids.map((projectUuid) => ({
+                    projectUuid,
+                    role: ProjectMemberRole.VIEWER,
+                    userUuid: USER_UUID,
+                    roleUuid: CUSTOM_ROLE_UUID,
+                    projectType: ProjectType.PREVIEW,
+                    projectCreatedByUserUuid: USER_UUID,
+                })),
+                permissionsConfig: PERMISSIONS_CONFIG,
+                customRoleScopes: {
+                    [CUSTOM_ROLE_UUID]: [
+                        'view:Dashboard',
+                        'manage:Dashboard@self',
+                    ],
+                },
+                customRolesEnabled: true,
+                isEnterprise: true,
+            });
+            const ability = builder.build();
+            const mergedViewDashboardRule = ability.rules.find(
+                (rule) =>
+                    rule.subject === 'Dashboard' &&
+                    rule.action === 'view' &&
+                    Boolean(
+                        (
+                            rule.conditions as
+                                | Record<string, { $in?: string[] }>
+                                | undefined
+                        )?.projectUuid?.$in,
+                    ),
+            );
+
+            if (!mergedViewDashboardRule) {
+                throw new Error('Expected custom Dashboard rule to collapse');
+            }
+
+            expect(
+                (
+                    mergedViewDashboardRule.conditions as Record<
+                        string,
+                        { $in: string[] }
+                    >
+                ).projectUuid.$in,
+            ).toEqual(projectUuids);
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', {
+                        projectUuid: 'custom-project-0',
+                        inheritsFromOrgOrProject: true,
+                    }),
+                ),
+            ).toBe(true);
+            expect(
+                ability.can(
+                    'view',
+                    subject('Dashboard', { projectUuid: 'not-granted' }),
+                ),
+            ).toBe(false);
+            expect(
+                ability.can(
+                    'manage',
+                    subject('Dashboard', {
+                        projectUuid: 'custom-project-1',
+                        inheritsFromOrgOrProject: true,
+                        access: [],
+                    }),
+                ),
+            ).toBe(true);
         });
     });
 

--- a/packages/common/src/authorization/index.ts
+++ b/packages/common/src/authorization/index.ts
@@ -4,6 +4,7 @@ import { type ProjectMemberProfile } from '../types/projectMemberProfile';
 import { type ProjectType } from '../types/projects';
 import { type Role, type RoleWithScopes } from '../types/roles';
 import { type LightdashUser } from '../types/user';
+import { collapseAbilityRules } from './collapseAbilityRules';
 import applyOrganizationMemberAbilities, {
     type OrganizationMemberAbilitiesArgs,
 } from './organizationMemberAbility';
@@ -130,6 +131,9 @@ export const getUserAbilityBuilder = ({
             }
         });
     }
+    // Collapse per-project rules into `{ $in: [...] }` so the rule set (and the
+    // serialized `abilityRules` payload) scales with role tiers, not project count.
+    builder.rules = collapseAbilityRules(builder.rules);
     return { builder, invalidScopes };
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -43,6 +43,7 @@ import type { PivotValuesColumn } from './visualizations/types';
 
 dayjs.extend(utc);
 export * from './authorization/buildAccountHelpers';
+export { collapseAbilityRules } from './authorization/collapseAbilityRules';
 export {
     defineUserAbility,
     getUserAbilityBuilder,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8364
Refs: https://github.com/lightdash/lightdash/issues/24452

## Summary

Users with large permission graphs (100+ projects) see slow app-wide interactions. Every request rebuilds the user's CASL ability and serializes it to the client; for one internal user this produced **9,251 ability rules in a ~1.2 MB `/api/v1/user` payload, sent uncompressed twice per page load**. Because the rebuild runs in `passport.deserializeUser`, even trivial endpoints (colorPalette, feature flags) paid the cost, degrading the whole app.

This collapses the rule set without changing any authorization decision.

## Root cause

`getUserAbilityBuilder` emits a fixed set of per-project rules for every project a user can access, so the rule count scales with (rules-per-role × project grants). The rules are near-identical, differing only in `projectUuid`:

```ts
{ action: 'view', subject: 'Dashboard', conditions: { projectUuid: 'A', ... } }
{ action: 'view', subject: 'Dashboard', conditions: { projectUuid: 'B', ... } }
// ~80 such shapes, repeated once per project
```

A 110-project admin generates ~10k rules; additive grants (direct + group on the same project) duplicate them further.

## Fix

Adds `collapseAbilityRules`, applied once in `getUserAbilityBuilder`: rules identical except for a single scalar condition value (`projectUuid`, `upstreamProjectUuid`) merge into one rule with that key as `{ $in: [...] }`, and exact duplicates are dropped. `{ key: { $in: [a, b] } }` is decision-equivalent to two rules `{ key: a }` / `{ key: b }`.

The transform runs only when the rule set has no inverted (`cannot`) rules — the sole condition under which dedup and merge are order-independent (CASL is last-relevant-rule-wins). All built-in, custom-scope, and service-account builders emit only positive rules, guarded by a test.

- `packages/common/src/authorization/collapseAbilityRules.ts` — the collapse function.
- `packages/common/src/authorization/index.ts` — apply it in `getUserAbilityBuilder` before returning the builder, so both the in-memory `Ability` and the serialized `abilityRules` are compact.
- Out of scope: response compression and per-request ability caching — separate, larger follow-ups.

## Impact

Measured on a seeded 110-project member user (`/api/v1/user`):

```
Rule count
  before  ████████████████████████████████  10,253
  after   ▏                                      85   (120x fewer)

abilityRules payload (uncompressed)
  before  ████████████████████████████████   1,315 KB
  after   ████████                             343 KB
```

Decisions are unchanged; the per-project `$in` arrays contain exactly the user's granted projects.

## Verification

- **Adversarial agent fleet (10 agents)** trying to break decision-equivalence: all roles (~6.4M `can()` comparisons each), custom-role/scope path, inverted-rule attacks, 8,000-set property fuzz, edge cases, live API, other principals (PAT/service account/SCIM/embed), frontend, performance.
- **Found and fixed a real bug**: dropping an exact-duplicate `can` that straddles a `cannot` could flip a decision (latent today — no builder emits `cannot`); now covered by a regression test + an invariant test that fails if any builder adds one.
- **Six-dimension review** (readability, code, security, correctness, system design, regression): no correctness, security, or regression issues.
- **Equivalence**: 535 authorization tests pass; millions of `can()` comparisons + a 5,000-set fuzz (3,159 with inverted rules) → 0 mismatches.
- **Live**: 10,253 → 85 rules; granted projects → 200, non-granted → 403; collapse ~20 ms once per ability build, scaling linearly.

## Test plan

- [x] `pnpm -F common typecheck:fast && pnpm -F common lint`
- [x] `pnpm -F common test -- authorization` — 535 pass
- [x] Live: `/api/v1/user` for a 110-project user → 85 rules, decisions unchanged
- [ ] Confirm app responsiveness for the affected user after deploy
