### PR TITLE
feat(ai-reviews): in-app bell notifications [1/3]

### DIFF
--- a/packages/backend/src/database/entities/notifications.ts
+++ b/packages/backend/src/database/entities/notifications.ts
@@ -1,17 +1,19 @@
+import { type NotificationAiReview } from '@lightdash/common';
 import { Knex } from 'knex';
 
 export enum DbNotificationResourceType {
     DashboardComments = 'dashboard_comments',
+    AiReviewItem = 'ai_review_item',
 }
 
 export const NotificationsTableName = 'notifications';
 
-interface NotificationDashboardTileCommentMetadata {
+export type DbNotificationDashboardTileCommentMetadata = {
     dashboard_uuid: string;
     dashboard_name: string;
     dashboard_tile_uuid: string;
     dashboard_tile_name: string;
-}
+};
 
 type DbNotifications = {
     notification_id: string;
@@ -22,7 +24,10 @@ type DbNotifications = {
     message: string | null;
     url: string | null;
     resource_type: DbNotificationResourceType;
-    metadata: NotificationDashboardTileCommentMetadata | null;
+    metadata:
+        | DbNotificationDashboardTileCommentMetadata
+        | NotificationAiReview['metadata']
+        | null;
 };
 
 type DbNotificationsInsertComment = Pick<

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -50,6 +50,7 @@ import { AiAgentContentValidation } from './services/ai/utils/AiAgentContentVali
 import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentDocumentService } from './services/AiAgentDocumentService';
 import { AiAgentReviewClassifierService } from './services/AiAgentReviewClassifierService';
+import { AiAgentReviewNotificationService } from './services/AiAgentReviewNotificationService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiAgentToolsService } from './services/AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
@@ -334,6 +335,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     aiAgentModel: models.getAiAgentModel(),
                     aiAgentReviewClassifierModel:
                         models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    aiAgentReviewNotificationService:
+                        repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
                     featureFlagService: repository.getFeatureFlagService(),
@@ -385,7 +388,17 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     catalogModel: models.getCatalogModel(),
                     projectModel: models.getProjectModel(),
                     featureFlagService: repository.getFeatureFlagService(),
+                    aiAgentReviewNotificationService:
+                        repository.getAiAgentReviewNotificationService<AiAgentReviewNotificationService>(),
                     lightdashConfig: context.lightdashConfig,
