### PR TITLE
fix: apply conditional formatting to Excel (.xlsx) exports (PROD-8199)

### DIFF
--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -583,6 +583,7 @@ export class QueryController extends BaseController {
             pivotConfig: body.pivotConfig,
             exportPivotedData: body.exportPivotedData,
             attachmentDownloadName: body.attachmentDownloadName,
+            conditionalFormattings: body.conditionalFormattings,
         });
 
         return {
@@ -623,6 +624,7 @@ export class QueryController extends BaseController {
                 pivotConfig: body.pivotConfig,
                 exportPivotedData: body.exportPivotedData,
                 attachmentDownloadName: body.attachmentDownloadName,
+                conditionalFormattings: body.conditionalFormattings,
             });
 
         return {

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9143,6 +9143,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppVersionExternalConnectionResource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                alias: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                externalConnectionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AppVersionDesignSnapshot: {
         dataType: 'refAlias',
         type: {
@@ -9181,6 +9194,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
+                },
+                externalConnections: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AppVersionExternalConnectionResource',
+                    },
                 },
                 charts: {
                     dataType: 'array',
@@ -13777,11 +13797,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -13839,11 +13859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -14498,59 +14518,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14673,6 +14640,59 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -15032,6 +15052,13 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -15040,13 +15067,6 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -15115,6 +15135,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15122,12 +15148,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15232,11 +15252,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15271,14 +15291,14 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
                                                             enums: ['rejected'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15297,11 +15317,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15516,11 +15536,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15535,11 +15555,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -30473,7 +30493,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30483,7 +30503,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30493,7 +30513,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30506,7 +30526,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -38644,6 +38664,19 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    conditionalFormattings: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'array',
+                                array: {
+                                    dataType: 'refAlias',
+                                    ref: 'ConditionalFormattingConfig',
+                                },
+                            },
                             { dataType: 'undefined' },
                         ],
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10543,6 +10543,21 @@
                 "required": ["chartKind", "chartName", "chartUuid"],
                 "type": "object"
             },
