### PR TITLE
fix: count explicitly-set falsy parameter values and defaults as supplied

### DIFF
--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -479,8 +479,7 @@ describe('getMissingRequiredParameters', () => {
     });
 
     it('does not flag a parameter whose default is a falsy value (0 / empty string)', () => {
-        // A default counts as supplied whenever it is declared, matching the backend's
-        // `default !== undefined`. Truthiness would wrongly require a `default: 0` param.
+        // A declared default counts as supplied (backend uses `default !== undefined`).
         const result = getMissingRequiredParameters(
             ['count', 'note'],
             {},

--- a/packages/common/src/compiler/parameters.test.ts
+++ b/packages/common/src/compiler/parameters.test.ts
@@ -455,6 +455,20 @@ describe('getMissingRequiredParameters', () => {
         expect(result).toEqual([]);
     });
 
+    it('does not flag a parameter explicitly set to a falsy value', () => {
+        // Key presence, not truthiness: a user can deliberately pick 0, '' or [].
+        const result = getMissingRequiredParameters(
+            ['amount', 'label', 'tags'],
+            { amount: 0, label: '', tags: [] },
+            {
+                amount: { label: 'Amount' },
+                label: { label: 'Label' },
+                tags: { label: 'Tags' },
+            },
+        );
+        expect(result).toEqual([]);
+    });
+
     it('does not flag a parameter that has a default', () => {
         const result = getMissingRequiredParameters(
             ['region'],
@@ -462,6 +476,29 @@ describe('getMissingRequiredParameters', () => {
             { region: { label: 'Region', default: 'EU' } },
         );
         expect(result).toEqual([]);
+    });
+
+    it('does not flag a parameter whose default is a falsy value (0 / empty string)', () => {
+        // A default counts as supplied whenever it is declared, matching the backend's
+        // `default !== undefined`. Truthiness would wrongly require a `default: 0` param.
+        const result = getMissingRequiredParameters(
+            ['count', 'note'],
+            {},
+            {
+                count: { label: 'Count', type: 'number', default: 0 },
+                note: { label: 'Note', default: '' },
+            },
+        );
+        expect(result).toEqual([]);
+    });
+
+    it('still flags a parameter declared with no default key', () => {
+        const result = getMissingRequiredParameters(
+            ['region'],
+            {},
+            { region: { label: 'Region' } },
+        );
+        expect(result).toEqual(['region']);
     });
 
     it('never flags a reserved parameter as missing', () => {

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -132,12 +132,9 @@ export const hasReservedParameterReference = (
 ): boolean => parameterReferences.some(isReservedParameterName);
 
 /**
- * Determine which referenced parameters still need a value before a query can run.
- * A parameter is required when it has no value and no default. Both checks use key
- * presence (not truthiness) so an explicitly-provided falsy value or default (`0`, `''`,
- * `[]`) counts as supplied — matching the backend, which applies a default whenever
- * `default !== undefined`. Reserved (system-owned) parameters are resolved server-side
- * and are never user-provided, so they are never treated as missing.
+ * Which referenced parameters still need a value (no value and no default). Both checks
+ * use key presence, so an explicit falsy value or default (`0`, `''`, `[]`) counts as
+ * supplied, matching the backend's `default !== undefined`. Reserved params never count.
  */
 export const getMissingRequiredParameters = (
     parameterReferences: string[],

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -133,21 +133,24 @@ export const hasReservedParameterReference = (
 
 /**
  * Determine which referenced parameters still need a value before a query can run.
- * A parameter is required when it has no value and no default. Reserved (system-owned)
- * parameters are resolved server-side from the query context and are never user-provided,
- * so they are never treated as missing.
+ * A parameter is required when it has no value and no default. Both checks use key
+ * presence (not truthiness) so an explicitly-provided falsy value or default (`0`, `''`,
+ * `[]`) counts as supplied — matching the backend, which applies a default whenever
+ * `default !== undefined`. Reserved (system-owned) parameters are resolved server-side
+ * and are never user-provided, so they are never treated as missing.
  */
 export const getMissingRequiredParameters = (
     parameterReferences: string[],
     parameterValues: ParametersValuesMap | undefined,
     parameterDefinitions: ParameterDefinitions | undefined,
 ): string[] =>
-    parameterReferences.filter(
-        (name) =>
-            !isReservedParameterName(name) &&
-            !parameterValues?.[name] &&
-            !parameterDefinitions?.[name]?.default,
-    );
+    parameterReferences.filter((name) => {
+        if (isReservedParameterName(name)) return false;
+        const hasValue = name in (parameterValues ?? {});
+        const definition = parameterDefinitions?.[name];
+        const hasDefault = definition !== undefined && 'default' in definition;
+        return !hasValue && !hasDefault;
+    });
 
 /**
  * Get all available parameter names for a project and explore

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -540,10 +540,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     const missingRequiredParameters = useMemo(() => {
         if (!dashboardParameterReferences.size) return [];
 
-        // A dashboard parameter is "set" when its key exists (even with an empty value),
-        // so map by key presence rather than the empty-stripping `parameterValues`. The
-        // shared helper keeps the reserved-name and default semantics in sync with the
-        // Explorer and the backend (a declared falsy default counts as supplied).
+        // Map by key presence (a param is "set" even with an empty value), not the
+        // empty-stripping `parameterValues`, so dashboard semantics are unchanged.
         const dashboardParameterValues: ParametersValuesMap =
             Object.fromEntries(
                 Object.entries(parameters).map(([key, parameter]) => [

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -7,9 +7,9 @@ import {
     FilterInteractivityValues,
     getFilterInteractivityValue,
     getItemId,
+    getMissingRequiredParameters,
     isDashboardChartTileType,
     isFilterLockedOnTab,
-    isReservedParameterName,
     isStandardDateGranularity,
     isSubDayGranularity,
     stripOverridesForLockedFiltersOnTab,
@@ -538,16 +538,24 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [projectParameters, addParameterDefinitions]);
 
     const missingRequiredParameters = useMemo(() => {
-        // If no parameter references, return empty array
         if (!dashboardParameterReferences.size) return [];
 
-        // Missing required parameters are the ones that are not set and don't have a
-        // default value. Reserved parameters are resolved server-side, never user-set.
-        return Array.from(dashboardParameterReferences).filter(
-            (parameterName) =>
-                !isReservedParameterName(parameterName) &&
-                !parameters[parameterName] &&
-                !parameterDefinitions[parameterName]?.default,
+        // A dashboard parameter is "set" when its key exists (even with an empty value),
+        // so map by key presence rather than the empty-stripping `parameterValues`. The
+        // shared helper keeps the reserved-name and default semantics in sync with the
+        // Explorer and the backend (a declared falsy default counts as supplied).
+        const dashboardParameterValues: ParametersValuesMap =
+            Object.fromEntries(
+                Object.entries(parameters).map(([key, parameter]) => [
+                    key,
+                    parameter.value,
+                ]),
+            );
+
+        return getMissingRequiredParameters(
+            Array.from(dashboardParameterReferences),
+            dashboardParameterValues,
+            parameterDefinitions,
         );
     }, [dashboardParameterReferences, parameters, parameterDefinitions]);
 


### PR DESCRIPTION
## What

Make the "missing required parameter" check use **key presence** instead of value/default truthiness, and route the dashboard through the same shared helper the Explorer already uses.

- `getMissingRequiredParameters` (`@lightdash/common`): a reference is missing only when its key is absent from the values map **and** its definition has no `default` key. Previously both were truthiness checks.
- `DashboardProvider`: drops its hand-rolled copy of the predicate and calls `getMissingRequiredParameters`, so the Explorer, the dashboard, and the backend all agree on one rule.

## Why

A parameter that was explicitly set to a **falsy value** (`0`, `''`, `[]`), or declared with a **falsy default** (e.g. a `number` parameter with `default: 0`), was wrongly flagged as "missing required" and blocked the query from running — even though the backend applies a default whenever `default !== undefined` and would have happily filled it.

The logic was also duplicated: the Explorer (`useExplorerQueryManager`) and the dashboard (`DashboardProvider`) each had their own predicate, and they had drifted from each other and from the backend. This consolidates them onto one helper.

## Scope

This is a general parameter-correctness fix, independent of the date-zoom reserved-parameter feature it sits on top of. It is split into its own branch (on top of `reserved-parameters-ui`) so the feature stack stays strictly scoped to "add the date_zoom reserved parameter + shadow collisions" with no behavioral changes, and this fix is easy to review and revert on its own.

Dashboard parameter "is set" semantics are preserved exactly (a key present with an empty value still counts as set); the only behavioral change is that falsy values/defaults are no longer mistaken for "missing".

## Tests

`getMissingRequiredParameters` unit tests cover: falsy value supplied (`0`/`''`/`[]`), falsy default declared (`0`/`''`), a parameter declared with no `default` key still flagged, and reserved parameters never flagged.