+                }),
+            aiAgentReviewNotificationService: ({ models }) =>
+                new AiAgentReviewNotificationService({
+                    notificationsModel: models.getNotificationsModel(),
+                    aiAgentReviewClassifierModel:
+                        models.getAiAgentReviewClassifierModel<AiAgentReviewClassifierModel>(),
+                    organizationMemberProfileModel:
+                        models.getOrganizationMemberProfileModel(),
                 }),
             aiOrganizationSettingsService: ({ models, context }) =>
                 new AiOrganizationSettingsService({

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -123,8 +123,25 @@ const makeAdminUser = (): SessionUser => ({
     timezone: null,
     ability: new Ability<PossibleAbilities>([
         { action: 'manage', subject: 'Organization' },
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
     ]),
     abilityRules: [],
+});
+
+const makeDeveloperUser = (): SessionUser => ({
+    ...makeAdminUser(),
+    role: OrganizationMemberRole.DEVELOPER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+    ]),
 });
 
 const makeService = ({
@@ -142,6 +159,7 @@ const makeService = ({
     writebackPreviewService = {},
     jobModel = {},
     userModel = {},
+    aiAgentReviewNotificationService = {},
 }: {
     aiAgentModel?: Record<string, unknown>;
     aiAgentReviewClassifierModel?: Record<string, unknown>;
@@ -157,6 +175,7 @@ const makeService = ({
     writebackPreviewService?: Record<string, unknown>;
     jobModel?: Record<string, unknown>;
     userModel?: Record<string, unknown>;
+    aiAgentReviewNotificationService?: Record<string, unknown>;
 } = {}) =>
     new AiAgentAdminService({
         analytics: { track: jest.fn() },
@@ -281,6 +300,10 @@ const makeService = ({
             findSessionUserByUUID: jest.fn().mockResolvedValue(makeAdminUser()),
             ...userModel,
         },
+        aiAgentReviewNotificationService: {
+            notifyAssigned: jest.fn().mockResolvedValue(undefined),
+            ...aiAgentReviewNotificationService,
+        },
         lightdashConfig: {
             siteUrl: SITE_URL,
             appRuntime: { e2bApiKey: 'e2b-api-key' },
@@ -328,6 +351,72 @@ describe('AiAgentAdminService.getPromptActivity', () => {
             'Insufficient permissions to access organization-wide AI agent data',
         );
         expect(findAdminPromptActivity).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService review access', () => {
+    it('allows developers with manage:AiAgent to access reviews', async () => {
+        const listReviewSignals = jest.fn().mockResolvedValue([]);
+        const service = makeService({
+            aiAgentReviewClassifierModel: { listReviewSignals },
+        });
+
+        await expect(
+            service.listReviewSignals(makeDeveloperUser()),
+        ).resolves.toEqual([]);
+        expect(listReviewSignals).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+        });
+    });
+
+    it('forbids users without manage:AiAgent from reviews', async () => {
+        const listReviewSignals = jest.fn();
+        const service = makeService({
+            aiAgentReviewClassifierModel: { listReviewSignals },
+        });
+        const user = {
+            ...makeAdminUser(),
+            role: OrganizationMemberRole.DEVELOPER,
+            ability: new Ability<PossibleAbilities>([]),
+        };
+
+        await expect(service.listReviewSignals(user)).rejects.toThrow(
+            'Insufficient permissions to access AI agent reviews',
+        );
+        expect(listReviewSignals).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService.updateReviewItemAssignee', () => {
+    it('notifies the assignee after the model write succeeds', async () => {
+        const notifyAssigned = jest.fn().mockResolvedValue(undefined);
+        const updateReviewItemAssignee = jest.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                updateReviewItemAssignee,
+                getReviewItem: jest.fn().mockResolvedValue(
+                    makeReviewItem({
+                        organizationUuid: ORGANIZATION_UUID,
+                        projectUuid: PROJECT_UUID,
+                    }),
+                ),
+            },
+            aiAgentReviewNotificationService: { notifyAssigned },
+        });
+
+        await service.updateReviewItemAssignee(
+            makeDeveloperUser(),
+            'fingerprint-1',
+            'user-2',
+        );
+
+        expect(notifyAssigned).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-2',
+            actorUserUuid: USER_UUID,
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -71,6 +71,7 @@ import {
     planReviewWriteback,
     PROJECT_CONTEXT_WORK_THREAD_INSTRUCTION,
 } from './ai/reviewWriteback/buildReviewWritebackPrompt';
+import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 import { type AiAgentService } from './AiAgentService/AiAgentService';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
 import { type WritebackPreviewService } from './AiWritebackService/WritebackPreviewService';
@@ -80,6 +81,7 @@ type AiAgentAdminServiceDependencies = {
     analytics: LightdashAnalytics;
     aiAgentModel: AiAgentModel;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     aiAgentService: AiAgentService;
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
@@ -290,6 +292,8 @@ export class AiAgentAdminService extends BaseService {
 
     private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
 
+    private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+
     private readonly aiAgentService: AiAgentService;
 
     private readonly featureFlagService: FeatureFlagService;
@@ -322,6 +326,8 @@ export class AiAgentAdminService extends BaseService {
         this.aiAgentModel = dependencies.aiAgentModel;
         this.aiAgentReviewClassifierModel =
             dependencies.aiAgentReviewClassifierModel;
+        this.aiAgentReviewNotificationService =
+            dependencies.aiAgentReviewNotificationService;
         this.aiAgentService = dependencies.aiAgentService;
         this.featureFlagService = dependencies.featureFlagService;
         this.aiOrganizationSettingsService =
@@ -353,6 +359,25 @@ export class AiAgentAdminService extends BaseService {
         ) {
             throw new ForbiddenError(
                 'Insufficient permissions to access organization-wide AI agent data',
+            );
+        }
+    }
+
+    private checkReviewAccess(
+        user: SessionUser,
+        organizationUuid: string,
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access AI agent reviews',
             );
         }
     }
@@ -426,7 +451,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const items = await this.aiAgentReviewClassifierModel.listReviewItems({
             organizationUuid,
@@ -808,7 +833,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         return this.aiAgentReviewClassifierModel.listReviewSignals({
             organizationUuid,
@@ -824,7 +849,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         if (update.status === 'dismissed' && !update.dismissedReason) {
             throw new ParameterError(
@@ -930,7 +955,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         // Resolve scope per fingerprint (reads — safe to parallelise), drop any
         // that are no longer promoted, then persist the whole lane order in one
@@ -968,7 +993,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         await this.aiAgentReviewClassifierModel.updateReviewItemAssignee({
             fingerprint,
@@ -976,7 +1001,19 @@ export class AiAgentAdminService extends BaseService {
             assignedToUserUuid,
         });
 
-        return this.getReviewItem(user, fingerprint);
+        const item = await this.getReviewItem(user, fingerprint);
+
+        if (assignedToUserUuid !== null && item.projectUuid !== null) {
+            await this.aiAgentReviewNotificationService.notifyAssigned({
+                organizationUuid,
+                projectUuid: item.projectUuid,
+                fingerprint,
+                assigneeUserUuid: assignedToUserUuid,
+                actorUserUuid: user.userUuid,
+            });
+        }
+
+        return item;
     }
 
     async createReviewItemWriteback(
@@ -987,7 +1024,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -1555,7 +1592,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -1636,7 +1673,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2052,7 +2089,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2099,7 +2136,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const remediation =
             await this.aiAgentReviewClassifierModel.findReviewRemediationByPreviewThread(
@@ -2123,7 +2160,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2180,7 +2217,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.test.ts
@@ -301,6 +301,9 @@ describe('AiAgentReviewClassifierService', () => {
     const projectModel = {
         getSummary: jest.fn(),
     };
+    const aiAgentReviewNotificationService = {
+        notifyNeedsReview: jest.fn(),
+    };
     const judgeTurn = jest.fn();
 
     const service = new AiAgentReviewClassifierService({
@@ -312,6 +315,8 @@ describe('AiAgentReviewClassifierService', () => {
         featureFlagService,
         lightdashConfig: {} as never,
         judgeTurn,
+        aiAgentReviewNotificationService:
+            aiAgentReviewNotificationService as never,
     });
 
     beforeEach(() => {
@@ -331,6 +336,9 @@ describe('AiAgentReviewClassifierService', () => {
         model.updateRun.mockResolvedValue(makeRun({ status: 'completed' }));
         model.createTurnSignal.mockResolvedValue(SIGNAL_UUID);
         model.getThreadWritebackPullRequests.mockResolvedValue(new Map());
+        aiAgentReviewNotificationService.notifyNeedsReview.mockResolvedValue(
+            undefined,
+        );
         aiAgentModel.getAgent.mockResolvedValue({
             uuid: AGENT_UUID,
             organizationUuid: ORGANIZATION_UUID,
@@ -467,6 +475,14 @@ describe('AiAgentReviewClassifierService', () => {
                 }),
             }),
         );
+        expect(
+            aiAgentReviewNotificationService.notifyNeedsReview,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            projectUuid: PROJECT_UUID,
+            reviewRunUuid: RUN_UUID,
+            fingerprints: [expect.stringContaining('ai_agent_review_item:')],
+        });
     });
 
     it('does not promote turns where writeback already opened a pull request', async () => {

--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -36,6 +36,7 @@ import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassi
 import { type AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { defaultAgentOptions } from './ai/agents/agentV2';
 import { getModel } from './ai/models';
+import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
 const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
@@ -78,6 +79,7 @@ type AiAgentReviewClassifierServiceDependencies = {
     projectModel: Pick<ProjectModel, 'getSummary'>;
     featureFlagService: FeatureFlagService;
     lightdashConfig: LightdashConfig;
+    aiAgentReviewNotificationService: AiAgentReviewNotificationService;
     judgeTurn?: AiAgentReviewClassifierJudge;
 };
 
@@ -231,6 +233,8 @@ export class AiAgentReviewClassifierService extends BaseService {
 
     private readonly featureFlagService: FeatureFlagService;
 
+    private readonly aiAgentReviewNotificationService: AiAgentReviewNotificationService;
+
     private readonly lightdashConfig: LightdashConfig;
 
     private readonly judgeTurn: AiAgentReviewClassifierJudge;
@@ -245,6 +249,8 @@ export class AiAgentReviewClassifierService extends BaseService {
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
         this.featureFlagService = dependencies.featureFlagService;
+        this.aiAgentReviewNotificationService =
+            dependencies.aiAgentReviewNotificationService;
         this.lightdashConfig = dependencies.lightdashConfig;
         this.judgeTurn =
             dependencies.judgeTurn ??
@@ -439,6 +445,7 @@ export class AiAgentReviewClassifierService extends BaseService {
         let findingCount = 0;
         let reviewItemCount = 0;
         const reviewItemFingerprints = new Set<string>();
+        const reviewItemFingerprintsByProject = new Map<string, Set<string>>();
         const shouldPersistSignals = args.persistSignals ?? !args.dryRun;
         const shouldPersistFindings = !args.dryRun && !!args.persistFindings;
         const shouldPromoteFindingsToReviewItems =
@@ -484,6 +491,17 @@ export class AiAgentReviewClassifierService extends BaseService {
                         reviewItemFingerprints.add(
                             classifiedTurn.finding.reviewItem.fingerprint,
                         );
+                        const projectFingerprints =
+                            reviewItemFingerprintsByProject.get(
+                                classifiedTurn.signal.subject.projectUuid,
+                            ) ?? new Set<string>();
+                        projectFingerprints.add(
+                            classifiedTurn.finding.reviewItem.fingerprint,
+                        );
+                        reviewItemFingerprintsByProject.set(
+                            classifiedTurn.signal.subject.projectUuid,
+                            projectFingerprints,
+                        );
                         reviewItemCount = reviewItemFingerprints.size;
                     }
                 }
@@ -509,6 +527,25 @@ export class AiAgentReviewClassifierService extends BaseService {
                 findingCount: reviewedFindingCount,
                 reviewItemCount,
             });
+
+            if (
+                shouldPromoteFindingsToReviewItems &&
+                reviewItemFingerprintsByProject.size > 0
+            ) {
+                await Promise.all(
+                    Array.from(reviewItemFingerprintsByProject.entries()).map(
+                        ([projectUuid, fingerprints]) =>
+                            this.aiAgentReviewNotificationService.notifyNeedsReview(
+                                {
+                                    organizationUuid: args.organizationUuid,
+                                    projectUuid,
+                                    reviewRunUuid: run.uuid,
+                                    fingerprints: Array.from(fingerprints),
+                                },
+                            ),
+                    ),
+                );
+            }
 
             return {
                 runUuid: run.uuid,

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.test.ts
@@ -1,0 +1,102 @@
+import {
+    AiReviewNotificationEvent,
+    OrganizationMemberRole,
+} from '@lightdash/common';
+import { AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
+
+const makeService = () => {
+    const notificationsModel = {
+        createAiReviewNotifications: jest.fn().mockResolvedValue(undefined),
+    };
+    const aiAgentReviewClassifierModel = {
+        getReviewItem: jest.fn().mockResolvedValue({
+            fingerprint: 'fingerprint-1',
+            title: 'Missing metric',
+            primaryRootCause: 'semantic_layer',
+        }),
+    };
+    const organizationMemberProfileModel = {
+        getOrganizationMembers: jest.fn().mockResolvedValue({
+            data: [
+                {
+                    userUuid: 'developer-1',
+                    email: 'dev@example.com',
+                    role: OrganizationMemberRole.DEVELOPER,
+                    organizationUuid: 'org-1',
+                    ability: undefined,
+                },
+                {
+                    userUuid: 'viewer-1',
+                    email: 'viewer@example.com',
+                    role: OrganizationMemberRole.VIEWER,
+                    organizationUuid: 'org-1',
+                    ability: undefined,
+                },
+            ],
+        }),
+    };
+    const service = new AiAgentReviewNotificationService({
+        notificationsModel,
+        aiAgentReviewClassifierModel,
+        organizationMemberProfileModel,
+    } as unknown as ConstructorParameters<
+        typeof AiAgentReviewNotificationService
+    >[0]);
+
+    return {
+        service,
+        notificationsModel,
+        aiAgentReviewClassifierModel,
+        organizationMemberProfileModel,
+    };
+};
+
+describe('AiAgentReviewNotificationService', () => {
+    it('filters recipients to members who can manage AiAgent', async () => {
+        const { service } = makeService();
+
+        await expect(service.getRecipients('org-1')).resolves.toEqual([
+            { userUuid: 'developer-1', email: 'dev@example.com' },
+        ]);
+    });
+
+    it('suppresses self-assignment notifications', async () => {
+        const { service, notificationsModel } = makeService();
+
+        await service.notifyAssigned({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-1',
+            actorUserUuid: 'user-1',
+        });
+
+        expect(
+            notificationsModel.createAiReviewNotifications,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('writes a bell notification for a different assignee', async () => {
+        const { service, notificationsModel } = makeService();
+
+        await service.notifyAssigned({
+            organizationUuid: 'org-1',
+            projectUuid: 'project-1',
+            fingerprint: 'fingerprint-1',
+            assigneeUserUuid: 'user-2',
+            actorUserUuid: 'user-1',
+        });
+
+        expect(
+            notificationsModel.createAiReviewNotifications,
+        ).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recipients: [{ userUuid: 'user-2' }],
+                metadata: expect.objectContaining({
+                    event: AiReviewNotificationEvent.Assigned,
+                    fingerprint: 'fingerprint-1',
+                }),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -1,0 +1,121 @@
+import { subject } from '@casl/ability';
+import {
+    AiReviewNotificationEvent,
+    AiReviewNotificationRecipient,
+    defineUserAbility,
+} from '@lightdash/common';
+import { type NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
+import { type OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
+import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
+
+type AiAgentReviewNotificationServiceArgs = {
+    notificationsModel: NotificationsModel;
+    aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+    organizationMemberProfileModel: OrganizationMemberProfileModel;
+};
+
+export class AiAgentReviewNotificationService {
+    private readonly notificationsModel: NotificationsModel;
+
+    private readonly aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
+
+    private readonly organizationMemberProfileModel: OrganizationMemberProfileModel;
+
+    constructor(args: AiAgentReviewNotificationServiceArgs) {
+        this.notificationsModel = args.notificationsModel;
+        this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
+        this.organizationMemberProfileModel =
+            args.organizationMemberProfileModel;
+    }
+
+    async getRecipients(
+        organizationUuid: string,
+    ): Promise<AiReviewNotificationRecipient[]> {
+        const members =
+            await this.organizationMemberProfileModel.getOrganizationMembers({
+                organizationUuid,
+                paginateArgs: { page: 1, pageSize: 10_000 },
+            });
+
+        return members.data
+            .filter((member) =>
+                defineUserAbility(member, []).can(
+                    'manage',
+                    subject('AiAgent', { organizationUuid }),
+                ),
+            )
+            .map((member) => ({
+                userUuid: member.userUuid,
+                email: member.email,
+            }));
+    }
+
+    async notifyAssigned(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        fingerprint: string;
+        assigneeUserUuid: string;
+        actorUserUuid: string;
+    }): Promise<void> {
+        if (args.assigneeUserUuid === args.actorUserUuid) {
+            return;
+        }
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                args.organizationUuid,
+                args.fingerprint,
+            );
+        const metadata = {
+            fingerprint: args.fingerprint,
+            event: AiReviewNotificationEvent.Assigned,
+            title: reviewItem?.title ?? 'AI review finding',
+            rootCause: reviewItem?.primaryRootCause ?? 'unknown',
+            projectUuid: args.projectUuid,
+            count: 1,
+            searchParams: `reviewItemUuid=${args.fingerprint}`,
+        };
+
+        await this.notificationsModel.createAiReviewNotifications({
+            recipients: [{ userUuid: args.assigneeUserUuid }],
+            metadata,
+            message: `You were assigned: ${metadata.title}`,
+            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+        });
+    }
+
+    async notifyNeedsReview(args: {
+        organizationUuid: string;
+        projectUuid: string;
+        reviewRunUuid: string;
+        fingerprints: string[];
+    }): Promise<void> {
+        if (args.fingerprints.length === 0) {
+            return;
+        }
+
+        const [recipients, reviewItem] = await Promise.all([
+            this.getRecipients(args.organizationUuid),
+            this.aiAgentReviewClassifierModel.getReviewItem(
+                args.organizationUuid,
+                args.fingerprints[0],
+            ),
+        ]);
+        const metadata = {
+            fingerprint: args.fingerprints[0],
+            event: AiReviewNotificationEvent.NeedsReview,
+            title: reviewItem?.title ?? 'AI review finding',
+            rootCause: reviewItem?.primaryRootCause ?? 'unknown',
+            projectUuid: args.projectUuid,
+            count: args.fingerprints.length,
+            searchParams: `reviewRunUuid=${args.reviewRunUuid}`,
+        };
+
+        await this.notificationsModel.createAiReviewNotifications({
+            recipients,
+            metadata,
+            message: `${args.fingerprints.length} AI context findings need review`,
+            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+        });
+    }
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -13900,11 +13900,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15252,11 +15252,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15317,11 +15317,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15517,11 +15517,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15536,11 +15536,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15555,11 +15555,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -30493,7 +30493,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30503,7 +30503,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30513,7 +30513,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30526,7 +30526,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -31181,7 +31181,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31191,7 +31191,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31201,7 +31201,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31214,7 +31214,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -34245,9 +34245,74 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiNotificationResourceType.AiReview': {
+        dataType: 'refEnum',
+        enums: ['aiReview'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiReviewNotificationEvent: {
+        dataType: 'refEnum',
+        enums: ['needs_review', 'assigned'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    NotificationAiReview: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'NotificationBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        metadata: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                searchParams: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                count: { dataType: 'double', required: true },
+                                projectUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                rootCause: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                title: { dataType: 'string', required: true },
+                                event: {
+                                    ref: 'AiReviewNotificationEvent',
+                                    required: true,
+                                },
+                                fingerprint: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        resourceType: {
+                            ref: 'ApiNotificationResourceType.AiReview',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Notification: {
         dataType: 'refAlias',
-        type: { ref: 'NotificationDashboardComment', validators: {} },
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'NotificationDashboardComment' },
+                { ref: 'NotificationAiReview' },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiNotificationsResults: {
@@ -34273,7 +34338,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiNotificationResourceType: {
         dataType: 'refEnum',
-        enums: ['dashboardComments'],
+        enums: ['dashboardComments', 'aiReview'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Notification.viewed_': {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15523,19 +15523,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -16159,8 +16146,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -31246,22 +31233,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -31821,22 +31808,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -34769,8 +34756,75 @@
                     }
                 ]
             },
+            "ApiNotificationResourceType.AiReview": {
+                "enum": ["aiReview"],
+                "type": "string"
+            },
+            "AiReviewNotificationEvent": {
+                "enum": ["needs_review", "assigned"],
+                "type": "string"
+            },
+            "NotificationAiReview": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/NotificationBase"
+                    },
+                    {
+                        "properties": {
+                            "metadata": {
+                                "properties": {
+                                    "searchParams": {
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "projectUuid": {
+                                        "type": "string"
+                                    },
+                                    "rootCause": {
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "event": {
+                                        "$ref": "#/components/schemas/AiReviewNotificationEvent"
+                                    },
+                                    "fingerprint": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "searchParams",
+                                    "count",
+                                    "projectUuid",
+                                    "rootCause",
+                                    "title",
+                                    "event",
+                                    "fingerprint"
+                                ],
+                                "type": "object"
+                            },
+                            "resourceType": {
+                                "$ref": "#/components/schemas/ApiNotificationResourceType.AiReview"
+                            }
+                        },
+                        "required": ["metadata", "resourceType"],
+                        "type": "object"
+                    }
+                ]
+            },
             "Notification": {
-                "$ref": "#/components/schemas/NotificationDashboardComment"
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/NotificationDashboardComment"
+                    },
+                    {
+                        "$ref": "#/components/schemas/NotificationAiReview"
+                    }
+                ]
             },
             "ApiNotificationsResults": {
                 "items": {
@@ -34793,7 +34847,7 @@
                 "type": "object"
             },
             "ApiNotificationResourceType": {
-                "enum": ["dashboardComments"],
+                "enum": ["dashboardComments", "aiReview"],
                 "type": "string"
             },
             "Pick_Notification.viewed_": {
@@ -40952,7 +41006,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3225.0",
+        "version": "0.3228.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.test.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.test.ts
@@ -1,6 +1,13 @@
+import {
+    AiReviewNotificationEvent,
+    ApiNotificationResourceType,
+} from '@lightdash/common';
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { NotificationsTableName } from '../../database/entities/notifications';
+import {
+    DbNotificationResourceType,
+    NotificationsTableName,
+} from '../../database/entities/notifications';
 import { NotificationsModel } from './NotificationsModel';
 
 describe('NotificationsModel', () => {
@@ -31,5 +38,78 @@ describe('NotificationsModel', () => {
         expect(query.sql).toContain('viewed');
         expect(query.sql).not.toContain('user_uuid');
         expect(query.bindings).not.toContain('attacker-user-uuid');
+    });
+
+    it('creates one AI review notification per recipient', async () => {
+        tracker.on.insert(NotificationsTableName).response([]);
+        tracker.on.insert(NotificationsTableName).response([]);
+
+        await model.createAiReviewNotifications({
+            recipients: [{ userUuid: 'user-1' }, { userUuid: 'user-2' }],
+            metadata: {
+                fingerprint: 'fingerprint-1',
+                event: AiReviewNotificationEvent.NeedsReview,
+                title: 'Missing metric',
+                rootCause: 'semantic_layer',
+                projectUuid: 'project-1',
+                count: 3,
+                searchParams: 'reviewItemUuid=fingerprint-1',
+            },
+            message: '3 AI context findings need review',
+            url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+        });
+
+        expect(tracker.history.insert).toHaveLength(2);
+        expect(tracker.history.insert[0].bindings).toContain(
+            DbNotificationResourceType.AiReviewItem,
+        );
+        expect(tracker.history.insert[0].bindings).toContain('user-1');
+        expect(tracker.history.insert[1].bindings).toContain('user-2');
+    });
+
+    it('maps AI review notification rows', async () => {
+        tracker.on.select(NotificationsTableName).response([
+            {
+                notification_id: 'notification-1',
+                resource_type: DbNotificationResourceType.AiReviewItem,
+                message: 'Missing metric needs review',
+                url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+                viewed: false,
+                created_at: new Date('2026-06-23T10:00:00.000Z'),
+                resource_uuid: 'fingerprint-1',
+                metadata: {
+                    fingerprint: 'fingerprint-1',
+                    event: AiReviewNotificationEvent.Assigned,
+                    title: 'Missing metric',
+                    rootCause: 'semantic_layer',
+                    projectUuid: 'project-1',
+                    count: 1,
+                    searchParams: 'reviewItemUuid=fingerprint-1',
+                },
+            },
+        ]);
+
+        await expect(model.getAiReviewNotifications('user-1')).resolves.toEqual(
+            [
+                {
+                    notificationId: 'notification-1',
+                    resourceType: ApiNotificationResourceType.AiReview,
+                    message: 'Missing metric needs review',
+                    url: '/ai-agents/admin/reviews?reviewItemUuid=fingerprint-1',
+                    viewed: false,
+                    createdAt: new Date('2026-06-23T10:00:00.000Z'),
+                    resourceUuid: 'fingerprint-1',
+                    metadata: {
+                        fingerprint: 'fingerprint-1',
+                        event: AiReviewNotificationEvent.Assigned,
+                        title: 'Missing metric',
+                        rootCause: 'semantic_layer',
+                        projectUuid: 'project-1',
+                        count: 1,
+                        searchParams: 'reviewItemUuid=fingerprint-1',
+                    },
+                },
+            ],
+        );
     });
 });

--- a/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
+++ b/packages/backend/src/models/NotificationsModel/NotificationsModel.ts
@@ -5,10 +5,12 @@ import {
     DashboardDAO,
     DashboardTile,
     LightdashUser,
+    NotificationAiReview,
     NotificationDashboardComment,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
+    DbNotificationDashboardTileCommentMetadata,
     DbNotificationResourceType,
     NotificationsTableName,
 } from '../../database/entities/notifications';
@@ -36,22 +38,51 @@ export class NotificationsModel {
             )
             .orderBy(`${NotificationsTableName}.created_at`, 'desc');
 
+        return notifications.map((notif) => {
+            const metadata =
+                notif.metadata as DbNotificationDashboardTileCommentMetadata | null;
+
+            return {
+                notificationId: notif.notification_id,
+                resourceType: ApiNotificationResourceType.DashboardComments,
+                message: notif.message ?? undefined,
+                url: notif.url ?? undefined,
+                viewed: notif.viewed,
+                createdAt: notif.created_at,
+                resourceUuid: notif.resource_uuid ?? undefined,
+                metadata: metadata
+                    ? {
+                          dashboardUuid: metadata.dashboard_uuid,
+                          dashboardName: metadata.dashboard_name,
+                          dashboardTileUuid: metadata.dashboard_tile_uuid,
+                          dashboardTileName: metadata.dashboard_tile_name,
+                      }
+                    : undefined,
+            };
+        });
+    }
+
+    async getAiReviewNotifications(
+        userUuid: string,
+    ): Promise<NotificationAiReview[]> {
+        const notifications = await this.database(NotificationsTableName)
+            .select()
+            .where(`${NotificationsTableName}.user_uuid`, userUuid)
+            .andWhere(
+                `${NotificationsTableName}.resource_type`,
+                DbNotificationResourceType.AiReviewItem,
+            )
+            .orderBy(`${NotificationsTableName}.created_at`, 'desc');
+
         return notifications.map((notif) => ({
             notificationId: notif.notification_id,
-            resourceType: ApiNotificationResourceType.DashboardComments,
+            resourceType: ApiNotificationResourceType.AiReview,
             message: notif.message ?? undefined,
             url: notif.url ?? undefined,
             viewed: notif.viewed,
             createdAt: notif.created_at,
             resourceUuid: notif.resource_uuid ?? undefined,
-            metadata: notif.metadata
-                ? {
-                      dashboardUuid: notif.metadata.dashboard_uuid,
-                      dashboardName: notif.metadata.dashboard_name,
-                      dashboardTileUuid: notif.metadata.dashboard_tile_uuid,
-                      dashboardTileName: notif.metadata.dashboard_tile_name,
-                  }
-                : undefined,
+            metadata: notif.metadata as NotificationAiReview['metadata'],
         }));
     }
 
@@ -125,6 +156,31 @@ export class NotificationsModel {
                         }),
                     });
                 }
+            }),
+        );
+    }
+
+    async createAiReviewNotifications({
+        recipients,
+        metadata,
+        message,
+        url,
+    }: {
+        recipients: { userUuid: string }[];
+        metadata: NotificationAiReview['metadata'];
+        message: string;
+        url: string;
+    }): Promise<void> {
+        await Promise.all(
+            recipients.map(async ({ userUuid }) => {
+                await this.database(NotificationsTableName).insert({
+                    user_uuid: userUuid,
+                    resource_uuid: metadata.fingerprint,
+                    resource_type: DbNotificationResourceType.AiReviewItem,
+                    message,
+                    url,
+                    metadata: JSON.stringify(metadata),
+                });
             }),
         );
     }

--- a/packages/backend/src/services/NotificationsService/NotificationsService.ts
+++ b/packages/backend/src/services/NotificationsService/NotificationsService.ts
@@ -28,6 +28,10 @@ export class NotificationsService extends BaseService {
                 return this.notificationsModel.getDashboardCommentNotifications(
                     userUuid,
                 );
+            case ApiNotificationResourceType.AiReview:
+                return this.notificationsModel.getAiReviewNotifications(
+                    userUuid,
+                );
             default:
                 return assertUnreachable(
                     type,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -145,6 +145,7 @@ interface ServiceManifest {
     permissionsService: PermissionsService;
     /** An implementation signature for these services are not available at this stage */
     aiWritebackService: unknown;
+    aiAgentReviewNotificationService: unknown;
     writebackPreviewService: unknown;
     previewDeploySetupService: unknown;
     appGenerateService: unknown;
@@ -1391,6 +1392,12 @@ export class ServiceRepository
         AiAgentReviewClassifierServiceImplT,
     >(): AiAgentReviewClassifierServiceImplT {
         return this.getService('aiAgentReviewClassifierService');
+    }
+
+    public getAiAgentReviewNotificationService<
+        AiAgentReviewNotificationServiceImplT,
+    >(): AiAgentReviewNotificationServiceImplT {
+        return this.getService('aiAgentReviewNotificationService');
     }
 
     public getAiRouterService<AiRouterServiceImplT>(): AiRouterServiceImplT {

--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -13,6 +13,7 @@ export * as preAggregateUtils from './preAggregates/utils';
 export * from './scim/errors';
 export * from './scim/types';
 export * from './serviceAccounts/types';
+export * from './types/aiReviewNotification';
 export * from './types/managedAgent';
 
 export enum ScimSchemaType {

--- a/packages/common/src/ee/types/aiReviewNotification.test.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.test.ts
@@ -1,0 +1,9 @@
+import {
+    AiReviewNotificationChannel,
+    AiReviewNotificationEvent,
+} from './aiReviewNotification';
+
+test('event and channel enums expose stable string values', () => {
+    expect(AiReviewNotificationEvent.NeedsReview).toBe('needs_review');
+    expect(AiReviewNotificationChannel.SlackDm).toBe('slack_dm');
+});

--- a/packages/common/src/ee/types/aiReviewNotification.ts
+++ b/packages/common/src/ee/types/aiReviewNotification.ts
@@ -1,0 +1,38 @@
+import { type ApiSuccess } from '../../types/api/success';
+
+export enum AiReviewNotificationEvent {
+    NeedsReview = 'needs_review',
+    Assigned = 'assigned',
+}
+
+export enum AiReviewNotificationChannel {
+    Bell = 'bell',
+    SlackChannel = 'slack_channel',
+    SlackDm = 'slack_dm',
+}
+
+export enum AiReviewNotificationStatus {
+    Sent = 'sent',
+    Errored = 'errored',
+    Clicked = 'clicked',
+    Dismissed = 'dismissed',
+}
+
+export type AiReviewNotificationSettings = {
+    organizationUuid: string;
+    enabled: boolean;
+    slackChannelId: string | null;
+};
+
+export type UpdateAiReviewNotificationSettings = Pick<
+    AiReviewNotificationSettings,
+    'enabled' | 'slackChannelId'
+>;
+
+export type ApiAiReviewNotificationSettingsResponse =
+    ApiSuccess<AiReviewNotificationSettings>;
+
+export type AiReviewNotificationRecipient = {
+    userUuid: string;
+    email: string;
+};

--- a/packages/common/src/types/api/notifications.test.ts
+++ b/packages/common/src/types/api/notifications.test.ts
@@ -1,0 +1,5 @@
+import { ApiNotificationResourceType } from './notifications';
+
+test('AiReview resource type is exposed', () => {
+    expect(ApiNotificationResourceType.AiReview).toBe('aiReview');
+});

--- a/packages/common/src/types/api/notifications.ts
+++ b/packages/common/src/types/api/notifications.ts
@@ -1,5 +1,8 @@
+import { type AiReviewNotificationEvent } from '../../ee/types/aiReviewNotification';
+
 export enum ApiNotificationResourceType {
     DashboardComments = 'dashboardComments',
+    AiReview = 'aiReview',
 }
 
 interface NotificationDashboardTileCommentMetadata {
@@ -23,7 +26,20 @@ export type NotificationDashboardComment = NotificationBase & {
     metadata: NotificationDashboardTileCommentMetadata | undefined;
 };
 
-export type Notification = NotificationDashboardComment;
+export type NotificationAiReview = NotificationBase & {
+    resourceType: ApiNotificationResourceType.AiReview;
+    metadata: {
+        fingerprint: string;
+        event: AiReviewNotificationEvent;
+        title: string;
+        rootCause: string;
+        projectUuid: string;
+        count: number;
+        searchParams: string;
+    };
+};
+
+export type Notification = NotificationDashboardComment | NotificationAiReview;
 
 export type ApiNotificationUpdateParams = Pick<Notification, 'viewed'>;
 export type ApiNotificationsResults = Notification[];

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -1,12 +1,15 @@
 import {
+    type Notification,
     NotificationResourceType,
     ValidationErrorType,
 } from '@lightdash/common';
 import { Button, getDefaultZIndex, Indicator, Menu } from '@mantine-8/core';
 import { IconBell } from '@tabler/icons-react';
-import { type FC } from 'react';
+import { Fragment, type FC, useMemo } from 'react';
+import { useAiAgentPermission } from '../../../ee/features/aiCopilot/hooks/useAiAgentPermission';
 import { useDashboardCommentsCheck } from '../../../features/comments';
 import {
+    AiReviewNotifications,
     DashboardCommentsNotifications,
     useGetNotifications,
 } from '../../../features/notifications';
@@ -46,6 +49,25 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
     const hasDashboardCommentsNotifications =
         dashboardCommentsNotifications &&
         dashboardCommentsNotifications.length > 0;
+    const canViewAiReviews = useAiAgentPermission({ action: 'manage' });
+    const { data: aiReviewNotifications } = useGetNotifications(
+        NotificationResourceType.AiReview,
+        !!canViewAiReviews,
+    );
+    const hasAiReviewNotifications =
+        aiReviewNotifications && aiReviewNotifications.length > 0;
+    const notifications = useMemo<Notification[]>(
+        () =>
+            [
+                ...(dashboardCommentsNotifications ?? []),
+                ...(aiReviewNotifications ?? []),
+            ].sort(
+                (a, b) =>
+                    new Date(b.createdAt).getTime() -
+                    new Date(a.createdAt).getTime(),
+            ),
+        [aiReviewNotifications, dashboardCommentsNotifications],
+    );
 
     const showNotificationBadge = () => {
         /**
@@ -61,14 +83,23 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
             const hasUnreadComments = dashboardCommentsNotifications?.some(
                 (n) => !n.viewed,
             );
-            return hasUnreadComments;
+            if (hasUnreadComments) return true;
+        }
+
+        if (canViewAiReviews) {
+            const hasUnreadAiReviews = aiReviewNotifications?.some(
+                (n) => !n.viewed,
+            );
+            if (hasUnreadAiReviews) return true;
         }
 
         return false;
     };
 
     const shouldDisplayMenu =
-        canViewDashboardComments || canUserManageValidations;
+        canViewDashboardComments ||
+        canUserManageValidations ||
+        canViewAiReviews;
 
     return shouldDisplayMenu ? (
         <Menu
@@ -106,14 +137,28 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                         validationData={validationErrors}
                     />
                 )}
-                {hasDashboardCommentsNotifications && (
-                    <DashboardCommentsNotifications
-                        notifications={dashboardCommentsNotifications}
-                        projectUuid={projectUuid}
-                    />
+                {notifications.length > 0 && (
+                    <>
+                        {notifications.map((notification) => (
+                            <Fragment key={notification.notificationId}>
+                                {notification.resourceType ===
+                                NotificationResourceType.DashboardComments ? (
+                                    <DashboardCommentsNotifications
+                                        notifications={[notification]}
+                                        projectUuid={projectUuid}
+                                    />
+                                ) : (
+                                    <AiReviewNotifications
+                                        notifications={[notification]}
+                                    />
+                                )}
+                            </Fragment>
+                        ))}
+                    </>
                 )}
                 {!hasValidationNotifications &&
-                    !hasDashboardCommentsNotifications && (
+                    !hasDashboardCommentsNotifications &&
+                    !hasAiReviewNotifications && (
                         <Menu.Item>No notifications</Menu.Item>
                     )}
             </Menu.Dropdown>

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -1,11 +1,12 @@
-import { type NotificationDashboardComment } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
+import { type NotificationAiReview } from '@lightdash/common';
+import { Box, Menu } from '@mantine-8/core';
 import { Text, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -13,8 +14,7 @@ import { useUpdateNotification } from '../hooks/useNotifications';
 import classes from './DashboardCommentsNotifications.module.css';
 
 type Props = {
-    projectUuid: string;
-    notifications: NotificationDashboardComment[];
+    notifications: NotificationAiReview[];
 };
 
 const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
@@ -22,7 +22,6 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
     return (
         <Tooltip
             position="top-end"
-            // Add offset so toolip pointer is closer to the text
             offset={-2}
             label={
                 <Text fz="xs">
@@ -42,17 +41,14 @@ const NotificationTime: FC<{ createdAt: Date }> = ({ createdAt }) => {
     );
 };
 
-export const DashboardCommentsNotifications: FC<Props> = ({
-    projectUuid,
-    notifications,
-}) => {
+export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
     const { track } = useTracking();
     const theme = useMantineTheme();
     const navigate = useNavigate();
     const { mutateAsync: updateNotification } = useUpdateNotification();
 
     const handleOnNotificationClick = useCallback(
-        async (notification: NotificationDashboardComment) => {
+        async (notification: NotificationAiReview) => {
             await updateNotification({
                 notificationId: notification.notificationId,
                 resourceType: notification.resourceType,
@@ -62,23 +58,19 @@ export const DashboardCommentsNotifications: FC<Props> = ({
             });
 
             track({
-                name: EventName.NOTIFICATIONS_COMMENTS_ITEM_CLICKED,
+                name: EventName.NOTIFICATIONS_ITEM_CLICKED,
                 properties: {
-                    hasMention: true, // TODO: At the moment, comments' notifications are always mentions
-                    dashboardUuid: notification.metadata?.dashboardUuid,
-                    dashboardTileUuid: notification.metadata?.dashboardTileUuid,
+                    resourceType: notification.resourceType,
+                    event: notification.metadata.event,
+                    projectUuid: notification.metadata.projectUuid,
+                    fingerprint: notification.metadata.fingerprint,
+                    count: notification.metadata.count,
                 },
             });
 
-            void navigate(
-                `/projects/${projectUuid}${notification.url}${
-                    notification.metadata?.dashboardTileUuid
-                        ? `?tileUuid=${notification.metadata?.dashboardTileUuid}`
-                        : ''
-                }`,
-            );
+            void navigate(notification.url ?? '/ai-agents/admin/reviews');
         },
-        [navigate, projectUuid, track, updateNotification],
+        [navigate, track, updateNotification],
     );
 
     return (
@@ -88,15 +80,24 @@ export const DashboardCommentsNotifications: FC<Props> = ({
                     p="xs"
                     key={notification.notificationId}
                     leftSection={
-                        <MantineIcon
-                            size={10}
-                            icon={IconCircleFilled}
+                        <Box
+                            display="flex"
                             style={{
-                                color: notification.viewed
-                                    ? 'transparent'
-                                    : theme.colors.blue[4],
+                                alignItems: 'center',
+                                gap: 6,
                             }}
-                        />
+                        >
+                            <MantineIcon
+                                size={8}
+                                icon={IconCircleFilled}
+                                style={{
+                                    color: notification.viewed
+                                        ? 'transparent'
+                                        : theme.colors.teal[5],
+                                }}
+                            />
+                            <AiAgentIcon size={16} calm />
+                        </Box>
                     }
                     onClick={() => handleOnNotificationClick(notification)}
                     fz="xs"

--- a/packages/frontend/src/features/notifications/hooks/useNotifications.tsx
+++ b/packages/frontend/src/features/notifications/hooks/useNotifications.tsx
@@ -9,18 +9,28 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
-const getNotifications = async (type: ApiNotificationResourceType) =>
-    lightdashApi<ApiGetNotifications['results']>({
+type NotificationForResource<T extends ApiNotificationResourceType> = Extract<
+    Notification,
+    { resourceType: T }
+>;
+
+const getNotifications = async <T extends ApiNotificationResourceType>(
+    type: T,
+): Promise<NotificationForResource<T>[]> => {
+    const results = await lightdashApi<ApiGetNotifications['results']>({
         url: `/notifications?type=${type}`,
         method: 'GET',
         body: undefined,
     });
 
-export const useGetNotifications = (
-    type: ApiNotificationResourceType,
+    return results as NotificationForResource<T>[];
+};
+
+export const useGetNotifications = <T extends ApiNotificationResourceType>(
+    type: T,
     enabled: boolean,
 ) =>
-    useQuery<ApiGetNotifications['results'], ApiError>(
+    useQuery<NotificationForResource<T>[], ApiError>(
         ['notifications', type],
         () => getNotifications(type),
         {

--- a/packages/frontend/src/features/notifications/index.ts
+++ b/packages/frontend/src/features/notifications/index.ts
@@ -1,2 +1,3 @@
+export * from './components/AiReviewNotifications';
 export * from './components/DashboardCommentsNotifications';
 export { useGetNotifications } from './hooks/useNotifications';


### PR DESCRIPTION
Part 1 of 3 — splits ZAP-488 ([#24632](https://github.com/lightdash/lightdash/pull/24632)) into a reviewable stack.

## Summary

Adds **in-app bell notifications** for AI reviews — the narrowest end-to-end slice. When a review finding is promoted (needs review) or a review item is assigned, a notification row is written and rendered in the navbar bell alongside dashboard comments.

- shared notification types (`NotificationAiReview`, event/channel/status enums, recipient type)
- `AiAgentReviewNotificationService` writes bell rows via the generic `NotificationsModel` (no Slack, no settings yet)
- fires on promoted findings (classifier) and on assignment (admin service)
- broadens review access from org-admin to `manage:AiAgent` (developers) — recipients are everyone who can manage AI agents
- navbar bell renders AI-review notifications, merged + time-sorted with dashboard comments

## Stack

1. **this PR** — in-app bell notifications
2. Slack delivery + click tracking
3. admin review-notification settings endpoints

## Regression analysis

No feature flag (per product decision): review access is already gated to org-admins/developers with `manage:AiAgent`, and the Slack channel path (PR 2/3) requires an admin to opt in via settings. So only users who can already see reviews receive bell notifications; viewers and non-members are unaffected. Dashboard-comment notifications are untouched (the menu now merges both lists).

## Validation

- `pnpm -F common build`
- `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`
- `pnpm -F backend test:dev:nowatch AiAgentReviewNotificationService AiAgentAdminService AiAgentReviewClassifierService NotificationsModel`