### PR TITLE
fix: keep reference line visible when hiding grouped series via legend (PROD-7119)

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -23,6 +23,7 @@ import {
     getStackTotalSeries,
     mergeLegendSettings,
     padDatasetForContinuousAxis,
+    relocateMarkLinesToVisibleSeries,
     resolveCartesianGranularityLabels,
     selectContinuousDateRange,
 } from './useEchartsCartesianConfig';
@@ -1558,5 +1559,117 @@ describe('applyLegendPlacementToGrid', () => {
             { left: '15%' },
         );
         expect(outsideLeft).toEqual({ ...baseGrid, left: '15%' });
+    });
+});
+
+describe('relocateMarkLinesToVisibleSeries (PROD-7119)', () => {
+    const REFERENCE_LINE = { yAxis: 100, name: 'Target' };
+
+    // Pivoted/grouped series have NO top-level `name`; ECharts (and the legend
+    // selection map) identify them by encode.seriesName -> the matching
+    // dimension's displayName. Build them that way so the test mirrors runtime.
+    const makeSeries = (
+        legendName: string,
+        withMarkLine: boolean,
+    ): EChartsSeries => {
+        const yRef = `revenue.group.${legendName}`;
+        return {
+            type: CartesianSeriesType.LINE,
+            encode: { x: 'date', y: yRef, tooltip: [yRef], seriesName: yRef },
+            dimensions: [
+                { name: 'date', displayName: 'Date' },
+                { name: yRef, displayName: legendName },
+            ],
+            ...(withMarkLine ? { markLine: { data: [REFERENCE_LINE] } } : {}),
+        } as unknown as EChartsSeries;
+    };
+
+    const legendNameOf = (serie: EChartsSeries): string | undefined =>
+        serie.dimensions?.find((d) => d.name === serie.encode?.seriesName)
+            ?.displayName ?? serie.name;
+
+    const markLineData = (serie: EChartsSeries) =>
+        (serie.markLine as { data?: unknown[] } | undefined)?.data ?? [];
+
+    test('keeps the reference line on a visible series when its host is hidden via the legend', () => {
+        const series = [
+            makeSeries('standard', true),
+            makeSeries('express', false),
+            makeSeries('overnight', false),
+        ];
+
+        const result = relocateMarkLinesToVisibleSeries(series, {
+            standard: false,
+            express: true,
+            overnight: true,
+        });
+
+        // the hidden host loses its markLine...
+        expect(markLineData(result[0])).toHaveLength(0);
+        // ...and the reference line is re-attached to a still-visible series
+        const stillShown = result.filter(
+            (s) => legendNameOf(s) !== 'standard' && markLineData(s).length > 0,
+        );
+        expect(stillShown).toHaveLength(1);
+        expect(markLineData(stillShown[0])).toEqual([REFERENCE_LINE]);
+    });
+
+    test('keeps the reference line when a single series is isolated via double-click', () => {
+        const series = [
+            makeSeries('standard', true),
+            makeSeries('express', false),
+            makeSeries('overnight', false),
+        ];
+
+        // double-click isolates "overnight" (every other series hidden)
+        const result = relocateMarkLinesToVisibleSeries(series, {
+            standard: false,
+            express: false,
+            overnight: true,
+        });
+
+        const overnight = result.find((s) => legendNameOf(s) === 'overnight')!;
+        expect(markLineData(overnight)).toEqual([REFERENCE_LINE]);
+        expect(markLineData(result[0])).toHaveLength(0);
+    });
+
+    test('leaves series untouched when the reference-line host is visible', () => {
+        const series = [
+            makeSeries('standard', true),
+            makeSeries('express', false),
+        ];
+
+        const result = relocateMarkLinesToVisibleSeries(series, {
+            standard: true,
+            express: true,
+        });
+
+        expect(result).toBe(series);
+        expect(markLineData(result[0])).toEqual([REFERENCE_LINE]);
+    });
+
+    test('returns series unchanged when there is no legend selection', () => {
+        const series = [makeSeries('standard', true)];
+        expect(relocateMarkLinesToVisibleSeries(series, undefined)).toBe(
+            series,
+        );
+    });
+
+    test('does not relocate series-relative reference lines (use series average)', () => {
+        const averageSeries = {
+            ...makeSeries('standard', false),
+            markLine: { data: [{ type: 'average', name: 'Avg' }] },
+        } as unknown as EChartsSeries;
+        const series = [averageSeries, makeSeries('express', false)];
+
+        // hiding the series whose average line it is -> the line hides with it,
+        // it is NOT moved onto the still-visible "express" series
+        const result = relocateMarkLinesToVisibleSeries(series, {
+            standard: false,
+            express: true,
+        });
+
+        expect(result).toBe(series);
+        expect(markLineData(result[1])).toHaveLength(0);
     });
 });

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2558,6 +2558,110 @@ export const getStackTotalSeries = (
     );
 };
 
