### PR TITLE
feat(ai-reviews): add review notifications

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -3,6 +3,12 @@ import {
     AiAgentReasoningTableName,
 } from '../database/entities/aiAgentReasoning';
 import {
+    AiReviewNotificationLogTable,
+    AiReviewNotificationLogTableName,
+    AiReviewNotificationSettingsTable,
+    AiReviewNotificationSettingsTableName,
+} from '../database/entities/aiReviewNotifications';
+import {
     AnalyticsAppViews,
     AnalyticsAppViewsTableName,
     AnalyticsChartViews,
@@ -591,6 +597,8 @@ declare module 'knex/types/tables' {
         [AiSqlApprovalTableName]: AiSqlApprovalTable;
         [DashboardTabsTableName]: DashboardTabsTable;
         [NotificationsTableName]: NotificationsTable;
+        [AiReviewNotificationLogTableName]: AiReviewNotificationLogTable;
+        [AiReviewNotificationSettingsTableName]: AiReviewNotificationSettingsTable;
         [DashboardSummariesTableName]: DashboardSummariesTable;
         [CatalogTableName]: CatalogTable;
         [SlackChannelProjectMappingsTableName]: SlackChannelProjectMappingsTable;

--- a/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackMessageBlocks.ts
@@ -31,13 +31,13 @@ const SLACK_LIMITS = {
 const DASHBOARD_CSV_COLLAPSE_THRESHOLD = 35;
 
 // Truncate text to fit Slack limits and add ellipsis if needed
-const truncateText = (text: string, maxLength: number): string => {
+export const truncateText = (text: string, maxLength: number): string => {
     if (!text || text.length <= maxLength) return text;
     return `${text.slice(0, maxLength - 3)}...`;
 };
 
 // Sanitize text to prevent invalid blocks
-const sanitizeText = (text: string | undefined): string => {
+export const sanitizeText = (text: string | undefined): string => {
     if (!text || text.trim() === '') return ' ';
     return text.trim();
 };
@@ -53,7 +53,7 @@ const sanitizeHeaderText = (text: string | undefined): string | undefined => {
 // Slack rejects button.url and image_url values that are malformed or longer
 // than 3000 chars. Returns undefined when the URL would be rejected so callers
 // can drop the surrounding block / accessory.
-const safeUrl = (
+export const safeUrl = (
     url: string | undefined,
     maxLength: number = SLACK_LIMITS.URL,
 ): string | undefined => {

--- a/packages/backend/src/clients/Slack/SlackReviewMessageBlocks.test.ts
+++ b/packages/backend/src/clients/Slack/SlackReviewMessageBlocks.test.ts
@@ -1,0 +1,19 @@
+import { buildReviewNeedsReviewBlocks } from './SlackReviewMessageBlocks';
+
+test('needs-review blocks contain only allow-listed fields and a button', () => {
+    const blocks = buildReviewNeedsReviewBlocks({
+        count: 3,
+        topTitle: 'Fiscal calendar conventions',
+        rootCause: 'semantic_layer',
+        projectName: 'Jaffle',
+        reviewUrl: 'https://app.lightdash.com/ai-agents/admin/reviews',
+        actionId: 'ai_review_open',
+        notificationLogUuid: 'log-1',
+    });
+
+    const json = JSON.stringify(blocks);
+    expect(json).toContain('3 context fixes need review');
+    expect(json).toContain('action_id');
+    expect(json).toContain('log-1');
+    expect(json).not.toMatch(/select|from\s|where\s/i);
+});

--- a/packages/backend/src/clients/Slack/SlackReviewMessageBlocks.ts
+++ b/packages/backend/src/clients/Slack/SlackReviewMessageBlocks.ts
@@ -1,0 +1,119 @@
+import { type KnownBlock } from '@slack/bolt';
+import { safeUrl, sanitizeText, truncateText } from './SlackMessageBlocks';
+
+const SECTION_TEXT_LIMIT = 3000;
+const HEADER_TEXT_LIMIT = 150;
+const BUTTON_TEXT_LIMIT = 75;
+
+type ReviewButtonArgs = {
+    reviewUrl: string;
+    actionId: string;
+    notificationLogUuid: string;
+};
+
+const buildReviewButton = ({
+    reviewUrl,
+    actionId,
+    notificationLogUuid,
+}: ReviewButtonArgs) => {
+    const url = safeUrl(reviewUrl);
+    if (!url) {
+        return undefined;
+    }
+
+    return {
+        type: 'button' as const,
+        text: {
+            type: 'plain_text' as const,
+            text: truncateText('Open review', BUTTON_TEXT_LIMIT),
+            emoji: true,
+        },
+        action_id: actionId,
+        value: notificationLogUuid,
+        url,
+    };
+};
+
+const buildBlocks = (args: {
+    header: string;
+    body: string;
+    rootCause: string;
+    projectName: string;
+    reviewUrl: string;
+    actionId: string;
+    notificationLogUuid: string;
+}): KnownBlock[] => {
+    const button = buildReviewButton(args);
+    const blocks: KnownBlock[] = [
+        {
+            type: 'header',
+            text: {
+                type: 'plain_text',
+                text: truncateText(
+                    sanitizeText(args.header),
+                    HEADER_TEXT_LIMIT,
+                ),
+            },
+        },
+        {
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: truncateText(
+                    [
+                        sanitizeText(args.body),
+                        `*Root cause:* ${sanitizeText(args.rootCause)}`,
+                        `*Project:* ${sanitizeText(args.projectName)}`,
+                    ].join('\n'),
+                    SECTION_TEXT_LIMIT,
+                ),
+            },
+        },
+    ];
+
+    if (button) {
+        blocks.push({
+            type: 'actions',
+            elements: [button],
+        });
+    }
+
+    return blocks;
+};
+
+export const buildReviewNeedsReviewBlocks = (args: {
+    count: number;
+    topTitle: string;
+    rootCause: string;
+    projectName: string;
+    reviewUrl: string;
+    actionId: string;
+    notificationLogUuid: string;
+}): KnownBlock[] =>
+    buildBlocks({
+        header: `${args.count} context fixes need review`,
+        body: `Top finding: ${args.topTitle}`,
+        rootCause: args.rootCause,
+        projectName: args.projectName,
+        reviewUrl: args.reviewUrl,
+        actionId: args.actionId,
+        notificationLogUuid: args.notificationLogUuid,
+    });
+
+export const buildReviewAssignedBlocks = (args: {
+    title: string;
+    rootCause: string;
+    projectName: string;
+    reviewUrl: string;
+    actionId: string;
+    notificationLogUuid: string;
+}): KnownBlock[] =>
+    buildBlocks({
+        header: 'AI review finding assigned',
+        body: `Finding: ${args.title}`,
+        rootCause: args.rootCause,
+        projectName: args.projectName,
+        reviewUrl: args.reviewUrl,
+        actionId: args.actionId,
+        notificationLogUuid: args.notificationLogUuid,
+    });

--- a/packages/backend/src/database/entities/aiReviewNotifications.ts
+++ b/packages/backend/src/database/entities/aiReviewNotifications.ts
@@ -1,0 +1,78 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+    AiReviewNotificationStatus,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+
+export const AiReviewNotificationLogTableName = 'ai_agent_review_notification';
+export const AiReviewNotificationSettingsTableName =
+    'ai_agent_review_notification_settings';
+
+export type DbAiReviewNotificationSettings = {
+    organization_uuid: string;
+    enabled: boolean;
+    slack_channel_id: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbAiReviewNotificationLog = {
+    notification_log_uuid: string;
+    organization_uuid: string;
+    fingerprint: string;
+    recipient_user_uuid: string | null;
+    channel: AiReviewNotificationChannel;
+    event: AiReviewNotificationEvent;
+    status: AiReviewNotificationStatus;
+    error: string | null;
+    sent_at: Date | null;
+    clicked_at: Date | null;
+    dismissed_at: Date | null;
+    created_at: Date;
+};
+
+export type AiReviewNotificationSettingsTable = Knex.CompositeTableType<
+    DbAiReviewNotificationSettings,
+    Pick<
+        DbAiReviewNotificationSettings,
+        'organization_uuid' | 'enabled' | 'slack_channel_id'
+    > &
+        Partial<
+            Pick<DbAiReviewNotificationSettings, 'created_at' | 'updated_at'>
+        >,
+    Partial<
+        Pick<
+            DbAiReviewNotificationSettings,
+            'enabled' | 'slack_channel_id' | 'updated_at'
+        >
+    >
+>;
+
+export type AiReviewNotificationLogTable = Knex.CompositeTableType<
+    DbAiReviewNotificationLog,
+    Omit<
+        Pick<
+            DbAiReviewNotificationLog,
+            | 'notification_log_uuid'
+            | 'organization_uuid'
+            | 'fingerprint'
+            | 'recipient_user_uuid'
+            | 'channel'
+            | 'event'
+            | 'status'
+            | 'error'
+            | 'sent_at'
+            | 'clicked_at'
+            | 'dismissed_at'
+        >,
+        'notification_log_uuid'
+    > &
+        Partial<Pick<DbAiReviewNotificationLog, 'notification_log_uuid'>>,
+    Partial<
+        Pick<
+            DbAiReviewNotificationLog,
+            'status' | 'error' | 'sent_at' | 'clicked_at' | 'dismissed_at'
+        >
+    >
+>;

--- a/packages/backend/src/database/entities/notifications.ts
+++ b/packages/backend/src/database/entities/notifications.ts
@@ -1,17 +1,19 @@
+import { type NotificationAiReview } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export enum DbNotificationResourceType {
     DashboardComments = 'dashboard_comments',
+    AiReviewItem = 'ai_review_item',
 }
 
 export const NotificationsTableName = 'notifications';
 
-interface NotificationDashboardTileCommentMetadata {
+export type DbNotificationDashboardTileCommentMetadata = {
     dashboard_uuid: string;
     dashboard_name: string;
     dashboard_tile_uuid: string;
     dashboard_tile_name: string;
-}
+};
 
 type DbNotifications = {
     notification_id: string;
@@ -22,7 +24,10 @@ type DbNotifications = {
     message: string | null;
     url: string | null;
     resource_type: DbNotificationResourceType;
-    metadata: NotificationDashboardTileCommentMetadata | null;
+    metadata:
+        | DbNotificationDashboardTileCommentMetadata
+        | NotificationAiReview['metadata']
+        | null;
 };
 
 type DbNotificationsInsertComment = Pick<

--- a/packages/backend/src/database/migrations/20260623153546_ai_review_notifications.ts
+++ b/packages/backend/src/database/migrations/20260623153546_ai_review_notifications.ts
@@ -1,0 +1,58 @@
+import { Knex } from 'knex';
+
+const SETTINGS_TABLE = 'ai_agent_review_notification_settings';
+const LOG_TABLE = 'ai_agent_review_notification';
+const ORGANIZATIONS_TABLE = 'organizations';
+const USERS_TABLE = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(SETTINGS_TABLE, (table) => {
+        table
+            .uuid('organization_uuid')
+            .primary()
+            .references('organization_uuid')
+            .inTable(ORGANIZATIONS_TABLE)
+            .onDelete('CASCADE');
+        table.boolean('enabled').notNullable().defaultTo(false);
+        table.text('slack_channel_id').nullable();
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.createTable(LOG_TABLE, (table) => {
+        table
+            .uuid('notification_log_uuid')
+            .primary()
+            .notNullable()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(ORGANIZATIONS_TABLE)
+            .onDelete('CASCADE')
+            .index();
+        table.text('fingerprint').notNullable();
+        table
+            .uuid('recipient_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table.text('channel').notNullable();
+        table.text('event').notNullable();
+        table.text('status').notNullable();
+        table.text('error').nullable();
+        table.timestamp('sent_at').nullable();
+        table.timestamp('clicked_at').nullable();
+        table.timestamp('dismissed_at').nullable();
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.index(['organization_uuid', 'fingerprint']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(LOG_TABLE);
+    await knex.schema.dropTableIfExists(SETTINGS_TABLE);
+}

--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -11,6 +11,7 @@ import {
     ApiAiAgentReviewSignalsResponse,
     ApiAiAgentSummaryResponse,
     ApiAiOrganizationSettingsResponse,
+    ApiAiReviewNotificationSettingsResponse,
     ApiErrorPayload,
     ApiSuccessEmpty,
     ApiUpdateAiOrganizationSettingsResponse,
@@ -20,6 +21,7 @@ import {
     UpdateAiAgentReviewItemAssignee,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
+    UpdateAiReviewNotificationSettings,
     type ApiAiAgentReviewItemWritebackPreviewResponse,
 } from '@lightdash/common';
 import {
@@ -31,6 +33,7 @@ import {
     Patch,
     Path,
     Post,
+    Put,
     Query,
     Request,
     Response,
@@ -487,6 +490,56 @@ export class AiAgentAdminController extends BaseController {
         return {
             status: 'ok',
             results,
+        };
+    }
+
+    /**
+     * Get AI review notification settings
+     * @summary Get AI review notification settings
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/review-notification-settings')
+    @OperationId('getAiReviewNotificationSettings')
+    async getReviewNotificationSettings(
+        @Request() req: express.Request,
+    ): Promise<ApiAiReviewNotificationSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().getReviewNotificationSettings(
+                    toSessionUser(req.account),
+                ),
+        };
+    }
+
+    /**
+     * Update AI review notification settings
+     * @summary Update AI review notification settings
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Put('/review-notification-settings')
+    @OperationId('updateAiReviewNotificationSettings')
+    async updateReviewNotificationSettings(
+        @Request() req: express.Request,
+        @Body() body: UpdateAiReviewNotificationSettings,
+    ): Promise<ApiAiReviewNotificationSettingsResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results:
+                await this.getAiAgentAdminService().updateReviewNotificationSettings(
+                    toSessionUser(req.account),
+                    body,
+                ),
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -29,6 +29,7 @@ import { CommercialSlackClient } from './clients/Slack/SlackClient';
 import { AiAgentDocumentModel } from './models/AiAgentDocumentModel';
 import { AiAgentModel } from './models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierModel';
+import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiRouterModel } from './models/AiRouterModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
@@ -50,6 +51,7 @@ import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentVali
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
 import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifierService';
+import { AiAgentReviewNotificationService } from './services/AiAgentReviewNotificationService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiAgentToolsService } from './services/AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
@@ -326,6 +328,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     pullRequestsModel: models.getPullRequestsModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentReviewNotificationModel:
+                        models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
                     prometheusMetrics,
                 }),
             aiAgentAdminService: ({ models, repository, context, clients }) =>
@@ -334,6 +338,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentReviewNotificationModel:
+                        models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
+                    aiAgentReviewNotificationService:
+                        repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
                     featureFlagService: repository.getFeatureFlagService(),
@@ -355,6 +363,16 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     writebackPreviewService:
                         repository.getWritebackPreviewService<WritebackPreviewService>(),
                     jobModel: models.getJobModel(),
+                }),
+            aiAgentReviewNotificationService: ({ models, clients }) =>
+                new AiAgentReviewNotificationService({
+                    notificationsModel: models.getNotificationsModel(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
+                    aiAgentReviewClassifierModel:
+                        models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    organizationMemberProfileModel:
+                        models.getOrganizationMemberProfileModel(),
                 }),
             aiRouterService: ({ models, repository, context }) =>
                 new AiRouterService({
@@ -386,6 +404,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     projectModel: models.getProjectModel(),
                     featureFlagService: repository.getFeatureFlagService(),
                     lightdashConfig: context.lightdashConfig,
+                    aiAgentReviewNotificationService:
+                        repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                 }),
             aiOrganizationSettingsService: ({ models, context }) =>
                 new AiOrganizationSettingsService({
@@ -743,6 +763,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new ProjectCiStatusModel({ database }),
             aiAgentReviewClassifierModel: ({ database }) =>
                 new AiAgentReviewClassifierModel({ database }),
+            aiAgentReviewNotificationModel: ({ database }) =>
+                new AiAgentReviewNotificationModel({ database }),
             projectContextModel: ({ database }) =>
                 new ProjectContextModel({ database }),
             aiRouterModel: ({ database }) => new AiRouterModel({ database }),
@@ -824,10 +846,18 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 workerHealth: context.workerHealth,
                 aiAgentReviewClassifierService:
                     context.serviceRepository.getAiAgentReviewClassifierService(),
+                aiAgentReviewClassifierModel:
+                    context.models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                aiAgentReviewNotificationModel:
+                    context.models.getAiAgentReviewNotificationModel<AiAgentReviewNotificationModel>(),
+                aiAgentReviewNotificationService:
+                    context.serviceRepository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                 aiAgentAdminService:
                     context.serviceRepository.getAiAgentAdminService<AiAgentAdminService>(),
                 projectContextService:
                     context.serviceRepository.getProjectContextService<ProjectContextService>(),
+                projectModel: context.models.getProjectModel(),
+                openIdIdentityModel: context.models.getOpenIdIdentityModel(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.test.ts
@@ -1,0 +1,56 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+    AiReviewNotificationStatus,
+} from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import {
+    AiReviewNotificationLogTableName,
+    AiReviewNotificationSettingsTableName,
+} from '../../database/entities/aiReviewNotifications';
+import { AiAgentReviewNotificationModel } from './AiAgentReviewNotificationModel';
+
+describe('AiAgentReviewNotificationModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AiAgentReviewNotificationModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('returns disabled settings defaults when no row exists', async () => {
+        tracker.on.select(AiReviewNotificationSettingsTableName).response([]);
+
+        await expect(model.getSettings('org-1')).resolves.toEqual({
+            organizationUuid: 'org-1',
+            enabled: false,
+            slackChannelId: null,
+        });
+    });
+
+    it('records sent notifications and returns the log uuid', async () => {
+        tracker.on
+            .insert(AiReviewNotificationLogTableName)
+            .response([{ notification_log_uuid: 'log-1' }]);
+
+        await expect(
+            model.recordSent({
+                organizationUuid: 'org-1',
+                fingerprint: 'fingerprint-1',
+                recipientUserUuid: 'user-1',
+                channel: AiReviewNotificationChannel.Bell,
+                event: AiReviewNotificationEvent.Assigned,
+            }),
+        ).resolves.toBe('log-1');
+
+        expect(tracker.history.insert[0].bindings).toContain(
+            AiReviewNotificationStatus.Sent,
+        );
+    });
+});

--- a/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewNotificationModel.ts
@@ -1,0 +1,137 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+    AiReviewNotificationSettings,
+    AiReviewNotificationStatus,
+} from '@lightdash/common';
+import { type Knex } from 'knex';
+import {
+    AiReviewNotificationLogTableName,
+    AiReviewNotificationSettingsTableName,
+    type DbAiReviewNotificationSettings,
+} from '../../database/entities/aiReviewNotifications';
+
+type AiAgentReviewNotificationModelArgs = {
+    database: Knex;
+};
+
+type LogArgs = {
+    notificationLogUuid?: string;
+    organizationUuid: string;
+    fingerprint: string;
+    recipientUserUuid: string | null;
+    channel: AiReviewNotificationChannel;
+    event: AiReviewNotificationEvent;
+};
+
+export class AiAgentReviewNotificationModel {
+    private readonly database: Knex;
+
+    constructor({ database }: AiAgentReviewNotificationModelArgs) {
+        this.database = database;
+    }
+
+    private static mapSettings(
+        row: DbAiReviewNotificationSettings,
+    ): AiReviewNotificationSettings {
+        return {
+            organizationUuid: row.organization_uuid,
+            enabled: row.enabled,
+            slackChannelId: row.slack_channel_id,
+        };
+    }
+
+    async getSettings(
+        organizationUuid: string,
+    ): Promise<AiReviewNotificationSettings> {
+        const row = await this.database(AiReviewNotificationSettingsTableName)
+            .where({ organization_uuid: organizationUuid })
+            .first();
+
+        if (!row) {
+            return {
+                organizationUuid,
+                enabled: false,
+                slackChannelId: null,
+            };
+        }
+
+        return AiAgentReviewNotificationModel.mapSettings(row);
+    }
+
+    async upsertSettings(
+        settings: AiReviewNotificationSettings,
+    ): Promise<AiReviewNotificationSettings> {
+        const [row] = await this.database(AiReviewNotificationSettingsTableName)
+            .insert({
+                organization_uuid: settings.organizationUuid,
+                enabled: settings.enabled,
+                slack_channel_id: settings.slackChannelId,
+                updated_at: new Date(),
+            })
+            .onConflict('organization_uuid')
+            .merge({
+                enabled: settings.enabled,
+                slack_channel_id: settings.slackChannelId,
+                updated_at: new Date(),
+            })
+            .returning('*');
+
+        return AiAgentReviewNotificationModel.mapSettings(row);
+    }
+
+    async recordSent(args: LogArgs): Promise<string> {
+        const [row] = await this.database(AiReviewNotificationLogTableName)
+            .insert({
+                ...(args.notificationLogUuid && {
+                    notification_log_uuid: args.notificationLogUuid,
+                }),
+                organization_uuid: args.organizationUuid,
+                fingerprint: args.fingerprint,
+                recipient_user_uuid: args.recipientUserUuid,
+                channel: args.channel,
+                event: args.event,
+                status: AiReviewNotificationStatus.Sent,
+                error: null,
+                sent_at: new Date(),
+                clicked_at: null,
+                dismissed_at: null,
+            })
+            .returning('notification_log_uuid');
+
+        return row.notification_log_uuid;
+    }
+
+    async recordError(args: LogArgs & { error: string }): Promise<void> {
+        await this.database(AiReviewNotificationLogTableName).insert({
+            organization_uuid: args.organizationUuid,
+            fingerprint: args.fingerprint,
+            recipient_user_uuid: args.recipientUserUuid,
+            channel: args.channel,
+            event: args.event,
+            status: AiReviewNotificationStatus.Errored,
+            error: args.error,
+            sent_at: null,
+            clicked_at: null,
+            dismissed_at: null,
+        });
+    }
+
+    async recordClicked(notificationLogUuid: string): Promise<void> {
+        await this.database(AiReviewNotificationLogTableName)
+            .where({ notification_log_uuid: notificationLogUuid })
+            .update({
+                status: AiReviewNotificationStatus.Clicked,
+                clicked_at: new Date(),
+            });
+    }
+
+    async recordDismissed(notificationLogUuid: string): Promise<void> {
+        await this.database(AiReviewNotificationLogTableName)
+            .where({ notification_log_uuid: notificationLogUuid })
+            .update({
+                status: AiReviewNotificationStatus.Dismissed,
+                dismissed_at: new Date(),
+            });
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -7,15 +7,21 @@ import {
     SchedulerJobStatus,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
+import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { tryJobOrTimeout } from '../../scheduler/SchedulerJobTimeout';
 import {
     SchedulerWorker,
     SchedulerWorkerArguments,
 } from '../../scheduler/SchedulerWorker';
+import { sendReviewNotification } from '../../scheduler/tasks/sendReviewNotification';
 import { TypedEETaskList } from '../../scheduler/types';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
 import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
+import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
@@ -31,17 +37,28 @@ const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
     aiAgentReviewClassifierService: AiAgentReviewClassifierService;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
+    aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     aiAgentAdminService: AiAgentAdminService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
     appGenerateService: AppGenerateService;
     projectContextService: ProjectContextService;
+    projectModel: ProjectModel;
+    openIdIdentityModel: OpenIdIdentityModel;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
 
     protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
+
+    protected readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+
+    protected readonly aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
+
+    protected readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
 
     protected readonly aiAgentAdminService: AiAgentAdminService;
 
@@ -53,16 +70,27 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly projectContextService: ProjectContextService;
 
+    protected readonly projectModel: ProjectModel;
+
+    protected readonly openIdIdentityModel: OpenIdIdentityModel;
+
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
         this.aiAgentReviewClassifierService =
             args.aiAgentReviewClassifierService;
+        this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
+        this.aiAgentReviewNotificationModel =
+            args.aiAgentReviewNotificationModel;
+        this.aiAgentReviewNotificationService =
+            args.aiAgentReviewNotificationService;
         this.aiAgentAdminService = args.aiAgentAdminService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
         this.appGenerateService = args.appGenerateService;
         this.projectContextService = args.projectContextService;
+        this.projectModel = args.projectModel;
+        this.openIdIdentityModel = args.openIdIdentityModel;
     }
 
     protected getCronItems() {
@@ -386,6 +414,19 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
                 await this.appGenerateService.sweepStaleLocks();
+            },
+            [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: async (payload) => {
+                await sendReviewNotification({
+                    siteUrl: this.lightdashConfig.siteUrl,
+                    model: this.aiAgentReviewNotificationModel,
+                    service: this.aiAgentReviewNotificationService,
+                    aiAgentReviewClassifierModel:
+                        this.aiAgentReviewClassifierModel,
+                    projectModel: this.projectModel,
+                    openIdIdentityModel: this.openIdIdentityModel,
+                    slackClient: this.slackClient,
+                    analytics: this.analytics,
+                })(payload);
             },
             [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: async (
                 payload,

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -123,13 +123,31 @@ const makeAdminUser = (): SessionUser => ({
     timezone: null,
     ability: new Ability<PossibleAbilities>([
         { action: 'manage', subject: 'Organization' },
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
     ]),
     abilityRules: [],
+});
+
+const makeDeveloperUser = (): SessionUser => ({
+    ...makeAdminUser(),
+    role: OrganizationMemberRole.DEVELOPER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+    ]),
 });
 
 const makeService = ({
     aiAgentModel = {},
     aiAgentReviewClassifierModel = {},
+    aiAgentReviewNotificationModel = {},
     featureFlagService = {},
     aiOrganizationSettingsService = {},
     projectModel = {},
@@ -142,9 +160,11 @@ const makeService = ({
     writebackPreviewService = {},
     jobModel = {},
     userModel = {},
+    aiAgentReviewNotificationService = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
+    aiAgentReviewNotificationModel?: Record<string, unknown>;
     featureFlagService?: Record<string, unknown>;
     aiOrganizationSettingsService?: Record<string, unknown>;
     projectModel?: Record<string, unknown>;
@@ -157,6 +177,7 @@ const makeService = ({
     writebackPreviewService?: Record<string, unknown>;
     jobModel?: Record<string, unknown>;
     userModel?: Record<string, unknown>;
+    aiAgentReviewNotificationService?: Record<string, unknown>;
 } = {}) =>
     new AiAgentAdminService({
         analytics: { track: jest.fn() },
@@ -208,6 +229,19 @@ const makeService = ({
                 .fn()
                 .mockResolvedValue(null),
             ...aiAgentReviewClassifierModel,
+        },
+        aiAgentReviewNotificationModel: {
+            getSettings: jest.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+                enabled: false,
+                slackChannelId: null,
+            }),
+            upsertSettings: jest.fn().mockResolvedValue({
+                organizationUuid: ORGANIZATION_UUID,
+                enabled: true,
+                slackChannelId: 'C123',
+            }),
+            ...aiAgentReviewNotificationModel,
         },
         featureFlagService: {
             get: jest.fn().mockResolvedValue({ enabled: true }),
@@ -281,6 +315,10 @@ const makeService = ({
             findSessionUserByUUID: jest.fn().mockResolvedValue(makeAdminUser()),
             ...userModel,
         },
+        aiAgentReviewNotificationService: {
+            notifyAssigned: jest.fn().mockResolvedValue(undefined),
+            ...aiAgentReviewNotificationService,
+        },
         lightdashConfig: {
             siteUrl: SITE_URL,
             appRuntime: { e2bApiKey: 'e2b-api-key' },
@@ -328,6 +366,111 @@ describe('AiAgentAdminService.getPromptActivity', () => {
             'Insufficient permissions to access organization-wide AI agent data',
         );
         expect(findAdminPromptActivity).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService review access', () => {
+    it('allows developers with manage:AiAgent to access reviews', async () => {
+        const listReviewSignals = jest.fn().mockResolvedValue([]);
+        const service = makeService({
+            aiAgentReviewClassifierModel: { listReviewSignals },
+        });
+
+        await expect(
+            service.listReviewSignals(makeDeveloperUser()),
+        ).resolves.toEqual([]);
+        expect(listReviewSignals).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+        });
+    });
+
+    it('forbids users without manage:AiAgent from reviews', async () => {
+        const listReviewSignals = jest.fn();
+        const service = makeService({
+            aiAgentReviewClassifierModel: { listReviewSignals },
+        });
+        const user = {
+            ...makeAdminUser(),
+            role: OrganizationMemberRole.DEVELOPER,
+            ability: new Ability<PossibleAbilities>([]),
+        };
+
+        await expect(service.listReviewSignals(user)).rejects.toThrow(
+            'Insufficient permissions to access AI agent reviews',
+        );
+        expect(listReviewSignals).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService.updateReviewItemAssignee', () => {
+    it('notifies the assignee after the model write succeeds', async () => {
+        const notifyAssigned = jest.fn().mockResolvedValue(undefined);
+        const updateReviewItemAssignee = jest.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                updateReviewItemAssignee,
+                getReviewItem: jest.fn().mockResolvedValue(
+                    makeReviewItem({
+                        organizationUuid: ORGANIZATION_UUID,
+                        projectUuid: PROJECT_UUID,
+                    }),
+                ),
+            },
+            aiAgentReviewNotificationService: { notifyAssigned },
+        });
+
+        await service.updateReviewItemAssignee(
+            makeDeveloperUser(),
+            'fingerprint-1',
+            'user-2',
+        );
+
+        expect(notifyAssigned).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-2',
+            actorUserUuid: USER_UUID,
+        });
+    });
+});
+
+describe('AiAgentAdminService review notification settings', () => {
+    it('allows developers to read settings', async () => {
+        const getSettings = jest.fn().mockResolvedValue({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            slackChannelId: 'C123',
+        });
+        const service = makeService({
+            aiAgentReviewNotificationModel: { getSettings },
+        });
+
+        await expect(
+            service.getReviewNotificationSettings(makeDeveloperUser()),
+        ).resolves.toEqual({
+            organizationUuid: ORGANIZATION_UUID,
+            enabled: true,
+            slackChannelId: 'C123',
+        });
+        expect(getSettings).toHaveBeenCalledWith(ORGANIZATION_UUID);
+    });
+
+    it('forbids developers from updating settings', async () => {
+        const upsertSettings = jest.fn();
+        const service = makeService({
+            aiAgentReviewNotificationModel: { upsertSettings },
+        });
+
+        await expect(
+            service.updateReviewNotificationSettings(makeDeveloperUser(), {
+                enabled: true,
+                slackChannelId: 'C123',
+            }),
+        ).rejects.toThrow(
+            'Insufficient permissions to access organization-wide AI agent data',
+        );
+        expect(upsertSettings).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -14,6 +14,7 @@ import {
     AiAgentReviewSignalSummary,
     AiAgentReviewWritebackJobPayload,
     AiAgentSummary,
+    AiReviewNotificationSettings,
     AlreadyExistsError,
     assertUnreachable,
     DbtProjectType,
@@ -32,6 +33,7 @@ import {
     PullRequestSource,
     RequestMethod,
     UpdateAiAgentReviewItemStatus,
+    UpdateAiReviewNotificationSettings,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentReviewItemWritebackEligibility,
     type AiAgentReviewItemWritebackPreview,
@@ -65,12 +67,14 @@ import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagS
 import { type ProjectService } from '../../services/ProjectService/ProjectService';
 import { AiAgentModel } from '../models/AiAgentModel';
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { type AiAgentReviewNotificationModel } from '../models/AiAgentReviewNotificationModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
 import {
     buildYmlPathByModel,
     planReviewWriteback,
     PROJECT_CONTEXT_WORK_THREAD_INSTRUCTION,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 import { type AiAgentService } from './AiAgentService/AiAgentService';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
 import { type WritebackPreviewService } from './AiWritebackService/WritebackPreviewService';
@@ -80,6 +84,8 @@ type AiAgentAdminServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
+    aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     aiAgentService: AiAgentService;
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
@@ -290,6 +296,10 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
 
+    private readonly aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
+
+    private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+
     private readonly aiAgentService: AiAgentService;
 
     private readonly featureFlagService: FeatureFlagService;
@@ -322,6 +332,10 @@ export class AiAgentAdminService extends BaseService {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentReviewNotificationModel =
+            dependencies.aiAgentReviewNotificationModel;
+        this.aiAgentReviewNotificationService =
+            dependencies.aiAgentReviewNotificationService;
         this.aiAgentService = dependencies.aiAgentService;
         this.featureFlagService = dependencies.featureFlagService;
         this.aiOrganizationSettingsService =
@@ -353,6 +367,22 @@ export class AiAgentAdminService extends BaseService {
         ) {
             throw new ForbiddenError(
                 'Insufficient permissions to access organization-wide AI agent data',
+            );
+        }
+    }
+
+    private checkReviewAccess(user: SessionUser): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid: user.organizationUuid!,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access AI agent reviews',
             );
         }
     }
@@ -418,6 +448,36 @@ export class AiAgentAdminService extends BaseService {
         });
     }
 
+    async getReviewNotificationSettings(
+        user: SessionUser,
+    ): Promise<AiReviewNotificationSettings> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkReviewAccess(user);
+
+        return this.aiAgentReviewNotificationModel.getSettings(
+            organizationUuid,
+        );
+    }
+
+    async updateReviewNotificationSettings(
+        user: SessionUser,
+        settings: UpdateAiReviewNotificationSettings,
+    ): Promise<AiReviewNotificationSettings> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        return this.aiAgentReviewNotificationModel.upsertSettings({
+            organizationUuid,
+            ...settings,
+        });
+    }
+
     async listReviewItems(
         user: SessionUser,
         statuses?: AiAgentReviewItemStatus[],
@@ -426,7 +486,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const items = await this.aiAgentReviewClassifierModel.listReviewItems({
             organizationUuid,
@@ -808,7 +868,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         return this.aiAgentReviewClassifierModel.listReviewSignals({
             organizationUuid,
@@ -824,7 +884,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         if (update.status === 'dismissed' && !update.dismissedReason) {
             throw new ParameterError(
@@ -930,7 +990,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         // Resolve scope per fingerprint (reads — safe to parallelise), drop any
         // that are no longer promoted, then persist the whole lane order in one
@@ -968,7 +1028,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         await this.aiAgentReviewClassifierModel.updateReviewItemAssignee({
             fingerprint,
@@ -976,7 +1036,19 @@ export class AiAgentAdminService extends BaseService {
             assignedToUserUuid,
         });
 
-        return this.getReviewItem(user, fingerprint);
+        const item = await this.getReviewItem(user, fingerprint);
+
+        if (assignedToUserUuid !== null && item.projectUuid !== null) {
+            await this.aiAgentReviewNotificationService.notifyAssigned({
+                organizationUuid,
+                projectUuid: item.projectUuid,
+                fingerprint,
+                assigneeUserUuid: assignedToUserUuid,
+                actorUserUuid: user.userUuid,
+            });
+        }
+
+        return item;
     }
 
     async createReviewItemWriteback(
@@ -987,7 +1059,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -1555,7 +1627,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -1636,7 +1708,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2052,7 +2124,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2099,7 +2171,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const remediation =
             await this.aiAgentReviewClassifierModel.findReviewRemediationByPreviewThread(
@@ -2123,7 +2195,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2180,7 +2252,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -301,6 +301,9 @@ describe('AiAgentReviewClassifierService', () => {
     const projectModel = {
         getSummary: jest.fn(),
     };
+    const aiAgentReviewNotificationService = {
+        notifyNeedsReview: jest.fn(),
+    };
     const judgeTurn = jest.fn();
 
     const service = new AiAgentReviewClassifierService({
@@ -312,6 +315,8 @@ describe('AiAgentReviewClassifierService', () => {
         featureFlagService,
         lightdashConfig: {} as never,
         judgeTurn,
+        aiAgentReviewNotificationService:
+            aiAgentReviewNotificationService as never,
     });
 
     beforeEach(() => {
@@ -330,6 +335,9 @@ describe('AiAgentReviewClassifierService', () => {
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
         model.createTurnSignal.mockResolvedValue(SIGNAL_UUID);
         model.getThreadWritebackPullRequests.mockResolvedValue(new Map());
+        aiAgentReviewNotificationService.notifyNeedsReview.mockResolvedValue(
+            undefined,
+        );
         aiAgentModel.getAgent.mockResolvedValue({
             uuid: AGENT_UUID,
             organizationUuid: ORGANIZATION_UUID,
@@ -465,6 +473,14 @@ describe('AiAgentReviewClassifierService', () => {
                 }),
             }),
         );
+        expect(
+            aiAgentReviewNotificationService.notifyNeedsReview,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            reviewRunUuid: RUN_UUID,
+            fingerprints: [expect.stringContaining('ai_agent_review_item:')],
+        });
     });
 
     it('does not promote turns where writeback already opened a pull request', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -36,6 +36,7 @@ import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassi
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
+import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
 const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
@@ -78,6 +79,7 @@ type AiAgentReviewClassifierServiceDependencies = {
     projectModel: Pick<ProjectModel, 'getSummary'>;
     featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
+    aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     judgeTurn?: AiAgentReviewClassifierJudge;
 };
 
@@ -231,6 +233,8 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly featureFlagService: FeatureFlagService;
 
+    private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly judgeTurn: AiAgentReviewClassifierJudge;
@@ -245,6 +249,8 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
         this.featureFlagService = dependencies.featureFlagService;
+        this.aiAgentReviewNotificationService =
+            dependencies.aiAgentReviewNotificationService;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.judgeTurn =
             dependencies.judgeTurn ??
@@ -439,6 +445,7 @@ export class AiAgentReviewClassifierService extends BaseService {
         let findingCount = 0;
         let reviewItemCount = 0;
         const reviewItemFingerprints = new Set<string>();
+        const reviewItemFingerprintsByProject = new Map<string, Set<string>>();
         const shouldPersistSignals = args.persistSignals ?? !args.dryRun;
         const shouldPersistFindings = !args.dryRun && !!args.persistFindings;
         const shouldPromoteFindingsToReviewItems =
@@ -484,6 +491,17 @@ export class AiAgentReviewClassifierService extends BaseService {
                         reviewItemFingerprints.add(
                             classifiedTurn.finding.reviewItem.fingerprint,
                         );
+                        const projectFingerprints =
+                            reviewItemFingerprintsByProject.get(
+                                classifiedTurn.signal.subject.projectUuid,
+                            ) ?? new Set<string>();
+                        projectFingerprints.add(
+                            classifiedTurn.finding.reviewItem.fingerprint,
+                        );
+                        reviewItemFingerprintsByProject.set(
+                            classifiedTurn.signal.subject.projectUuid,
+                            projectFingerprints,
+                        );
                         reviewItemCount = reviewItemFingerprints.size;
                     }
                 }
@@ -509,6 +527,25 @@ export class AiAgentReviewClassifierService extends BaseService {
                 findingCount: reviewedFindingCount,
                 reviewItemCount,
             });
+
+            if (
+                shouldPromoteFindingsToReviewItems &&
+                reviewItemFingerprintsByProject.size > 0
+            ) {
+                await Promise.all(
+                    Array.from(reviewItemFingerprintsByProject.entries()).map(
+                        ([projectUuid, fingerprints]) =>
+                            this.aiAgentReviewNotificationService.notifyNeedsReview(
+                                {
+                                    organizationUuid: args.organizationUuid,
+                                    projectUuid,
+                                    reviewRunUuid: run.uuid,
+                                    fingerprints: Array.from(fingerprints),
+                                },
+                            ),
+                    ),
+                );
+            }
 
             return {
                 runUuid: run.uuid,

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
@@ -1,0 +1,116 @@
+import {
+    AiReviewNotificationEvent,
+    EE_SCHEDULER_TASKS,
+    OrganizationMemberRole,
+} from '@lightdash/common';
+import { AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
+
+const makeService = () => {
+    const notificationsModel = {
+        createAiReviewNotifications: jest.fn().mockResolvedValue(undefined),
+    };
+    const schedulerClient = {
+        scheduleTask: jest.fn().mockResolvedValue({ jobId: 'job-1' }),
+    };
+    const aiAgentReviewClassifierModel = {
+        getReviewItem: jest.fn().mockResolvedValue({
+            fingerprint: 'fingerprint-1',
+            title: 'Missing metric',
+            primaryRootCause: 'semantic_layer',
+        }),
+    };
+    const organizationMemberProfileModel = {
+        getOrganizationMembers: jest.fn().mockResolvedValue({
+            data: [
+                {
+                    userUuid: 'developer-1',
+                    email: 'dev@example.com',
+                    role: OrganizationMemberRole.DEVELOPER,
+                    organizationUuid: 'org-1',
+                    ability: undefined,
+                },
+                {
+                    userUuid: 'viewer-1',
+                    email: 'viewer@example.com',
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: 'org-1',
+                    ability: undefined,
+                },
+            ],
+        }),
+    };
+    const service = new AiAgentReviewNotificationService({
+        notificationsModel,
+        schedulerClient,
+        aiAgentReviewClassifierModel,
+        organizationMemberProfileModel,
+    } as unknown as ConstructorParameters<
+        typeof AiAgentReviewNotificationService
+    >[0]);
+
+    return {
+        service,
+        notificationsModel,
+        schedulerClient,
+        aiAgentReviewClassifierModel,
+        organizationMemberProfileModel,
+    };
+};
+
+describe('AiAgentReviewNotificationService', () => {
+    it('filters recipients to members who can manage AiAgent', async () => {
+        const { service } = makeService();
+
+        await expect(service.getRecipients('org-1')).resolves.toEqual([
+            { userUuid: 'developer-1', email: 'dev@example.com' },
+        ]);
+    });
+
+    it('suppresses self-assignment notifications', async () => {
+        const { service, notificationsModel, schedulerClient } = makeService();
+
+        await service.notifyAssigned({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-1',
+            actorUserUuid: 'user-1',
+        });
+
+        expect(
+            notificationsModel.createAiReviewNotifications,
+        ).not.toHaveBeenCalled();
+        expect(schedulerClient.scheduleTask).not.toHaveBeenCalled();
+    });
+
+    it('writes bell and enqueues task for different assignee', async () => {
+        const { service, notificationsModel, schedulerClient } = makeService();
+
+        await service.notifyAssigned({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-2',
+            actorUserUuid: 'user-1',
+        });
+
+        expect(
+            notificationsModel.createAiReviewNotifications,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recipients: [{ userUuid: 'user-2' }],
+                metadata: expect.objectContaining({
+                    event: AiReviewNotificationEvent.Assigned,
+                    fingerprint: 'fingerprint-1',
+                }),
+            }),
+        );
+        expect(schedulerClient.scheduleTask).toHaveBeenCalledWith(
+            EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION,
+            expect.objectContaining({
+                event: AiReviewNotificationEvent.Assigned,
+                assigneeUserUuid: 'user-2',
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -1,0 +1,152 @@
+import { subject } from '@casl/ability';
+import {
+    AiReviewNotificationEvent,
+    AiReviewNotificationRecipient,
+    defineUserAbility,
+    EE_SCHEDULER_TASKS,
+} from '@lightdash/common';
+import { type NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
+import { type OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
+
+type AiAgentReviewNotificationServiceArgs = {
+    notificationsModel: NotificationsModel;
+    schedulerClient: CommercialSchedulerClient;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
+};
+
+export class AiAgentReviewNotificationService {
+    private readonly notificationsModel: NotificationsModel;
+
+    private readonly schedulerClient: CommercialSchedulerClient;
+
+    private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+
+    private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
+
+    constructor(args: AiAgentReviewNotificationServiceArgs) {
+        this.notificationsModel = args.notificationsModel;
+        this.schedulerClient = args.schedulerClient;
+        this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
+        this.organizationMemberProfileModel =
+            args.organizationMemberProfileModel;
+    }
+
+    async getRecipients(
+        organizationUuid: string,
+    ): Promise<AiReviewNotificationRecipient[]> {
+        const members =
+            await this.organizationMemberProfileModel.getOrganizationMembers({
+                organizationUuid,
+                paginateArgs: { page: 1, pageSize: 10_000 },
+            });
+
+        return members.data
+            .filter((member) =>
+                defineUserAbility(member, []).can(
+                    'manage',
+                    subject('AiAgent', { organizationUuid }),
+                ),
+            )
+            .map((member) => ({
+                userUuid: member.userUuid,
+                email: member.email,
+            }));
+    }
+
+    async notifyAssigned(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        fingerprint: string;
+        assigneeUserUuid: string;
+        actorUserUuid: string;
+    }): Promise<void> {
+        if (args.assigneeUserUuid === args.actorUserUuid) {
+            return;
+        }
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                args.organizationUuid,
+                args.fingerprint,
+            );
+        const metadata = {
+            fingerprint: args.fingerprint,
+            event: AiReviewNotificationEvent.Assigned,
+            title: reviewItem?.title ?? 'AI review finding',
+            rootCause: reviewItem?.primaryRootCause ?? 'unknown',
+            projectUuid: args.projectUuid,
+            count: 1,
+            searchParams: `reviewItemUuid=${args.fingerprint}`,
+        };
+
+        await this.notificationsModel.createAiReviewNotifications({
+            recipients: [{ userUuid: args.assigneeUserUuid }],
+            metadata,
+            message: `You were assigned: ${metadata.title}`,
+            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+        });
+
+        await this.schedulerClient.scheduleTask(
+            EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION,
+            {
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                event: AiReviewNotificationEvent.Assigned,
+                fingerprints: [args.fingerprint],
+                assigneeUserUuid: args.assigneeUserUuid,
+                reviewRunUuid: null,
+                userUuid: args.actorUserUuid,
+            },
+        );
+    }
+
+    async notifyNeedsReview(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        reviewRunUuid: string;
+        fingerprints: string[];
+    }): Promise<void> {
+        if (args.fingerprints.length === 0) {
+            return;
+        }
+
+        const [recipients, reviewItem] = await Promise.all([
+            this.getRecipients(args.organizationUuid),
+            this.aiAgentReviewClassifierModel.getReviewItem(
+                args.organizationUuid,
+                args.fingerprints[0],
+            ),
+        ]);
+        const metadata = {
+            fingerprint: args.fingerprints[0],
+            event: AiReviewNotificationEvent.NeedsReview,
+            title: reviewItem?.title ?? 'AI review finding',
+            rootCause: reviewItem?.primaryRootCause ?? 'unknown',
+            projectUuid: args.projectUuid,
+            count: args.fingerprints.length,
+            searchParams: `reviewRunUuid=${args.reviewRunUuid}`,
+        };
+
+        await this.notificationsModel.createAiReviewNotifications({
+            recipients,
+            metadata,
+            message: `${args.fingerprints.length} AI context findings need review`,
+            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+        });
+
+        await this.schedulerClient.scheduleTask(
+            EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION,
+            {
+                organizationUuid: args.organizationUuid,
+                projectUuid: args.projectUuid,
+                event: AiReviewNotificationEvent.NeedsReview,
+                fingerprints: args.fingerprints,
+                assigneeUserUuid: null,
+                reviewRunUuid: args.reviewRunUuid,
+            },
+        );
+    }
+}

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -201,6 +201,7 @@ import {
     type AiMcpServerWithSensitiveData,
 } from '../../models/AiAgentModel';
 import { AiAgentReviewClassifierModel } from '../../models/AiAgentReviewClassifierModel';
+import { AiAgentReviewNotificationModel } from '../../models/AiAgentReviewNotificationModel';
 import { CommercialSlackAuthenticationModel } from '../../models/CommercialSlackAuthenticationModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
@@ -392,6 +393,10 @@ type AiAgentServiceDependencies = {
         | 'findReviewRemediationByPreviewThread'
         | 'findReviewRemediationByWorkThread'
         | 'createRemediationEvent'
+    >;
+    aiAgentReviewNotificationModel: Pick<
+        AiAgentReviewNotificationModel,
+        'recordClicked'
     >;
     prometheusMetrics?: PrometheusMetrics;
 };
@@ -649,6 +654,11 @@ export class AiAgentService extends BaseService {
         | 'findReviewRemediationByPreviewThread'
         | 'findReviewRemediationByWorkThread'
         | 'createRemediationEvent'
+    >;
+
+    private readonly aiAgentReviewNotificationModel: Pick<
+        AiAgentReviewNotificationModel,
+        'recordClicked'
     >;
 
     private readonly aiAgentMcpRuntimeClient: AiAgentMcpRuntimeClient;
@@ -930,6 +940,8 @@ export class AiAgentService extends BaseService {
         this.pullRequestsModel = dependencies.pullRequestsModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentReviewNotificationModel =
+            dependencies.aiAgentReviewNotificationModel;
         this.aiAgentMcpRuntimeClient = new AiAgentMcpRuntimeClient({
             aiAgentModel: this.aiAgentModel,
             lightdashConfig: this.lightdashConfig,
@@ -9130,6 +9142,47 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
     public handleClickExploreButton(app: App) {
         app.action('actions.explore_button_click', async ({ ack, respond }) => {
             await ack();
+        });
+    }
+
+    public handleAiReviewOpenButton(app: App) {
+        app.action('ai_review_open', async ({ ack, body, action, context }) => {
+            await ack();
+
+            try {
+                if (body.type !== 'block_actions' || action.type !== 'button') {
+                    return;
+                }
+                const notificationLogUuid = action.value;
+                if (!notificationLogUuid) {
+                    return;
+                }
+
+                await this.aiAgentReviewNotificationModel.recordClicked(
+                    notificationLogUuid,
+                );
+
+                if (!context.teamId) {
+                    return;
+                }
+                const organizationUuid =
+                    await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
+                        context.teamId,
+                    );
+                this.analytics.track({
+                    event: 'ai_review_notification.clicked',
+                    anonymousId: organizationUuid,
+                    properties: {
+                        organizationId: organizationUuid,
+                    },
+                });
+            } catch (error) {
+                Logger.warn(
+                    `Failed to track AI review notification click: ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+            }
         });
     }
 

--- a/packages/backend/src/ee/services/SlackService/SlackService.ts
+++ b/packages/backend/src/ee/services/SlackService/SlackService.ts
@@ -38,6 +38,7 @@ export class CommercialSlackService extends SlackService {
         this.aiAgentService.handlePromptFeedbackButtons(slackApp);
         this.aiAgentService.handleDownvoteFeedbackModalSubmit(slackApp);
         this.aiAgentService.handleClickExploreButton(slackApp);
+        this.aiAgentService.handleAiReviewOpenButton(slackApp);
         this.aiAgentService.handleViewArtifact(slackApp);
         this.aiAgentService.handleViewPullRequestButton(slackApp);
         this.aiAgentService.handleClickOAuthButton(slackApp);

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9143,6 +9143,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppVersionExternalConnectionResource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                alias: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                externalConnectionUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AppVersionDesignSnapshot: {
         dataType: 'refAlias',
         type: {
@@ -9181,6 +9194,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
+                },
+                externalConnections: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'AppVersionExternalConnectionResource',
+                    },
                 },
                 charts: {
                     dataType: 'array',
@@ -13777,11 +13797,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -13839,11 +13859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType:
@@ -13880,11 +13900,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14498,59 +14518,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14673,6 +14640,59 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -15032,6 +15052,13 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -15040,13 +15067,6 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -15115,6 +15135,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15122,12 +15148,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15274,11 +15294,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15497,11 +15517,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -23095,6 +23115,76 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiReviewNotificationSettings: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                slackChannelId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                enabled: { dataType: 'boolean', required: true },
+                organizationUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_AiReviewNotificationSettings_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'AiReviewNotificationSettings',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiReviewNotificationSettingsResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess_AiReviewNotificationSettings_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                enabled: { dataType: 'boolean', required: true },
+                slackChannelId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateAiReviewNotificationSettings: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiOrganizationSettings: {
         dataType: 'refAlias',
         type: {
@@ -27372,6 +27462,7 @@ const models: TsoaRoute.Models = {
                     enums: ['aiAgentReviewRemediationCompile'],
                 },
                 { dataType: 'enum', enums: ['aiAgentReviewRemediationRun'] },
+                { dataType: 'enum', enums: ['sendReviewNotification'] },
                 { dataType: 'enum', enums: ['embedArtifactVersion'] },
                 { dataType: 'enum', enums: ['generateArtifactQuestion'] },
                 { dataType: 'enum', enums: ['appGeneratePipeline'] },
@@ -31161,7 +31252,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31171,7 +31262,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31181,7 +31272,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31194,7 +31285,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34225,9 +34316,74 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiNotificationResourceType.AiReview': {
+        dataType: 'refEnum',
+        enums: ['aiReview'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiReviewNotificationEvent: {
+        dataType: 'refEnum',
+        enums: ['needs_review', 'assigned'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    NotificationAiReview: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'NotificationBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        metadata: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                searchParams: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                count: { dataType: 'double', required: true },
+                                projectUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                rootCause: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                title: { dataType: 'string', required: true },
+                                event: {
+                                    ref: 'AiReviewNotificationEvent',
+                                    required: true,
+                                },
+                                fingerprint: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        resourceType: {
+                            ref: 'ApiNotificationResourceType.AiReview',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Notification: {
         dataType: 'refAlias',
-        type: { ref: 'NotificationDashboardComment', validators: {} },
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'NotificationDashboardComment' },
+                { ref: 'NotificationAiReview' },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiNotificationsResults: {
@@ -34253,7 +34409,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiNotificationResourceType: {
         dataType: 'refEnum',
-        enums: ['dashboardComments'],
+        enums: ['dashboardComments', 'aiReview'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Notification.viewed_': {
@@ -55393,6 +55549,122 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getEmbedToken',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_getReviewNotificationSettings: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/aiAgents/admin/review-notification-settings',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.getReviewNotificationSettings,
+        ),
+
+        async function AiAgentAdminController_getReviewNotificationSettings(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_getReviewNotificationSettings,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getReviewNotificationSettings',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_updateReviewNotificationSettings: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateAiReviewNotificationSettings',
+        },
+    };
+    app.put(
+        '/api/v1/aiAgents/admin/review-notification-settings',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.updateReviewNotificationSettings,
+        ),
+
+        async function AiAgentAdminController_updateReviewNotificationSettings(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_updateReviewNotificationSettings,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateReviewNotificationSettings',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10543,6 +10543,21 @@
                 "required": ["chartKind", "chartName", "chartUuid"],
                 "type": "object"
             },
+            "AppVersionExternalConnectionResource": {
+                "properties": {
+                    "alias": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "externalConnectionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["alias", "name", "externalConnectionUuid"],
+                "type": "object"
+            },
             "AppVersionDesignSnapshot": {
                 "properties": {
                     "fileCount": {
@@ -10581,6 +10596,12 @@
                     "dashboardName": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "externalConnections": {
+                        "items": {
+                            "$ref": "#/components/schemas/AppVersionExternalConnectionResource"
+                        },
+                        "type": "array"
                     },
                     "charts": {
                         "items": {
@@ -15408,8 +15429,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15467,8 +15488,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "rejected",
-                                                            "accepted"
+                                                            "accepted",
+                                                            "rejected"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15492,19 +15513,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -15777,36 +15785,6 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "joinedTables",
-                                                                            "baseTable",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -15867,6 +15845,36 @@
                                                                         },
                                                                         "type": "array"
                                                                     },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "joinedTables",
+                                                                            "baseTable",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
+                                                                    },
                                                                     "status": {
                                                                         "type": "string",
                                                                         "enum": [
@@ -15876,9 +15884,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "fields",
                                                                     "rationale",
                                                                     "explore",
-                                                                    "fields",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16047,9 +16055,9 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
+                                                                        "search",
                                                                         "read",
                                                                         "edit",
-                                                                        "search",
                                                                         "compile",
                                                                         "stage"
                                                                     ]
@@ -16086,9 +16094,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16152,8 +16160,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "success",
                                                             "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -23539,6 +23547,56 @@
             "ApiAiAgentReviewSignalsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewSignalSummary-Array_"
             },
+            "AiReviewNotificationSettings": {
+                "properties": {
+                    "slackChannelId": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "organizationUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["slackChannelId", "enabled", "organizationUuid"],
+                "type": "object"
+            },
+            "ApiSuccess_AiReviewNotificationSettings_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/AiReviewNotificationSettings"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiReviewNotificationSettingsResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiReviewNotificationSettings_"
+            },
+            "Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_": {
+                "properties": {
+                    "enabled": {
+                        "type": "boolean"
+                    },
+                    "slackChannelId": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["enabled", "slackChannelId"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "UpdateAiReviewNotificationSettings": {
+                "$ref": "#/components/schemas/Pick_AiReviewNotificationSettings.enabled-or-slackChannelId_"
+            },
             "AiOrganizationSettings": {
                 "properties": {
                     "mcpContentWritesEnabled": {
@@ -27892,6 +27950,7 @@
                     "aiAgentReviewRemediationPreview",
                     "aiAgentReviewRemediationCompile",
                     "aiAgentReviewRemediationRun",
+                    "sendReviewNotification",
                     "embedArtifactVersion",
                     "generateArtifactQuestion",
                     "appGeneratePipeline",
@@ -31800,22 +31859,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -34748,8 +34807,75 @@
                     }
                 ]
             },
+            "ApiNotificationResourceType.AiReview": {
+                "enum": ["aiReview"],
+                "type": "string"
+            },
+            "AiReviewNotificationEvent": {
+                "enum": ["needs_review", "assigned"],
+                "type": "string"
+            },
+            "NotificationAiReview": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/NotificationBase"
+                    },
+                    {
+                        "properties": {
+                            "metadata": {
+                                "properties": {
+                                    "searchParams": {
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "projectUuid": {
+                                        "type": "string"
+                                    },
+                                    "rootCause": {
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "event": {
+                                        "$ref": "#/components/schemas/AiReviewNotificationEvent"
+                                    },
+                                    "fingerprint": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "searchParams",
+                                    "count",
+                                    "projectUuid",
+                                    "rootCause",
+                                    "title",
+                                    "event",
+                                    "fingerprint"
+                                ],
+                                "type": "object"
+                            },
+                            "resourceType": {
+                                "$ref": "#/components/schemas/ApiNotificationResourceType.AiReview"
+                            }
+                        },
+                        "required": ["metadata", "resourceType"],
+                        "type": "object"
+                    }
+                ]
+            },
             "Notification": {
-                "$ref": "#/components/schemas/NotificationDashboardComment"
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/NotificationDashboardComment"
+                    },
+                    {
+                        "$ref": "#/components/schemas/NotificationAiReview"
+                    }
+                ]
             },
             "ApiNotificationsResults": {
                 "items": {
@@ -34772,7 +34898,7 @@
                 "type": "object"
             },
             "ApiNotificationResourceType": {
-                "enum": ["dashboardComments"],
+                "enum": ["dashboardComments", "aiReview"],
                 "type": "string"
             },
             "Pick_Notification.viewed_": {
@@ -40925,7 +41051,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3220.0",
+        "version": "0.3224.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -48419,6 +48545,76 @@
                 },
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/aiAgents/admin/review-notification-settings": {
+            "get": {
+                "operationId": "getAiReviewNotificationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiReviewNotificationSettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get AI review notification settings",
+                "summary": "Get AI review notification settings",
+                "security": [],
+                "parameters": []
+            },
+            "put": {
+                "operationId": "updateAiReviewNotificationSettings",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiReviewNotificationSettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Update AI review notification settings",
+                "summary": "Update AI review notification settings",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAiReviewNotificationSettings"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/aiAgents/admin/settings": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -145,6 +145,7 @@ export type ModelManifest = {
     aiWritebackThreadModel: unknown;
     projectCiStatusModel: unknown;
     aiAgentReviewClassifierModel: unknown;
+    aiAgentReviewNotificationModel: unknown;
     projectContextModel: unknown;
     aiRouterModel: unknown;
     managedAgentModel: unknown;
@@ -774,6 +775,10 @@ export class ModelRepository
 
     public getAiAgentReviewClassifierModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentReviewClassifierModel');
+    }
+
+    public getAiAgentReviewNotificationModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiAgentReviewNotificationModel');
     }
 
     public getAiRouterModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.test.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.test.ts
@@ -1,6 +1,13 @@
+import {
+    AiReviewNotificationEvent,
+    ApiNotificationResourceType,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { NotificationsTableName } from '../../database/entities/notifications';
+import {
+    DbNotificationResourceType,
+    NotificationsTableName,
+} from '../../database/entities/notifications';
 import { NotificationsModel } from './NotificationsModel';
 
 describe('NotificationsModel', () => {
@@ -31,5 +38,78 @@ describe('NotificationsModel', () => {
         expect(query.sql).toContain('viewed');
         expect(query.sql).not.toContain('user_uuid');
         expect(query.bindings).not.toContain('attacker-user-uuid');
+    });
+
+    it('creates one AI review notification per recipient', async () => {
+        tracker.on.insert(NotificationsTableName).response([]);
+        tracker.on.insert(NotificationsTableName).response([]);
+
+        await model.createAiReviewNotifications({
+            recipients: [{ userUuid: 'user-1' }, { userUuid: 'user-2' }],
+            metadata: {
+                fingerprint: 'fingerprint-1',
+                event: AiReviewNotificationEvent.NeedsReview,
+                title: 'Missing metric',
+                rootCause: 'semantic_layer',
+                projectUuid: 'project-1',
+                count: 3,
+                searchParams: 'reviewItemUuid=fingerprint-1',
+            },
+            message: '3 AI context findings need review',
+            url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+        });
+
+        expect(tracker.history.insert).toHaveLength(2);
+        expect(tracker.history.insert[0].bindings).toContain(
+            DbNotificationResourceType.AiReviewItem,
+        );
+        expect(tracker.history.insert[0].bindings).toContain('user-1');
+        expect(tracker.history.insert[1].bindings).toContain('user-2');
+    });
+
+    it('maps AI review notification rows', async () => {
+        tracker.on.select(NotificationsTableName).response([
+            {
+                notification_id: 'notification-1',
+                resource_type: DbNotificationResourceType.AiReviewItem,
+                message: 'Missing metric needs review',
+                url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+                viewed: false,
+                created_at: new Date('2026-06-23T10:00:00.000Z'),
+                resource_uuid: 'fingerprint-1',
+                metadata: {
+                    fingerprint: 'fingerprint-1',
+                    event: AiReviewNotificationEvent.Assigned,
+                    title: 'Missing metric',
+                    rootCause: 'semantic_layer',
+                    projectUuid: 'project-1',
+                    count: 1,
+                    searchParams: 'reviewItemUuid=fingerprint-1',
+                },
+            },
+        ]);
+
+        await expect(model.getAiReviewNotifications('user-1')).resolves.toEqual(
+            [
+                {
+                    notificationId: 'notification-1',
+                    resourceType: ApiNotificationResourceType.AiReview,
+                    message: 'Missing metric needs review',
+                    url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+                    viewed: false,
+                    createdAt: new Date('2026-06-23T10:00:00.000Z'),
+                    resourceUuid: 'fingerprint-1',
+                    metadata: {
+                        fingerprint: 'fingerprint-1',
+                        event: AiReviewNotificationEvent.Assigned,
+                        title: 'Missing metric',
+                        rootCause: 'semantic_layer',
+                        projectUuid: 'project-1',
+                        count: 1,
+                        searchParams: 'reviewItemUuid=fingerprint-1',
+                    },
+                },
+            ],
+        );
     });
 });

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -5,10 +5,12 @@ import {
     DashboardDAO,
     DashboardTile,
     LightdashUser,
+    NotificationAiReview,
     NotificationDashboardComment,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
+    DbNotificationDashboardTileCommentMetadata,
     DbNotificationResourceType,
     NotificationsTableName,
 } from '../../database/entities/notifications';
@@ -36,22 +38,51 @@ export class NotificationsModel {
             )
             .orderBy(`${NotificationsTableName}.created_at`, 'desc');
 
+        return notifications.map((notif) => {
+            const metadata =
+                notif.metadata as DbNotificationDashboardTileCommentMetadata | null;
+
+            return {
+                notificationId: notif.notification_id,
+                resourceType: ApiNotificationResourceType.DashboardComments,
+                message: notif.message ?? undefined,
+                url: notif.url ?? undefined,
+                viewed: notif.viewed,
+                createdAt: notif.created_at,
+                resourceUuid: notif.resource_uuid ?? undefined,
+                metadata: metadata
+                    ? {
+                          dashboardUuid: metadata.dashboard_uuid,
+                          dashboardName: metadata.dashboard_name,
+                          dashboardTileUuid: metadata.dashboard_tile_uuid,
+                          dashboardTileName: metadata.dashboard_tile_name,
+                      }
+                    : undefined,
+            };
+        });
+    }
+
+    async getAiReviewNotifications(
+        userUuid: string,
+    ): Promise<NotificationAiReview[]> {
+        const notifications = await this.database(NotificationsTableName)
+            .select()
+            .where(`${NotificationsTableName}.user_uuid`, userUuid)
+            .andWhere(
+                `${NotificationsTableName}.resource_type`,
+                DbNotificationResourceType.AiReviewItem,
+            )
+            .orderBy(`${NotificationsTableName}.created_at`, 'desc');
+
         return notifications.map((notif) => ({
             notificationId: notif.notification_id,
-            resourceType: ApiNotificationResourceType.DashboardComments,
+            resourceType: ApiNotificationResourceType.AiReview,
             message: notif.message ?? undefined,
             url: notif.url ?? undefined,
             viewed: notif.viewed,
             createdAt: notif.created_at,
             resourceUuid: notif.resource_uuid ?? undefined,
-            metadata: notif.metadata
-                ? {
-                      dashboardUuid: notif.metadata.dashboard_uuid,
-                      dashboardName: notif.metadata.dashboard_name,
-                      dashboardTileUuid: notif.metadata.dashboard_tile_uuid,
-                      dashboardTileName: notif.metadata.dashboard_tile_name,
-                  }
-                : undefined,
+            metadata: notif.metadata as NotificationAiReview['metadata'],
         }));
     }
 
@@ -125,6 +156,31 @@ export class NotificationsModel {
                         }),
                     });
                 }
+            }),
+        );
+    }
+
+    async createAiReviewNotifications({
+        recipients,
+        metadata,
+        message,
+        url,
+    }: {
+        recipients: { userUuid: string }[];
+        metadata: NotificationAiReview['metadata'];
+        message: string;
+        url: string;
+    }): Promise<void> {
+        await Promise.all(
+            recipients.map(async ({ userUuid }) => {
+                await this.database(NotificationsTableName).insert({
+                    user_uuid: userUuid,
+                    resource_uuid: metadata.fingerprint,
+                    resource_type: DbNotificationResourceType.AiReviewItem,
+                    message,
+                    url,
+                    metadata: JSON.stringify(metadata),
+                });
             }),
         );
     }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -203,6 +203,12 @@ const getTagsForTask: {
         'ai_agent_review.remediation_uuid': payload.remediationUuid,
     }),
 
+    [SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'project.uuid': payload.projectUuid,
+        'user.uuid': payload.userUuid ?? '',
+    }),
+
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: (payload) => ({
         'organization.uuid': payload.organizationUuid,
         'user.uuid': payload.userUuid,

--- a/packages/backend/src/scheduler/tasks/sendReviewNotification.test.ts
+++ b/packages/backend/src/scheduler/tasks/sendReviewNotification.test.ts
@@ -1,0 +1,110 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+} from '@lightdash/common';
+import { sendReviewNotification } from './sendReviewNotification';
+
+const makeDeps = ({
+    recipients = [{ userUuid: 'user-2', email: 'user-2@example.com' }],
+    slackIdentity = { subject: 'U123' },
+    settings = { enabled: true, slackChannelId: 'C123' },
+}: {
+    recipients?: Array<{ userUuid: string; email: string }>;
+    slackIdentity?: { subject: string } | null;
+    settings?: { enabled: boolean; slackChannelId: string | null };
+} = {}) => {
+    const deps = {
+        siteUrl: 'https://app.lightdash.com',
+        model: {
+            getSettings: jest.fn().mockResolvedValue({
+                organizationUuid: 'org-1',
+                ...settings,
+            }),
+            recordSent: jest.fn().mockResolvedValue('log-1'),
+            recordError: jest.fn().mockResolvedValue(undefined),
+        },
+        service: {
+            getRecipients: jest.fn().mockResolvedValue(recipients),
+        },
+        aiAgentReviewClassifierModel: {
+            getReviewItem: jest.fn().mockResolvedValue({
+                title: 'Missing metric',
+                primaryRootCause: 'semantic_layer',
+            }),
+        },
+        projectModel: {
+            get: jest.fn().mockResolvedValue({ name: 'Jaffle' }),
+        },
+        openIdIdentityModel: {
+            findIdentityByUserUuid: jest.fn().mockResolvedValue(slackIdentity),
+        },
+        slackClient: {
+            getWebClient: jest.fn().mockResolvedValue({
+                conversations: {
+                    open: jest.fn().mockResolvedValue({
+                        ok: true,
+                        channel: { id: 'D123' },
+                    }),
+                },
+            }),
+            postMessage: jest.fn().mockResolvedValue({ ok: true }),
+        },
+        analytics: {
+            track: jest.fn(),
+        },
+    };
+
+    return deps;
+};
+
+const assignedPayload = {
+    event: AiReviewNotificationEvent.Assigned,
+    assigneeUserUuid: 'user-2',
+    fingerprints: ['fingerprint-1'],
+    organizationUuid: 'org-1',
+    projectUuid: 'project-1',
+    reviewRunUuid: null,
+};
+
+test('assigned DM is skipped when assignee has no linked Slack identity', async () => {
+    const deps = makeDeps({ slackIdentity: null });
+
+    await sendReviewNotification(deps as never)(assignedPayload);
+
+    expect(deps.slackClient.postMessage).not.toHaveBeenCalled();
+    expect(deps.model.recordSent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+            channel: AiReviewNotificationChannel.SlackDm,
+        }),
+    );
+});
+
+test('assigned DM is skipped when assignee lost manage:AiAgent', async () => {
+    const deps = makeDeps({ recipients: [] });
+
+    await sendReviewNotification(deps as never)(assignedPayload);
+
+    expect(deps.slackClient.postMessage).not.toHaveBeenCalled();
+});
+
+test('needs_review posts to configured channel when enabled', async () => {
+    const deps = makeDeps();
+
+    await sendReviewNotification(deps as never)({
+        event: AiReviewNotificationEvent.NeedsReview,
+        fingerprints: ['fingerprint-1', 'fingerprint-2', 'fingerprint-3'],
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        reviewRunUuid: 'run-1',
+        assigneeUserUuid: null,
+    });
+
+    expect(deps.slackClient.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C123' }),
+    );
+    expect(deps.model.recordSent).toHaveBeenCalledWith(
+        expect.objectContaining({
+            channel: AiReviewNotificationChannel.SlackChannel,
+        }),
+    );
+});

--- a/packages/backend/src/scheduler/tasks/sendReviewNotification.ts
+++ b/packages/backend/src/scheduler/tasks/sendReviewNotification.ts
@@ -1,0 +1,223 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+    getErrorMessage,
+    OpenIdIdentityIssuerType,
+    type SendReviewNotificationPayload,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { type LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { type SlackClient } from '../../clients/Slack/SlackClient';
+import {
+    buildReviewAssignedBlocks,
+    buildReviewNeedsReviewBlocks,
+} from '../../clients/Slack/SlackReviewMessageBlocks';
+import { type AiAgentReviewClassifierModel } from '../../ee/models/AiAgentReviewClassifierModel';
+import { type AiAgentReviewNotificationModel } from '../../ee/models/AiAgentReviewNotificationModel';
+import { type AiAgentReviewNotificationService } from '../../ee/services/AiAgentReviewNotificationService';
+import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+
+type SendReviewNotificationDeps = {
+    siteUrl: string;
+    model: AiAgentReviewNotificationModel;
+    service: AiAgentReviewNotificationService;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    projectModel: ProjectModel;
+    openIdIdentityModel: OpenIdIdentityModel;
+    slackClient: SlackClient;
+    analytics: LightdashAnalytics;
+};
+
+const ACTION_ID = 'ai_review_open';
+
+const getReviewContext = async (
+    deps: SendReviewNotificationDeps,
+    payload: SendReviewNotificationPayload,
+) => {
+    const [reviewItem, project] = await Promise.all([
+        deps.aiAgentReviewClassifierModel.getReviewItem(
+            payload.organizationUuid,
+            payload.fingerprints[0],
+        ),
+        deps.projectModel.get(payload.projectUuid),
+    ]);
+
+    return {
+        title: reviewItem?.title ?? 'AI review finding',
+        rootCause: reviewItem?.primaryRootCause ?? 'unknown',
+        projectName: project.name,
+        reviewUrl: `${deps.siteUrl}/ai-agents/admin/reviews?${
+            payload.reviewRunUuid
+                ? `reviewRunUuid=${payload.reviewRunUuid}`
+                : `reviewItemUuid=${payload.fingerprints[0]}`
+        }`,
+    };
+};
+
+const track = (
+    deps: SendReviewNotificationDeps,
+    event: 'ai_review_notification.sent' | 'ai_review_notification.errored',
+    payload: SendReviewNotificationPayload,
+    channel: AiReviewNotificationChannel,
+    error?: string,
+) =>
+    deps.analytics.track({
+        event,
+        anonymousId: payload.organizationUuid,
+        properties: {
+            organizationId: payload.organizationUuid,
+            projectId: payload.projectUuid,
+            channel,
+            notificationEvent: payload.event,
+            error,
+        },
+    });
+
+export const sendReviewNotification =
+    (deps: SendReviewNotificationDeps) =>
+    async (payload: SendReviewNotificationPayload): Promise<void> => {
+        if (
+            payload.event === AiReviewNotificationEvent.NeedsReview &&
+            payload.fingerprints.length > 0
+        ) {
+            const settings = await deps.model.getSettings(
+                payload.organizationUuid,
+            );
+            if (!settings.enabled || !settings.slackChannelId) {
+                return;
+            }
+
+            const context = await getReviewContext(deps, payload);
+            const notificationLogUuid = randomUUID();
+            try {
+                await deps.slackClient.postMessage({
+                    organizationUuid: payload.organizationUuid,
+                    channel: settings.slackChannelId,
+                    text: `${payload.fingerprints.length} context fixes need review`,
+                    blocks: buildReviewNeedsReviewBlocks({
+                        count: payload.fingerprints.length,
+                        topTitle: context.title,
+                        rootCause: context.rootCause,
+                        projectName: context.projectName,
+                        reviewUrl: context.reviewUrl,
+                        actionId: ACTION_ID,
+                        notificationLogUuid,
+                    }),
+                });
+                await deps.model.recordSent({
+                    notificationLogUuid,
+                    organizationUuid: payload.organizationUuid,
+                    fingerprint: payload.fingerprints[0],
+                    recipientUserUuid: null,
+                    channel: AiReviewNotificationChannel.SlackChannel,
+                    event: payload.event,
+                });
+                track(
+                    deps,
+                    'ai_review_notification.sent',
+                    payload,
+                    AiReviewNotificationChannel.SlackChannel,
+                );
+            } catch (error) {
+                const message = getErrorMessage(error);
+                await deps.model.recordError({
+                    organizationUuid: payload.organizationUuid,
+                    fingerprint: payload.fingerprints[0],
+                    recipientUserUuid: null,
+                    channel: AiReviewNotificationChannel.SlackChannel,
+                    event: payload.event,
+                    error: message,
+                });
+                track(
+                    deps,
+                    'ai_review_notification.errored',
+                    payload,
+                    AiReviewNotificationChannel.SlackChannel,
+                    message,
+                );
+            }
+            return;
+        }
+
+        if (
+            payload.event !== AiReviewNotificationEvent.Assigned ||
+            !payload.assigneeUserUuid ||
+            payload.fingerprints.length === 0
+        ) {
+            return;
+        }
+
+        const recipients = await deps.service.getRecipients(
+            payload.organizationUuid,
+        );
+        if (!recipients.some((r) => r.userUuid === payload.assigneeUserUuid)) {
+            return;
+        }
+
+        const identity = await deps.openIdIdentityModel.findIdentityByUserUuid(
+            payload.assigneeUserUuid,
+            OpenIdIdentityIssuerType.SLACK,
+        );
+        if (!identity) {
+            return;
+        }
+
+        const context = await getReviewContext(deps, payload);
+        const notificationLogUuid = randomUUID();
+        try {
+            const webClient = await deps.slackClient.getWebClient(
+                payload.organizationUuid,
+            );
+            const conversation = await webClient.conversations.open({
+                users: identity.subject,
+            });
+            if (!conversation.ok || !conversation.channel?.id) {
+                throw new Error('Failed to open Slack DM');
+            }
+            await deps.slackClient.postMessage({
+                organizationUuid: payload.organizationUuid,
+                channel: conversation.channel.id,
+                text: `AI review finding assigned: ${context.title}`,
+                blocks: buildReviewAssignedBlocks({
+                    title: context.title,
+                    rootCause: context.rootCause,
+                    projectName: context.projectName,
+                    reviewUrl: context.reviewUrl,
+                    actionId: ACTION_ID,
+                    notificationLogUuid,
+                }),
+            });
+            await deps.model.recordSent({
+                notificationLogUuid,
+                organizationUuid: payload.organizationUuid,
+                fingerprint: payload.fingerprints[0],
+                recipientUserUuid: payload.assigneeUserUuid,
+                channel: AiReviewNotificationChannel.SlackDm,
+                event: payload.event,
+            });
+            track(
+                deps,
+                'ai_review_notification.sent',
+                payload,
+                AiReviewNotificationChannel.SlackDm,
+            );
+        } catch (error) {
+            const message = getErrorMessage(error);
+            await deps.model.recordError({
+                organizationUuid: payload.organizationUuid,
+                fingerprint: payload.fingerprints[0],
+                recipientUserUuid: payload.assigneeUserUuid,
+                channel: AiReviewNotificationChannel.SlackDm,
+                event: payload.event,
+                error: message,
+            });
+            track(
+                deps,
+                'ai_review_notification.errored',
+                payload,
+                AiReviewNotificationChannel.SlackDm,
+                message,
+            );
+        }
+    };

--- a/packages/backend/src/services/NotificationsService/NotificationsService.ts
+++ b/packages/backend/src/services/NotificationsService/NotificationsService.ts
@@ -28,6 +28,10 @@ export class NotificationsService extends BaseService {
                 return this.notificationsModel.getDashboardCommentNotifications(
                     userUuid,
                 );
+            case ApiNotificationResourceType.AiReview:
+                return this.notificationsModel.getAiReviewNotifications(
+                    userUuid,
+                );
             default:
                 return assertUnreachable(
                     type,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -145,6 +145,7 @@ interface ServiceManifest {
     permissionsService: PermissionsService;
     /** An implementation signature for these services are not available at this stage */
     aiWritebackService: unknown;
+    aiAgentReviewNotificationService: unknown;
     writebackPreviewService: unknown;
     previewDeploySetupService: unknown;
     appGenerateService: unknown;
@@ -1391,6 +1392,12 @@ export class ServiceRepository
         AiAgentReviewClassifierServiceImplT,
     >(): AiAgentReviewClassifierServiceImplT {
         return this.getService('aiAgentReviewClassifierService');
+    }
+
+    public getAiAgentReviewNotificationService<
+        AiAgentReviewNotificationServiceImplT,
+    >(): AiAgentReviewNotificationServiceImplT {
+        return this.getService('aiAgentReviewNotificationService');
     }
 
     public getAiRouterService<AiRouterServiceImplT>(): AiRouterServiceImplT {

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -13,6 +13,7 @@ export * as preAggregateUtils from './preAggregates/utils';
 export * from './scim/errors';
 export * from './scim/types';
 export * from './serviceAccounts/types';
+export * from './types/aiReviewNotification';
 export * from './types/managedAgent';
 
 export enum ScimSchemaType {

--- a/packages/common/src/ee/types/aiReviewNotification.test.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.test.ts
@@ -1,0 +1,9 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+} from './aiReviewNotification';
+
+test('event and channel enums expose stable string values', () => {
+    expect(AiReviewNotificationEvent.NeedsReview).toBe('needs_review');
+    expect(AiReviewNotificationChannel.SlackDm).toBe('slack_dm');
+});

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -1,0 +1,38 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+export enum AiReviewNotificationEvent {
+    NeedsReview = 'needs_review',
+    Assigned = 'assigned',
+}
+
+export enum AiReviewNotificationChannel {
+    Bell = 'bell',
+    SlackChannel = 'slack_channel',
+    SlackDm = 'slack_dm',
+}
+
+export enum AiReviewNotificationStatus {
+    Sent = 'sent',
+    Errored = 'errored',
+    Clicked = 'clicked',
+    Dismissed = 'dismissed',
+}
+
+export type AiReviewNotificationSettings = {
+    organizationUuid: string;
+    enabled: boolean;
+    slackChannelId: string | null;
+};
+
+export type UpdateAiReviewNotificationSettings = Pick<
+    AiReviewNotificationSettings,
+    'enabled' | 'slackChannelId'
+>;
+
+export type ApiAiReviewNotificationSettingsResponse =
+    ApiSuccess<AiReviewNotificationSettings>;
+
+export type AiReviewNotificationRecipient = {
+    userUuid: string;
+    email: string;
+};

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -33,6 +33,7 @@ import type {
     ApiAiGenerateTableCalculationResponse,
     ApiAiGetDashboardSummaryResponse,
     ApiAiOrganizationSettingsResponse,
+    ApiAiReviewNotificationSettingsResponse,
     ApiAiRouterDecisionCommitResponse,
     ApiAiRouterDecisionListResponse,
     ApiAiRouterInstructionResponse,
@@ -1126,6 +1127,7 @@ type ApiResults =
     | ApiGetChangeResponse['results']
     | ApiAiOrganizationSettingsResponse['results']
     | ApiUpdateAiOrganizationSettingsResponse['results']
+    | ApiAiReviewNotificationSettingsResponse['results']
     | ApiAiRouterResponse['results']
     | ApiAiRouterRouteResponse['results']
     | ApiAiRouterInstructionResponse['results']

--- a/packages/common/src/types/api/notifications.test.ts
+++ b/packages/common/src/types/api/notifications.test.ts
@@ -1,0 +1,5 @@
+import { ApiNotificationResourceType } from './notifications';
+
+test('AiReview resource type is exposed', () => {
+    expect(ApiNotificationResourceType.AiReview).toBe('aiReview');
+});

--- a/packages/common/src/types/api/notifications.ts
+++ b/packages/common/src/types/api/notifications.ts
@@ -1,5 +1,8 @@
+import { type AiReviewNotificationEvent } from '../../ee/types/aiReviewNotification';
+
 export enum ApiNotificationResourceType {
     DashboardComments = 'dashboardComments',
+    AiReview = 'aiReview',
 }
 
 interface NotificationDashboardTileCommentMetadata {
@@ -23,7 +26,20 @@ export type NotificationDashboardComment = NotificationBase & {
     metadata: NotificationDashboardTileCommentMetadata | undefined;
 };
 
-export type Notification = NotificationDashboardComment;
+export type NotificationAiReview = NotificationBase & {
+    resourceType: ApiNotificationResourceType.AiReview;
+    metadata: {
+        fingerprint: string;
+        event: AiReviewNotificationEvent;
+        title: string;
+        rootCause: string;
+        projectUuid: string;
+        count: number;
+        searchParams: string;
+    };
+};
+
+export type Notification = NotificationDashboardComment | NotificationAiReview;
 
 export type ApiNotificationUpdateParams = Pick<Notification, 'viewed'>;
 export type ApiNotificationsResults = Notification[];

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -1,3 +1,4 @@
+import { type AiReviewNotificationEvent } from '../ee/types/aiReviewNotification';
 import assertUnreachable from '../utils/assertUnreachable';
 import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
@@ -816,4 +817,15 @@ export type SyncSlackChannelsPayload = Pick<
 > & {
     projectUuid: undefined;
     userUuid: undefined;
+};
+
+export type SendReviewNotificationPayload = {
+    organizationUuid: string;
+    event: AiReviewNotificationEvent;
+    fingerprints: string[];
+    projectUuid: string;
+    assigneeUserUuid: string | null;
+    reviewRunUuid: string | null;
+    schedulerUuid?: string;
+    userUuid?: string;
 };

--- a/packages/common/src/types/schedulerTaskList.test.ts
+++ b/packages/common/src/types/schedulerTaskList.test.ts
@@ -1,0 +1,7 @@
+import { EE_SCHEDULER_TASKS } from './schedulerTaskList';
+
+test('SEND_REVIEW_NOTIFICATION task is registered', () => {
+    expect(EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION).toBe(
+        'sendReviewNotification',
+    );
+});

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -33,6 +33,7 @@ import {
     type ReplaceCustomFieldsPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
+    type SendReviewNotificationPayload,
     type SlackBatchNotificationPayload,
     type SlackNotificationPayload,
     type SyncSlackChannelsPayload,
@@ -71,6 +72,7 @@ export const EE_SCHEDULER_TASKS = {
     AI_AGENT_REVIEW_REMEDIATION_PREVIEW: 'aiAgentReviewRemediationPreview',
     AI_AGENT_REVIEW_REMEDIATION_COMPILE: 'aiAgentReviewRemediationCompile',
     AI_AGENT_REVIEW_REMEDIATION_RUN: 'aiAgentReviewRemediationRun',
+    SEND_REVIEW_NOTIFICATION: 'sendReviewNotification',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
@@ -163,6 +165,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
+    [SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
@@ -177,6 +180,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_PREVIEW]: AiAgentReviewRemediationPreviewJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_COMPILE]: AiAgentReviewRemediationCompileJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_REVIEW_REMEDIATION_RUN]: AiAgentReviewRemediationRunJobPayload;
+    [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: SendReviewNotificationPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -1,12 +1,15 @@
 import {
+    type Notification,
     NotificationResourceType,
     ValidationErrorType,
 } from '@lightdash/common';
 import { Button, getDefaultZIndex, Indicator, Menu } from '@mantine-8/core';
 import { IconBell } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { Fragment, type FC, useMemo } from 'react';
+import { useAiAgentPermission } from '../../../ee/features/aiCopilot/hooks/useAiAgentPermission';
 import { useDashboardCommentsCheck } from '../../../features/comments';
 import {
+    AiReviewNotifications,
     DashboardCommentsNotifications,
     useGetNotifications,
 } from '../../../features/notifications';
@@ -46,6 +49,25 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
     const hasDashboardCommentsNotifications =
         dashboardCommentsNotifications &&
         dashboardCommentsNotifications.length > 0;
+    const canViewAiReviews = useAiAgentPermission({ action: 'manage' });
+    const { data: aiReviewNotifications } = useGetNotifications(
+        NotificationResourceType.AiReview,
+        !!canViewAiReviews,
+    );
+    const hasAiReviewNotifications =
+        aiReviewNotifications && aiReviewNotifications.length > 0;
+    const notifications = useMemo<Notification[]>(
+        () =>
+            [
+                ...(dashboardCommentsNotifications ?? []),
+                ...(aiReviewNotifications ?? []),
+            ].sort(
+                (a, b) =>
+                    new Date(b.createdAt).getTime() -
+                    new Date(a.createdAt).getTime(),
+            ),
+        [aiReviewNotifications, dashboardCommentsNotifications],
+    );
 
     const showNotificationBadge = () => {
         /**
@@ -61,14 +83,23 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
             const hasUnreadComments = dashboardCommentsNotifications?.some(
                 (n) => !n.viewed,
             );
-            return hasUnreadComments;
+            if (hasUnreadComments) return true;
+        }
+
+        if (canViewAiReviews) {
+            const hasUnreadAiReviews = aiReviewNotifications?.some(
+                (n) => !n.viewed,
+            );
+            if (hasUnreadAiReviews) return true;
         }
 
         return false;
     };
 
     const shouldDisplayMenu =
-        canViewDashboardComments || canUserManageValidations;
+        canViewDashboardComments ||
+        canUserManageValidations ||
+        canViewAiReviews;
 
     return shouldDisplayMenu ? (
         <Menu
@@ -106,14 +137,28 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                         validationData={validationErrors}
                     />
                 )}
-                {hasDashboardCommentsNotifications && (
-                    <DashboardCommentsNotifications
-                        notifications={dashboardCommentsNotifications}
-                        projectUuid={projectUuid}
-                    />
+                {notifications.length > 0 && (
+                    <>
+                        {notifications.map((notification) => (
+                            <Fragment key={notification.notificationId}>
+                                {notification.resourceType ===
+                                NotificationResourceType.DashboardComments ? (
+                                    <DashboardCommentsNotifications
+                                        notifications={[notification]}
+                                        projectUuid={projectUuid}
+                                    />
+                                ) : (
+                                    <AiReviewNotifications
+                                        notifications={[notification]}
+                                    />
+                                )}
+                            </Fragment>
+                        ))}
+                    </>
                 )}
                 {!hasValidationNotifications &&
-                    !hasDashboardCommentsNotifications && (
+                    !hasDashboardCommentsNotifications &&
+                    !hasAiReviewNotifications && (
                         <Menu.Item>No notifications</Menu.Item>
                     )}
             </Menu.Dropdown>

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -1,11 +1,12 @@
-import { type NotificationDashboardComment } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
+import { type NotificationAiReview } from '@lightdash/common';
+import { Box, Menu } from '@mantine-8/core';
 import { Text, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -13,8 +14,7 @@ import { useUpdateNotification } from '../hooks/useNotifications';
 import classes from './DashboardCommentsNotifications.module.css';
 
 type Props = {
-    projectUuid: string;
-    notifications: NotificationDashboardComment[];
+    notifications: NotificationAiReview[];
 };
 
 const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
@@ -22,7 +22,6 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
     return (
         <Tooltip
             position="top-end"
-            // Add offset so toolip pointer is closer to the text
             offset={-2}
             label={
                 <Text fz="xs">
@@ -42,17 +41,14 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
     );
 };
 
-export const DashboardCommentsNotifications: FC<Props> = ({
-    projectUuid,
-    notifications,
-}) => {
+export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
     const { track } = useTracking();
     const theme = useMantineTheme();
     const navigate = useNavigate();
     const { mutateAsync: updateNotification } = useUpdateNotification();
 
     const handleOnNotificationClick = useCallback(
-        async (notification: NotificationDashboardComment) => {
+        async (notification: NotificationAiReview) => {
             await updateNotification({
                 notificationId: notification.notificationId,
                 resourceType: notification.resourceType,
@@ -62,23 +58,19 @@ export const DashboardCommentsNotifications: FC<Props> = ({
             });
 
             track({
-                name: EventName.NOTIFICATIONS_COMMENTS_ITEM_CLICKED,
+                name: EventName.NOTIFICATIONS_ITEM_CLICKED,
                 properties: {
-                    hasMention: true, // TODO: At the moment, comments' notifications are always mentions
-                    dashboardUuid: notification.metadata?.dashboardUuid,
-                    dashboardTileUuid: notification.metadata?.dashboardTileUuid,
+                    resourceType: notification.resourceType,
+                    event: notification.metadata.event,
+                    projectUuid: notification.metadata.projectUuid,
+                    fingerprint: notification.metadata.fingerprint,
+                    count: notification.metadata.count,
                 },
             });
 
-            void navigate(
-                `/projects/${projectUuid}${notification.url}${
-                    notification.metadata?.dashboardTileUuid
-                        ? `?tileUuid=${notification.metadata?.dashboardTileUuid}`
-                        : ''
-                }`,
-            );
+            void navigate(notification.url ?? '/ai-agents/admin/reviews');
         },
-        [navigate, projectUuid, track, updateNotification],
+        [navigate, track, updateNotification],
     );
 
     return (
@@ -88,15 +80,24 @@ export const DashboardCommentsNotifications: FC<Props> = ({
                     p="xs"
                     key={notification.notificationId}
                     leftSection={
-                        <MantineIcon
-                            size={10}
-                            icon={IconCircleFilled}
+                        <Box
+                            display="flex"
                             style={{
-                                color: notification.viewed
-                                    ? 'transparent'
-                                    : theme.colors.blue[4],
+                                alignItems: 'center',
+                                gap: 6,
                             }}
-                        />
+                        >
+                            <MantineIcon
+                                size={8}
+                                icon={IconCircleFilled}
+                                style={{
+                                    color: notification.viewed
+                                        ? 'transparent'
+                                        : theme.colors.teal[5],
+                                }}
+                            />
+                            <AiAgentIcon size={16} calm />
+                        </Box>
                     }
                     onClick={() => handleOnNotificationClick(notification)}
                     fz="xs"

--- a/packages/frontend/src/features/notifications/hooks/useNotifications.tsx
+++ b/packages/frontend/src/features/notifications/hooks/useNotifications.tsx
@@ -9,18 +9,28 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-const getNotifications = async (type: ApiNotificationResourceType) =>
-    lightdashApi<ApiGetNotifications['results']>({
+type NotificationForResource<T extends ApiNotificationResourceType> = Extract<
+    Notification,
+    { resourceType: T }
+>;
+
+const getNotifications = async <T extends ApiNotificationResourceType>(
+    type: T,
+): Promise<NotificationForResource<T>[]> => {
+    const results = await lightdashApi<ApiGetNotifications['results']>({
         url: `/notifications?type=${type}`,
         method: 'GET',
         body: undefined,
     });
 
-export const useGetNotifications = (
-    type: ApiNotificationResourceType,
+    return results as NotificationForResource<T>[];
+};
+
+export const useGetNotifications = <T extends ApiNotificationResourceType>(
+    type: T,
     enabled: boolean,
 ) =>
-    useQuery<ApiGetNotifications['results'], ApiError>(
+    useQuery<NotificationForResource<T>[], ApiError>(
         ['notifications', type],
         () => getNotifications(type),
         {

--- a/packages/frontend/src/features/notifications/index.ts
+++ b/packages/frontend/src/features/notifications/index.ts
@@ -1,2 +1,3 @@
+export * from './components/AiReviewNotifications';
 export * from './components/DashboardCommentsNotifications';
 export { useGetNotifications } from './hooks/useNotifications';

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -170,7 +170,6 @@ export enum EventName {
     AI_AGENT_CHAT_MINIMIZED = 'ai_agent_chat.minimized',
     AI_AGENT_SUGGESTION_IMPRESSION = 'ai_agent.suggestion_impression',
     AI_AGENT_SUGGESTION_CLICK = 'ai_agent.suggestion_click',
-
     // Theme
     THEME_TOGGLED = 'theme.toggled',
 


### PR DESCRIPTION
## Summary

Adds AI review notifications across common types, backend delivery, Slack, and the in-app bell.

- adds shared AI-review notification settings/event/channel/status types and scheduler payloads
- adds DB entities/migration for review notification settings and delivery logs
- writes AI-review bell notifications and sends Slack channel/DM notifications from a Graphile worker
- fires notifications on review-item assignment and promoted review findings
- adds review notification settings GET/PUT endpoints and Slack click tracking
- renders AI-review notifications in the navbar bell alongside dashboard comments

## Validation

- `corepack pnpm -F common build`
- `corepack pnpm generate-api`
- `corepack pnpm -F backend test:dev:nowatch AiAgentAdminService AiAgentReviewClassifierService sendReviewNotification`
- `corepack pnpm -F backend typecheck:fast`
- pre-commit hooks: git-secrets, staged frontend/backend/common lint + formatter, frontend unused exports

## Notes

- Local migration run was blocked because `db-dev` did not resolve in this worktree.
- `corepack pnpm -F frontend typecheck:fast` is still blocked by unrelated existing jest-dom matcher typings in AI copilot tests (`toBeVisible`, `toHaveAttribute`).