### PR TITLE
fix: drop system-variable description tooltip in custom SQL autocomplete

### DIFF
--- a/packages/frontend/src/hooks/useExplorerAceEditorCompleter.ts
+++ b/packages/frontend/src/hooks/useExplorerAceEditorCompleter.ts
@@ -166,14 +166,11 @@ const mapReservedParametersToCompletions = (
                 return acc;
             }
             const reference = `\${ld.parameters.${name}}`;
-            // `docText` renders the description in the autocomplete doc tooltip. It is
-            // supported by ace's language-tools at runtime but missing from its types.
-            const technicalOption: Ace.Completion & { docText?: string } = {
+            const technicalOption: Ace.Completion = {
                 caption: reference,
                 value: reference,
                 meta: 'System variable',
                 score: Number.MAX_VALUE,
-                docText: definition.description,
             };
             const friendlyOption: Ace.Completion = {
                 ...technicalOption,


### PR DESCRIPTION
Removes the floating description doc tooltip that ace rendered for reserved/system-variable completions in the custom SQL editor. The system variables are still offered in autocomplete (both the `${ld.parameters.date_zoom}` reference and the friendly label) — only the large description popover is gone.

Follow-up polish on top of the reserved-parameters UI work.

Relates to: GLITCH-195