+// Pivoted/grouped series have no top-level `name`; ECharts derives their legend
+// name (the key in the legend selection map) from `encode.seriesName` -> the
+// matching dimension's displayName. Resolve that so visibility matches the legend.
+const getSeriesLegendName = (serie: EChartsSeries): string | undefined => {
+    const seriesNameRef = serie.encode?.seriesName;
+    const dimension = seriesNameRef
+        ? serie.dimensions?.find((d) => d.name === seriesNameRef)
+        : undefined;
+    return dimension?.displayName ?? serie.name;
+};
+
+const isSeriesVisibleInLegend = (
+    serie: EChartsSeries,
+    selectedLegends: LegendValues,
+): boolean => {
+    if (!selectedLegends) return true;
+    const legendName = getSeriesLegendName(serie);
+    if (legendName === undefined || !(legendName in selectedLegends)) {
+        return true;
+    }
+    return selectedLegends[legendName] !== false;
+};
+
+const getMarkLineData = (
+    markLine: Record<string, unknown> | undefined,
+): MarkLineData[] => {
+    const data = (markLine as { data?: MarkLineData[] } | undefined)?.data;
+    return data ?? [];
+};
+
+// Series-relative reference lines (e.g. "use series average") belong to their
+// own series and should hide with it; only absolute-value lines get relocated.
+const SERIES_RELATIVE_MARKLINE_TYPES = ['average', 'min', 'max', 'median'];
+const isRelocatableMarkLineData = (entry: MarkLineData): boolean =>
+    !SERIES_RELATIVE_MARKLINE_TYPES.includes(
+        (entry as { type?: string }).type ?? '',
+    );
+
+// Reference lines (markLines) are attached to a single data series at config
+// time. Hiding that series via the interactive legend hides its markLine too,
+// so re-attach orphaned reference lines to a still-visible series.
+export const relocateMarkLinesToVisibleSeries = (
+    series: EChartsSeries[],
+    selectedLegends: LegendValues,
+): EChartsSeries[] => {
+    if (!selectedLegends) return series;
+
+    const hiddenWithMarkLine = series.filter(
+        (serie) =>
+            !isSeriesVisibleInLegend(serie, selectedLegends) &&
+            getMarkLineData(serie.markLine).length > 0,
+    );
+    const orphanedData = hiddenWithMarkLine
+        .flatMap((serie) => getMarkLineData(serie.markLine))
+        .filter(isRelocatableMarkLineData);
+    if (orphanedData.length === 0) return series;
+
+    const preferredHostIndex = series.findIndex(
+        (serie) =>
+            serie.encode !== undefined &&
+            isSeriesVisibleInLegend(serie, selectedLegends) &&
+            getMarkLineData(serie.markLine).length === 0,
+    );
+    const fallbackHostIndex = series.findIndex(
+        (serie) =>
+            serie.encode !== undefined &&
+            isSeriesVisibleInLegend(serie, selectedLegends),
+    );
+    const hostIndex =
+        preferredHostIndex !== -1 ? preferredHostIndex : fallbackHostIndex;
+    if (hostIndex === -1) return series;
+
+    const templateMarkLine =
+        (series[hostIndex].markLine as Record<string, unknown> | undefined) ??
+        (hiddenWithMarkLine[0].markLine as Record<string, unknown>);
+
+    return series.map((serie, index) => {
+        if (index === hostIndex) {
+            return {
+                ...serie,
+                markLine: {
+                    ...templateMarkLine,
+                    data: [...getMarkLineData(serie.markLine), ...orphanedData],
+                },
+            };
+        }
+        if (isSeriesVisibleInLegend(serie, selectedLegends)) return serie;
+        // hidden series: drop the lines we relocated, keep series-relative ones
+        const original = getMarkLineData(serie.markLine);
+        const kept = original.filter((e) => !isRelocatableMarkLineData(e));
+        if (kept.length === original.length) return serie;
+        return {
+            ...serie,
+            markLine:
+                kept.length > 0
+                    ? {
+                          ...(serie.markLine as Record<string, unknown>),
+                          data: kept,
+                      }
+                    : undefined,
+        };
+    });
+};
+
 const useEchartsCartesianConfig = (
     validCartesianConfigLegend?: LegendValues,
     isInDashboard?: boolean,
@@ -3696,7 +3800,10 @@ const useEchartsCartesianConfig = (
             xAxis: resolvedLabels.xAxis,
             yAxis: resolvedLabels.yAxis,
             useUTC: true,
-            series: resolvedLabels.series,
+            series: relocateMarkLinesToVisibleSeries(
+                resolvedLabels.series,
+                validCartesianConfigLegend,
+            ),
             animation: !(isInDashboard || minimal),
             legend: legendConfigWithInstructionsTooltip,
             dataset: {
@@ -3743,6 +3850,7 @@ const useEchartsCartesianConfig = (
         sortedAxes,
         sortedSeriesForChart,
         itemsMap,
+        validCartesianConfigLegend,
         isInDashboard,
         minimal,
         legendConfigWithInstructionsTooltip,


### PR DESCRIPTION
## Problem

Reference lines (ECharts `markLine`) on grouped line/bar charts disappeared when a user hid a series via the **interactive legend** (single-click to hide one group, or double-click to isolate one). The markLine is attached to a single data series at config time, so when that series is toggled off at ECharts runtime, its markLine vanishes with it — even though the reference line relates to the whole dataset, not one group.

This is a **separate code path** from PROD-2619, which only handled series hidden via the chart Series settings panel (config-time `applyReferenceLines`). Legend toggling happens at ECharts runtime and bypasses that logic.

## Root cause

Legend selection is captured into React state (`useLegendDoubleClickSelection` → `legendselectchanged`) and fed back into `useEchartsCartesianConfig` as `validCartesianConfigLegend`, but the series→markLine attachment was never reconciled against which series are currently visible.

## Fix

Add `relocateMarkLinesToVisibleSeries` in `useEchartsCartesianConfig`: when a series carrying a markLine is hidden via the legend, re-attach its reference-line data to a still-visible series (preferring one without its own markLine, falling back to any visible series). It is applied via a `useMemo` keyed on the series and the legend selection, and **recomputes purely from the base series on every legend change**, so repeated toggling never duplicates or accumulates reference lines, and un-hiding restores the original attachment.

## Verification

- Confirmed the runtime wiring: `legendselectchanged → onLegendChange → selectedLegends` state is passed into `useEchartsCartesianConfig`, so the relocation triggers on every legend interaction.
- `pnpm -F frontend typecheck:fast` clean for the changed file (the only failures are pre-existing, unrelated `toHaveAttribute` jest-dom typings in EE aiCopilot test files). Lint + format clean via pre-commit.
- **Suggested manual check before merge:** grouped line chart (date x-axis, metric y-axis, ≥3 groups) + horizontal metric reference line → hide the first group via the legend and double-click to isolate another group; the reference line should remain visible in all states.

Fixes PROD-7119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)