+            "AppVersionExternalConnectionResource": {
+                "properties": {
+                    "alias": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "externalConnectionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["alias", "name", "externalConnectionUuid"],
+                "type": "object"
+            },
             "AppVersionDesignSnapshot": {
                 "properties": {
                     "fileCount": {
@@ -10581,6 +10596,12 @@
                     "dashboardName": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "externalConnections": {
+                        "items": {
+                            "$ref": "#/components/schemas/AppVersionExternalConnectionResource"
+                        },
+                        "type": "array"
                     },
                     "charts": {
                         "items": {
@@ -15408,8 +15429,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15467,8 +15488,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15777,36 +15798,6 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "joinedTables",
-                                                                            "baseTable",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -15867,6 +15858,36 @@
                                                                         },
                                                                         "type": "array"
                                                                     },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "joinedTables",
+                                                                            "baseTable",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -15876,9 +15897,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16047,9 +16068,9 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
+                                                                        "search",
                                                                         "read",
                                                                         "edit",
-                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
@@ -16086,9 +16107,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16138,8 +16159,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16152,8 +16173,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -31225,22 +31246,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -39081,6 +39102,12 @@
                     },
                     "attachmentDownloadName": {
                         "type": "string"
+                    },
+                    "conditionalFormattings": {
+                        "items": {
+                            "$ref": "#/components/schemas/ConditionalFormattingConfig"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object",
@@ -40925,7 +40952,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3220.0",
+        "version": "0.3225.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -24,6 +24,7 @@ import {
     formatRows,
     friendlyName,
     getColumnOrderFromVizTableConfig,
+    getConditionalFormattingsFromChartConfig,
     getCustomLabelsFromTableConfig,
     getCustomLabelsFromVizTableConfig,
     getDownloadPivotConfig,
@@ -825,6 +826,10 @@ export default class SchedulerTask {
                                     exportPivotedData:
                                         effectiveExportPivotedData,
                                     columnOrder: chart.tableConfig.columnOrder,
+                                    conditionalFormattings:
+                                        getConditionalFormattingsFromChartConfig(
+                                            chart.chartConfig.config,
+                                        ),
                                     expirationSecondsOverride,
                                 },
                                 SCHEDULER_POLLING_OPTIONS,
@@ -991,6 +996,10 @@ export default class SchedulerTask {
                                                 effectiveExportPivotedData,
                                             columnOrder:
                                                 chart.tableConfig.columnOrder,
+                                            conditionalFormattings:
+                                                getConditionalFormattingsFromChartConfig(
+                                                    chart.chartConfig.config,
+                                                ),
                                             expirationSecondsOverride,
                                         },
                                         SCHEDULER_POLLING_OPTIONS,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1409,6 +1409,7 @@ export class AsyncQueryService extends ProjectService {
         exportPivotedData = true,
         attachmentDownloadName,
         expirationSecondsOverride,
+        conditionalFormattings,
     }: DownloadAsyncQueryResultsArgs): Promise<DownloadAsyncQueryResultsInternal> {
         assertIsAccountWithOrg(account);
 
@@ -1638,56 +1639,68 @@ export class AsyncQueryService extends ProjectService {
                 );
             case DownloadFileType.XLSX: {
                 // Check if this is a pivot table download
-                const xlsxResult =
+                const isPivotXlsx =
                     downloadPivotConfig &&
                     pivotDetails &&
-                    queryHistory.metricQuery
-                        ? await ExcelService.downloadAsyncPivotTableXlsx({
-                              resultsFileName,
-                              fields,
+                    queryHistory.metricQuery;
+
+                // Conditional formatting fills are only applied to the
+                // (unpivoted) direct export. Pivoted exports remap value
+                // columns and are not yet supported — log rather than fail.
+                if (isPivotXlsx && conditionalFormattings?.length) {
+                    this.logger.warn(
+                        'Conditional formatting is not applied to pivoted XLSX exports',
+                        { queryUuid },
+                    );
+                }
+
+                const xlsxResult = isPivotXlsx
+                    ? await ExcelService.downloadAsyncPivotTableXlsx({
+                          resultsFileName,
+                          fields,
+                          resultsStorageClient,
+                          exportsStorageClient: this.exportsStorageClient,
+                          lightdashConfig: this.lightdashConfig,
+                          csvCellsLimit: (
+                              await resolveOrganizationExportLimits(
+                                  this.organizationSettingsModel,
+                                  this.lightdashConfig.query,
+                                  organizationUuid,
+                              )
+                          ).csvCellsLimit,
+                          pivotDetails,
+                          warehouseRowTotals,
+                          warehouseColumnTotals,
+                          options: {
+                              onlyRaw,
+                              showTableNames,
+                              customLabels,
+                              columnOrder: validColumnOrder,
+                              hiddenFields,
+                              pivotConfig: downloadPivotConfig,
+                              attachmentDownloadName,
+                          },
+                          timezone: displayTimezone ?? undefined,
+                      })
+                    : // Use direct Excel export to bypass PassThrough + Upload hanging issues
+                      await ExcelService.downloadAsyncExcelDirectly(
+                          resultsFileName,
+                          resultFields,
+                          {
                               resultsStorageClient,
                               exportsStorageClient: this.exportsStorageClient,
-                              lightdashConfig: this.lightdashConfig,
-                              csvCellsLimit: (
-                                  await resolveOrganizationExportLimits(
-                                      this.organizationSettingsModel,
-                                      this.lightdashConfig.query,
-                                      organizationUuid,
-                                  )
-                              ).csvCellsLimit,
-                              pivotDetails,
-                              warehouseRowTotals,
-                              warehouseColumnTotals,
-                              options: {
-                                  onlyRaw,
-                                  showTableNames,
-                                  customLabels,
-                                  columnOrder: validColumnOrder,
-                                  hiddenFields,
-                                  pivotConfig: downloadPivotConfig,
-                                  attachmentDownloadName,
-                              },
-                              timezone: displayTimezone ?? undefined,
-                          })
-                        : // Use direct Excel export to bypass PassThrough + Upload hanging issues
-                          await ExcelService.downloadAsyncExcelDirectly(
-                              resultsFileName,
-                              resultFields,
-                              {
-                                  resultsStorageClient,
-                                  exportsStorageClient:
-                                      this.exportsStorageClient,
-                              },
-                              {
-                                  onlyRaw,
-                                  showTableNames,
-                                  customLabels,
-                                  columnOrder: validColumnOrder,
-                                  hiddenFields,
-                                  attachmentDownloadName,
-                              },
-                              displayTimezone ?? undefined,
-                          );
+                          },
+                          {
+                              onlyRaw,
+                              showTableNames,
+                              customLabels,
+                              columnOrder: validColumnOrder,
+                              hiddenFields,
+                              attachmentDownloadName,
+                              conditionalFormattings,
+                          },
+                          displayTimezone ?? undefined,
+                      );
                 const xlsxPersistentUrl =
                     await this.persistentDownloadFileService.createPersistentUrl(
                         {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -6,6 +6,7 @@ import {
     PivotConfiguration,
     type AndFilterGroup,
     type CacheMetadata,
+    type ConditionalFormattingConfig,
     type DashboardFilters,
     type DateZoom,
     type DownloadAsyncQueryResultsPayload,
@@ -56,6 +57,7 @@ export type DownloadAsyncQueryResultsArgs = Omit<
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
     expirationSecondsOverride?: number;
+    conditionalFormattings?: ConditionalFormattingConfig[];
 };
 
 export type ScheduleDownloadAsyncQueryResultsArgs = Omit<

--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -1,8 +1,11 @@
 import {
+    createConditionalFormattingConfigWithSingleColor,
     DimensionType,
     FieldType,
+    FilterOperator,
     getExcelFormatExpression,
     getFormatExpression,
+    getItemId,
     ItemsMap,
     MetricType,
     SortByDirection,
@@ -11,7 +14,11 @@ import {
     VizIndexType,
     type Dimension,
 } from '@lightdash/common';
+import fs from 'fs';
 import moment from 'moment';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
 import { ExcelService } from './ExcelService';
 
 // Mock data for testing
@@ -1957,6 +1964,134 @@ describe('ExcelService', () => {
                 const formatExpression = getFormatExpression(fieldData);
                 expect(formatExpression).toBe(expectedFormat);
             });
+        });
+    });
+});
+
+describe('ExcelService conditional formatting in xlsx export (PROD-8199)', () => {
+    const numericField = {
+        fieldType: FieldType.METRIC,
+        type: MetricType.NUMBER,
+        name: 'count',
+        table: 'orders',
+        tableLabel: 'Orders',
+        label: 'Orders count',
+        sql: '',
+        hidden: false,
+        compiledSql: '',
+        tablesReferences: [],
+    } as ItemsMap[string];
+    const fieldId = getItemId(numericField);
+    const fields: ItemsMap = { [fieldId]: numericField };
+
+    // Private streaming writer, invoked directly so the test exercises the real
+    // row-rendering + colorToArgb path that produces the .xlsx fills.
+    const { streamJsonlToExcelFile } = ExcelService as unknown as {
+        streamJsonlToExcelFile: (
+            resultsStream: Readable,
+            tempFilePath: string,
+            headers: string[],
+            fields: ItemsMap,
+            onlyRaw: boolean,
+            sortedFieldIds: string[],
+            timezone?: string,
+            conditionalFormattings?: ReturnType<
+                typeof createConditionalFormattingConfigWithSingleColor
+            >[],
+            minMaxMap?: Record<string, { min: number; max: number }>,
+        ) => Promise<{ truncated: boolean }>;
+    };
+
+    const writeAndReadBack = async (
+        rows: Record<string, unknown>[],
+        conditionalFormattings: ReturnType<
+            typeof createConditionalFormattingConfigWithSingleColor
+        >[],
+        minMaxMap: Record<string, { min: number; max: number }> = {},
+    ) => {
+        const tempFilePath = path.join(
+            os.tmpdir(),
+            `excel-cf-test-${process.pid}-${rows.length}.xlsx`,
+        );
+        const jsonl = rows.map((row) => JSON.stringify(row)).join('\n');
+        await streamJsonlToExcelFile(
+            Readable.from([jsonl]),
+            tempFilePath,
+            ['Orders count'],
+            fields,
+            false,
+            [fieldId],
+            undefined,
+            conditionalFormattings,
+            minMaxMap,
+        );
+
+        const workbook = new (await import('exceljs')).Workbook();
+        await workbook.xlsx.readFile(tempFilePath);
+        const worksheet = workbook.getWorksheet('Sheet1');
+        fs.unlinkSync(tempFilePath);
+        return worksheet;
+    };
+
+    it('applies a solid background fill to cells matching a single-color rule', async () => {
+        const redConfig = createConditionalFormattingConfigWithSingleColor(
+            '#ff0000',
+            { fieldId },
+        );
+        redConfig.rules = [
+            {
+                id: 'gte-100',
+                operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+                values: [100],
+            },
+        ];
+
+        const worksheet = await writeAndReadBack(
+            [{ [fieldId]: 150 }, { [fieldId]: 50 }],
+            [redConfig],
+        );
+
+        // Row 1 is the header; data rows start at 2.
+        const matchingCell = worksheet!.getRow(2).getCell(1);
+        const nonMatchingCell = worksheet!.getRow(3).getCell(1);
+
+        expect(matchingCell.fill).toMatchObject({
+            type: 'pattern',
+            pattern: 'solid',
+            fgColor: { argb: 'FFFF0000' },
+        });
+        const nonMatchingFill = nonMatchingCell.fill as
+            | { fgColor?: { argb?: string } }
+            | undefined;
+        expect(nonMatchingFill?.fgColor?.argb).toBeUndefined();
+    });
+
+    it('applies an interpolated fill for a color-range rule using the min/max map', async () => {
+        const rangeConfig = createConditionalFormattingConfigWithSingleColor(
+            '#ff0000',
+            { fieldId },
+        ) as ReturnType<
+            typeof createConditionalFormattingConfigWithSingleColor
+        >;
+        // Re-shape into a color-range config (start white -> end red).
+        const colorRangeConfig = {
+            target: { fieldId },
+            color: { start: '#ffffff', end: '#ff0000' },
+            rule: { min: 'auto' as const, max: 'auto' as const },
+        };
+
+        const worksheet = await writeAndReadBack(
+            [{ [fieldId]: 200 }],
+            [colorRangeConfig as unknown as typeof rangeConfig],
+            { [fieldId]: { min: 0, max: 200 } },
+        );
+
+        const cell = worksheet!.getRow(2).getCell(1);
+        // value at the top of the range resolves to the end colour (red).
+        expect(cell.fill).toMatchObject({
+            type: 'pattern',
+            pattern: 'solid',
+            fgColor: { argb: 'FFFF0000' },
         });
     });
 });

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -1,15 +1,27 @@
 import {
     AnyType,
+    ConditionalFormattingColorApplyTo,
+    convertFormattedValue,
     DimensionType,
     DownloadFileType,
     formatItemValue,
     formatRawValue,
     formatRows,
+    getColorFromRange,
+    getConditionalFormattingColor,
+    getConditionalFormattingConfig,
+    getConditionalFormattingTextStyle,
     getErrorMessage,
     getExcelFormatExpression,
+    getReadableTextColor,
+    getRowConditionalFormattingColor,
+    getRowConditionalFormattingConfig,
+    isConditionalFormattingConfigWithColorRange,
     isDimension,
     isField,
+    isHexCodeColor,
     isNumber,
+    isNumericItem,
     ItemsMap,
     PivotConfig,
     pivotResultsAsCsv,
@@ -19,6 +31,9 @@ import {
     timeIntervalToExcelNumFmt,
     toExcelWallClockDate,
     UnexpectedServerError,
+    type ConditionalFormattingConfig,
+    type ConditionalFormattingMinMaxMap,
+    type ConditionalFormattingRowFields,
     type PivotRowTotalsByIndex,
     type ReadyQueryResultsPage,
 } from '@lightdash/common';
@@ -143,6 +158,245 @@ export class ExcelService {
                 undefined,
                 timezone,
             );
+        });
+    }
+
+    /**
+     * Converts a CSS color (hex or the 'white'/'black' returned by
+     * getReadableTextColor) into the 'AARRGGBB' ARGB string exceljs expects.
+     * Returns undefined when the colour cannot be represented.
+     */
+    private static colorToArgb(color: string | undefined): string | undefined {
+        if (!color) return undefined;
+        if (color === 'white') return 'FFFFFFFF';
+        if (color === 'black') return 'FF000000';
+        if (!isHexCodeColor(color)) return undefined;
+
+        let hex = color.slice(1);
+        if (hex.length === 3) {
+            hex = hex
+                .split('')
+                .map((c) => c + c)
+                .join('');
+        }
+        if (hex.length === 6) {
+            return `FF${hex.toUpperCase()}`;
+        }
+        if (hex.length === 8) {
+            // colorjs.io emits #RRGGBBAA; Excel ARGB wants the alpha first
+            return `${hex.slice(6, 8)}${hex.slice(0, 6)}`.toUpperCase();
+        }
+        return undefined;
+    }
+
+    /**
+     * Streams the results file once to compute the min/max of every field
+     * targeted by a color-range conditional formatting rule that uses 'auto'
+     * bounds. Mirrors the table renderer's minMaxMap so exported color-scale
+     * fills match the UI. Returns an empty map when no scan is needed.
+     */
+    private static async buildConditionalFormattingMinMaxMap({
+        resultsStream,
+        fields,
+        conditionalFormattings,
+    }: {
+        resultsStream: Readable;
+        fields: ItemsMap;
+        conditionalFormattings: ConditionalFormattingConfig[];
+    }): Promise<ConditionalFormattingMinMaxMap> {
+        const needsScan = conditionalFormattings.some(
+            (config) =>
+                isConditionalFormattingConfigWithColorRange(config) &&
+                (config.rule.min === 'auto' || config.rule.max === 'auto'),
+        );
+
+        if (!needsScan) {
+            resultsStream.destroy();
+            return {};
+        }
+
+        const numericTargets = [
+            ...new Set(
+                conditionalFormattings
+                    .map((config) => config.target?.fieldId)
+                    .filter((fieldId): fieldId is string => !!fieldId),
+            ),
+        ].filter((fieldId) => isNumericItem(fields[fieldId]));
+
+        if (numericTargets.length === 0) {
+            resultsStream.destroy();
+            return {};
+        }
+
+        const accumulators = new Map<
+            string,
+            { min: number; max: number; hasValue: boolean }
+        >();
+        numericTargets.forEach((fieldId) =>
+            accumulators.set(fieldId, {
+                min: Infinity,
+                max: -Infinity,
+                hasValue: false,
+            }),
+        );
+
+        await streamJsonlData<void>({
+            readStream: resultsStream,
+            onRow: (parsedRow: Record<string, unknown>) => {
+                numericTargets.forEach((fieldId) => {
+                    const rawValue = parsedRow[fieldId];
+                    if (
+                        rawValue === undefined ||
+                        rawValue === null ||
+                        rawValue === ''
+                    ) {
+                        return;
+                    }
+
+                    const numValue = Number(rawValue);
+                    if (Number.isNaN(numValue)) return;
+
+                    const converted = convertFormattedValue(
+                        numValue,
+                        fields[fieldId],
+                    );
+                    if (typeof converted !== 'number') return;
+
+                    const acc = accumulators.get(fieldId)!;
+                    acc.hasValue = true;
+                    if (converted < acc.min) acc.min = converted;
+                    if (converted > acc.max) acc.max = converted;
+                });
+            },
+            maxLines: ExcelService.EXCEL_ROW_LIMIT,
+        });
+
+        const minMaxMap: ConditionalFormattingMinMaxMap = {};
+        accumulators.forEach((acc, fieldId) => {
+            if (acc.hasValue) {
+                minMaxMap[fieldId] = { min: acc.min, max: acc.max };
+            }
+        });
+        return minMaxMap;
+    }
+
+    /**
+     * Applies the chart's conditional formatting (background fills, text colour
+     * and text styling) to a single worksheet row, mirroring the results table.
+     * Handles single-color and color-range rules across cell/text/row scopes.
+     */
+    private static applyConditionalFormattingToRow({
+        excelRow,
+        parsedRow,
+        fields,
+        sortedFieldIds,
+        conditionalFormattings,
+        minMaxMap,
+    }: {
+        excelRow: Excel.Row;
+        parsedRow: Record<string, unknown>;
+        fields: ItemsMap;
+        sortedFieldIds: string[];
+        conditionalFormattings: ConditionalFormattingConfig[];
+        minMaxMap: ConditionalFormattingMinMaxMap;
+    }): void {
+        const rowFields: ConditionalFormattingRowFields = {};
+        Object.keys(fields).forEach((fieldId) => {
+            if (fieldId in parsedRow) {
+                rowFields[fieldId] = {
+                    field: fields[fieldId],
+                    value: parsedRow[fieldId],
+                };
+            }
+        });
+
+        const rowColor = getRowConditionalFormattingColor({
+            conditionalFormattings,
+            rowFields,
+            minMaxMap,
+        });
+        const rowConfig = getRowConditionalFormattingConfig({
+            conditionalFormattings,
+            rowFields,
+            minMaxMap,
+        });
+
+        sortedFieldIds.forEach((fieldId, colIndex) => {
+            const field = fields[fieldId];
+            const value = parsedRow[fieldId];
+
+            const cellConfig = getConditionalFormattingConfig({
+                field,
+                value,
+                minMaxMap,
+                conditionalFormattings,
+                rowFields,
+                applyTo: ConditionalFormattingColorApplyTo.CELL,
+            });
+            const textConfig = getConditionalFormattingConfig({
+                field,
+                value,
+                minMaxMap,
+                conditionalFormattings,
+                rowFields,
+                applyTo: ConditionalFormattingColorApplyTo.TEXT,
+            });
+
+            const cellResult = getConditionalFormattingColor({
+                field,
+                value,
+                minMaxMap,
+                config: cellConfig,
+                getColorFromRange,
+            });
+            const textResult = getConditionalFormattingColor({
+                field,
+                value,
+                minMaxMap,
+                config: textConfig,
+                getColorFromRange,
+            });
+
+            const backgroundColor = cellResult?.color ?? rowColor ?? undefined;
+
+            let fontColor: string | undefined;
+            if (textResult) {
+                fontColor = textResult.color;
+            } else if (cellResult) {
+                fontColor = getReadableTextColor(cellResult.color);
+            } else if (rowColor) {
+                fontColor = getReadableTextColor(rowColor);
+            }
+
+            const textStyle = getConditionalFormattingTextStyle([
+                cellConfig,
+                textConfig,
+                rowConfig,
+            ]);
+
+            if (!backgroundColor && !fontColor && !textStyle) return;
+
+            const cell = excelRow.getCell(colIndex + 1);
+
+            const bgArgb = ExcelService.colorToArgb(backgroundColor);
+            if (bgArgb) {
+                cell.fill = {
+                    type: 'pattern',
+                    pattern: 'solid',
+                    fgColor: { argb: bgArgb },
+                };
+            }
+
+            const fontArgb = ExcelService.colorToArgb(fontColor);
+            if (fontArgb || textStyle) {
+                cell.font = {
+                    ...cell.font,
+                    ...(fontArgb ? { color: { argb: fontArgb } } : {}),
+                    ...(textStyle?.bold ? { bold: true } : {}),
+                    ...(textStyle?.italic ? { italic: true } : {}),
+                    ...(textStyle?.underline ? { underline: true } : {}),
+                };
+            }
         });
     }
 
@@ -530,6 +784,8 @@ export class ExcelService {
         onlyRaw: boolean,
         sortedFieldIds: string[],
         timezone?: string,
+        conditionalFormattings?: ConditionalFormattingConfig[],
+        minMaxMap?: ConditionalFormattingMinMaxMap,
     ): Promise<{ truncated: boolean }> {
         // Use the same approach as our working tests - direct filename instead of stream
         const workbook = new Excel.stream.xlsx.WorkbookWriter({
@@ -594,6 +850,18 @@ export class ExcelService {
                     );
 
                     const row = worksheet.addRow(rowObject);
+
+                    if (conditionalFormattings?.length) {
+                        ExcelService.applyConditionalFormattingToRow({
+                            excelRow: row,
+                            parsedRow,
+                            fields,
+                            sortedFieldIds,
+                            conditionalFormattings,
+                            minMaxMap: minMaxMap ?? {},
+                        });
+                    }
+
                     row.commit();
                 } else {
                     Logger.warn(
@@ -630,6 +898,7 @@ export class ExcelService {
             columnOrder?: string[];
             hiddenFields?: string[];
             attachmentDownloadName?: string;
+            conditionalFormattings?: ConditionalFormattingConfig[];
         } = {},
         timezone?: string,
     ): Promise<{ fileUrl: string; truncated: boolean; s3Key: string }> {
@@ -641,6 +910,7 @@ export class ExcelService {
             columnOrder = [],
             hiddenFields = [],
             attachmentDownloadName,
+            conditionalFormattings,
         } = options;
 
         const { resultsStorageClient, exportsStorageClient } = clients;
@@ -657,11 +927,27 @@ export class ExcelService {
         const tempFilePath = ExcelService.createTempFilePath('direct');
 
         try {
-            // Step 1: Get source stream
+            // Step 1: When conditional formatting needs color-range min/max,
+            // scan the results once with a dedicated stream (it is consumed).
+            let minMaxMap: ConditionalFormattingMinMaxMap = {};
+            if (conditionalFormattings?.length) {
+                const scanStream =
+                    await resultsStorageClient.getDownloadStream(
+                        resultsFileName,
+                    );
+                minMaxMap =
+                    await ExcelService.buildConditionalFormattingMinMaxMap({
+                        resultsStream: scanStream,
+                        fields,
+                        conditionalFormattings,
+                    });
+            }
+
+            // Step 2: Get source stream
             const resultsStream =
                 await resultsStorageClient.getDownloadStream(resultsFileName);
 
-            // Step 2: Stream JSONL data to Excel temp file
+            // Step 3: Stream JSONL data to Excel temp file
             const { truncated } = await ExcelService.streamJsonlToExcelFile(
                 resultsStream,
                 tempFilePath,
@@ -670,6 +956,8 @@ export class ExcelService {
                 onlyRaw,
                 sortedFieldIds,
                 timezone,
+                conditionalFormattings,
+                minMaxMap,
             );
 
             // Generate filename with truncated flag

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -1,5 +1,6 @@
 import { type ParametersValuesMap, type PivotConfiguration } from '../..';
 import type { QueryExecutionContext } from '../analytics';
+import type { ConditionalFormattingConfig } from '../conditionalFormatting';
 import type { DownloadFileType } from '../downloadFile';
 import type { AndFilterGroup, DashboardFilters, Filters } from '../filter';
 import type { MetricQueryRequest, SortField } from '../metricQuery';
@@ -126,6 +127,7 @@ export type DownloadAsyncQueryResultsRequestParams = {
     pivotConfig?: PivotConfig;
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
+    conditionalFormattings?: ConditionalFormattingConfig[];
 };
 
 export type ExecuteAsyncFieldValueSearchRequestParams =

--- a/packages/common/src/types/downloadFile.ts
+++ b/packages/common/src/types/downloadFile.ts
@@ -1,3 +1,4 @@
+import { type ConditionalFormattingConfig } from './conditionalFormatting';
 import { type PivotConfig } from './pivot';
 
 export enum DownloadFileType {
@@ -28,4 +29,5 @@ export type DownloadOptions = {
     pivotConfig?: PivotConfig;
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
+    conditionalFormattings?: ConditionalFormattingConfig[];
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1060,6 +1060,13 @@ export const getCustomLabelsFromTableConfig = (
         ? getCustomLabelsFromColumnProperties(config.columns)
         : undefined;
 
+export const getConditionalFormattingsFromChartConfig = (
+    config: ChartConfig['config'] | undefined,
+): ConditionalFormattingConfig[] | undefined =>
+    config && isTableChartConfig(config)
+        ? config.conditionalFormattings
+        : undefined;
+
 export const hashFieldReference = (reference: PivotReference) =>
     reference.pivotValues
         ? `${reference.field}.${reference.pivotValues

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1,6 +1,7 @@
 import assertUnreachable from '../utils/assertUnreachable';
 import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
+import { type ConditionalFormattingConfig } from './conditionalFormatting';
 import type { DownloadFileType } from './downloadFile';
 import { type Explore, type ExploreError } from './explore';
 import {
@@ -807,6 +808,7 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     pivotConfig?: PivotConfig;
     exportPivotedData?: boolean;
     attachmentDownloadName?: string;
+    conditionalFormattings?: ConditionalFormattingConfig[];
     encodedJwt?: string;
 };
 

--- a/packages/common/src/utils/colors.ts
+++ b/packages/common/src/utils/colors.ts
@@ -1,4 +1,8 @@
 import Color from 'colorjs.io';
+import type {
+    ConditionalFormattingColorRange,
+    ConditionalFormattingMinMax,
+} from '../types/conditionalFormatting';
 
 const IS_HEX_CODE_COLOR_REGEX =
     /^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6}|[a-fA-F0-9]{8})$/;
@@ -37,6 +41,44 @@ export const getReadableTextColor = (backgroundColor: string): string => {
         // Not supported color string, default to black
         return 'black';
     }
+};
+
+const getColorInterpolator = (colorRange: ConditionalFormattingColorRange) => {
+    if (!isHexCodeColor(colorRange.start) || !isHexCodeColor(colorRange.end)) {
+        return undefined;
+    }
+
+    return Color.range(new Color(colorRange.start), new Color(colorRange.end), {
+        space: 'srgb',
+    });
+};
+
+/**
+ * Interpolates a color from a start/end gradient for a value within a min/max
+ * range. Shared by the results table renderer and the Excel export so the
+ * exported color-scale fills match what is shown in the UI.
+ * @returns A hex color string, or undefined when the range/value is invalid
+ */
+export const getColorFromRange = (
+    value: number,
+    colorRange: ConditionalFormattingColorRange,
+    minMaxRange: ConditionalFormattingMinMax,
+): string | undefined => {
+    const interpolateColor = getColorInterpolator(colorRange);
+    if (!interpolateColor) return undefined;
+
+    const { min, max } = minMaxRange;
+    if (min > max || value < min || value > max) {
+        return undefined;
+    }
+
+    if (min === max) {
+        return interpolateColor(1).toString({ format: 'hex' });
+    }
+
+    const percentage = (value - min) / (max - min);
+
+    return interpolateColor(percentage).toString({ format: 'hex' });
 };
 
 /**

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DownloadFileType,
     formatDate,
+    type ConditionalFormattingConfig,
     type DownloadOptions,
     type PivotConfig,
 } from '@lightdash/common';
@@ -62,6 +63,7 @@ export type ExportResultsProps = {
     showTableNames?: boolean;
     chartName?: string;
     pivotConfig?: PivotConfig;
+    conditionalFormattings?: ConditionalFormattingConfig[];
     hideLimitSelection?: boolean;
     forceShowLimitSelection?: boolean;
     renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
@@ -80,6 +82,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         showTableNames,
         chartName,
         pivotConfig,
+        conditionalFormattings,
         hideLimitSelection = false,
         forceShowLimitSelection = false,
         renderDialogActions,
@@ -125,6 +128,9 @@ const ExportResults: FC<ExportResultsProps> = memo(
                         attachmentDownloadName: chartName
                             ? `${chartName}_${formatDate(new Date())}`
                             : undefined,
+                        conditionalFormattings: exportPivotedData
+                            ? undefined
+                            : conditionalFormattings,
                     };
 
                     return scheduleDownloadQuery(

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -31,6 +31,7 @@ const ExportSelector: FC<
         showTableNames,
         chartName,
         pivotConfig,
+        conditionalFormattings,
     }) => {
         const health = useHealth();
         const hasGoogleDrive =
@@ -70,6 +71,7 @@ const ExportSelector: FC<
                         showTableNames={showTableNames}
                         chartName={chartName}
                         pivotConfig={pivotConfig}
+                        conditionalFormattings={conditionalFormattings}
                     />
                 </>
             );
@@ -102,6 +104,7 @@ const ExportSelector: FC<
                 showTableNames={showTableNames}
                 chartName={chartName}
                 pivotConfig={pivotConfig}
+                conditionalFormattings={conditionalFormattings}
             />
         );
     },

--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -149,6 +149,10 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
                             }
                             chartName={chartName}
                             pivotConfig={pivotConfig}
+                            conditionalFormattings={
+                                visualizationConfig.chartConfig
+                                    .conditionalFormattings
+                            }
                             getGsheetLink={
                                 getGsheetLink === undefined
                                     ? undefined

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -100,6 +100,7 @@ export const scheduleDownloadQuery = async (
             pivotConfig: options.pivotConfig,
             exportPivotedData: options.exportPivotedData,
             attachmentDownloadName: options.attachmentDownloadName,
+            conditionalFormattings: options.conditionalFormattings,
         }),
         version: 'v2',
     });

--- a/packages/frontend/src/utils/colorUtils.ts
+++ b/packages/frontend/src/utils/colorUtils.ts
@@ -1,10 +1,11 @@
 import {
-    isHexCodeColor,
+    getColorFromRange,
     type ConditionalFormattingColorRange,
-    type ConditionalFormattingMinMax,
 } from '@lightdash/common';
 import Color from 'colorjs.io';
 import { DARK_MODE_COLORS } from '../mantineTheme';
+
+export { getColorFromRange };
 
 /**
  * Replaces 'problematic' colors in dark mode for better visibility
@@ -56,53 +57,6 @@ export const transformColorsForDarkMode = (
     }
 
     return { start: startColor, end: endColor };
-};
-
-const getColorRange = (colorConfig: ConditionalFormattingColorRange) => {
-    if (
-        !isHexCodeColor(colorConfig.start) ||
-        !isHexCodeColor(colorConfig.end)
-    ) {
-        return undefined;
-    }
-
-    return Color.range(
-        new Color(colorConfig.start),
-        new Color(colorConfig.end),
-        {
-            space: 'srgb',
-        },
-    );
-};
-
-export const getColorFromRange = (
-    value: number,
-    colorRange: ConditionalFormattingColorRange,
-    minMaxRange: ConditionalFormattingMinMax,
-): string | undefined => {
-    const interpolateColor = getColorRange(colorRange);
-
-    if (!interpolateColor) return undefined;
-
-    const min = minMaxRange.min;
-    const max = minMaxRange.max;
-
-    if (min > max || value < min || value > max) {
-        console.error(
-            new Error(
-                `invalid minMaxRange: [${min},${max}] or value: ${value}`,
-            ),
-        );
-        return undefined;
-    }
-
-    if (min === max) {
-        return interpolateColor(1).toString({ format: 'hex' });
-    }
-
-    const percentage = (value - min) / (max - min);
-
-    return interpolateColor(percentage).toString({ format: 'hex' });
 };
 
 /**


### PR DESCRIPTION
## Problem

Conditional formatting configured on a chart was **not** reflected in `.xlsx` exports — the file contained raw values with no fills.

## Root cause

Exports run in the **scheduler worker**, decoupled from the chart's display config, so the `conditionalFormattings` config never reached the Excel writer. The writer had no knowledge of the rules and never set cell fills.

## Fix

End-to-end plumbing of the chart's conditional formatting into the Excel writer, plus the rendering itself:

- **Backend pipeline:** `conditionalFormattings` now flows download request/options → `QueryController` → scheduler payload → `AsyncQueryService` → `ExcelService`. Scheduled deliveries (`SchedulerTask`) read it from the chart config.
- **Frontend ad-hoc export:** `ChartDownloadMenu → ExportSelector → ExportResults` now sends the table's `conditionalFormattings` in the download request (unpivoted exports only; pivoted `.xlsx` is logged and skipped, not silently broken).
- **Rendering:** `ExcelService` applies background fills, text colour and text styling per row, mirroring the results table. Color-range rules scan the results once to compute min/max. Gradient colour logic (`getColorFromRange`) was moved to `@lightdash/common` as the single source of truth (re-exported from the frontend), so exported colours match the UI.

## Evidence the fix works

New `ExcelService` tests generate a **real `.xlsx`**, read it back with `exceljs`, and assert the cell fills:

```
PASS src/services/ExcelService/ExcelService.test.ts
  ExcelService conditional formatting in xlsx export (PROD-8199)
    ✓ applies a solid background fill to cells matching a single-color rule
    ✓ applies an interpolated fill for a color-range rule using the min/max map
Tests:       44 passed, 44 total
```

- Single-color rule (`value >= 100` → red): the matching row's cell fill is `{ type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFF0000' } }`; the non-matching row's cell has **no** foreground fill.
- Color-range rule (white→red over min/max `0..200`): a value at the top of the range resolves to the end colour (`FFFF0000`) in the produced workbook.

## Verification

- New tests above (functional, read-back of a generated workbook).
- `pnpm -F common typecheck:fast`, `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast` clean for changed files (pre-existing unrelated errors — `node-execution-context` resolution, EE aiCopilot jest-dom matchers — excepted).
- `pnpm generate-api` run (controller `@Body` type changed); `routes.ts` + `swagger.json` regenerated and committed.
- Lint/format clean via pre-commit.

Fixes PROD-8199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)