### PR TITLE
feat(ai-agents): add issues board workflows

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -16,9 +16,12 @@ import {
     ApiSuccessEmpty,
     ApiUpdateAiOrganizationSettingsResponse,
     assertRegisteredAccount,
+    CreateAiAgentReviewItem,
+    CreateAiAgentReviewItemComment,
     KnexPaginateArgs,
     ReorderAiAgentReviewItems,
     UpdateAiAgentReviewItemAssignee,
+    UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
     UpdateAiReviewNotificationSettings,
@@ -189,6 +192,33 @@ export class AiAgentAdminController extends BaseController {
             results: await this.getAiAgentAdminService().listReviewItems(
                 toSessionUser(req.account),
                 status,
+            ),
+        };
+    }
+
+    /**
+     * Create a manual AI agent issue
+     * @summary Create AI agent review item
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/review-items')
+    @OperationId('createAiAgentReviewItem')
+    async createReviewItem(
+        @Request() req: express.Request,
+        @Body() body: CreateAiAgentReviewItem,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().createReviewItem(
+                toSessionUser(req.account),
+                body,
             ),
         };
     }
@@ -369,6 +399,62 @@ export class AiAgentAdminController extends BaseController {
                 toSessionUser(req.account),
                 fingerprint,
                 body.assignedToUserUuid,
+            );
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Set the priority on an AI agent review item
+     * @summary Update AI agent review item priority
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/review-items/{fingerprint}/priority')
+    @OperationId('updateAiAgentReviewItemPriority')
+    async updateReviewItemPriority(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+        @Body() body: UpdateAiAgentReviewItemPriority,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAiAgentAdminService().updateReviewItemPriority(
+                toSessionUser(req.account),
+                fingerprint,
+                body,
+            );
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Add a comment to an AI agent review item
+     * @summary Add AI agent review item comment
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/review-items/{fingerprint}/comments')
+    @OperationId('addAiAgentReviewItemComment')
+    async addReviewItemComment(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+        @Body() body: CreateAiAgentReviewItemComment,
+    ): Promise<ApiAiAgentReviewItemActivityResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAiAgentAdminService().addReviewItemComment(
+                toSessionUser(req.account),
+                fingerprint,
+                body.body,
             );
         return { status: 'ok', results };
     }

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -12,7 +12,9 @@ import type {
     AiAgentReviewClassifierRunStatus,
     AiAgentReviewItemDismissedReason,
     AiAgentReviewItemOwnerType,
+    AiAgentReviewItemPriority,
     AiAgentReviewItemPrState,
+    AiAgentReviewItemSource,
     AiAgentReviewItemStatus,
     AiAgentReviewItemWritebackStatus,
     AiAgentReviewRemediationEventDetail,
@@ -178,7 +180,8 @@ export const AiAgentReviewRemediationEventsTableName =
 
 export type DbAiAgentReviewRemediationEvent = {
     ai_agent_review_remediation_event_uuid: string;
-    ai_agent_review_remediation_uuid: string;
+    ai_agent_review_remediation_uuid: string | null;
+    fingerprint: string | null;
     organization_uuid: string;
     event_type: AiAgentReviewRemediationEventType;
     occurred_at: Date;
@@ -191,15 +194,15 @@ export type AiAgentReviewRemediationEventsTable = Knex.CompositeTableType<
     DbAiAgentReviewRemediationEvent,
     Pick<
         DbAiAgentReviewRemediationEvent,
-        | 'ai_agent_review_remediation_uuid'
-        | 'organization_uuid'
-        | 'event_type'
-        | 'occurred_at'
+        'organization_uuid' | 'event_type' | 'occurred_at'
     > &
         Partial<
             Pick<
                 DbAiAgentReviewRemediationEvent,
-                'payload' | 'created_by_user_uuid'
+                | 'ai_agent_review_remediation_uuid'
+                | 'fingerprint'
+                | 'payload'
+                | 'created_by_user_uuid'
             >
         >,
     never
@@ -208,9 +211,14 @@ export type AiAgentReviewRemediationEventsTable = Knex.CompositeTableType<
 export type DbAiAgentReviewItem = {
     ai_agent_review_item_uuid: string;
     fingerprint: string;
+    source: AiAgentReviewItemSource;
     organization_uuid: string;
     project_uuid: string | null;
     agent_uuid: string | null;
+    title: string | null;
+    description: string | null;
+    primary_root_cause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
     status: AiAgentReviewItemStatus;
     dismissed_reason: AiAgentReviewItemDismissedReason | null;
     assigned_to_user_uuid: string | null;
@@ -223,6 +231,7 @@ export type DbAiAgentReviewItem = {
     status_updated_at: Date | null;
     status_updated_by_user_uuid: string | null;
     board_position: number | null;
+    created_by_user_uuid: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -236,7 +245,6 @@ export type AiAgentReviewItemTable = Knex.CompositeTableType<
         Partial<
             Omit<
                 DbAiAgentReviewItem,
-                | 'ai_agent_review_item_uuid'
                 | 'created_at'
                 | 'updated_at'
                 | 'fingerprint'
@@ -257,9 +265,9 @@ export type DbAiAgentReviewRemediation = {
     ai_agent_review_remediation_uuid: string;
     fingerprint: string;
     organization_uuid: string;
-    source_ai_agent_review_turn_signal_uuid: string;
-    source_prompt_uuid: string;
-    source_thread_uuid: string;
+    source_ai_agent_review_turn_signal_uuid: string | null;
+    source_prompt_uuid: string | null;
+    source_thread_uuid: string | null;
     source_project_uuid: string;
     source_agent_uuid: string;
     work_thread_uuid: string | null;

--- a/packages/backend/src/ee/database/migrations/20260623120000_add_manual_ai_agent_review_items.ts
+++ b/packages/backend/src/ee/database/migrations/20260623120000_add_manual_ai_agent_review_items.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const reviewItemTable = 'ai_agent_review_item';
+const usersTable = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table
+            .text('source')
+            .notNullable()
+            .defaultTo('ai_finding')
+            .checkIn(['ai_finding', 'manual']);
+        table.text('title').nullable();
+        table.text('description').nullable();
+        table.text('primary_root_cause').nullable();
+        table
+            .text('priority')
+            .notNullable()
+            .defaultTo('none')
+            .checkIn(['urgent', 'high', 'medium', 'low', 'none']);
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table.dropColumn('created_by_user_uuid');
+        table.dropColumn('priority');
+        table.dropColumn('primary_root_cause');
+        table.dropColumn('description');
+        table.dropColumn('title');
+        table.dropColumn('source');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260623121000_generalize_ai_agent_review_activity.ts
+++ b/packages/backend/src/ee/database/migrations/20260623121000_generalize_ai_agent_review_activity.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+const eventsTable = 'ai_agent_review_remediation_events';
+const fingerprintIndex = 'ai_agent_review_events_fingerprint_occurred_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(eventsTable, (table) => {
+        table.text('fingerprint').nullable();
+    });
+
+    await knex.schema.alterTable(eventsTable, (table) => {
+        table.uuid('ai_agent_review_remediation_uuid').nullable().alter();
+        table.index(['fingerprint', 'occurred_at'], fingerprintIndex);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(eventsTable, (table) => {
+        table.dropIndex(['fingerprint', 'occurred_at'], fingerprintIndex);
+    });
+    await knex.schema.alterTable(eventsTable, (table) => {
+        table.uuid('ai_agent_review_remediation_uuid').notNullable().alter();
+        table.dropColumn('fingerprint');
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260623122000_allow_manual_ai_agent_review_remediation.ts
+++ b/packages/backend/src/ee/database/migrations/20260623122000_allow_manual_ai_agent_review_remediation.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+const remediationTable = 'ai_agent_review_remediation';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table
+            .uuid('source_ai_agent_review_turn_signal_uuid')
+            .nullable()
+            .alter();
+        table.uuid('source_prompt_uuid').nullable().alter();
+        table.uuid('source_thread_uuid').nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table
+            .uuid('source_ai_agent_review_turn_signal_uuid')
+            .notNullable()
+            .alter();
+        table.uuid('source_prompt_uuid').notNullable().alter();
+        table.uuid('source_thread_uuid').notNullable().alter();
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -16,6 +16,7 @@ import type {
     AiAgentReviewClassifierTurnCandidate,
     AiAgentReviewClassifierTurnSignal,
     AiAgentReviewItemDismissedReason,
+    AiAgentReviewItemPriority,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
@@ -31,6 +32,7 @@ import type {
     AiAgentTurnSignal,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
 import { ProjectTableName } from '../../database/entities/projects';
 import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import { QueryHistoryTableName } from '../../database/entities/queryHistory';
@@ -190,8 +192,8 @@ type ListReviewItemsArgs = {
 type UpsertReviewItemStateArgs = {
     fingerprint: string;
     organizationUuid: string;
-    projectUuid: string;
-    agentUuid: string;
+    projectUuid: string | null;
+    agentUuid: string | null;
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     statusUpdatedByUserUuid: string | null;
@@ -200,12 +202,24 @@ type UpsertReviewItemStateArgs = {
     boardPosition?: number | null;
 };
 
+type CreateManualReviewItemArgs = {
+    organizationUuid: string;
+    title: string;
+    description: string | null;
+    projectUuid: string;
+    agentUuid: string | null;
+    assignedToUserUuid: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
+    createdByUserUuid: string | null;
+};
+
 type CreateReviewRemediationArgs = {
     fingerprint: string;
     organizationUuid: string;
-    sourceFindingUuid: string;
-    sourcePromptUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourcePromptUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
     workThreadUuid: string | null;
@@ -1035,27 +1049,29 @@ export class AiAgentReviewClassifierModel {
             .limit(limit)) as ReviewItemAggregateRow[];
 
         const fingerprints = aggregateRows.map((row) => row.fingerprint);
-        if (fingerprints.length === 0) {
-            return [];
-        }
-
-        const latestRows = (await this.database<AiAgentTurnSignalTable>(
-            AiAgentTurnSignalTableName,
-        )
-            .distinctOn('fingerprint')
-            .select('*')
-            .where('organization_uuid', args.organizationUuid)
-            .whereIn('fingerprint', fingerprints)
-            .modify((query) => {
-                if (args.projectUuid) {
-                    void query.where('project_uuid', args.projectUuid);
-                }
-                if (args.agentUuid) {
-                    void query.where('agent_uuid', args.agentUuid);
-                }
-            })
-            .orderBy('fingerprint')
-            .orderBy('created_at', 'desc')) as DbAiAgentTurnSignal[];
+        const latestRows =
+            fingerprints.length === 0
+                ? []
+                : ((await this.database<AiAgentTurnSignalTable>(
+                      AiAgentTurnSignalTableName,
+                  )
+                      .distinctOn('fingerprint')
+                      .select('*')
+                      .where('organization_uuid', args.organizationUuid)
+                      .whereIn('fingerprint', fingerprints)
+                      .modify((query) => {
+                          if (args.projectUuid) {
+                              void query.where(
+                                  'project_uuid',
+                                  args.projectUuid,
+                              );
+                          }
+                          if (args.agentUuid) {
+                              void query.where('agent_uuid', args.agentUuid);
+                          }
+                      })
+                      .orderBy('fingerprint')
+                      .orderBy('created_at', 'desc')) as DbAiAgentTurnSignal[]);
 
         const latestByFingerprint = new Map(
             latestRows
@@ -1106,12 +1122,14 @@ export class AiAgentReviewClassifierModel {
                 return {
                     uuid: fingerprint,
                     fingerprint,
+                    source: item?.source ?? 'ai_finding',
                     organizationUuid: latest.organization_uuid,
                     projectUuid: latest.project_uuid,
                     agentUuid: latest.agent_uuid,
                     title: latest.review_item_title ?? 'Review AI agent issue',
                     description: latest.review_item_description ?? '',
                     primaryRootCause: latest.primary_root_cause ?? 'ambiguous',
+                    priority: item?.priority ?? 'none',
                     status: item?.status ?? 'triage',
                     dismissedReason: item?.dismissed_reason ?? null,
                     ownerType: latest.owner_type ?? 'unknown',
@@ -1132,6 +1150,7 @@ export class AiAgentReviewClassifierModel {
                         ? WRITEBACK_TIMED_OUT_MESSAGE
                         : (item?.pr_writeback_message ?? null),
                     boardPosition: item?.board_position ?? null,
+                    createdByUserUuid: item?.created_by_user_uuid ?? null,
                     writebackEligible: false,
                     writebackEligibility: defaultWritebackEligibility,
                     remediation,
@@ -1159,7 +1178,152 @@ export class AiAgentReviewClassifierModel {
                     reviewItem !== null,
             );
 
-        return reviewItems;
+        const aiFingerprints = new Set(
+            reviewItems.map((item) => item.fingerprint),
+        );
+        const manualRows = (await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .where('source', 'manual')
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.where('project_uuid', args.projectUuid);
+                }
+                if (args.agentUuid) {
+                    void query.where('agent_uuid', args.agentUuid);
+                }
+                if (args.fingerprint) {
+                    void query.where('fingerprint', args.fingerprint);
+                }
+                if (args.statuses) {
+                    void query.whereIn('status', args.statuses);
+                }
+            })
+            .select<ReviewItemRow[]>(
+                '*',
+                this.database.raw(
+                    '(extract(epoch from (now() - updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )) as ReviewItemRow[];
+
+        const manualFingerprints = manualRows
+            .map((row) => row.fingerprint)
+            .filter((fingerprint) => !aiFingerprints.has(fingerprint));
+        const manualRemediations =
+            await this.getLatestReviewRemediationsByFingerprint({
+                organizationUuid: args.organizationUuid,
+                fingerprints: manualFingerprints,
+            });
+        const manualItems = manualRows
+            .filter((row) => !aiFingerprints.has(row.fingerprint))
+            .map((row): AiAgentReviewItemSummary => {
+                const writebackStale = isStaleWritebackStatus(
+                    row.pr_writeback_status,
+                    row.updated_at_age_ms,
+                );
+                const remediation =
+                    manualRemediations.get(row.fingerprint) ?? null;
+                return {
+                    uuid: row.ai_agent_review_item_uuid,
+                    fingerprint: row.fingerprint,
+                    source: 'manual',
+                    organizationUuid: row.organization_uuid,
+                    projectUuid: row.project_uuid,
+                    agentUuid: row.agent_uuid,
+                    title: row.title ?? 'Untitled issue',
+                    description: row.description ?? '',
+                    primaryRootCause: row.primary_root_cause ?? 'ambiguous',
+                    priority: row.priority ?? 'none',
+                    status: row.status,
+                    dismissedReason: row.dismissed_reason,
+                    ownerType: 'unknown',
+                    assignedToUserUuid: row.assigned_to_user_uuid,
+                    firstSeenAt: row.created_at,
+                    lastSeenAt: row.updated_at,
+                    findingCount: 0,
+                    statusUpdatedAt: row.status_updated_at ?? row.updated_at,
+                    statusUpdatedByUserUuid: row.status_updated_by_user_uuid,
+                    linkedIssueUrl: row.linked_issue_url,
+                    linkedPrUrl: row.linked_pr_url,
+                    prState: row.pr_state,
+                    prWritebackStatus: writebackStale
+                        ? 'failed'
+                        : row.pr_writeback_status,
+                    prWritebackMessage: writebackStale
+                        ? WRITEBACK_TIMED_OUT_MESSAGE
+                        : row.pr_writeback_message,
+                    boardPosition: row.board_position,
+                    createdByUserUuid: row.created_by_user_uuid,
+                    writebackEligible: false,
+                    writebackEligibility: defaultWritebackEligibility,
+                    remediation,
+                    createdAt: row.created_at,
+                    updatedAt: row.updated_at,
+                    latestFinding: null,
+                };
+            });
+
+        return [...reviewItems, ...manualItems]
+            .sort((a, b) => {
+                if (a.boardPosition == null && b.boardPosition == null) {
+                    return (
+                        new Date(b.lastSeenAt).getTime() -
+                        new Date(a.lastSeenAt).getTime()
+                    );
+                }
+                if (a.boardPosition == null) return 1;
+                if (b.boardPosition == null) return -1;
+                return a.boardPosition - b.boardPosition;
+            })
+            .slice(0, limit);
+    }
+
+    async createManualReviewItem(
+        args: CreateManualReviewItemArgs,
+    ): Promise<AiAgentReviewItemSummary> {
+        const itemUuid = uuidv4();
+        const fingerprint = `manual:${itemUuid}`;
+        await this.database.transaction(async (trx) => {
+            await trx<AiAgentReviewItemTable>(
+                AiAgentReviewItemTableName,
+            ).insert({
+                ai_agent_review_item_uuid: itemUuid,
+                fingerprint,
+                source: 'manual',
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid: args.agentUuid,
+                title: args.title,
+                description: args.description,
+                primary_root_cause: args.primaryRootCause,
+                priority: args.priority,
+                status: 'open',
+                assigned_to_user_uuid: args.assignedToUserUuid,
+                created_by_user_uuid: args.createdByUserUuid,
+                status_updated_at: trx.fn.now() as never,
+                status_updated_by_user_uuid: args.createdByUserUuid,
+            });
+            await trx<AiAgentReviewRemediationEventsTable>(
+                AiAgentReviewRemediationEventsTableName,
+            ).insert({
+                fingerprint,
+                organization_uuid: args.organizationUuid,
+                event_type: 'created',
+                payload: {},
+                occurred_at: trx.fn.now() as never,
+                created_by_user_uuid: args.createdByUserUuid,
+            });
+        });
+
+        const item = await this.getReviewItem(
+            args.organizationUuid,
+            fingerprint,
+        );
+        if (!item) {
+            throw new Error('Failed to create manual review item');
+        }
+        return item;
     }
 
     async getReviewItemsByFingerprint(
@@ -1466,6 +1630,7 @@ export class AiAgentReviewClassifierModel {
             AiAgentReviewRemediationEventsTableName,
         ).insert({
             ai_agent_review_remediation_uuid: args.remediationUuid,
+            fingerprint: null,
             organization_uuid: args.organizationUuid,
             event_type: args.event.eventType,
             payload: args.event.payload,
@@ -1489,12 +1654,64 @@ export class AiAgentReviewClassifierModel {
         return rows.map(AiAgentReviewClassifierModel.mapRemediationEvent);
     }
 
+    async createIssueActivityEvent(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        event: AiAgentReviewRemediationEventDetail;
+        createdByUserUuid?: string | null;
+    }): Promise<void> {
+        await this.database<AiAgentReviewRemediationEventsTable>(
+            AiAgentReviewRemediationEventsTableName,
+        ).insert({
+            fingerprint: args.fingerprint,
+            organization_uuid: args.organizationUuid,
+            event_type: args.event.eventType,
+            payload: args.event.payload,
+            occurred_at: this.database.fn.now() as never,
+            created_by_user_uuid: args.createdByUserUuid ?? null,
+        });
+    }
+
+    async listIssueActivity(args: {
+        fingerprint: string;
+        organizationUuid: string;
+    }): Promise<AiAgentReviewRemediationEvent[]> {
+        const remediations = await this.database<AiAgentReviewRemediationTable>(
+            AiAgentReviewRemediationTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .where('fingerprint', args.fingerprint)
+            .select('ai_agent_review_remediation_uuid');
+        const remediationUuids = remediations.map(
+            (row) => row.ai_agent_review_remediation_uuid,
+        );
+
+        const rows = await this.database<AiAgentReviewRemediationEventsTable>(
+            AiAgentReviewRemediationEventsTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .where((query) => {
+                void query.where('fingerprint', args.fingerprint);
+                if (remediationUuids.length > 0) {
+                    void query.orWhereIn(
+                        'ai_agent_review_remediation_uuid',
+                        remediationUuids,
+                    );
+                }
+            })
+            .orderBy('occurred_at', 'asc')
+            .select('*');
+
+        return rows.map(AiAgentReviewClassifierModel.mapRemediationEvent);
+    }
+
     private static mapRemediationEvent(
         row: DbAiAgentReviewRemediationEvent,
     ): AiAgentReviewRemediationEvent {
         return {
             uuid: row.ai_agent_review_remediation_event_uuid,
             remediationUuid: row.ai_agent_review_remediation_uuid,
+            fingerprint: row.fingerprint,
             occurredAt: row.occurred_at,
             createdByUserUuid: row.created_by_user_uuid,
             eventType: row.event_type,
@@ -1623,6 +1840,32 @@ export class AiAgentReviewClassifierModel {
         return { projectUuid: row.project_uuid, agentUuid: row.agent_uuid };
     }
 
+    async getReviewItemScope(
+        organizationUuid: string,
+        fingerprint: string,
+    ): Promise<{
+        projectUuid: string | null;
+        agentUuid: string | null;
+    } | null> {
+        const promoted = await this.getPromotedFingerprintScope(
+            organizationUuid,
+            fingerprint,
+        );
+        if (promoted) {
+            return promoted;
+        }
+        const row = await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .where('fingerprint', fingerprint)
+            .first('project_uuid', 'agent_uuid');
+        if (!row) {
+            return null;
+        }
+        return { projectUuid: row.project_uuid, agentUuid: row.agent_uuid };
+    }
+
     async upsertReviewItemState(
         args: UpsertReviewItemStateArgs,
     ): Promise<void> {
@@ -1662,8 +1905,8 @@ export class AiAgentReviewClassifierModel {
         organizationUuid: string;
         items: {
             fingerprint: string;
-            projectUuid: string;
-            agentUuid: string;
+            projectUuid: string | null;
+            agentUuid: string | null;
         }[];
     }): Promise<void> {
         if (args.items.length === 0) return;
@@ -1699,6 +1942,20 @@ export class AiAgentReviewClassifierModel {
             .where('organization_uuid', args.organizationUuid)
             .update({
                 assigned_to_user_uuid: args.assignedToUserUuid,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
+    async setReviewItemPriority(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        priority: AiAgentReviewItemPriority;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                priority: args.priority,
                 updated_at: this.database.fn.now() as never,
             });
     }

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -41,12 +41,14 @@ const makeReviewItem = (
 ): AiAgentReviewItemSummary => ({
     uuid: 'fingerprint-1',
     fingerprint: 'fingerprint-1',
+    source: 'ai_finding',
     organizationUuid: 'org-1',
     projectUuid: 'project-1',
     agentUuid: 'agent-1',
     title: 'Missing metric',
     description: 'The agent could not answer because a metric was missing.',
     primaryRootCause: 'semantic_layer',
+    priority: 'none',
     status: 'open',
     dismissedReason: null,
     ownerType: 'semantic_layer_owner',
@@ -62,6 +64,7 @@ const makeReviewItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     boardPosition: null,
+    createdByUserUuid: null,
     createdAt: NOW,
     updatedAt: NOW,
     writebackEligible: false,
@@ -206,6 +209,10 @@ const makeService = ({
                 projectUuid: PROJECT_UUID,
                 agentUuid: AGENT_UUID,
             }),
+            getReviewItemScope: jest.fn().mockResolvedValue({
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+            }),
             updateReviewItemWritebackProgress: jest
                 .fn()
                 .mockResolvedValue(undefined),
@@ -217,7 +224,9 @@ const makeService = ({
                 .fn()
                 .mockResolvedValue(undefined),
             createRemediationEvent: jest.fn().mockResolvedValue(undefined),
+            createIssueActivityEvent: jest.fn().mockResolvedValue(undefined),
             listRemediationEvents: jest.fn().mockResolvedValue([]),
+            listIssueActivity: jest.fn().mockResolvedValue([]),
             getThreadWritebackPullRequests: jest
                 .fn()
                 .mockResolvedValue(
@@ -517,6 +526,53 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
         });
     });
 
+    it('allows manual project context writeback without a generated finding entry', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    source: 'manual',
+                    latestFinding: null,
+                    findingCount: 0,
+                    primaryRootCause: 'project_context',
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: true,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: false,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toEqual({
+            eligible: true,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'project_context',
+            reason: null,
+        });
+    });
+
+    it('blocks writeback when no agent is linked', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({ agentUuid: null }),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: null,
+            strategy: 'semantic_layer',
+            reason: 'missing_agent',
+        });
+    });
+
     it('blocks project context writeback for GitLab projects', () => {
         expect(
             getAiAgentReviewItemWritebackEligibility({
@@ -664,7 +720,7 @@ describe('AiAgentAdminService.updateReviewItemStatus', () => {
             remediation: makeRemediation({ status: 'pr_open' }),
         });
         const aiAgentReviewClassifierModel = {
-            getPromotedFingerprintScope: jest.fn().mockResolvedValue({
+            getReviewItemScope: jest.fn().mockResolvedValue({
                 projectUuid: PROJECT_UUID,
                 agentUuid: AGENT_UUID,
             }),
@@ -1009,7 +1065,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
                     remediation: makeRemediation({ status: 'running' }),
                 }),
             ),
-            listRemediationEvents: jest
+            listIssueActivity: jest
                 .fn()
                 .mockResolvedValue([makeEvent('finding_opened')]),
         };
@@ -1031,7 +1087,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
                     remediation: makeRemediation({ status: 'pr_open' }),
                 }),
             ),
-            listRemediationEvents: jest
+            listIssueActivity: jest
                 .fn()
                 .mockResolvedValue([
                     makeEvent('finding_opened'),
@@ -1056,7 +1112,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
                     remediation: makeRemediation({ status: 'preview_ready' }),
                 }),
             ),
-            listRemediationEvents: jest
+            listIssueActivity: jest
                 .fn()
                 .mockResolvedValue([
                     makeEvent('finding_opened'),
@@ -1081,7 +1137,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
                     remediation: makeRemediation({ status: 'resolved' }),
                 }),
             ),
-            listRemediationEvents: jest
+            listIssueActivity: jest
                 .fn()
                 .mockResolvedValue([
                     makeEvent('pr_opened'),
@@ -1105,7 +1161,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
             getReviewItem: jest
                 .fn()
                 .mockResolvedValue(makeReviewItem({ remediation: null })),
-            listRemediationEvents: jest.fn(),
+            listIssueActivity: jest.fn().mockResolvedValue([]),
         };
         const service = makeService({ aiAgentReviewClassifierModel });
 
@@ -1121,8 +1177,11 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
             verdictStale: false,
         });
         expect(
-            aiAgentReviewClassifierModel.listRemediationEvents,
-        ).not.toHaveBeenCalled();
+            aiAgentReviewClassifierModel.listIssueActivity,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            fingerprint: 'fingerprint-1',
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -17,6 +17,7 @@ import {
     AiReviewNotificationSettings,
     AlreadyExistsError,
     assertUnreachable,
+    CreateAiAgentReviewItem,
     DbtProjectType,
     extractPreviewProjectUuidFromUrl,
     extractPreviewUrlFromComments,
@@ -32,6 +33,7 @@ import {
     PullRequestProvider,
     PullRequestSource,
     RequestMethod,
+    UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiReviewNotificationSettings,
     type AiAgentReviewItemWritebackBlockedReason,
@@ -178,6 +180,9 @@ const getWritebackStrategy = (
         };
     }
     if (!item.latestFinding?.projectContextEntry) {
+        if (item.source === 'manual') {
+            return { strategy: 'project_context' };
+        }
         return {
             eligibility: unavailableWritebackEligibility(
                 'missing_project_context_entry',
@@ -247,6 +252,9 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
 
     if (!item.projectUuid) {
         return unavailableWritebackEligibility('missing_project', strategy);
+    }
+    if (!item.agentUuid) {
+        return unavailableWritebackEligibility('missing_agent', strategy);
     }
     if (!projectAccess || !projectAccess.provider) {
         return unavailableWritebackEligibility(
@@ -582,6 +590,63 @@ export class AiAgentAdminService extends BaseService {
         return filtered;
     }
 
+    async createReviewItem(
+        user: SessionUser,
+        body: CreateAiAgentReviewItem,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const title = body.title.trim();
+        if (title.length === 0) {
+            throw new ParameterError('Issue title is required');
+        }
+
+        const project = await this.projectModel.get(body.projectUuid);
+        if (project.organizationUuid !== organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
+
+        if (body.agentUuid) {
+            const agents = await this.aiAgentModel.findAllAgents({
+                organizationUuid,
+            });
+            if (!agents.some((agent) => agent.uuid === body.agentUuid)) {
+                throw new NotFoundError('Agent not found');
+            }
+        }
+
+        const item =
+            await this.aiAgentReviewClassifierModel.createManualReviewItem({
+                organizationUuid,
+                title,
+                description: body.description?.trim() || null,
+                projectUuid: body.projectUuid,
+                agentUuid: body.agentUuid,
+                assignedToUserUuid: body.assignedToUserUuid,
+                primaryRootCause: body.primaryRootCause,
+                priority: body.priority,
+                createdByUserUuid: user.userUuid,
+            });
+
+        this.analytics.track({
+            event: 'ai_agent_review_item.created',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                fingerprint: item.fingerprint,
+                projectId: item.projectUuid,
+                agentId: item.agentUuid,
+                priority: item.priority,
+            },
+        });
+
+        return item;
+    }
+
     private async areReviewsEnabled(user: SessionUser): Promise<boolean> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
@@ -727,6 +792,10 @@ export class AiAgentAdminService extends BaseService {
             case 'missing_project':
                 throw new ParameterError(
                     'Writeback requires a project-scoped review item',
+                );
+            case 'missing_agent':
+                throw new ParameterError(
+                    'Writeback requires an agent-scoped review item',
                 );
             case 'missing_project_context_entry':
                 throw new ParameterError(
@@ -901,7 +970,7 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
@@ -934,6 +1003,19 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
         if (previousReviewItem?.status !== update.status) {
+            await this.aiAgentReviewClassifierModel.createIssueActivityEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'status_changed',
+                    payload: {
+                        from: previousReviewItem?.status ?? null,
+                        to: update.status,
+                        dismissedReason: update.dismissedReason,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
             this.analytics.track({
                 event: 'ai_agent_review_item.status_changed',
                 userId: user.userUuid,
@@ -1001,7 +1083,7 @@ export class AiAgentAdminService extends BaseService {
         const resolved = await Promise.all(
             orderedFingerprints.map(async (fingerprint) => {
                 const scope =
-                    await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+                    await this.aiAgentReviewClassifierModel.getReviewItemScope(
                         organizationUuid,
                         fingerprint,
                     );
@@ -1033,11 +1115,34 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkReviewAccess(user, organizationUuid);
 
+        const previousReviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
         await this.aiAgentReviewClassifierModel.updateReviewItemAssignee({
             fingerprint,
             organizationUuid,
             assignedToUserUuid,
         });
+        if (
+            previousReviewItem &&
+            previousReviewItem.assignedToUserUuid !== assignedToUserUuid
+        ) {
+            await this.aiAgentReviewClassifierModel.createIssueActivityEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'assignee_changed',
+                    payload: {
+                        fromUserUuid:
+                            previousReviewItem?.assignedToUserUuid ?? null,
+                        toUserUuid: assignedToUserUuid,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
+        }
 
         const item = await this.getReviewItem(user, fingerprint);
 
@@ -1052,6 +1157,48 @@ export class AiAgentAdminService extends BaseService {
         }
 
         return item;
+    }
+
+    async updateReviewItemPriority(
+        user: SessionUser,
+        fingerprint: string,
+        update: UpdateAiAgentReviewItemPriority,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const previousReviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        await this.aiAgentReviewClassifierModel.setReviewItemPriority({
+            fingerprint,
+            organizationUuid,
+            priority: update.priority,
+        });
+        if (
+            previousReviewItem &&
+            previousReviewItem.priority !== update.priority
+        ) {
+            await this.aiAgentReviewClassifierModel.createIssueActivityEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'priority_changed',
+                    payload: {
+                        from: previousReviewItem?.priority ?? 'none',
+                        to: update.priority,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
+        }
+
+        return this.getReviewItem(user, fingerprint);
     }
 
     async createReviewItemWriteback(
@@ -1073,11 +1220,6 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
         const finding = reviewItem.latestFinding;
-        if (!finding) {
-            throw new ParameterError(
-                'Writeback requires a promoted review finding',
-            );
-        }
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.areReviewsEnabled(user),
             reviewItem.primaryRootCause === 'project_context'
@@ -1088,11 +1230,13 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
-        const writebackPrByThread =
-            await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
-                [finding.threadUuid],
-            );
+        const writebackPrByThread = finding
+            ? await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                  [finding.threadUuid],
+              )
+            : new Map();
         const sourceThreadHasWritebackPr =
+            finding !== null &&
             (writebackPrByThread.get(finding.threadUuid)?.length ?? 0) > 0;
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
             item: reviewItem,
@@ -1109,20 +1253,22 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
-        if (!scope) {
-            throw new NotFoundError('Review item not found');
+        if (!scope?.projectUuid || !scope.agentUuid) {
+            throw new NotFoundError('Review item scope not found');
         }
+        const { projectUuid } = scope;
+        const { agentUuid } = scope;
 
         // Plan the writeback up front: for semantic_layer we seed a real
         // Build-fix thread with the writeback prompt so the workspace can show
         // it the moment Create PR is clicked; project_context stays a
         // deterministic, threadless writeback.
         const explores = await this.projectModel.findExploresFromCache(
-            scope.projectUuid,
+            projectUuid,
             'name',
         );
         const plan = planReviewWriteback(
@@ -1141,11 +1287,21 @@ export class AiAgentAdminService extends BaseService {
             });
         }
 
-        const retryPrompt =
-            await this.aiAgentReviewClassifierModel.getPromptText({
-                organizationUuid,
-                promptUuid: finding.promptUuid,
-            });
+        let retryPrompt: string | null;
+        if (finding) {
+            retryPrompt = await this.aiAgentReviewClassifierModel.getPromptText(
+                {
+                    organizationUuid,
+                    promptUuid: finding.promptUuid,
+                },
+            );
+        } else if (plan.strategy === 'prompt') {
+            retryPrompt = plan.promptText;
+        } else {
+            retryPrompt = [reviewItem.title, reviewItem.description]
+                .filter(Boolean)
+                .join('\n\n');
+        }
 
         // Create the work thread before the remediation row so a failed
         // unique-index insert leaves only a harmless orphan thread, never a
@@ -1162,10 +1318,10 @@ export class AiAgentAdminService extends BaseService {
             await this.aiAgentModel.createWebAppThreadWithPrompt({
                 thread: {
                     organizationUuid,
-                    projectUuid: scope.projectUuid,
+                    projectUuid,
                     userUuid: user.userUuid,
                     createdFrom: 'web_app' as const,
-                    agentUuid: scope.agentUuid,
+                    agentUuid,
                 },
                 prompt: {
                     createdByUserUuid: user.userUuid,
@@ -1174,11 +1330,15 @@ export class AiAgentAdminService extends BaseService {
                     // structured agent context). The PR/preview pins are added
                     // once those exist — they post-date this seed.
                     context: [
-                        {
-                            type: 'thread',
-                            threadUuid: finding.threadUuid,
-                            promptUuid: finding.promptUuid,
-                        },
+                        ...(finding
+                            ? [
+                                  {
+                                      type: 'thread' as const,
+                                      threadUuid: finding.threadUuid,
+                                      promptUuid: finding.promptUuid,
+                                  },
+                              ]
+                            : []),
                         { type: 'review_finding', fingerprint },
                         { type: 'proposed_change', fingerprint },
                     ],
@@ -1186,7 +1346,7 @@ export class AiAgentAdminService extends BaseService {
             });
         await this.aiAgentModel.updateThreadTitle({
             threadUuid: workThreadUuid,
-            title: `Fix review: ${reviewItem.title}`,
+            title: `Fix issue: ${reviewItem.title}`,
         });
 
         // The one-active-per-fingerprint index can still reject the insert in
@@ -1199,11 +1359,11 @@ export class AiAgentAdminService extends BaseService {
                     {
                         fingerprint,
                         organizationUuid,
-                        sourceFindingUuid: finding.uuid,
-                        sourcePromptUuid: finding.promptUuid,
-                        sourceThreadUuid: finding.threadUuid,
-                        sourceProjectUuid: finding.projectUuid,
-                        sourceAgentUuid: finding.agentUuid,
+                        sourceFindingUuid: finding?.uuid ?? null,
+                        sourcePromptUuid: finding?.promptUuid ?? null,
+                        sourceThreadUuid: finding?.threadUuid ?? null,
+                        sourceProjectUuid: projectUuid,
+                        sourceAgentUuid: agentUuid,
                         workThreadUuid,
                         retryPrompt,
                         createdByUserUuid: user.userUuid,
@@ -1220,25 +1380,27 @@ export class AiAgentAdminService extends BaseService {
 
         // Anchor the feed at the finding itself, backdated to when it was
         // first seen — the remediation row is created much later.
-        await this.aiAgentReviewClassifierModel.createRemediationEvent({
-            remediationUuid: remediation.uuid,
-            organizationUuid,
-            event: {
-                eventType: 'finding_opened',
-                payload: {
-                    excerpt: retryPrompt,
-                    sourceThreadUuid: finding.threadUuid,
-                    sourcePromptUuid: finding.promptUuid,
+        if (finding) {
+            await this.aiAgentReviewClassifierModel.createRemediationEvent({
+                remediationUuid: remediation.uuid,
+                organizationUuid,
+                event: {
+                    eventType: 'finding_opened',
+                    payload: {
+                        excerpt: retryPrompt,
+                        sourceThreadUuid: finding.threadUuid,
+                        sourcePromptUuid: finding.promptUuid,
+                    },
                 },
-            },
-            occurredAt: reviewItem.firstSeenAt,
-        });
+                occurredAt: reviewItem.firstSeenAt,
+            });
+        }
 
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
             fingerprint,
             organizationUuid,
-            projectUuid: scope.projectUuid,
-            agentUuid: scope.agentUuid,
+            projectUuid,
+            agentUuid,
             status: 'queued',
             message: 'Queued',
         });
@@ -1246,7 +1408,7 @@ export class AiAgentAdminService extends BaseService {
         await this.schedulerClient.aiAgentReviewWriteback({
             fingerprint,
             organizationUuid,
-            projectUuid: scope.projectUuid,
+            projectUuid,
             userUuid: user.userUuid,
             remediationUuid: remediation.uuid,
         });
@@ -1256,7 +1418,7 @@ export class AiAgentAdminService extends BaseService {
             userId: user.userUuid,
             properties: {
                 organizationId: organizationUuid,
-                projectId: scope.projectUuid,
+                projectId: projectUuid,
                 fingerprint,
                 rootCause: reviewItem.primaryRootCause,
                 strategy: writebackEligibility.strategy,
@@ -1293,7 +1455,7 @@ export class AiAgentAdminService extends BaseService {
             );
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
@@ -1302,7 +1464,7 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 fingerprint,
             );
-        if (!scope || !reviewItem) {
+        if (!scope?.projectUuid || !scope.agentUuid || !reviewItem) {
             if (remediationUuid) {
                 await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                     {
@@ -1637,7 +1799,7 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 fingerprint,
             );
-        if (!reviewItem?.remediation) {
+        if (!reviewItem) {
             return {
                 events: [],
                 liveState: null,
@@ -1647,13 +1809,13 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const events =
-            await this.aiAgentReviewClassifierModel.listRemediationEvents({
-                remediationUuid: reviewItem.remediation.uuid,
+            await this.aiAgentReviewClassifierModel.listIssueActivity({
+                fingerprint,
                 organizationUuid,
             });
 
         const liveState = AiAgentAdminService.deriveRemediationLiveState(
-            reviewItem.remediation.status,
+            reviewItem.remediation?.status ?? 'failed',
             events,
         );
         return {
@@ -1665,6 +1827,44 @@ export class AiAgentAdminService extends BaseService {
                     : null,
             verdictStale: AiAgentAdminService.deriveVerdictStale(events),
         };
+    }
+
+    async addReviewItemComment(
+        user: SessionUser,
+        fingerprint: string,
+        body: string,
+    ): Promise<AiAgentReviewItemActivity> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const comment = body.trim();
+        if (comment.length === 0) {
+            throw new ParameterError('Comment body is required');
+        }
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!reviewItem) {
+            throw new NotFoundError('Review item not found');
+        }
+
+        await this.aiAgentReviewClassifierModel.createIssueActivityEvent({
+            fingerprint,
+            organizationUuid,
+            event: {
+                eventType: 'comment_added',
+                payload: { body: comment },
+            },
+            createdByUserUuid: user.userUuid,
+        });
+
+        return this.getReviewItemActivity(user, fingerprint);
     }
 
     /**
@@ -1921,11 +2121,18 @@ export class AiAgentAdminService extends BaseService {
                             remediation.linkedPrUrl,
                         ),
                         context: [
-                            {
-                                type: 'thread',
-                                threadUuid: remediation.sourceThreadUuid,
-                                promptUuid: remediation.sourcePromptUuid,
-                            },
+                            ...(remediation.sourceThreadUuid &&
+                            remediation.sourcePromptUuid
+                                ? [
+                                      {
+                                          type: 'thread' as const,
+                                          threadUuid:
+                                              remediation.sourceThreadUuid,
+                                          promptUuid:
+                                              remediation.sourcePromptUuid,
+                                      },
+                                  ]
+                                : []),
                         ],
                     },
                 }));

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -12,12 +12,14 @@ const baseItem = (
 ): AiAgentReviewItemSummary => ({
     uuid: 'fp',
     fingerprint: 'fp',
+    source: 'ai_finding',
     organizationUuid: 'org',
     projectUuid: 'project',
     agentUuid: 'agent',
     title: 'Agent picked the wrong revenue metric',
     description: 'It used order count instead of revenue.',
     primaryRootCause: 'semantic_layer',
+    priority: 'none',
     status: 'open',
     dismissedReason: null,
     ownerType: 'semantic_layer_owner',
@@ -33,6 +35,7 @@ const baseItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     boardPosition: null,
+    createdByUserUuid: null,
     writebackEligible: true,
     writebackEligibility: {
         eligible: true,
@@ -119,6 +122,26 @@ describe('planReviewWriteback', () => {
         expect(plan.promptText).not.toContain('(yaml:');
     });
 
+    it('builds a prompt from a manual semantic-layer issue', () => {
+        const plan = expectPromptPlan(
+            planReviewWriteback(
+                baseItem({
+                    source: 'manual',
+                    latestFinding: null,
+                    findingCount: 0,
+                    title: 'Add a revenue metric on orders',
+                    description: 'Finance needs a governed revenue metric.',
+                }),
+            ),
+        );
+
+        expect(plan.promptText).toContain('Add a revenue metric on orders');
+        expect(plan.promptText).toContain(
+            'Finance needs a governed revenue metric.',
+        );
+        expect(plan.promptText).toContain('No source conversation is attached');
+    });
+
     it('returns a project_context plan when the finding carries an entry', () => {
         const item = baseItem({ primaryRootCause: 'project_context' });
         const entry = {
@@ -135,6 +158,31 @@ describe('planReviewWriteback', () => {
 
         const plan = planReviewWriteback(item);
         expect(plan).toEqual({ strategy: 'project_context', entry });
+    });
+
+    it('builds a project_context entry from a manual issue', () => {
+        const plan = planReviewWriteback(
+            baseItem({
+                source: 'manual',
+                latestFinding: null,
+                findingCount: 0,
+                primaryRootCause: 'project_context',
+                title: 'Document ARR',
+                description: 'ARR should exclude one-off services.',
+            }),
+        );
+
+        expect(plan).toEqual({
+            strategy: 'project_context',
+            entry: {
+                op: 'create',
+                id: null,
+                kind: 'definition',
+                content: 'Document ARR\n\nARR should exclude one-off services.',
+                terms: [],
+                objects: [],
+            },
+        });
     });
 
     it('throws for a project_context item with no entry', () => {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -87,6 +87,21 @@ const buildSemanticLayerWritebackPrompt = (
     ymlPathByModel: Map<string, string>,
 ): ReviewWritebackPlan => {
     const finding = item.latestFinding;
+    if (item.source === 'manual') {
+        const sections = [
+            'You are improving the dbt/Lightdash semantic layer YAML to resolve a manually filed data issue. Make the smallest change that resolves it.',
+            `Issue: ${item.title}`,
+            item.description ? `Description: ${item.description}` : null,
+            'No source conversation is attached. Use the issue title and description as the source of truth, inspect the dbt project, and open a pull request if a semantic-layer change can resolve the ask.',
+            'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required.',
+        ].filter((section): section is string => section !== null);
+
+        return {
+            strategy: 'prompt',
+            promptText: sections.join('\n\n'),
+            aggregationKey: null,
+        };
+    }
     const targetLines = (finding?.targetRefs ?? [])
         .filter(isSemanticTargetRef)
         .map((ref) => `- ${formatSemanticTargetRef(ref, ymlPathByModel)}`);
@@ -134,12 +149,29 @@ export const planReviewWriteback = (
     }
     if (item.primaryRootCause === 'project_context') {
         const entry = item.latestFinding?.projectContextEntry ?? null;
+        if (entry) {
+            return { strategy: 'project_context', entry };
+        }
+        if (item.source === 'manual') {
+            return {
+                strategy: 'project_context',
+                entry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'definition',
+                    content: [item.title, item.description]
+                        .filter(Boolean)
+                        .join('\n\n'),
+                    terms: [],
+                    objects: [],
+                },
+            };
+        }
         if (!entry) {
             throw new Error(
                 'Writeback for project_context requires a projectContextEntry on the finding',
             );
         }
-        return { strategy: 'project_context', entry };
     }
     throw new Error(
         `Writeback is not supported for root cause "${item.primaryRootCause}"`,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -21769,6 +21769,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['ai_finding'] },
+                { dataType: 'enum', enums: ['manual'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemPriority: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['urgent'] },
+                { dataType: 'enum', enums: ['high'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['low'] },
+                { dataType: 'enum', enums: ['none'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewItemStatus: {
         dataType: 'refAlias',
         type: {
@@ -21836,6 +21863,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 boardPosition: {
                     dataType: 'union',
                     subSchemas: [
@@ -21917,6 +21952,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { ref: 'AiAgentReviewItemStatus', required: true },
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
                 primaryRootCause: { ref: 'AiAgentRootCause', required: true },
                 description: { dataType: 'string', required: true },
                 title: { dataType: 'string', required: true },
@@ -21937,6 +21973,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 organizationUuid: { dataType: 'string', required: true },
+                source: { ref: 'AiAgentReviewItemSource', required: true },
                 fingerprint: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
             },
@@ -21964,6 +22001,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['reviews_disabled'] },
                 { dataType: 'enum', enums: ['unsupported_root_cause'] },
                 { dataType: 'enum', enums: ['missing_project'] },
+                { dataType: 'enum', enums: ['missing_agent'] },
                 { dataType: 'enum', enums: ['missing_project_context_entry'] },
                 { dataType: 'enum', enums: ['project_context_disabled'] },
                 { dataType: 'enum', enums: ['unsupported_source_control'] },
@@ -22142,9 +22180,30 @@ const models: TsoaRoute.Models = {
                 },
                 sourceAgentUuid: { dataType: 'string', required: true },
                 sourceProjectUuid: { dataType: 'string', required: true },
-                sourceThreadUuid: { dataType: 'string', required: true },
-                sourcePromptUuid: { dataType: 'string', required: true },
-                sourceFindingUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourcePromptUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceFindingUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 organizationUuid: { dataType: 'string', required: true },
                 fingerprint: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
@@ -22339,6 +22398,51 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiAgentReviewItemSummary_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAiAgentReviewItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
+                primaryRootCause: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentRootCause' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                assignedToUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                agentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewRemediationEventDetail: {
         dataType: 'refAlias',
         type: {
@@ -22348,14 +22452,147 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         payload: {
+                            ref: 'Record_string.never_',
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['created'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                dismissedReason: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            ref: 'AiAgentReviewItemDismissedReason',
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                to: {
+                                    ref: 'AiAgentReviewItemStatus',
+                                    required: true,
+                                },
+                                from: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentReviewItemStatus' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['status_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                toUserUuid: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                fromUserUuid: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['assignee_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                to: {
+                                    ref: 'AiAgentReviewItemPriority',
+                                    required: true,
+                                },
+                                from: {
+                                    ref: 'AiAgentReviewItemPriority',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['priority_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                body: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['comment_added'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
                                 sourcePromptUuid: {
-                                    dataType: 'string',
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
                                     required: true,
                                 },
                                 sourceThreadUuid: {
-                                    dataType: 'string',
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
                                     required: true,
                                 },
                                 excerpt: {
@@ -22596,7 +22833,22 @@ const models: TsoaRoute.Models = {
                             required: true,
                         },
                         occurredAt: { dataType: 'datetime', required: true },
-                        remediationUuid: { dataType: 'string', required: true },
+                        fingerprint: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        remediationUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         uuid: { dataType: 'string', required: true },
                     },
                 },
@@ -22781,6 +23033,26 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateAiAgentReviewItemPriority: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAiAgentReviewItemComment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { body: { dataType: 'string', required: true } },
             validators: {},
         },
     },
@@ -28483,8 +28755,22 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 sourceAgentUuid: { dataType: 'string', required: true },
                 sourceProjectUuid: { dataType: 'string', required: true },
-                sourceThreadUuid: { dataType: 'string', required: true },
-                sourceFindingUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceFindingUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 primaryRootCause: { ref: 'AiAgentRootCause', required: true },
                 reviewStatus: {
                     ref: 'AiAgentReviewItemStatus',
@@ -30564,7 +30850,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30574,7 +30860,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30584,7 +30870,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30597,7 +30883,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -31252,7 +31538,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31262,7 +31548,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31272,7 +31558,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31285,7 +31571,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -54842,6 +55128,67 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_createReviewItem: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAiAgentReviewItem',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-items',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.createReviewItem,
+        ),
+
+        async function AiAgentAdminController_createReviewItem(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_createReviewItem,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createReviewItem',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentAdminController_getReviewItem: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -55269,6 +55616,140 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateReviewItemAssignee',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_updateReviewItemPriority: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateAiAgentReviewItemPriority',
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/priority',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.updateReviewItemPriority,
+        ),
+
+        async function AiAgentAdminController_updateReviewItemPriority(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_updateReviewItemPriority,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateReviewItemPriority',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_addReviewItemComment: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAiAgentReviewItemComment',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/comments',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.addReviewItemComment,
+        ),
+
+        async function AiAgentAdminController_addReviewItemComment(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_addReviewItemComment,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'addReviewItemComment',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -22240,6 +22240,14 @@
             "ApiAiAgentAdminPromptActivityResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentAdminPromptActivityPoint-Array_"
             },
+            "AiAgentReviewItemSource": {
+                "type": "string",
+                "enum": ["ai_finding", "manual"]
+            },
+            "AiAgentReviewItemPriority": {
+                "type": "string",
+                "enum": ["urgent", "high", "medium", "low", "none"]
+            },
             "AiAgentReviewItemStatus": {
                 "type": "string",
                 "enum": [
@@ -22284,6 +22292,10 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
                     },
                     "boardPosition": {
                         "type": "number",
@@ -22356,6 +22368,9 @@
                     "status": {
                         "$ref": "#/components/schemas/AiAgentReviewItemStatus"
                     },
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    },
                     "primaryRootCause": {
                         "$ref": "#/components/schemas/AiAgentRootCause"
                     },
@@ -22376,6 +22391,9 @@
                     "organizationUuid": {
                         "type": "string"
                     },
+                    "source": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemSource"
+                    },
                     "fingerprint": {
                         "type": "string"
                     },
@@ -22386,6 +22404,7 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "createdByUserUuid",
                     "boardPosition",
                     "prWritebackMessage",
                     "prWritebackStatus",
@@ -22401,12 +22420,14 @@
                     "ownerType",
                     "dismissedReason",
                     "status",
+                    "priority",
                     "primaryRootCause",
                     "description",
                     "title",
                     "agentUuid",
                     "projectUuid",
                     "organizationUuid",
+                    "source",
                     "fingerprint",
                     "uuid"
                 ],
@@ -22422,6 +22443,7 @@
                     "reviews_disabled",
                     "unsupported_root_cause",
                     "missing_project",
+                    "missing_agent",
                     "missing_project_context_entry",
                     "project_context_disabled",
                     "unsupported_source_control",
@@ -22564,13 +22586,16 @@
                         "type": "string"
                     },
                     "sourceThreadUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourcePromptUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourceFindingUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "organizationUuid": {
                         "type": "string"
@@ -22771,17 +22796,180 @@
             "ApiAiAgentReviewItemResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemSummary_"
             },
+            "CreateAiAgentReviewItem": {
+                "properties": {
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    },
+                    "primaryRootCause": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentRootCause"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "assignedToUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "agentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "priority",
+                    "primaryRootCause",
+                    "assignedToUserUuid",
+                    "agentUuid",
+                    "projectUuid",
+                    "description",
+                    "title"
+                ],
+                "type": "object"
+            },
             "AiAgentReviewRemediationEventDetail": {
                 "anyOf": [
                     {
                         "properties": {
                             "payload": {
+                                "$ref": "#/components/schemas/Record_string.never_"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["created"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "dismissedReason": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentReviewItemDismissedReason"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "to": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                                    },
+                                    "from": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["dismissedReason", "to", "from"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["status_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "toUserUuid": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "fromUserUuid": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["toUserUuid", "fromUserUuid"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["assignee_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "to": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                                    },
+                                    "from": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                                    }
+                                },
+                                "required": ["to", "from"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["priority_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "body": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["body"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["comment_added"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
                                 "properties": {
                                     "sourcePromptUuid": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "nullable": true
                                     },
                                     "sourceThreadUuid": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "nullable": true
                                     },
                                     "excerpt": {
                                         "type": "string",
@@ -23012,8 +23200,13 @@
                                 "type": "string",
                                 "format": "date-time"
                             },
+                            "fingerprint": {
+                                "type": "string",
+                                "nullable": true
+                            },
                             "remediationUuid": {
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "uuid": {
                                 "type": "string"
@@ -23022,6 +23215,7 @@
                         "required": [
                             "createdByUserUuid",
                             "occurredAt",
+                            "fingerprint",
                             "remediationUuid",
                             "uuid"
                         ],
@@ -23212,6 +23406,24 @@
                     }
                 },
                 "required": ["assignedToUserUuid"],
+                "type": "object"
+            },
+            "UpdateAiAgentReviewItemPriority": {
+                "properties": {
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    }
+                },
+                "required": ["priority"],
+                "type": "object"
+            },
+            "CreateAiAgentReviewItemComment": {
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "required": ["body"],
                 "type": "object"
             },
             "AiAgentReviewItemWritebackPreview": {
@@ -29043,10 +29255,12 @@
                         "type": "string"
                     },
                     "sourceThreadUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourceFindingUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "primaryRootCause": {
                         "$ref": "#/components/schemas/AiAgentRootCause"
@@ -31284,22 +31498,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31859,22 +32073,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -48103,6 +48317,45 @@
                         }
                     }
                 ]
+            },
+            "post": {
+                "operationId": "createAiAgentReviewItem",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a manual AI agent issue",
+                "summary": "Create AI agent review item",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAiAgentReviewItem"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}": {
@@ -48398,6 +48651,106 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdateAiAgentReviewItemAssignee"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/priority": {
+            "patch": {
+                "operationId": "updateAiAgentReviewItemPriority",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Set the priority on an AI agent review item",
+                "summary": "Update AI agent review item priority",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAiAgentReviewItemPriority"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/comments": {
+            "post": {
+                "operationId": "addAiAgentReviewItemComment",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add a comment to an AI agent review item",
+                "summary": "Add AI agent review item comment",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAiAgentReviewItemComment"
                             }
                         }
                     }

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -46,8 +46,8 @@ type AiThreadInfo = { aiThreadUuid: string; aiAgentUuid: string | null };
 type ReviewSourceInfo = {
     reviewItemTitle: string | null;
     primaryRootCause: AiAgentRootCause | null;
-    sourceFindingUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
 };
@@ -217,18 +217,21 @@ export class PullRequestsModel {
                 'remediation.source_ai_agent_review_turn_signal_uuid',
             )
             .whereIn('remediation.pull_request_uuid', pullRequestUuids)
-            .select<DirectReviewContextRow[]>({
-                pullRequestUuid: 'remediation.pull_request_uuid',
-                fingerprint: 'remediation.fingerprint',
-                reviewStatus: 'review_item.status',
-                reviewItemTitle: 'source_finding.review_item_title',
-                primaryRootCause: 'source_finding.primary_root_cause',
-                sourceFindingUuid:
-                    'remediation.source_ai_agent_review_turn_signal_uuid',
-                sourceThreadUuid: 'remediation.source_thread_uuid',
-                sourceProjectUuid: 'remediation.source_project_uuid',
-                sourceAgentUuid: 'remediation.source_agent_uuid',
-            })
+            .select<DirectReviewContextRow[]>(
+                'remediation.pull_request_uuid as pullRequestUuid',
+                'remediation.fingerprint as fingerprint',
+                'review_item.status as reviewStatus',
+                this.database.raw(
+                    'coalesce(source_finding.review_item_title, review_item.title) as "reviewItemTitle"',
+                ),
+                this.database.raw(
+                    'coalesce(source_finding.primary_root_cause, review_item.primary_root_cause) as "primaryRootCause"',
+                ),
+                'remediation.source_ai_agent_review_turn_signal_uuid as sourceFindingUuid',
+                'remediation.source_thread_uuid as sourceThreadUuid',
+                'remediation.source_project_uuid as sourceProjectUuid',
+                'remediation.source_agent_uuid as sourceAgentUuid',
+            )
             .orderBy('remediation.updated_at', 'desc');
 
         rows.forEach((row) => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -329,6 +329,7 @@ export type AiAgentReviewItemWritebackBlockedReason =
     | 'reviews_disabled'
     | 'unsupported_root_cause'
     | 'missing_project'
+    | 'missing_agent'
     | 'missing_project_context_entry'
     | 'project_context_disabled'
     | 'unsupported_source_control'
@@ -365,9 +366,9 @@ export type AiAgentReviewRemediation = {
     uuid: string;
     fingerprint: string;
     organizationUuid: string;
-    sourceFindingUuid: string;
-    sourcePromptUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourcePromptUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
     workThreadUuid: string | null;
@@ -592,12 +593,14 @@ export type AiAgentReviewClassifierJudgeOutput = z.infer<
 export type AiAgentReviewItem = {
     uuid: string;
     fingerprint: string;
+    source: AiAgentReviewItemSource;
     organizationUuid: string;
     projectUuid: string | null;
     agentUuid: string | null;
     title: string;
     description: string;
     primaryRootCause: AiAgentRootCause;
+    priority: AiAgentReviewItemPriority;
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     ownerType: AiAgentReviewItemOwnerType;
@@ -614,9 +617,19 @@ export type AiAgentReviewItem = {
     prWritebackMessage: string | null;
     // Manual board sort key; null = default (last-seen) order.
     boardPosition: number | null;
+    createdByUserUuid: string | null;
     createdAt: Date;
     updatedAt: Date;
 };
+
+export type AiAgentReviewItemSource = 'ai_finding' | 'manual';
+
+export type AiAgentReviewItemPriority =
+    | 'urgent'
+    | 'high'
+    | 'medium'
+    | 'low'
+    | 'none';
 
 export type AiAgentReviewItemSummary = AiAgentReviewItem & {
     /**
@@ -656,6 +669,24 @@ export type UpdateAiAgentReviewItemStatus = {
 
 export type UpdateAiAgentReviewItemAssignee = {
     assignedToUserUuid: string | null;
+};
+
+export type CreateAiAgentReviewItem = {
+    title: string;
+    description: string | null;
+    projectUuid: string;
+    agentUuid: string | null;
+    assignedToUserUuid: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
+};
+
+export type UpdateAiAgentReviewItemPriority = {
+    priority: AiAgentReviewItemPriority;
+};
+
+export type CreateAiAgentReviewItemComment = {
+    body: string;
 };
 
 // Persists the board's manual card order: the fingerprints of one lane in their
@@ -706,12 +737,36 @@ export type ApiAiAgentReviewItemPrDiffResponse =
     ApiSuccess<AiAgentReviewItemPrDiff>;
 
 export type AiAgentReviewRemediationEventDetail =
+    | { eventType: 'created'; payload: Record<string, never> }
+    | {
+          eventType: 'status_changed';
+          payload: {
+              from: AiAgentReviewItemStatus | null;
+              to: AiAgentReviewItemStatus;
+              dismissedReason: AiAgentReviewItemDismissedReason | null;
+          };
+      }
+    | {
+          eventType: 'assignee_changed';
+          payload: {
+              fromUserUuid: string | null;
+              toUserUuid: string | null;
+          };
+      }
+    | {
+          eventType: 'priority_changed';
+          payload: {
+              from: AiAgentReviewItemPriority;
+              to: AiAgentReviewItemPriority;
+          };
+      }
+    | { eventType: 'comment_added'; payload: { body: string } }
     | {
           eventType: 'finding_opened';
           payload: {
               excerpt: string | null;
-              sourceThreadUuid: string;
-              sourcePromptUuid: string;
+              sourceThreadUuid: string | null;
+              sourcePromptUuid: string | null;
           };
       }
     | {
@@ -745,7 +800,8 @@ export type AiAgentReviewRemediationEventType =
 
 export type AiAgentReviewRemediationEvent = {
     uuid: string;
-    remediationUuid: string;
+    remediationUuid: string | null;
+    fingerprint: string | null;
     occurredAt: Date;
     createdByUserUuid: string | null;
 } & AiAgentReviewRemediationEventDetail;

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -20,8 +20,8 @@ export type PullRequestReviewContext = {
     reviewTitle: string;
     reviewStatus: AiAgentReviewItemStatus;
     primaryRootCause: AiAgentRootCause;
-    sourceFindingUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
 };

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -77,7 +77,7 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         );
     }
 
-    const reviewsUrl = `/generalSettings/ai/reviews?projects=${encodeURIComponent(
+    const reviewsUrl = `/generalSettings/ai/issues?projects=${encodeURIComponent(
         projectUuid,
     )}`;
 

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -167,7 +167,11 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     },
     {
         path: '/ai-agents/admin/reviews',
-        element: <Navigate to="/generalSettings/ai/reviews" replace />,
+        element: <Navigate to="/generalSettings/ai/issues" replace />,
+    },
+    {
+        path: '/ai-agents/admin/issues',
+        element: <Navigate to="/generalSettings/ai/issues" replace />,
     },
     {
         path: '/ai-agents/',

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -98,8 +98,8 @@ const AiSearchBoxInner: FC<Props> = ({
     ).length;
     const reviewsPromoLabel =
         prReadyCount > 0
-            ? 'Review findings, ship PRs, improve agents'
-            : 'Review AI findings to improve future answers';
+            ? 'Review issues, ship PRs, improve agents'
+            : 'Review AI issues to improve future answers';
 
     const noAgentsAvailable =
         !isLoadingAgents && (!agents || agents.length === 0);
@@ -347,7 +347,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                             />
                                         }
                                         component={Link}
-                                        to={`/generalSettings/ai/reviews?projects=${projectUuid}`}
+                                        to={`/generalSettings/ai/issues?projects=${projectUuid}`}
                                         className={styles.reviewsPromoButton}
                                     >
                                         <Group gap="xs" wrap="nowrap">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -134,7 +134,7 @@ const getSignalResultLabel = (signal: AiAgentReviewSignalSummary): string => {
 const getSignalWhyText = (signal: AiAgentReviewSignalSummary): string =>
     signal.promotionReason ??
     signal.finding?.recommendation?.rationale ??
-    'The judge reviewed this turn but did not promote it into a review item.';
+    'The judge reviewed this turn but did not promote it into an issue.';
 
 const getSignalActionText = (signal: AiAgentReviewSignalSummary): string => {
     if (signal.finding?.recommendation) {
@@ -680,7 +680,7 @@ const AiAgentAdminReviewItemsTable = ({
     }: {
         visibleCount: number;
         totalCount: number;
-        noun: 'finding' | 'turn';
+        noun: 'issue' | 'turn';
         isLoading: boolean;
         surface: ReviewSurface;
         selectedCount?: number;
@@ -696,7 +696,7 @@ const AiAgentAdminReviewItemsTable = ({
               ? `${visibleCount} of ${totalCount} ${pluralised}`
               : `${visibleCount} ${pluralised}`;
         const helperCopy =
-            'Findings are issues worth attention. Click a row to inspect details and thread context.';
+            'Issues are items worth attention. Click a row to inspect details and thread context.';
 
         return (
             <Box>
@@ -705,7 +705,7 @@ const AiAgentAdminReviewItemsTable = ({
                         <SearchFilter
                             search={search}
                             setSearch={setSearch}
-                            placeholder="Search findings"
+                            placeholder="Search issues"
                         />
 
                         <Group
@@ -714,7 +714,7 @@ const AiAgentAdminReviewItemsTable = ({
                             className={styles.toolbarHeading}
                         >
                             <Text fz="sm" fw={700} c="ldGray.9">
-                                Findings
+                                Issues
                             </Text>
                             <ReviewConceptHelp />
                         </Group>
@@ -784,7 +784,7 @@ const AiAgentAdminReviewItemsTable = ({
                                         }
                                         onClick={onDismissSelected}
                                     >
-                                        Dismiss findings
+                                        Dismiss issues
                                     </Button>
                                     {onClearSelection && (
                                         <Button
@@ -1243,7 +1243,7 @@ const AiAgentAdminReviewItemsTable = ({
             return renderReviewsToolbar({
                 visibleCount: filteredReviewItems.length,
                 totalCount: searchFilteredReviewItems.length,
-                noun: 'finding',
+                noun: 'issue',
                 isLoading,
                 surface: 'findings',
                 selectedCount: selectedRows.length,
@@ -1254,9 +1254,9 @@ const AiAgentAdminReviewItemsTable = ({
             });
         },
         emptyState: {
-            entityName: 'findings',
+            entityName: 'issues',
             emptyMessage:
-                'Nothing to review yet. When an agent answer looks wrong, it shows up here.',
+                'No issues yet. When an agent answer looks wrong, it shows up here.',
             search,
             hasActiveFilters,
             onClearFilters: clearAllFilters,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 /**
- * Resolves a review item from the workspace: optionally merge the open PR, then
+ * Resolves an issue from the workspace: optionally merge the open PR, then
  * mark the item resolved (which also closes its remediation server-side).
  */
 export const MarkResolvedModal: FC<Props> = ({
@@ -50,13 +50,13 @@ export const MarkResolvedModal: FC<Props> = ({
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Resolve review item"
+            title="Resolve issue"
             icon={IconCircleCheck}
             size="md"
         >
             <Stack gap="md">
                 <Text size="sm" c="dimmed">
-                    Resolving marks this review item as done and closes its
+                    Resolving marks this issue as done and closes its
                     remediation.
                     {prUrl
                         ? ' Merge the pull request first, or resolve without merging.'

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -50,12 +50,38 @@ const eventRow = (
 ): Pick<TimelineRow, 'label' | 'meta'> => {
     const remediation = reviewItem.remediation;
     switch (event.eventType) {
+        case 'created':
+            return { label: 'Issue created', meta: null };
+        case 'status_changed':
+            return {
+                label: 'Status changed',
+                meta: `${event.payload.from ?? 'none'} → ${event.payload.to}`,
+            };
+        case 'assignee_changed':
+            return {
+                label: 'Assignee changed',
+                meta: `${event.payload.fromUserUuid ?? 'Unassigned'} → ${
+                    event.payload.toUserUuid ?? 'Unassigned'
+                }`,
+            };
+        case 'priority_changed':
+            return {
+                label: 'Priority changed',
+                meta: `${event.payload.from} → ${event.payload.to}`,
+            };
+        case 'comment_added':
+            return {
+                label: 'Comment added',
+                meta: truncate(event.payload.body, 160),
+            };
         case 'finding_opened': {
-            const threadPath = buildThreadPath(
-                reviewItem.projectUuid,
-                reviewItem.agentUuid,
-                event.payload.sourceThreadUuid,
-            );
+            const threadPath = event.payload.sourceThreadUuid
+                ? buildThreadPath(
+                      reviewItem.projectUuid,
+                      reviewItem.agentUuid,
+                      event.payload.sourceThreadUuid,
+                  )
+                : null;
             return {
                 label: 'Finding opened',
                 meta: (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -41,7 +41,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     const navigate = useNavigate();
     const [previewOpen, setPreviewOpen] = useState(false);
 
-    const workspaceUrl = `/generalSettings/ai/reviews/${encodeURIComponent(
+    const workspaceUrl = `/generalSettings/ai/issues/${encodeURIComponent(
         reviewItem.fingerprint,
     )}`;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -37,6 +37,7 @@ import {
 } from './reviewItemDetails';
 import styles from './ReviewKanbanBoard.module.css';
 import { getStartWritebackKind, isWritebackRetry } from './reviewLane';
+import { ReviewPriorityMenu } from './ReviewPriorityMenu';
 
 type Props = {
     item: AiAgentReviewItemSummary;
@@ -87,7 +88,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
 
     const remediation = item.remediation;
     const hasWorkspace = Boolean(remediation);
-    const workspaceHref = `/generalSettings/ai/reviews/${encodeURIComponent(
+    const workspaceHref = `/generalSettings/ai/issues/${encodeURIComponent(
         item.fingerprint,
     )}`;
     const activityLabel = getWorkspaceActivityLabel(item);
@@ -195,6 +196,10 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                 label={
                                     reviewRootCauseLabels[item.primaryRootCause]
                                 }
+                            />
+                            <ReviewPriorityMenu
+                                fingerprint={item.fingerprint}
+                                priority={item.priority}
                             />
                         </Group>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
@@ -1,0 +1,65 @@
+import { type AiAgentReviewItemPriority } from '@lightdash/common';
+import { Menu, UnstyledButton } from '@mantine-8/core';
+import { type FC } from 'react';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import { useUpdateAiAgentReviewItemPriority } from '../../hooks/useAiAgentAdmin';
+import {
+    reviewPriorityColors,
+    reviewPriorityLabels,
+} from './reviewItemDetails';
+
+type Props = {
+    fingerprint: string;
+    priority: AiAgentReviewItemPriority;
+};
+
+const priorities: AiAgentReviewItemPriority[] = [
+    'urgent',
+    'high',
+    'medium',
+    'low',
+    'none',
+];
+
+export const ReviewPriorityMenu: FC<Props> = ({ fingerprint, priority }) => {
+    const updatePriority = useUpdateAiAgentReviewItemPriority();
+
+    return (
+        <Menu width={160} position="bottom-start" shadow="sm" withinPortal>
+            <Menu.Target>
+                <UnstyledButton
+                    aria-label="Change priority"
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                >
+                    <CategoryBadge
+                        color={reviewPriorityColors[priority]}
+                        label={reviewPriorityLabels[priority]}
+                    />
+                </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+            >
+                {priorities.map((nextPriority) => (
+                    <Menu.Item
+                        key={nextPriority}
+                        disabled={
+                            nextPriority === priority ||
+                            updatePriority.isLoading
+                        }
+                        onClick={() =>
+                            updatePriority.mutate({
+                                fingerprint,
+                                priority: nextPriority,
+                            })
+                        }
+                    >
+                        {reviewPriorityLabels[nextPriority]}
+                    </Menu.Item>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -179,13 +179,13 @@ export const ReviewRemediationWorkspace = () => {
                 <PageBreadcrumbs
                     items={[
                         { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                        { title: 'Reviews', to: '/generalSettings/ai/reviews' },
+                        { title: 'Issues', to: '/generalSettings/ai/issues' },
                         { title: 'Workspace', active: true },
                     ]}
                 />
                 <Text c="dimmed">
-                    No remediation workspace for this finding yet. Open a pull
-                    request from the reviews board first.
+                    No remediation workspace for this issue yet. Open a pull
+                    request from the issues board first.
                 </Text>
             </Stack>
         );
@@ -357,8 +357,8 @@ export const ReviewRemediationWorkspace = () => {
                                 to: '/generalSettings/ai/general',
                             },
                             {
-                                title: 'Reviews',
-                                to: '/generalSettings/ai/reviews',
+                                title: 'Issues',
+                                to: '/generalSettings/ai/issues',
                             },
                             { title: reviewItem.title, active: true },
                         ]}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -99,7 +99,7 @@ export const ReviewVerificationPanel: FC<Props> = ({
     const isResolved = reviewItem.status === 'resolved';
     const previewProjectUuid = remediation?.previewProjectUuid ?? null;
     const sourceThreadUrl =
-        remediation &&
+        remediation?.sourceThreadUuid &&
         `/projects/${remediation.sourceProjectUuid}/ai-agents/${remediation.sourceAgentUuid}/threads/${remediation.sourceThreadUuid}`;
 
     const { data: prDiff, isLoading: isLoadingPrDiff } =
@@ -373,11 +373,11 @@ export const ReviewVerificationPanel: FC<Props> = ({
                 {isResolved ? (
                     <Anchor
                         component={Link}
-                        to="/generalSettings/ai/reviews"
+                        to="/generalSettings/ai/issues"
                         fz="sm"
                         fw={500}
                     >
-                        Back to reviews
+                        Back to issues
                     </Anchor>
                 ) : (
                     <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -9,6 +9,7 @@ import {
     LoadingOverlay,
     Stack,
     Text,
+    Textarea,
     Title,
     Tooltip,
     UnstyledButton,
@@ -20,6 +21,7 @@ import {
     IconChevronRight,
     IconExternalLink,
     IconGitPullRequest,
+    IconSend,
     IconSettings,
     IconX,
 } from '@tabler/icons-react';
@@ -29,6 +31,7 @@ import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
+    useAddAiAgentReviewItemComment,
     useAiAgentAdminAgents,
     useAiAgentAdminReviewItems,
 } from '../../hooks/useAiAgentAdmin';
@@ -44,6 +47,7 @@ import {
     getReviewReasoningText,
     getReviewSecondaryDetail,
 } from './reviewItemDetails';
+import { ReviewPriorityMenu } from './ReviewPriorityMenu';
 import { ReviewValidationList } from './ReviewValidationList';
 import styles from './ThreadPreviewSidebar.module.css';
 import {
@@ -141,6 +145,8 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
 }) => {
     const theme = useMantineTheme();
     const navigate = useNavigate();
+    const addComment = useAddAiAgentReviewItemComment();
+    const [commentBody, setCommentBody] = useState('');
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
         projectUuid,
         agentUuid,
@@ -311,6 +317,14 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                         ]
                                                     }
                                                 />
+                                                <ReviewPriorityMenu
+                                                    fingerprint={
+                                                        selectedReviewItem.fingerprint
+                                                    }
+                                                    priority={
+                                                        selectedReviewItem.priority
+                                                    }
+                                                />
                                             </Group>
 
                                             <Title order={5} fw={600}>
@@ -466,22 +480,62 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         </Collapse>
                                     )}
 
-                                    {selectedReviewItem.remediation && (
-                                        <Stack gap={6} pt="xs">
-                                            <Text
-                                                size="10px"
-                                                fw={700}
-                                                tt="uppercase"
-                                                lts={0.4}
-                                                c="ldGray.7"
+                                    <Stack gap={6} pt="xs">
+                                        <Text
+                                            size="10px"
+                                            fw={700}
+                                            tt="uppercase"
+                                            lts={0.4}
+                                            c="ldGray.7"
+                                        >
+                                            Activity
+                                        </Text>
+                                        <RemediationActivityTimeline
+                                            reviewItem={selectedReviewItem}
+                                        />
+                                        <Textarea
+                                            value={commentBody}
+                                            onChange={(event) =>
+                                                setCommentBody(
+                                                    event.currentTarget.value,
+                                                )
+                                            }
+                                            minRows={2}
+                                            placeholder="Add a comment"
+                                        />
+                                        <Group justify="flex-end">
+                                            <Button
+                                                size="compact-xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconSend}
+                                                    />
+                                                }
+                                                loading={addComment.isLoading}
+                                                disabled={!commentBody.trim()}
+                                                onClick={() => {
+                                                    const body =
+                                                        commentBody.trim();
+                                                    if (!body) return;
+                                                    addComment.mutate(
+                                                        {
+                                                            fingerprint:
+                                                                selectedReviewItem.fingerprint,
+                                                            body,
+                                                        },
+                                                        {
+                                                            onSuccess: () =>
+                                                                setCommentBody(
+                                                                    '',
+                                                                ),
+                                                        },
+                                                    );
+                                                }}
                                             >
-                                                Activity
-                                            </Text>
-                                            <RemediationActivityTimeline
-                                                reviewItem={selectedReviewItem}
-                                            />
-                                        </Stack>
-                                    )}
+                                                Comment
+                                            </Button>
+                                        </Group>
+                                    </Stack>
                                 </Stack>
                             </Stack>
 
@@ -496,7 +550,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         align="center"
                                     >
                                         <Title order={6} fw={600}>
-                                            Review findings
+                                            Issues
                                         </Title>
                                         <Badge variant="light" color="violet">
                                             {reviewSummary.findingCount}
@@ -628,11 +682,11 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                                 reviewItem.uuid,
                                                             );
                                                             void navigate(
-                                                                `/generalSettings/ai/reviews?${params.toString()}`,
+                                                                `/generalSettings/ai/issues?${params.toString()}`,
                                                             );
                                                         }}
                                                     >
-                                                        View review
+                                                        View issue
                                                     </Button>
 
                                                     {reviewItem.linkedPrUrl && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -22,6 +22,7 @@ const makeExampleReviewItem = (
         >,
 ): AiAgentReviewItemSummary => ({
     fingerprint: overrides.uuid,
+    source: 'ai_finding',
     organizationUuid: '',
     projectUuid: null,
     agentUuid: null,
@@ -31,6 +32,7 @@ const makeExampleReviewItem = (
     firstSeenAt: EXAMPLE_SEEN_AT,
     lastSeenAt: EXAMPLE_SEEN_AT,
     findingCount: 1,
+    priority: 'none',
     statusUpdatedAt: EXAMPLE_SEEN_AT,
     statusUpdatedByUserUuid: null,
     linkedIssueUrl: null,
@@ -47,6 +49,7 @@ const makeExampleReviewItem = (
     },
     remediation: null,
     boardPosition: null,
+    createdByUserUuid: null,
     createdAt: EXAMPLE_SEEN_AT,
     updatedAt: EXAMPLE_SEEN_AT,
     latestFinding: null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
@@ -2,7 +2,7 @@ import { Stack, Text } from '@mantine-8/core';
 import { type GuidedTourStep } from '../../../../../../components/common/GuidedTour';
 import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
 
-// First-visit tour for the Reviews board. All step copy lives here.
+// First-visit tour for the Issues board. All step copy lives here.
 export const REVIEWS_TOUR_STEPS: GuidedTourStep[] = [
     {
         target: '[data-tour="reviews-intro"]',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -1,5 +1,6 @@
 import {
     type AiAgentRecommendationAction,
+    type AiAgentReviewItemPriority,
     type AiAgentReviewItemSummary,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentRootCause,
@@ -37,13 +38,30 @@ export const reviewRootCauseColors: Record<AiAgentRootCause, string> = {
     ambiguous: 'gray',
 };
 
+export const reviewPriorityLabels: Record<AiAgentReviewItemPriority, string> = {
+    urgent: 'Urgent',
+    high: 'High',
+    medium: 'Medium',
+    low: 'Low',
+    none: 'No priority',
+};
+
+export const reviewPriorityColors: Record<AiAgentReviewItemPriority, string> = {
+    urgent: 'red',
+    high: 'orange',
+    medium: 'yellow',
+    low: 'blue',
+    none: 'gray',
+};
+
 export const writebackBlockedReasonLabels: Record<
     AiAgentReviewItemWritebackBlockedReason,
     string
 > = {
-    reviews_disabled: 'Reviews are not enabled for this organization',
+    reviews_disabled: 'Issues are not enabled for this organization',
     unsupported_root_cause: 'No writeback strategy for this root cause',
-    missing_project: 'No project is linked to this finding',
+    missing_project: 'No project is linked to this issue',
+    missing_agent: 'No agent is linked to this issue',
     missing_project_context_entry: 'No project context entry was generated',
     project_context_disabled: 'Project context is not enabled',
     unsupported_source_control: 'Project is not connected to GitHub or GitLab',
@@ -52,7 +70,7 @@ export const writebackBlockedReasonLabels: Record<
     pull_request_open: 'A pull request is already open',
     source_thread_writeback_exists:
         'The agent already opened a pull request in the source thread',
-    terminal_state: 'Finding is already closed',
+    terminal_state: 'Issue is already closed',
     writeback_in_progress: 'Writeback is already in progress',
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -129,13 +129,13 @@ export const AiGeneralSettingsPage = () => {
                                     {settings.aiAgentReviewsEnabled && (
                                         <>
                                             {' '}
-                                            See findings in{' '}
+                                            See issues in{' '}
                                             <Anchor
                                                 component={Link}
-                                                to="/generalSettings/ai/reviews"
+                                                to="/generalSettings/ai/issues"
                                                 fz="inherit"
                                             >
-                                                Ask AI &gt; Reviews
+                                                Ask AI &gt; Issues
                                             </Anchor>
                                             .
                                         </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
@@ -47,7 +47,7 @@ vi.mock('../AiAgentAdminReviewItemsTable', () => ({
                     })
                 }
             >
-                Open review
+                Open issue
             </button>
         );
     },
@@ -74,14 +74,14 @@ describe('AiReviewsSettingsPage', () => {
         localStorage.clear();
     });
 
-    it('opens the drawer after selecting a finding from the table', async () => {
+    it('opens the drawer after selecting an issue from the table', async () => {
         const user = userEvent.setup();
 
         renderWithProviders(
-            <MemoryRouter initialEntries={['/generalSettings/ai/reviews']}>
+            <MemoryRouter initialEntries={['/generalSettings/ai/issues']}>
                 <Routes>
                     <Route
-                        path="/generalSettings/ai/reviews"
+                        path="/generalSettings/ai/issues"
                         element={<AiReviewsSettingsPage />}
                     />
                 </Routes>
@@ -90,7 +90,7 @@ describe('AiReviewsSettingsPage', () => {
 
         // Board is the default view; switch to the table for this flow.
         await user.click(screen.getByText('Table'));
-        await user.click(screen.getByRole('button', { name: 'Open review' }));
+        await user.click(screen.getByRole('button', { name: 'Open issue' }));
 
         expect(
             await screen.findByText('Sidebar thread thread-1 / demo-review:1'),
@@ -101,12 +101,12 @@ describe('AiReviewsSettingsPage', () => {
         renderWithProviders(
             <MemoryRouter
                 initialEntries={[
-                    '/generalSettings/ai/reviews?reviewProjectUuid=project-1&reviewAgentUuid=agent-1&reviewThreadUuid=thread-1&reviewItemUuid=demo-review:1',
+                    '/generalSettings/ai/issues?reviewProjectUuid=project-1&reviewAgentUuid=agent-1&reviewThreadUuid=thread-1&reviewItemUuid=demo-review:1',
                 ]}
             >
                 <Routes>
                     <Route
-                        path="/generalSettings/ai/reviews"
+                        path="/generalSettings/ai/issues"
                         element={<AiReviewsSettingsPage />}
                     />
                 </Routes>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,20 +1,38 @@
 import {
+    type AiAgentReviewItemPriority,
+    type AiAgentRootCause,
+} from '@lightdash/common';
+import {
     Button,
     Drawer,
     Group,
     SegmentedControl,
+    Select,
     Stack,
     Text,
+    Textarea,
+    TextInput,
 } from '@mantine-8/core';
 import { useLocalStorage } from '@mantine-8/hooks';
-import { IconLayoutKanban, IconRoute, IconTable } from '@tabler/icons-react';
-import { useMemo } from 'react';
+import {
+    IconLayoutKanban,
+    IconPlus,
+    IconRoute,
+    IconTable,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FormEvent } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../../components/common/MantineModal';
 import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
+import { useProjects } from '../../../../../../hooks/useProjects';
+import {
+    useAiAgentAdminAgents,
+    useCreateAiAgentReviewItem,
+} from '../../../hooks/useAiAgentAdmin';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
@@ -25,11 +43,41 @@ import { ThreadPreviewSidebar } from '../ThreadPreviewSidebar';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 import drawerClasses from './ThreadPreviewDrawer.module.css';
 
+const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
+    { value: 'semantic_layer', label: 'Semantic layer' },
+    { value: 'project_context', label: 'Project context' },
+    { value: 'agent_configuration', label: 'Agent configuration' },
+    { value: 'product_capability', label: 'Product capability' },
+    { value: 'runtime_reliability', label: 'Runtime reliability' },
+    { value: 'feedback_quality', label: 'Feedback quality' },
+    { value: 'not_a_failure', label: 'Not a failure' },
+    { value: 'ambiguous', label: 'Ambiguous' },
+];
+
+const priorityOptions: { value: AiAgentReviewItemPriority; label: string }[] = [
+    { value: 'none', label: 'None' },
+    { value: 'urgent', label: 'Urgent' },
+    { value: 'high', label: 'High' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'low', label: 'Low' },
+];
+
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
+    const { data: projects = [] } = useProjects();
+    const { data: agents = [] } = useAiAgentAdminAgents();
+    const createIssue = useCreateAiAgentReviewItem();
     const [searchParams, setSearchParams] = useSearchParams();
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const [agentUuid, setAgentUuid] = useState<string | null>(null);
+    const [primaryRootCause, setPrimaryRootCause] =
+        useState<AiAgentRootCause | null>(null);
+    const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
 
-    // The selected review item and the sidebar's open state are derived
+    // The selected issue and the sidebar's open state are derived
     // directly from the URL — every mutation (deep-link, row select, close)
     // goes through `setSearchParams`, so there's no separate state to sync.
     const selectedReviewItem = useMemo(() => {
@@ -101,6 +149,41 @@ export const AiReviewsSettingsPage = () => {
         updateReviewSearchParams(null);
     };
 
+    const resetCreateForm = () => {
+        setTitle('');
+        setDescription('');
+        setProjectUuid(null);
+        setAgentUuid(null);
+        setPrimaryRootCause(null);
+        setPriority('none');
+    };
+
+    const handleCreateIssue = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!projectUuid || title.trim().length === 0) return;
+        createIssue.mutate(
+            {
+                title: title.trim(),
+                description: description.trim() || null,
+                projectUuid,
+                agentUuid,
+                assignedToUserUuid: null,
+                primaryRootCause,
+                priority,
+            },
+            {
+                onSuccess: () => {
+                    resetCreateForm();
+                    setIsCreateOpen(false);
+                },
+            },
+        );
+    };
+
+    const agentOptions = agents
+        .filter((agent) => !projectUuid || agent.projectUuid === projectUuid)
+        .map((agent) => ({ value: agent.uuid, label: agent.name }));
+
     return (
         <Stack mb="lg" gap="md">
             <Stack gap={4} data-tour="reviews-intro">
@@ -111,10 +194,17 @@ export const AiReviewsSettingsPage = () => {
                                 title: 'Ask AI',
                                 to: '/generalSettings/ai/general',
                             },
-                            { title: 'Reviews', active: true },
+                            { title: 'Issues', active: true },
                         ]}
                     />
                     <Group gap="xs">
+                        <Button
+                            size="compact-xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setIsCreateOpen(true)}
+                        >
+                            New issue
+                        </Button>
                         <SegmentedControl
                             size="xs"
                             value={effectiveView}
@@ -157,9 +247,9 @@ export const AiReviewsSettingsPage = () => {
                 </Group>
 
                 <Text c="dimmed" fz="sm" maw={760}>
-                    An actionable queue of answers your agents probably got
-                    wrong. Click a finding to inspect the thread, metadata, and
-                    suggested fix.{' '}
+                    An actionable queue of data issues from AI findings and
+                    human asks. Open an issue to inspect the thread, metadata,
+                    and suggested fix.{' '}
                     <Text span fw={600} fz="inherit">
                         Semantic layer
                     </Text>{' '}
@@ -221,6 +311,97 @@ export const AiReviewsSettingsPage = () => {
                     />
                 )}
             </Drawer>
+
+            <MantineModal
+                opened={isCreateOpen}
+                onClose={() => setIsCreateOpen(false)}
+                title="New issue"
+                icon={IconPlus}
+                size="lg"
+            >
+                <form onSubmit={handleCreateIssue}>
+                    <Stack gap="sm">
+                        <TextInput
+                            label="Title"
+                            value={title}
+                            onChange={(event) =>
+                                setTitle(event.currentTarget.value)
+                            }
+                            required
+                            autoFocus
+                        />
+                        <Textarea
+                            label="Description"
+                            value={description}
+                            onChange={(event) =>
+                                setDescription(event.currentTarget.value)
+                            }
+                            minRows={4}
+                        />
+                        <Select
+                            label="Project"
+                            data={projects.map((project) => ({
+                                value: project.projectUuid,
+                                label: project.name,
+                            }))}
+                            value={projectUuid}
+                            onChange={(value) => {
+                                setProjectUuid(value);
+                                setAgentUuid(null);
+                            }}
+                            searchable
+                            required
+                        />
+                        <Select
+                            label="Agent"
+                            data={agentOptions}
+                            value={agentUuid}
+                            onChange={setAgentUuid}
+                            searchable
+                            clearable
+                            disabled={!projectUuid}
+                        />
+                        <Select
+                            label="Root cause"
+                            data={rootCauseOptions}
+                            value={primaryRootCause}
+                            onChange={(value) =>
+                                setPrimaryRootCause(
+                                    value as AiAgentRootCause | null,
+                                )
+                            }
+                            clearable
+                        />
+                        <Select
+                            label="Priority"
+                            data={priorityOptions}
+                            value={priority}
+                            onChange={(value) =>
+                                setPriority(
+                                    (value ??
+                                        'none') as AiAgentReviewItemPriority,
+                                )
+                            }
+                        />
+                        <Group justify="flex-end">
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                onClick={() => setIsCreateOpen(false)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                loading={createIssue.isLoading}
+                                disabled={!projectUuid || !title.trim()}
+                            >
+                                Create issue
+                            </Button>
+                        </Group>
+                    </Stack>
+                </form>
+            </MantineModal>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
@@ -136,7 +136,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
             </Box>
 
             <Group justify="space-between" px="xs" pt={4} pb={2} wrap="nowrap">
-                <Text className={classes.heading}>Review findings</Text>
+                <Text className={classes.heading}>Issues</Text>
                 <Text className={classes.heading}>{totalOpen} open</Text>
             </Group>
 
@@ -144,7 +144,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
                 <Box
                     key={item.fingerprint}
                     component={Link}
-                    to={`/generalSettings/ai/reviews/${encodeURIComponent(
+                    to={`/generalSettings/ai/issues/${encodeURIComponent(
                         item.fingerprint,
                     )}`}
                     className={classes.row}
@@ -167,7 +167,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
 
             <Box component={Link} to={reviewsUrl} className={classes.footer}>
                 <Text size="xs" fw={500}>
-                    View all reviews
+                    View all issues
                 </Text>
                 <MantineIcon icon={IconArrowRight} size={12} />
             </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -15,8 +15,11 @@ import {
     type ApiAiAgentVerifiedArtifactsResponse,
     type ApiError,
     type ApiUpstreamDiffResponse,
+    type CreateAiAgentReviewItemComment,
+    type CreateAiAgentReviewItem,
     type ReorderAiAgentReviewItems,
     type UpdateAiAgentReviewItemAssignee,
+    type UpdateAiAgentReviewItemPriority,
     type UpdateAiAgentReviewItemStatus,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
@@ -175,6 +178,44 @@ const getAiAgentAdminReviewItems = async (args: {
 
 const AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY = 'ai-agent-admin-review-items';
 
+const createAiAgentReviewItem = async (body: CreateAiAgentReviewItem) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+};
+
+export const useCreateAiAgentReviewItem = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemResponse['results'],
+        ApiError,
+        CreateAiAgentReviewItem
+    >({
+        mutationFn: createAiAgentReviewItem,
+        onSuccess: (createdItem) => {
+            showToastSuccess({ title: 'Issue created' });
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item', createdItem.fingerprint],
+                createdItem,
+            );
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create issue',
+                apiError: error,
+            });
+        },
+    });
+};
+
 export const updateCachedReviewItemLists = (
     queryClient: QueryClient,
     updatedItem: AiAgentReviewItemSummary,
@@ -319,6 +360,47 @@ export const useRetestAiAgentReviewRemediation = () => {
         },
         onError: ({ error }) => {
             showToastApiError({ title: 'Failed to retest', apiError: error });
+        },
+    });
+};
+
+const addAiAgentReviewItemComment = async (args: {
+    fingerprint: string;
+    body: string;
+}) => {
+    return lightdashApi<ApiAiAgentReviewItemActivityResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(
+            args.fingerprint,
+        )}/comments`,
+        method: 'POST',
+        body: JSON.stringify({
+            body: args.body,
+        } satisfies CreateAiAgentReviewItemComment),
+    });
+};
+
+export const useAddAiAgentReviewItemComment = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemActivityResponse['results'],
+        ApiError,
+        { fingerprint: string; body: string }
+    >({
+        mutationFn: addAiAgentReviewItemComment,
+        onSuccess: (activity, { fingerprint }) => {
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item-activity', fingerprint],
+                activity,
+            );
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to add comment',
+                apiError: error,
+            });
         },
     });
 };
@@ -516,6 +598,53 @@ export const useUpdateAiAgentReviewItemAssignee = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to update assignee',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const updateAiAgentReviewItemPriority = async (args: {
+    fingerprint: string;
+    priority: UpdateAiAgentReviewItemPriority['priority'];
+}) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(args.fingerprint)}/priority`,
+        method: 'PATCH',
+        body: JSON.stringify({
+            priority: args.priority,
+        } satisfies UpdateAiAgentReviewItemPriority),
+    });
+};
+
+export const useUpdateAiAgentReviewItemPriority = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemResponse['results'],
+        ApiError,
+        {
+            fingerprint: string;
+            priority: UpdateAiAgentReviewItemPriority['priority'];
+        }
+    >({
+        mutationFn: updateAiAgentReviewItemPriority,
+        onSuccess: (updatedItem, { fingerprint }) => {
+            showToastSuccess({ title: 'Priority updated' });
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item', fingerprint],
+                updatedItem,
+            );
+            updateCachedReviewItemLists(queryClient, updatedItem);
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update priority',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -294,7 +294,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                                     variant="subtle"
                                                     color="gray"
                                                 >
-                                                    View review
+                                                    View issue
                                                 </Button>
                                             )}
                                             {threadPreviewTarget && (

--- a/packages/frontend/src/features/pullRequests/utils.test.ts
+++ b/packages/frontend/src/features/pullRequests/utils.test.ts
@@ -51,7 +51,7 @@ describe('pullRequests utils', () => {
         });
     });
 
-    it('builds a reviews deep link for pull requests tied to findings', () => {
+    it('builds an issues deep link for pull requests tied to findings', () => {
         expect(
             getReviewPath(
                 makeRow({
@@ -69,7 +69,7 @@ describe('pullRequests utils', () => {
                 }),
             ),
         ).toBe(
-            '/generalSettings/ai/reviews?reviewProjectUuid=review-project-1&reviewAgentUuid=review-agent-1&reviewThreadUuid=review-thread-1&reviewItemUuid=fingerprint-1',
+            '/generalSettings/ai/issues?reviewProjectUuid=review-project-1&reviewAgentUuid=review-agent-1&reviewThreadUuid=review-thread-1&reviewItemUuid=fingerprint-1',
         );
     });
 

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -84,7 +84,7 @@ export const getThreadPath = (row: PullRequestRow): string | null => {
 export const getThreadPreviewTarget = (
     row: PullRequestRow,
 ): PullRequestThreadPreviewTarget | null => {
-    if (row.reviewContext) {
+    if (row.reviewContext?.sourceThreadUuid) {
         return {
             projectUuid: row.reviewContext.sourceProjectUuid,
             agentUuid: row.reviewContext.sourceAgentUuid,
@@ -112,8 +112,10 @@ export const getReviewPath = (row: PullRequestRow): string | null => {
     const params = new URLSearchParams();
     params.set('reviewProjectUuid', row.reviewContext.sourceProjectUuid);
     params.set('reviewAgentUuid', row.reviewContext.sourceAgentUuid);
-    params.set('reviewThreadUuid', row.reviewContext.sourceThreadUuid);
+    if (row.reviewContext.sourceThreadUuid) {
+        params.set('reviewThreadUuid', row.reviewContext.sourceThreadUuid);
+    }
     params.set('reviewItemUuid', row.reviewContext.reviewItemUuid);
 
-    return `/generalSettings/ai/reviews?${params.toString()}`;
+    return `/generalSettings/ai/issues?${params.toString()}`;
 };

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -416,10 +416,10 @@ export const useSettingsNavigation = (
 
             if (shouldShowAiAgentReviews) {
                 aiChildren.push({
-                    label: 'Reviews',
-                    to: '/generalSettings/ai/reviews',
+                    label: 'Issues',
+                    to: '/generalSettings/ai/issues',
                     icon: IconListCheck,
-                    keywords: ['classifier'],
+                    keywords: ['classifier', 'reviews'],
                     children: [],
                     exact: true,
                 });

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ import {
     matchPath,
     Navigate,
     useLocation,
+    useParams,
     useRoutes,
     type RouteObject,
 } from 'react-router';
@@ -85,6 +86,27 @@ import { PageName } from '../types/Events';
 import classes from './Settings.module.css';
 
 const SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY = 'settings:sidebar-collapsed';
+
+const AiReviewsToIssuesRedirect = ({
+    itemRoute = false,
+}: {
+    itemRoute?: boolean;
+}) => {
+    const { fingerprint } = useParams<{ fingerprint: string }>();
+    const location = useLocation();
+
+    const pathname =
+        itemRoute && fingerprint
+            ? `/generalSettings/ai/issues/${encodeURIComponent(fingerprint)}`
+            : '/generalSettings/ai/issues';
+
+    return (
+        <Navigate
+            to={`${pathname}${location.search}${location.hash}`}
+            replace
+        />
+    );
+};
 
 const Settings: FC = () => {
     const context = useSettingsContext();
@@ -572,7 +594,7 @@ const Settings: FC = () => {
             });
             if (shouldShowAiAgentReviews) {
                 allowedRoutes.push({
-                    path: '/ai/reviews',
+                    path: '/ai/issues',
                     element: (
                         <AiSettingsProviders>
                             <AiReviewsSettingsPage />
@@ -580,12 +602,20 @@ const Settings: FC = () => {
                     ),
                 });
                 allowedRoutes.push({
-                    path: '/ai/reviews/:fingerprint',
+                    path: '/ai/issues/:fingerprint',
                     element: (
                         <AiSettingsProviders>
                             <ReviewRemediationWorkspace />
                         </AiSettingsProviders>
                     ),
+                });
+                allowedRoutes.push({
+                    path: '/ai/reviews',
+                    element: <AiReviewsToIssuesRedirect />,
+                });
+                allowedRoutes.push({
+                    path: '/ai/reviews/:fingerprint',
+                    element: <AiReviewsToIssuesRedirect itemRoute />,
                 });
             }
         }
@@ -728,6 +758,14 @@ const Settings: FC = () => {
             !matchPath(
                 { path: '/generalSettings/ai/reviews/:fingerprint' },
                 location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/issues' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/issues/:fingerprint' },
+                location.pathname,
             )
         );
     }, [location.pathname]);
@@ -738,7 +776,7 @@ const Settings: FC = () => {
         isOrganizationLoading ||
         isActiveProjectUuidLoading ||
         isProjectLoading ||
-        // Wait for AI org settings so the /ai/reviews route is registered before
+        // Wait for AI org settings so the AI issues route is registered before
         // routing — otherwise a hard refresh there falls through to the default.
         isAiOrganizationSettingsLoading
     ) {


### PR DESCRIPTION
## Summary

- Rename the AI review board surface to Issues with canonical `/generalSettings/ai/issues` routes and redirects from the old Reviews paths.
- Add manual issue creation, priority editing, comments, and generalized issue activity events alongside AI-generated findings.
- Extend remediation/writeback so manual issues can generate semantic-layer or project-context fixes when scoped to a project and agent.
- Update generated API routes/swagger and focused backend/frontend coverage.

## Validation

- `pnpm generate-api`
- `pnpm -F common typecheck:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F backend test -- --runInBand src/ee/services/AiAgentAdminService.test.ts src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts`
- `pnpm -F frontend test -- --run src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx src/features/pullRequests/utils.test.ts src/ee/features/aiCopilot/hooks/useAiAgentAdmin.test.ts`
- `git diff --check`

## Notes

- `pnpm -F frontend typecheck:fast` still fails on existing Vitest matcher typings for `toBeVisible` / `toHaveAttribute`.
- Local migration run was blocked because `db-dev` did not resolve in this worktree environment.