### PR TITLE
fix: omit hardcoded pivot values from downloaded chart-as-code YAML (PROD-8299)

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -31,6 +31,7 @@ import {
     ProjectType,
     PromotionAction,
     PromotionChanges,
+    removePivotedSeriesValuesFromChartConfig,
     SavedChartDAO,
     SessionUser,
     Space,
@@ -213,7 +214,9 @@ export class CoderService extends BaseService {
             tableName: chart.tableName,
             updatedAt: chart.updatedAt,
             metricQuery: chart.metricQuery,
-            chartConfig: chart.chartConfig,
+            chartConfig: removePivotedSeriesValuesFromChartConfig(
+                chart.chartConfig,
+            ),
             pivotConfig: chart.pivotConfig,
             dashboardSlug: chart.dashboardUuid
                 ? dashboardSlugs[chart.dashboardUuid]

--- a/packages/common/src/types/savedCharts.test.ts
+++ b/packages/common/src/types/savedCharts.test.ts
@@ -1,0 +1,126 @@
+import {
+    CartesianSeriesType,
+    ChartType,
+    removePivotedSeriesValuesFromChartConfig,
+    type CartesianChartConfig,
+    type ChartConfig,
+    type Series,
+} from './savedCharts';
+
+const pivotedSeries = (
+    field: string,
+    pivotField: string,
+    pivotValue: string,
+    overrides: Partial<Series> = {},
+): Series => ({
+    type: CartesianSeriesType.LINE,
+    stack: field,
+    encode: {
+        xRef: { field: 'orders_date' },
+        yRef: {
+            field,
+            pivotValues: [{ field: pivotField, value: pivotValue }],
+        },
+        x: 'orders_date',
+        y: `${field}.${pivotField}.${pivotValue}`,
+    },
+    ...overrides,
+});
+
+const cartesianConfig = (series: Series[]): CartesianChartConfig => ({
+    type: ChartType.CARTESIAN,
+    config: {
+        layout: { xField: 'orders_date', yField: ['orders_count'] },
+        eChartsConfig: { series },
+    },
+});
+
+describe('removePivotedSeriesValuesFromChartConfig', () => {
+    it('strips data-level pivot values and dedupes pivoted series', () => {
+        const config = cartesianConfig([
+            pivotedSeries('orders_count', 'orders_status', 'completed', {
+                name: 'completed',
+                color: '#ff0000',
+            }),
+            pivotedSeries('orders_count', 'orders_status', 'placed', {
+                name: 'placed',
+                color: '#00ff00',
+            }),
+            pivotedSeries('orders_count', 'orders_status', 'shipped', {
+                name: 'shipped',
+                color: '#0000ff',
+            }),
+        ]);
+
+        const result = removePivotedSeriesValuesFromChartConfig(
+            config,
+        ) as CartesianChartConfig;
+
+        const series = result.config!.eChartsConfig.series!;
+        expect(series).toHaveLength(1);
+        expect(series[0].encode.yRef).toEqual({ field: 'orders_count' });
+        expect(series[0].encode.yRef.pivotValues).toBeUndefined();
+        // computed hashes and data-specific name/color are dropped
+        expect(series[0].encode.x).toBeUndefined();
+        expect(series[0].encode.y).toBeUndefined();
+        expect(series[0].name).toBeUndefined();
+        expect(series[0].color).toBeUndefined();
+        // chart-level styling that drives regeneration is preserved
+        expect(series[0].type).toBe(CartesianSeriesType.LINE);
+        expect(series[0].stack).toBe('orders_count');
+    });
+
+    it('keeps multiple metrics as separate portable series', () => {
+        const config = cartesianConfig([
+            pivotedSeries('orders_count', 'orders_status', 'completed'),
+            pivotedSeries('orders_count', 'orders_status', 'placed'),
+            pivotedSeries('orders_total', 'orders_status', 'completed'),
+        ]);
+
+        const result = removePivotedSeriesValuesFromChartConfig(
+            config,
+        ) as CartesianChartConfig;
+
+        const series = result.config!.eChartsConfig.series!;
+        expect(series).toHaveLength(2);
+        expect(series.map((s) => s.encode.yRef.field)).toEqual([
+            'orders_count',
+            'orders_total',
+        ]);
+    });
+
+    it('leaves non-pivoted series (and their customizations) untouched', () => {
+        const nonPivotedSeries: Series = {
+            type: CartesianSeriesType.BAR,
+            encode: {
+                xRef: { field: 'orders_date' },
+                yRef: { field: 'orders_count' },
+            },
+            name: 'Order count',
+            color: '#abcabc',
+        };
+        const config = cartesianConfig([nonPivotedSeries]);
+
+        const result = removePivotedSeriesValuesFromChartConfig(
+            config,
+        ) as CartesianChartConfig;
+
+        expect(result.config!.eChartsConfig.series).toEqual([nonPivotedSeries]);
+    });
+
+    it('returns non-cartesian configs unchanged', () => {
+        const config: ChartConfig = {
+            type: ChartType.BIG_NUMBER,
+            config: { selectedField: 'orders_count' },
+        };
+
+        expect(removePivotedSeriesValuesFromChartConfig(config)).toBe(config);
+    });
+
+    it('handles missing or empty series', () => {
+        const emptyConfig = cartesianConfig([]);
+        expect(removePivotedSeriesValuesFromChartConfig(emptyConfig)).toBe(
+            emptyConfig,
+        );
+    });
+});

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1072,6 +1072,59 @@ export const getSeriesId = (series: Series) =>
         series.encode.yRef,
     )}`;
 
+const stripPivotValuesFromSeries = (series: Series): Series => {
+    const { encode, name, color, ...rest } = series;
+    return {
+        ...rest,
+        encode: {
+            xRef: { field: encode.xRef.field },
+            yRef: { field: encode.yRef.field },
+        },
+    };
+};
+
+// Strip data-level pivot values (and dedupe) so pivoted series regenerate from
+// `pivotConfig` on load instead of hardcoding non-portable values in the config.
+export const removePivotedSeriesValuesFromChartConfig = (
+    chartConfig: ChartConfig,
+): ChartConfig => {
+    if (chartConfig.type !== ChartType.CARTESIAN || !chartConfig.config) {
+        return chartConfig;
+    }
+
+    const { series } = chartConfig.config.eChartsConfig;
+    if (!series || series.length === 0) {
+        return chartConfig;
+    }
+
+    const seenSeriesIds = new Set<string>();
+    const portableSeries = series.reduce<Series[]>((acc, currentSeries) => {
+        const hasPivotValues =
+            isPivotReferenceWithValues(currentSeries.encode.yRef) ||
+            isPivotReferenceWithValues(currentSeries.encode.xRef);
+        const portableSerie = hasPivotValues
+            ? stripPivotValuesFromSeries(currentSeries)
+            : currentSeries;
+        const seriesId = getSeriesId(portableSerie);
+        if (seenSeriesIds.has(seriesId)) {
+            return acc;
+        }
+        seenSeriesIds.add(seriesId);
+        return [...acc, portableSerie];
+    }, []);
+
+    return {
+        ...chartConfig,
+        config: {
+            ...chartConfig.config,
+            eChartsConfig: {
+                ...chartConfig.config.eChartsConfig,
+                series: portableSeries,
+            },
+        },
+    };
+};
+
 export const ECHARTS_DEFAULT_COLORS = [
     '#5470c6',
     '#fc8452',


### PR DESCRIPTION
## Problem

When a cartesian chart with a pivot/group-by dimension is downloaded via `lightdash download` (chart-as-code), `chartConfig.config.eChartsConfig.series` was serialized with **one entry per pivot dimension value**, each hardcoding the actual data value under `encode.yRef.pivotValues[].value` (plus data-derived `name`/`color`/computed hashes).

This made the YAML **non-portable**: uploading it to an environment with a different set of pivot values is wrong, and the series array grows with the cardinality of the pivot dimension.

## Root cause

Pivoted cartesian series are auto-generated at load time from `pivotConfig` + live query data, but the download path persisted the materialised, data-specific series verbatim.

## Fix

- Add `removePivotedSeriesValuesFromChartConfig` in `@lightdash/common`, which strips the data-level pivot values from pivoted series (using the existing `isPivotReferenceWithValues`) and dedupes the result by `getSeriesId`, so the series regenerate from `pivotConfig` on load.
- Apply it in `CoderService` when serializing `chartConfig` for download.
- Non-pivoted series and their per-series customizations are left untouched.

## Verification

- New unit tests in `savedCharts.test.ts` (5 passing): strips + dedupes pivoted series, keeps multiple metrics as separate portable series, leaves non-pivoted series/customizations untouched, passes through non-cartesian and empty/missing-series configs.
- `pnpm -F common typecheck:fast` and `pnpm -F backend typecheck:fast` clean; lint clean (no new warnings).

Fixes PROD-8299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)