### PR TITLE
feat: roadmap service customer resolution and curated mirror sync

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -452,6 +452,12 @@ import {
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
 import {
+    RoadmapCustomerLinksTable,
+    RoadmapCustomerLinksTableName,
+    RoadmapItemsTable,
+    RoadmapItemsTableName,
+} from '../ee/database/entities/roadmap';
+import {
     AppExternalConnectionsTable,
     AppExternalConnectionsTableName,
     ExternalConnectionRateCountersTable,
@@ -652,6 +658,8 @@ declare module 'knex/types/tables' {
         [AiReviewNotificationLogTableName]: AiReviewNotificationLogTable;
         [AiReviewNotificationSettingsTableName]: AiReviewNotificationSettingsTable;
         [DashboardSummariesTableName]: DashboardSummariesTable;
+        [RoadmapCustomerLinksTableName]: RoadmapCustomerLinksTable;
+        [RoadmapItemsTableName]: RoadmapItemsTable;
         [CatalogTableName]: CatalogTable;
         [SlackChannelProjectMappingsTableName]: SlackChannelProjectMappingsTable;
         [WarehouseAvailableTablesTableName]: WarehouseAvailableTablesTable;

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -207,6 +207,15 @@ export const lightdashConfigMock: LightdashConfig = {
     license: {
         licenseKey: null,
     },
+    roadmap: {
+        enabled: false,
+        syncCron: '17 * * * *',
+        linear: {
+            apiKey: null,
+            apiUrl: 'https://api.linear.app/graphql',
+            featureRequestLabel: null,
+        },
+    },
     groups: {
         enabled: false,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1275,6 +1275,15 @@ export type LightdashConfig = {
     license: {
         licenseKey: string | null;
     };
+    roadmap: {
+        enabled: boolean;
+        syncCron: string;
+        linear: {
+            apiKey: string | null;
+            apiUrl: string;
+            featureRequestLabel: string | null;
+        };
+    };
     sentry: SentryConfig;
     auth: AuthConfig;
     intercom: IntercomConfig;
@@ -2423,6 +2432,18 @@ export const parseConfig = (): LightdashConfig => {
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {
             licenseKey,
+        },
+        roadmap: {
+            enabled: process.env.ROADMAP_ENABLED === 'true',
+            syncCron: process.env.ROADMAP_SYNC_CRON || '17 * * * *',
+            linear: {
+                apiKey: process.env.ROADMAP_LINEAR_API_KEY || null,
+                apiUrl:
+                    process.env.ROADMAP_LINEAR_API_URL ||
+                    'https://api.linear.app/graphql',
+                featureRequestLabel:
+                    process.env.ROADMAP_LINEAR_FEATURE_REQUEST_LABEL || null,
+            },
         },
         security: {
             contentSecurityPolicy: {

--- a/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
+++ b/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
@@ -1,0 +1,183 @@
+import { LinearClient } from './LinearClient';
+
+const buildResponse = (data: unknown) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ data }),
+});
+
+const customerPage = (
+    nodes: Array<{ id: string; name: string; externalIds: string[] }>,
+    hasNextPage = false,
+    endCursor: string | null = null,
+) => ({
+    customers: { nodes, pageInfo: { hasNextPage, endCursor } },
+});
+
+const needsPage = (
+    issues: Array<{
+        id: string;
+        title: string;
+        description: string | null;
+        labels: string[];
+        state: { name: string; type: string };
+    } | null>,
+    hasNextPage = false,
+    endCursor: string | null = null,
+) => ({
+    customer: {
+        needs: {
+            nodes: issues.map((issue) =>
+                issue === null
+                    ? { issue: null }
+                    : {
+                          issue: {
+                              id: issue.id,
+                              title: issue.title,
+                              description: issue.description,
+                              labels: {
+                                  nodes: issue.labels.map((name) => ({ name })),
+                              },
+                              state: issue.state,
+                          },
+                      },
+            ),
+            pageInfo: { hasNextPage, endCursor },
+        },
+    },
+});
+
+describe('LinearClient', () => {
+    const fetchMock = jest.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    const buildClient = (featureRequestLabel: string | null = null) =>
+        new LinearClient({
+            apiKey: 'lin_api_test',
+            apiUrl: 'https://api.linear.app/graphql',
+            featureRequestLabel,
+        });
+
+    it('paginates listCustomers across pages', async () => {
+        fetchMock
+            .mockResolvedValueOnce(
+                buildResponse(
+                    customerPage(
+                        [{ id: 'c1', name: 'One', externalIds: ['org-1'] }],
+                        true,
+                        'cursor-1',
+                    ),
+                ),
+            )
+            .mockResolvedValueOnce(
+                buildResponse(
+                    customerPage([{ id: 'c2', name: 'Two', externalIds: [] }]),
+                ),
+            );
+
+        const client = buildClient();
+        const customers = await client.listCustomers();
+
+        expect(customers).toEqual([
+            { id: 'c1', name: 'One', externalIds: ['org-1'] },
+            { id: 'c2', name: 'Two', externalIds: [] },
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        // The Linear API key is sent verbatim in the Authorization header.
+        expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe(
+            'lin_api_test',
+        );
+    });
+
+    it('returns mapped feature requests and skips null issues', async () => {
+        fetchMock.mockResolvedValueOnce(
+            buildResponse(
+                needsPage([
+                    {
+                        id: 'i1',
+                        title: 'Dark mode',
+                        description: 'please',
+                        labels: ['Feature request'],
+                        state: { name: 'In Progress', type: 'started' },
+                    },
+                    null,
+                ]),
+            ),
+        );
+
+        const client = buildClient();
+        const issues = await client.getCustomerFeatureRequests('c1');
+
+        expect(issues).toEqual([
+            {
+                id: 'i1',
+                title: 'Dark mode',
+                description: 'please',
+                state: { name: 'In Progress', type: 'started' },
+            },
+        ]);
+    });
+
+    it('filters by label when a feature-request label is configured', async () => {
+        fetchMock.mockResolvedValueOnce(
+            buildResponse(
+                needsPage([
+                    {
+                        id: 'i1',
+                        title: 'Keep',
+                        description: null,
+                        labels: ['Feature request'],
+                        state: { name: 'Todo', type: 'unstarted' },
+                    },
+                    {
+                        id: 'i2',
+                        title: 'Drop',
+                        description: null,
+                        labels: ['Bug'],
+                        state: { name: 'Todo', type: 'unstarted' },
+                    },
+                ]),
+            ),
+        );
+
+        const client = buildClient('Feature request');
+        const issues = await client.getCustomerFeatureRequests('c1');
+
+        expect(issues.map((i) => i.id)).toEqual(['i1']);
+    });
+
+    it('returns an empty list when the customer is missing', async () => {
+        fetchMock.mockResolvedValueOnce(buildResponse({ customer: null }));
+
+        const client = buildClient();
+        const issues = await client.getCustomerFeatureRequests('missing');
+
+        expect(issues).toEqual([]);
+    });
+
+    it('throws when the API returns GraphQL errors', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ errors: [{ message: 'Bad request' }] }),
+        });
+
+        const client = buildClient();
+        await expect(client.listCustomers()).rejects.toThrow('Bad request');
+    });
+
+    it('throws when the API responds with a non-ok status', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            json: async () => ({}),
+        });
+
+        const client = buildClient();
+        await expect(client.listCustomers()).rejects.toThrow('status 401');
+    });
+});

--- a/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
+++ b/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
@@ -25,25 +25,23 @@ const needsPage = (
     hasNextPage = false,
     endCursor: string | null = null,
 ) => ({
-    customer: {
-        needs: {
-            nodes: issues.map((issue) =>
-                issue === null
-                    ? { issue: null }
-                    : {
-                          issue: {
-                              id: issue.id,
-                              title: issue.title,
-                              description: issue.description,
-                              labels: {
-                                  nodes: issue.labels.map((name) => ({ name })),
-                              },
-                              state: issue.state,
+    customerNeeds: {
+        nodes: issues.map((issue) =>
+            issue === null
+                ? { issue: null }
+                : {
+                      issue: {
+                          id: issue.id,
+                          title: issue.title,
+                          description: issue.description,
+                          labels: {
+                              nodes: issue.labels.map((name) => ({ name })),
                           },
+                          state: issue.state,
                       },
-            ),
-            pageInfo: { hasNextPage, endCursor },
-        },
+                  },
+        ),
+        pageInfo: { hasNextPage, endCursor },
     },
 });
 
@@ -150,8 +148,8 @@ describe('LinearClient', () => {
         expect(issues.map((i) => i.id)).toEqual(['i1']);
     });
 
-    it('returns an empty list when the customer is missing', async () => {
-        fetchMock.mockResolvedValueOnce(buildResponse({ customer: null }));
+    it('returns an empty list when the customer has no needs', async () => {
+        fetchMock.mockResolvedValueOnce(buildResponse(needsPage([])));
 
         const client = buildClient();
         const issues = await client.getCustomerFeatureRequests('missing');
@@ -170,14 +168,17 @@ describe('LinearClient', () => {
         await expect(client.listCustomers()).rejects.toThrow('Bad request');
     });
 
-    it('throws when the API responds with a non-ok status', async () => {
+    it('throws with the response body when the API responds with a non-ok status', async () => {
         fetchMock.mockResolvedValueOnce({
             ok: false,
-            status: 401,
-            json: async () => ({}),
+            status: 400,
+            text: async () =>
+                '{"errors":[{"message":"Unknown argument \\"first\\""}]}',
         });
 
         const client = buildClient();
-        await expect(client.listCustomers()).rejects.toThrow('status 401');
+        await expect(client.listCustomers()).rejects.toThrow(
+            /status 400.*Unknown argument/,
+        );
     });
 });

--- a/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
+++ b/packages/backend/src/ee/clients/Linear/LinearClient.test.ts
@@ -48,7 +48,7 @@ const needsPage = (
 });
 
 describe('LinearClient', () => {
-    const fetchMock = jest.fn();
+    const fetchMock = vi.fn();
 
     beforeEach(() => {
         fetchMock.mockReset();

--- a/packages/backend/src/ee/clients/Linear/LinearClient.ts
+++ b/packages/backend/src/ee/clients/Linear/LinearClient.ts
@@ -1,0 +1,206 @@
+import { UnexpectedServerError } from '@lightdash/common';
+
+/**
+ * A Linear customer as read from the Linear API. `externalIds` is how a
+ * customer is linked back to a Lightdash organization (set to the org uuid at
+ * onboarding — see CS-27).
+ */
+export type LinearCustomer = {
+    id: string;
+    name: string;
+    externalIds: string[];
+};
+
+/**
+ * The public parts of a Linear issue associated with a customer. The workflow
+ * state is mapped to a customer-facing status during curation; nothing else
+ * here is exposed verbatim.
+ */
+export type LinearCustomerIssue = {
+    id: string;
+    title: string;
+    description: string | null;
+    state: {
+        name: string;
+        type: string;
+    };
+};
+
+type GraphqlResponse<T> = {
+    data?: T;
+    errors?: Array<{ message: string }>;
+};
+
+type PageInfo = {
+    hasNextPage: boolean;
+    endCursor: string | null;
+};
+
+type CustomersQueryResponse = {
+    customers: {
+        nodes: LinearCustomer[];
+        pageInfo: PageInfo;
+    };
+};
+
+type CustomerNeedsQueryResponse = {
+    customer: {
+        needs: {
+            nodes: Array<{
+                issue: {
+                    id: string;
+                    title: string;
+                    description: string | null;
+                    labels: { nodes: Array<{ name: string }> };
+                    state: { name: string; type: string };
+                } | null;
+            }>;
+            pageInfo: PageInfo;
+        };
+    } | null;
+};
+
+const PAGE_SIZE = 100;
+
+const CUSTOMERS_QUERY = `
+    query Customers($after: String) {
+        customers(first: ${PAGE_SIZE}, after: $after) {
+            nodes { id name externalIds }
+            pageInfo { hasNextPage endCursor }
+        }
+    }
+`;
+
+const CUSTOMER_NEEDS_QUERY = `
+    query CustomerNeeds($customerId: String!, $after: String) {
+        customer(id: $customerId) {
+            needs(first: ${PAGE_SIZE}, after: $after) {
+                nodes {
+                    issue {
+                        id
+                        title
+                        description
+                        labels { nodes { name } }
+                        state { name type }
+                    }
+                }
+                pageInfo { hasNextPage endCursor }
+            }
+        }
+    }
+`;
+
+type LinearClientArgs = {
+    apiKey: string;
+    apiUrl: string;
+    featureRequestLabel: string | null;
+};
+
+/**
+ * Thin wrapper over the Linear GraphQL API used by the roadmap service to
+ * mirror customer feature requests. Read-only.
+ */
+export class LinearClient {
+    private readonly apiKey: string;
+
+    private readonly apiUrl: string;
+
+    private readonly featureRequestLabel: string | null;
+
+    constructor(args: LinearClientArgs) {
+        this.apiKey = args.apiKey;
+        this.apiUrl = args.apiUrl;
+        this.featureRequestLabel = args.featureRequestLabel;
+    }
+
+    private async graphql<T>(
+        query: string,
+        variables: Record<string, unknown>,
+    ): Promise<T> {
+        const response = await fetch(this.apiUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: this.apiKey,
+            },
+            body: JSON.stringify({ query, variables }),
+        });
+
+        if (!response.ok) {
+            throw new UnexpectedServerError(
+                `Linear API request failed with status ${response.status}`,
+            );
+        }
+
+        const { data, errors } = (await response.json()) as GraphqlResponse<T>;
+        if (errors && errors.length > 0) {
+            throw new UnexpectedServerError(
+                `Linear API error: ${errors.map((e) => e.message).join(', ')}`,
+            );
+        }
+        if (!data) {
+            throw new UnexpectedServerError('Linear API returned no data');
+        }
+        return data;
+    }
+
+    async listCustomers(): Promise<LinearCustomer[]> {
+        const customers: LinearCustomer[] = [];
+        let after: string | null = null;
+        // Cursor pagination is inherently sequential.
+        /* eslint-disable no-await-in-loop */
+        do {
+            const { customers: page }: CustomersQueryResponse =
+                await this.graphql<CustomersQueryResponse>(CUSTOMERS_QUERY, {
+                    after,
+                });
+            customers.push(...page.nodes);
+            after = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+        } while (after !== null);
+        /* eslint-enable no-await-in-loop */
+        return customers;
+    }
+
+    async getCustomerFeatureRequests(
+        customerId: string,
+    ): Promise<LinearCustomerIssue[]> {
+        const issues: LinearCustomerIssue[] = [];
+        let after: string | null = null;
+        // Cursor pagination is inherently sequential.
+        /* eslint-disable no-await-in-loop */
+        do {
+            const { customer }: CustomerNeedsQueryResponse =
+                await this.graphql<CustomerNeedsQueryResponse>(
+                    CUSTOMER_NEEDS_QUERY,
+                    { customerId, after },
+                );
+            if (!customer) {
+                break;
+            }
+            customer.needs.nodes.forEach((need) => {
+                const { issue } = need;
+                if (!issue) {
+                    return;
+                }
+                const labels = issue.labels.nodes.map((l) => l.name);
+                if (
+                    this.featureRequestLabel !== null &&
+                    !labels.includes(this.featureRequestLabel)
+                ) {
+                    return;
+                }
+                issues.push({
+                    id: issue.id,
+                    title: issue.title,
+                    description: issue.description,
+                    state: issue.state,
+                });
+            });
+            after = customer.needs.pageInfo.hasNextPage
+                ? customer.needs.pageInfo.endCursor
+                : null;
+        } while (after !== null);
+        /* eslint-enable no-await-in-loop */
+        return issues;
+    }
+}

--- a/packages/backend/src/ee/clients/Linear/LinearClient.ts
+++ b/packages/backend/src/ee/clients/Linear/LinearClient.ts
@@ -44,20 +44,18 @@ type CustomersQueryResponse = {
 };
 
 type CustomerNeedsQueryResponse = {
-    customer: {
-        needs: {
-            nodes: Array<{
-                issue: {
-                    id: string;
-                    title: string;
-                    description: string | null;
-                    labels: { nodes: Array<{ name: string }> };
-                    state: { name: string; type: string };
-                } | null;
-            }>;
-            pageInfo: PageInfo;
-        };
-    } | null;
+    customerNeeds: {
+        nodes: Array<{
+            issue: {
+                id: string;
+                title: string;
+                description: string | null;
+                labels: { nodes: Array<{ name: string }> };
+                state: { name: string; type: string };
+            } | null;
+        }>;
+        pageInfo: PageInfo;
+    };
 };
 
 const PAGE_SIZE = 100;
@@ -71,21 +69,21 @@ const CUSTOMERS_QUERY = `
     }
 `;
 
+// Customer.needs is a plain list in Linear's schema, so pagination has to go
+// through the top-level customerNeeds connection filtered by customer id.
 const CUSTOMER_NEEDS_QUERY = `
-    query CustomerNeeds($customerId: String!, $after: String) {
-        customer(id: $customerId) {
-            needs(first: ${PAGE_SIZE}, after: $after) {
-                nodes {
-                    issue {
-                        id
-                        title
-                        description
-                        labels { nodes { name } }
-                        state { name type }
-                    }
+    query CustomerNeeds($customerId: ID, $after: String) {
+        customerNeeds(first: ${PAGE_SIZE}, after: $after, filter: { customer: { id: { eq: $customerId } } }) {
+            nodes {
+                issue {
+                    id
+                    title
+                    description
+                    labels { nodes { name } }
+                    state { name type }
                 }
-                pageInfo { hasNextPage endCursor }
             }
+            pageInfo { hasNextPage endCursor }
         }
     }
 `;
@@ -127,8 +125,13 @@ export class LinearClient {
         });
 
         if (!response.ok) {
+            // Linear returns GraphQL validation errors with a 400 — surface
+            // them or the failure is undiagnosable from logs.
+            const body = await response.text().catch(() => '');
             throw new UnexpectedServerError(
-                `Linear API request failed with status ${response.status}`,
+                `Linear API request failed with status ${response.status}${
+                    body ? `: ${body.slice(0, 500)}` : ''
+                }`,
             );
         }
 
@@ -169,15 +172,12 @@ export class LinearClient {
         // Cursor pagination is inherently sequential.
         /* eslint-disable no-await-in-loop */
         do {
-            const { customer }: CustomerNeedsQueryResponse =
+            const { customerNeeds }: CustomerNeedsQueryResponse =
                 await this.graphql<CustomerNeedsQueryResponse>(
                     CUSTOMER_NEEDS_QUERY,
                     { customerId, after },
                 );
-            if (!customer) {
-                break;
-            }
-            customer.needs.nodes.forEach((need) => {
+            customerNeeds.nodes.forEach((need) => {
                 const { issue } = need;
                 if (!issue) {
                     return;
@@ -196,8 +196,8 @@ export class LinearClient {
                     state: issue.state,
                 });
             });
-            after = customer.needs.pageInfo.hasNextPage
-                ? customer.needs.pageInfo.endCursor
+            after = customerNeeds.pageInfo.hasNextPage
+                ? customerNeeds.pageInfo.endCursor
                 : null;
         } while (after !== null);
         /* eslint-enable no-await-in-loop */

--- a/packages/backend/src/ee/controllers/authentication/roadmapServiceAuthentication.ts
+++ b/packages/backend/src/ee/controllers/authentication/roadmapServiceAuthentication.ts
@@ -1,0 +1,48 @@
+import { AuthorizationError, getErrorMessage } from '@lightdash/common';
+import { RequestHandler } from 'express';
+import Logger from '../../../logging/logger';
+import LicenseClient from '../../clients/License/LicenseClient';
+
+export const ROADMAP_LICENSE_KEY_HEADER = 'lightdash-license-key';
+
+// Validated keys are cached by LicenseClient, so repeated calls from the same
+// instance don't hit the licensing API on every request.
+const licenseClient = new LicenseClient({});
+
+/**
+ * Authenticates a request to the central roadmap service using a Lightdash
+ * license key (sent by the calling instance in the `lightdash-license-key`
+ * header). This is service-to-service auth — it establishes no user session.
+ * The calling instance is trusted to request its own organization's roadmap.
+ */
+export const isRoadmapServiceAuthenticated: RequestHandler = (
+    req,
+    res,
+    next,
+) => {
+    const licenseKey = req.headers[ROADMAP_LICENSE_KEY_HEADER];
+    if (typeof licenseKey !== 'string' || licenseKey.length === 0) {
+        next(new AuthorizationError('Missing license key'));
+        return;
+    }
+
+    licenseClient
+        .get(licenseKey)
+        .then((license) => {
+            if (license.isValid) {
+                next();
+            } else {
+                next(
+                    new AuthorizationError(
+                        `Invalid license key [${license.code}]`,
+                    ),
+                );
+            }
+        })
+        .catch((error) => {
+            Logger.error(
+                `Failed to validate roadmap license key: ${getErrorMessage(error)}`,
+            );
+            next(new AuthorizationError('Could not validate license key'));
+        });
+};

--- a/packages/backend/src/ee/controllers/roadmapController.ts
+++ b/packages/backend/src/ee/controllers/roadmapController.ts
@@ -1,0 +1,43 @@
+import { ApiErrorPayload, ApiRoadmapResponse, UUID } from '@lightdash/common';
+import {
+    Get,
+    Hidden,
+    Middlewares,
+    OperationId,
+    Path,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+} from '@tsoa/runtime';
+import express from 'express';
+import { BaseController } from '../../controllers/baseController';
+import type { RoadmapService } from '../services/RoadmapService/RoadmapService';
+import { isRoadmapServiceAuthenticated } from './authentication/roadmapServiceAuthentication';
+
+@Route('/api/v1/roadmap')
+@Hidden()
+@Response<ApiErrorPayload>('default', 'Error')
+export class RoadmapController extends BaseController {
+    /**
+     * Get the curated, read-only roadmap for an organization. Served from the
+     * cached mirror; authenticated with the calling instance's license key.
+     * @summary Get organization roadmap
+     */
+    @Middlewares([isRoadmapServiceAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/organizations/{organizationUuid}')
+    @OperationId('getOrganizationRoadmap')
+    async getOrganizationRoadmap(
+        @Request() req: express.Request,
+        @Path() organizationUuid: UUID,
+    ): Promise<ApiRoadmapResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getRoadmapService<RoadmapService>()
+                .getRoadmapForOrg({ organizationUuid }),
+        };
+    }
+}

--- a/packages/backend/src/ee/database/entities/roadmap.ts
+++ b/packages/backend/src/ee/database/entities/roadmap.ts
@@ -1,0 +1,57 @@
+import { RoadmapItemStatus } from '@lightdash/common';
+import { Knex } from 'knex';
+
+/**
+ * Curated mirror of Linear feature requests served by the central roadmap
+ * service. `roadmap_customer_links` records which Lightdash organization an
+ * org resolves to in Linear (one row per org); `roadmap_items` holds the
+ * curated, customer-safe items for that link.
+ */
+
+export const RoadmapCustomerLinksTableName = 'roadmap_customer_links';
+export const RoadmapItemsTableName = 'roadmap_items';
+
+type DbRoadmapCustomerLink = {
+    roadmap_customer_link_uuid: string;
+    organization_uuid: string;
+    linear_customer_id: string;
+    linear_customer_name: string;
+    synced_at: Date;
+};
+
+type DbRoadmapCustomerLinkInsert = Omit<
+    DbRoadmapCustomerLink,
+    'roadmap_customer_link_uuid' | 'synced_at'
+>;
+
+type DbRoadmapCustomerLinkUpdate = Pick<
+    DbRoadmapCustomerLink,
+    'linear_customer_id' | 'linear_customer_name' | 'synced_at'
+>;
+
+export type RoadmapCustomerLinksTable = Knex.CompositeTableType<
+    DbRoadmapCustomerLink,
+    DbRoadmapCustomerLinkInsert,
+    DbRoadmapCustomerLinkUpdate
+>;
+
+type DbRoadmapItem = {
+    roadmap_item_uuid: string;
+    roadmap_customer_link_uuid: string;
+    linear_issue_id: string;
+    title: string;
+    description: string | null;
+    status: RoadmapItemStatus;
+    position: number;
+    synced_at: Date;
+};
+
+type DbRoadmapItemInsert = Omit<
+    DbRoadmapItem,
+    'roadmap_item_uuid' | 'synced_at'
+>;
+
+export type RoadmapItemsTable = Knex.CompositeTableType<
+    DbRoadmapItem,
+    DbRoadmapItemInsert
+>;

--- a/packages/backend/src/ee/database/migrations/20260623220000_add_roadmap_mirror_tables.ts
+++ b/packages/backend/src/ee/database/migrations/20260623220000_add_roadmap_mirror_tables.ts
@@ -1,0 +1,52 @@
+import { Knex } from 'knex';
+
+const RoadmapCustomerLinksTableName = 'roadmap_customer_links';
+const RoadmapItemsTableName = 'roadmap_items';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(RoadmapCustomerLinksTableName, (table) => {
+        table
+            .uuid('roadmap_customer_link_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        // Identifier of the Lightdash organization this Linear customer maps
+        // to. This is an external instance's org, so there is intentionally no
+        // foreign key to the local organizations table.
+        table.uuid('organization_uuid').notNullable().unique();
+        table.text('linear_customer_id').notNullable();
+        table.text('linear_customer_name').notNullable();
+        table
+            .timestamp('synced_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.createTable(RoadmapItemsTableName, (table) => {
+        table
+            .uuid('roadmap_item_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('roadmap_customer_link_uuid')
+            .notNullable()
+            .references('roadmap_customer_link_uuid')
+            .inTable(RoadmapCustomerLinksTableName)
+            .onDelete('CASCADE')
+            .index();
+        table.text('linear_issue_id').notNullable();
+        table.text('title').notNullable();
+        table.text('description').nullable();
+        table.text('status').notNullable();
+        table.integer('position').notNullable().defaultTo(0);
+        table
+            .timestamp('synced_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table.unique(['roadmap_customer_link_uuid', 'linear_issue_id']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(RoadmapItemsTableName);
+    await knex.schema.dropTableIfExists(RoadmapCustomerLinksTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -25,6 +25,7 @@ import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
 import { AiModelCatalog } from './clients/Ai/AiModelCatalog';
 import { AiDeepResearchClient } from './clients/AiDeepResearchClient';
 import LicenseClient from './clients/License/LicenseClient';
+import { LinearClient } from './clients/Linear/LinearClient';
 import { ManagedAgentClient } from './clients/ManagedAgentClient';
 import OpenAi from './clients/OpenAi';
 import { CommercialSlackClient } from './clients/Slack/SlackClient';
@@ -50,6 +51,7 @@ import { ProjectContextModel } from './models/ProjectContextModel';
 import { ProjectHomepageModel } from './models/ProjectHomepageModel';
 import { SandboxRegistryModel } from './models/SandboxRegistryModel';
 import { SchedulerAiAugmentationModel } from './models/SchedulerAiAugmentationModel';
+import { RoadmapModel } from './models/RoadmapModel';
 import { ServiceAccountModel } from './models/ServiceAccountModel';
 import { createLightdashPgWireHandlers } from './postgresWire/lightdashHandlers';
 import { PostgresWireServer } from './postgresWire/PostgresWireServer';
@@ -91,6 +93,7 @@ import { ProjectContextService } from './services/ProjectContextService/ProjectC
 import { ProjectHomepageService } from './services/ProjectHomepageService';
 import { provisionOnboardingHomepage } from './services/ProjectService/provisionOnboardingHomepage';
 import { SchedulerAiAugmentationService } from './services/SchedulerAiAugmentationService/SchedulerAiAugmentationService';
+import { RoadmapService } from './services/RoadmapService/RoadmapService';
 import { ScimService } from './services/ScimService/ScimService';
 import { ServiceAccountService } from './services/ServiceAccountService/ServiceAccountService';
 import { CommercialSlackService } from './services/SlackService/SlackService';
@@ -311,6 +314,21 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         aiModelCatalog,
                     }),
                 }),
+            roadmapService: ({ context, models }) => {
+                const { roadmap } = context.lightdashConfig;
+                return new RoadmapService({
+                    lightdashConfig: context.lightdashConfig,
+                    roadmapModel: models.getRoadmapModel<RoadmapModel>(),
+                    linearClient: roadmap.linear.apiKey
+                        ? new LinearClient({
+                              apiKey: roadmap.linear.apiKey,
+                              apiUrl: roadmap.linear.apiUrl,
+                              featureRequestLabel:
+                                  roadmap.linear.featureRequestLabel,
+                          })
+                        : null,
+                });
+            },
             embedService: ({ repository, context, models }) =>
                 new EmbedService({
                     analytics: context.lightdashAnalytics,
@@ -982,6 +1000,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             mcpContextModel: ({ database }) => new McpContextModel(database),
             dashboardSummaryModel: ({ database }) =>
                 new DashboardSummaryModel({ database }),
+            roadmapModel: ({ database }) => new RoadmapModel({ database }),
             slackAuthenticationModel: ({ database }) =>
                 new CommercialSlackAuthenticationModel({ database }),
             serviceAccountModel: ({ database }) =>
@@ -1079,6 +1098,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 mcpToolCallModel:
                     context.models.getMcpToolCallModel<McpToolCallModel>(),
                 prometheusMetrics: context.prometheusMetrics,
+                roadmapService:
+                    context.serviceRepository.getRoadmapService<RoadmapService>(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/models/RoadmapModel.ts
+++ b/packages/backend/src/ee/models/RoadmapModel.ts
@@ -1,0 +1,136 @@
+import { RoadmapItemStatus } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    RoadmapCustomerLinksTableName,
+    RoadmapItemsTableName,
+} from '../database/entities/roadmap';
+
+export type RoadmapCustomerLink = {
+    organizationUuid: string;
+    linearCustomerId: string;
+    linearCustomerName: string;
+    syncedAt: Date;
+};
+
+/** A curated item ready to be persisted to the mirror. */
+export type CuratedRoadmapItem = {
+    linearIssueId: string;
+    title: string;
+    description: string | null;
+    status: RoadmapItemStatus;
+};
+
+/** A stored item read back for serving (curated fields only). */
+export type StoredRoadmapItem = {
+    title: string;
+    description: string | null;
+    status: RoadmapItemStatus;
+};
+
+type Dependencies = {
+    database: Knex;
+};
+
+export class RoadmapModel {
+    private readonly database: Knex;
+
+    constructor(dependencies: Dependencies) {
+        this.database = dependencies.database;
+    }
+
+    /**
+     * Replace the curated mirror for a single org -> Linear customer link.
+     * Upserts the link and atomically swaps its items so a sync run leaves the
+     * store in a consistent state.
+     */
+    async replaceCustomerMirror(params: {
+        organizationUuid: string;
+        linearCustomerId: string;
+        linearCustomerName: string;
+        items: CuratedRoadmapItem[];
+    }): Promise<void> {
+        const {
+            organizationUuid,
+            linearCustomerId,
+            linearCustomerName,
+            items,
+        } = params;
+        await this.database.transaction(async (trx) => {
+            const [link] = await trx(RoadmapCustomerLinksTableName)
+                .insert({
+                    organization_uuid: organizationUuid,
+                    linear_customer_id: linearCustomerId,
+                    linear_customer_name: linearCustomerName,
+                })
+                .onConflict('organization_uuid')
+                .merge({
+                    linear_customer_id: linearCustomerId,
+                    linear_customer_name: linearCustomerName,
+                    synced_at: trx.fn.now(),
+                })
+                .returning('roadmap_customer_link_uuid');
+
+            const linkUuid = link.roadmap_customer_link_uuid;
+
+            await trx(RoadmapItemsTableName)
+                .where('roadmap_customer_link_uuid', linkUuid)
+                .delete();
+
+            if (items.length > 0) {
+                await trx(RoadmapItemsTableName).insert(
+                    items.map((item, index) => ({
+                        roadmap_customer_link_uuid: linkUuid,
+                        linear_issue_id: item.linearIssueId,
+                        title: item.title,
+                        description: item.description,
+                        status: item.status,
+                        position: index,
+                    })),
+                );
+            }
+        });
+    }
+
+    async findCustomerLinkForOrg(
+        organizationUuid: string,
+    ): Promise<RoadmapCustomerLink | null> {
+        const row = await this.database(RoadmapCustomerLinksTableName)
+            .where('organization_uuid', organizationUuid)
+            .first();
+        if (!row) {
+            return null;
+        }
+        return {
+            organizationUuid: row.organization_uuid,
+            linearCustomerId: row.linear_customer_id,
+            linearCustomerName: row.linear_customer_name,
+            syncedAt: row.synced_at,
+        };
+    }
+
+    async getRoadmapItemsForOrg(
+        organizationUuid: string,
+    ): Promise<StoredRoadmapItem[]> {
+        const rows = await this.database(RoadmapItemsTableName)
+            .innerJoin(
+                RoadmapCustomerLinksTableName,
+                `${RoadmapItemsTableName}.roadmap_customer_link_uuid`,
+                `${RoadmapCustomerLinksTableName}.roadmap_customer_link_uuid`,
+            )
+            .where(
+                `${RoadmapCustomerLinksTableName}.organization_uuid`,
+                organizationUuid,
+            )
+            .orderBy(`${RoadmapItemsTableName}.position`, 'asc')
+            .select(
+                `${RoadmapItemsTableName}.title`,
+                `${RoadmapItemsTableName}.description`,
+                `${RoadmapItemsTableName}.status`,
+            );
+        return rows.map((row) => ({
+            title: row.title,
+            description: row.description,
+            status: row.status,
+        }));
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -31,9 +31,11 @@ import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgen
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
 import { sendReviewNotification } from './tasks/sendReviewNotification';
+import { RoadmapService } from '../services/RoadmapService/RoadmapService';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const ROADMAP_SYNC_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_REMEDIATION_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const AI_AGENT_REVIEW_CLASSIFIER_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
 const AI_AGENT_REVIEW_WRITEBACK_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
@@ -59,6 +61,7 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     projectModel: ProjectModel;
     openIdIdentityModel: OpenIdIdentityModel;
     mcpToolCallModel: McpToolCallModel;
+    roadmapService: RoadmapService;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -93,6 +96,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly openIdIdentityModel: OpenIdIdentityModel;
 
     protected readonly mcpToolCallModel: McpToolCallModel;
+    protected readonly roadmapService: RoadmapService;
 
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
@@ -115,6 +119,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectModel = args.projectModel;
         this.openIdIdentityModel = args.openIdIdentityModel;
         this.mcpToolCallModel = args.mcpToolCallModel;
+        this.roadmapService = args.roadmapService;
     }
 
     protected getCronItems() {
@@ -150,6 +155,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 options: {
                     backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
                     maxAttempts: 3,
+                },
+            },
+            {
+                task: EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR,
+                pattern: this.lightdashConfig.roadmap.syncCron,
+                options: {
+                    backfillPeriod: 60 * 60 * 1000, // 1 hour
+                    maxAttempts: 1,
                 },
             },
         ];
@@ -661,6 +674,34 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     slackClient: this.slackClient,
                     analytics: this.analytics,
                 })(payload);
+            [EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.roadmapService.syncMirror();
+                        },
+                    ),
+                    helpers.job,
+                    ROADMAP_SYNC_TIMEOUT_MS,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                error: getErrorMessage(e),
+                            },
+                        });
+                    },
+                );
             },
             [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: async (
                 payload,

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -30,8 +30,8 @@ import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
 import { type OnboardingAgentService } from '../services/OnboardingAgentService/OnboardingAgentService';
 import { ProjectContextService } from '../services/ProjectContextService/ProjectContextService';
-import { sendReviewNotification } from './tasks/sendReviewNotification';
 import { RoadmapService } from '../services/RoadmapService/RoadmapService';
+import { sendReviewNotification } from './tasks/sendReviewNotification';
 
 const MCP_TOOL_CALL_RETENTION_DAYS = 90;
 const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -96,6 +96,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly openIdIdentityModel: OpenIdIdentityModel;
 
     protected readonly mcpToolCallModel: McpToolCallModel;
+
     protected readonly roadmapService: RoadmapService;
 
     constructor(args: CommercialSchedulerWorkerArguments) {
@@ -674,6 +675,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     slackClient: this.slackClient,
                     analytics: this.analytics,
                 })(payload);
+            },
             [EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR]: async (
                 payload,
                 helpers,

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -1,0 +1,228 @@
+import { RoadmapItemStatus } from '@lightdash/common';
+import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import type { LinearClient } from '../../clients/Linear/LinearClient';
+import type { RoadmapModel } from '../../models/RoadmapModel';
+import { RoadmapService } from './RoadmapService';
+
+const organizationUuid = '11111111-1111-1111-1111-111111111111';
+
+const enabledConfig: LightdashConfig = {
+    ...lightdashConfigMock,
+    roadmap: {
+        ...lightdashConfigMock.roadmap,
+        enabled: true,
+    },
+};
+
+const createLinearClient = (): jest.Mocked<
+    Pick<LinearClient, 'listCustomers' | 'getCustomerFeatureRequests'>
+> => ({
+    listCustomers: jest.fn(),
+    getCustomerFeatureRequests: jest.fn(),
+});
+
+const createRoadmapModel = (): jest.Mocked<
+    Pick<
+        RoadmapModel,
+        | 'replaceCustomerMirror'
+        | 'findCustomerLinkForOrg'
+        | 'getRoadmapItemsForOrg'
+    >
+> => ({
+    replaceCustomerMirror: jest.fn(),
+    findCustomerLinkForOrg: jest.fn(),
+    getRoadmapItemsForOrg: jest.fn(),
+});
+
+const buildService = (
+    roadmapModel: ReturnType<typeof createRoadmapModel>,
+    linearClient: ReturnType<typeof createLinearClient> | null,
+    config: LightdashConfig = enabledConfig,
+) =>
+    new RoadmapService({
+        lightdashConfig: config,
+        roadmapModel: roadmapModel as unknown as RoadmapModel,
+        linearClient: linearClient as unknown as LinearClient | null,
+    });
+
+describe('RoadmapService', () => {
+    describe('syncMirror', () => {
+        it('does nothing when the feature is disabled', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            const service = buildService(roadmapModel, linearClient, {
+                ...enabledConfig,
+                roadmap: { ...enabledConfig.roadmap, enabled: false },
+            });
+
+            const summary = await service.syncMirror();
+
+            expect(summary).toEqual({
+                customers: 0,
+                skippedCustomers: 0,
+                syncedItems: 0,
+                rejectedItems: 0,
+            });
+            expect(linearClient.listCustomers).not.toHaveBeenCalled();
+            expect(roadmapModel.replaceCustomerMirror).not.toHaveBeenCalled();
+        });
+
+        it('does nothing when there is no Linear client', async () => {
+            const roadmapModel = createRoadmapModel();
+            const service = buildService(roadmapModel, null);
+
+            const summary = await service.syncMirror();
+
+            expect(summary.customers).toBe(0);
+            expect(roadmapModel.replaceCustomerMirror).not.toHaveBeenCalled();
+        });
+
+        it('curates mappable issues and stores them per resolved org', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            linearClient.listCustomers.mockResolvedValue([
+                {
+                    id: 'cust-1',
+                    name: 'Acme',
+                    externalIds: [organizationUuid],
+                },
+            ]);
+            linearClient.getCustomerFeatureRequests.mockResolvedValue([
+                {
+                    id: 'issue-1',
+                    title: 'Dark mode',
+                    description: 'Please',
+                    state: { name: 'In Progress', type: 'started' },
+                },
+                {
+                    id: 'issue-2',
+                    title: 'Unmappable',
+                    description: null,
+                    state: { name: 'Mystery', type: 'mystery' },
+                },
+            ]);
+
+            const service = buildService(roadmapModel, linearClient);
+            const summary = await service.syncMirror();
+
+            expect(summary).toEqual({
+                customers: 1,
+                skippedCustomers: 0,
+                syncedItems: 1,
+                rejectedItems: 1,
+            });
+            expect(roadmapModel.replaceCustomerMirror).toHaveBeenCalledWith({
+                organizationUuid,
+                linearCustomerId: 'cust-1',
+                linearCustomerName: 'Acme',
+                items: [
+                    {
+                        linearIssueId: 'issue-1',
+                        title: 'Dark mode',
+                        description: 'Please',
+                        status: RoadmapItemStatus.BUILDING,
+                    },
+                ],
+            });
+        });
+
+        it('skips customers that do not resolve to exactly one org', async () => {
+            const roadmapModel = createRoadmapModel();
+            const linearClient = createLinearClient();
+            linearClient.listCustomers.mockResolvedValue([
+                { id: 'cust-none', name: 'No ids', externalIds: [] },
+                {
+                    id: 'cust-many',
+                    name: 'Ambiguous',
+                    externalIds: ['a', 'b'],
+                },
+            ]);
+
+            const service = buildService(roadmapModel, linearClient);
+            const summary = await service.syncMirror();
+
+            expect(summary.skippedCustomers).toBe(2);
+            expect(
+                linearClient.getCustomerFeatureRequests,
+            ).not.toHaveBeenCalled();
+            expect(roadmapModel.replaceCustomerMirror).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getRoadmapForOrg', () => {
+        it('returns an empty list when the org has no mapped customer', async () => {
+            const roadmapModel = createRoadmapModel();
+            roadmapModel.findCustomerLinkForOrg.mockResolvedValue(null);
+            const service = buildService(roadmapModel, createLinearClient());
+
+            const result = await service.getRoadmapForOrg({ organizationUuid });
+
+            expect(result).toEqual([]);
+            expect(roadmapModel.getRoadmapItemsForOrg).not.toHaveBeenCalled();
+        });
+
+        it('returns redacted items from the store', async () => {
+            const roadmapModel = createRoadmapModel();
+            roadmapModel.findCustomerLinkForOrg.mockResolvedValue({
+                organizationUuid,
+                linearCustomerId: 'cust-1',
+                linearCustomerName: 'Acme',
+                syncedAt: new Date(),
+            });
+            roadmapModel.getRoadmapItemsForOrg.mockResolvedValue([
+                {
+                    title: 'Dark mode',
+                    description: 'Please',
+                    status: RoadmapItemStatus.BUILDING,
+                },
+            ]);
+            const service = buildService(roadmapModel, createLinearClient());
+
+            const result = await service.getRoadmapForOrg({ organizationUuid });
+
+            expect(result).toEqual([
+                {
+                    title: 'Dark mode',
+                    description: 'Please',
+                    status: RoadmapItemStatus.BUILDING,
+                },
+            ]);
+        });
+
+        it('excludes stored items that fail the redaction checkpoint', async () => {
+            const roadmapModel = createRoadmapModel();
+            roadmapModel.findCustomerLinkForOrg.mockResolvedValue({
+                organizationUuid,
+                linearCustomerId: 'cust-1',
+                linearCustomerName: 'Acme',
+                syncedAt: new Date(),
+            });
+            roadmapModel.getRoadmapItemsForOrg.mockResolvedValue([
+                {
+                    title: 'Safe',
+                    description: null,
+                    status: RoadmapItemStatus.PLANNED,
+                },
+                // A leaked internal field must be rejected, not served.
+                {
+                    title: 'Leaky',
+                    description: null,
+                    status: RoadmapItemStatus.PLANNED,
+                    arr: 50000,
+                } as never,
+            ]);
+            const service = buildService(roadmapModel, createLinearClient());
+
+            const result = await service.getRoadmapForOrg({ organizationUuid });
+
+            expect(result).toEqual([
+                {
+                    title: 'Safe',
+                    description: null,
+                    status: RoadmapItemStatus.PLANNED,
+                },
+            ]);
+        });
+    });
+});

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -1,4 +1,5 @@
 import { RoadmapItemStatus } from '@lightdash/common';
+import type { Mocked } from 'vitest';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { LinearClient } from '../../clients/Linear/LinearClient';
@@ -15,14 +16,14 @@ const enabledConfig: LightdashConfig = {
     },
 };
 
-const createLinearClient = (): jest.Mocked<
+const createLinearClient = (): Mocked<
     Pick<LinearClient, 'listCustomers' | 'getCustomerFeatureRequests'>
 > => ({
-    listCustomers: jest.fn(),
-    getCustomerFeatureRequests: jest.fn(),
+    listCustomers: vi.fn(),
+    getCustomerFeatureRequests: vi.fn(),
 });
 
-const createRoadmapModel = (): jest.Mocked<
+const createRoadmapModel = (): Mocked<
     Pick<
         RoadmapModel,
         | 'replaceCustomerMirror'
@@ -30,9 +31,9 @@ const createRoadmapModel = (): jest.Mocked<
         | 'getRoadmapItemsForOrg'
     >
 > => ({
-    replaceCustomerMirror: jest.fn(),
-    findCustomerLinkForOrg: jest.fn(),
-    getRoadmapItemsForOrg: jest.fn(),
+    replaceCustomerMirror: vi.fn(),
+    findCustomerLinkForOrg: vi.fn(),
+    getRoadmapItemsForOrg: vi.fn(),
 });
 
 const buildService = (

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -1,0 +1,200 @@
+import {
+    buildRoadmapItem,
+    getErrorMessage,
+    redactRoadmapItems,
+    RoadmapItem,
+} from '@lightdash/common';
+import type { LightdashConfig } from '../../../config/parseConfig';
+import { BaseService } from '../../../services/BaseService';
+import { LinearClient } from '../../clients/Linear/LinearClient';
+import { CuratedRoadmapItem, RoadmapModel } from '../../models/RoadmapModel';
+
+type Dependencies = {
+    lightdashConfig: LightdashConfig;
+    roadmapModel: RoadmapModel;
+    linearClient: LinearClient | null;
+};
+
+export type RoadmapSyncSummary = {
+    customers: number;
+    skippedCustomers: number;
+    syncedItems: number;
+    rejectedItems: number;
+};
+
+/**
+ * Central roadmap service. Mirrors Linear feature requests into a curated,
+ * customer-safe store on a schedule, and serves read-only per-org roadmap
+ * responses from that store. The Linear API is only ever touched by the sync
+ * path; serving reads exclusively from the mirror.
+ */
+export class RoadmapService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly roadmapModel: RoadmapModel;
+
+    private readonly linearClient: LinearClient | null;
+
+    constructor(dependencies: Dependencies) {
+        super({ serviceName: 'RoadmapService' });
+        this.lightdashConfig = dependencies.lightdashConfig;
+        this.roadmapModel = dependencies.roadmapModel;
+        this.linearClient = dependencies.linearClient;
+    }
+
+    private isSyncEnabled(): boolean {
+        return (
+            this.lightdashConfig.roadmap.enabled && this.linearClient !== null
+        );
+    }
+
+    /**
+     * Resolve a Linear customer's external ids to the single Lightdash
+     * organization it maps to. A customer with no (or multiple) org-shaped
+     * external ids can't be resolved unambiguously and is skipped.
+     */
+    private static resolveOrganizationUuid(
+        externalIds: string[],
+    ): string | null {
+        return externalIds.length === 1 ? externalIds[0] : null;
+    }
+
+    /**
+     * Scheduled job entry point. Pulls every Linear customer, resolves it to a
+     * Lightdash org, curates its feature requests and replaces that org's
+     * mirror. Per-customer failures are logged and skipped so one bad customer
+     * can't fail the whole run.
+     */
+    async syncMirror(): Promise<RoadmapSyncSummary> {
+        const summary: RoadmapSyncSummary = {
+            customers: 0,
+            skippedCustomers: 0,
+            syncedItems: 0,
+            rejectedItems: 0,
+        };
+
+        if (!this.isSyncEnabled() || this.linearClient === null) {
+            this.logger.info(
+                'Roadmap sync skipped: feature disabled or Linear API key missing',
+            );
+            return summary;
+        }
+
+        const customers = await this.linearClient.listCustomers();
+        summary.customers = customers.length;
+
+        for (const customer of customers) {
+            const organizationUuid = RoadmapService.resolveOrganizationUuid(
+                customer.externalIds,
+            );
+            if (organizationUuid === null) {
+                summary.skippedCustomers += 1;
+                this.logger.warn(
+                    `Roadmap sync: Linear customer ${customer.id} has no resolvable organization, skipping`,
+                );
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            try {
+                // Customers are synced sequentially to avoid hammering the
+                // Linear API.
+                // eslint-disable-next-line no-await-in-loop
+                const result = await this.syncCustomer(
+                    customer,
+                    organizationUuid,
+                );
+                summary.syncedItems += result.syncedItems;
+                summary.rejectedItems += result.rejectedItems;
+            } catch (error) {
+                summary.skippedCustomers += 1;
+                this.logger.error(
+                    `Roadmap sync: failed to sync Linear customer ${customer.id}: ${getErrorMessage(error)}`,
+                );
+            }
+        }
+
+        this.logger.info('Roadmap mirror sync complete', { ...summary });
+        return summary;
+    }
+
+    /**
+     * Fetch, curate and store the feature requests for one already-resolved
+     * customer. Issues whose status can't be mapped are excluded (counted in
+     * `rejectedItems`) rather than served with a wrong status.
+     */
+    private async syncCustomer(
+        customer: { id: string; name: string },
+        organizationUuid: string,
+    ): Promise<{ syncedItems: number; rejectedItems: number }> {
+        if (this.linearClient === null) {
+            return { syncedItems: 0, rejectedItems: 0 };
+        }
+
+        const issues = await this.linearClient.getCustomerFeatureRequests(
+            customer.id,
+        );
+
+        const items: CuratedRoadmapItem[] = [];
+        let rejectedItems = 0;
+        issues.forEach((issue) => {
+            try {
+                const built = buildRoadmapItem({
+                    title: issue.title,
+                    description: issue.description,
+                    state: issue.state,
+                });
+                items.push({
+                    linearIssueId: issue.id,
+                    title: built.title,
+                    description: built.description,
+                    status: built.status,
+                });
+            } catch (error) {
+                // Unmappable status — exclude rather than mislabel.
+                rejectedItems += 1;
+                this.logger.warn(
+                    `Roadmap sync: skipping Linear issue ${issue.id} for customer ${customer.id}: ${getErrorMessage(error)}`,
+                );
+            }
+        });
+
+        await this.roadmapModel.replaceCustomerMirror({
+            organizationUuid,
+            linearCustomerId: customer.id,
+            linearCustomerName: customer.name,
+            items,
+        });
+
+        return { syncedItems: items.length, rejectedItems };
+    }
+
+    /**
+     * Serve the curated roadmap for an organization from the mirror. Returns an
+     * empty list when the org has no mapped customer or no items. Runs the
+     * stored items through the redaction checkpoint as a final defensive
+     * boundary before they leave the service.
+     */
+    async getRoadmapForOrg(params: {
+        organizationUuid: string;
+    }): Promise<RoadmapItem[]> {
+        const { organizationUuid } = params;
+        const link =
+            await this.roadmapModel.findCustomerLinkForOrg(organizationUuid);
+        if (link === null) {
+            return [];
+        }
+
+        const stored =
+            await this.roadmapModel.getRoadmapItemsForOrg(organizationUuid);
+        const { items, rejected } = redactRoadmapItems(stored);
+        if (rejected.length > 0) {
+            // Reaching here means curation upstream is broken — the stored
+            // mirror should already be safe. Alarm internally; never surface.
+            this.logger.error(
+                `Roadmap redaction rejected ${rejected.length} stored item(s) for organization ${organizationUuid}`,
+            );
+        }
+        return items;
+    }
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -166,6 +166,7 @@ export type ModelManifest = {
     aiOrganizationSettingsModel: unknown;
     embedModel: unknown;
     dashboardSummaryModel: unknown;
+    roadmapModel: unknown;
     serviceAccountModel: unknown;
     externalConnectionModel: unknown;
     schedulerAiAugmentationModel: unknown;
@@ -878,6 +879,10 @@ export class ModelRepository
 
     public getDashboardSummaryModel<ModelImplT>(): ModelImplT {
         return this.getModel('dashboardSummaryModel');
+    }
+
+    public getRoadmapModel<ModelImplT>(): ModelImplT {
+        return this.getModel('roadmapModel');
     }
 
     public getTagsModel(): TagsModel {

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -279,6 +279,7 @@ const getTagsForTask: {
         'user.uuid': payload.userUuid,
         'project.uuid': payload.projectUuid,
     }),
+    [SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
     [SCHEDULER_TASKS.COMPACT_USAGE_EVENTS]: () => ({}),
     [SCHEDULER_TASKS.POLL_EMAIL_WHITELABEL]: () => ({}),

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -179,6 +179,7 @@ interface ServiceManifest {
     instanceConfigurationService: unknown;
     managedAgentService: unknown;
     mcpService: unknown;
+    roadmapService: unknown;
     rolesService: RolesService;
     slackService: SlackService;
     organizationWarehouseCredentialsService: unknown;
@@ -1438,6 +1439,10 @@ export class ServiceRepository
         AiAgentCoderServiceImplT,
     >(): AiAgentCoderServiceImplT {
         return this.getService('aiAgentCoderService');
+    }
+
+    public getRoadmapService<RoadmapServiceImplT>(): RoadmapServiceImplT {
+        return this.getService('roadmapService');
     }
 
     public getAiAgentService<AiAgentServiceImplT>(): AiAgentServiceImplT {

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -125,6 +125,7 @@ export const EE_SCHEDULER_TASKS = {
     SWEEP_STALE_AI_WRITEBACK_RUNS: 'sweepStaleAiWritebackRuns',
     SWEEP_STALE_AI_DEEP_RESEARCH_RUNS: 'sweepStaleAiDeepResearchRuns',
     CLEAN_MCP_TOOL_CALLS: 'cleanMcpToolCalls',
+    SYNC_ROADMAP_MIRROR: 'syncRoadmapMirror',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -230,6 +231,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
     [SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
+    [SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR]: TraceTaskBase;
 }
 
 export interface EETaskPayloadMap {
@@ -253,6 +255,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_DEEP_RESEARCH]: AiDeepResearchPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AGENT_ONBOARDING_RUN]: AgentOnboardingPipelineJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EDIT_DBT_PROJECT_PIPELINE]: AiAgentEditDbtProjectPipelineJobPayload;
+    [EE_SCHEDULER_TASKS.SYNC_ROADMAP_MIRROR]: TraceTaskBase;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
Implements the central roadmap service for v1: a license-key-authenticated, read-only API that serves per-org roadmap data from a curated, cached mirror of Linear feature requests. The Linear API is only ever touched by the scheduled sync; serving reads exclusively from the mirror.

Builds on the CS-15 shared contract (`packages/common/src/types/roadmap.ts`) for status mapping and the redaction boundary.

### What's included
- **License-key auth** — `isRoadmapServiceAuthenticated` validates the calling instance's Lightdash license key (via the existing keygen `LicenseClient`, cached). Service-to-service; no user session.
- **Org → Linear customer resolution** — during sync, each Linear customer's single `externalId` resolves to a Lightdash org (per CS-27). Customers with zero/multiple external ids are skipped.
- **Fetch feature requests** — `LinearClient` (read-only Linear GraphQL) lists customers and their associated feature-request issues, with optional label filtering.
- **Curated mirror sync** — `syncRoadmapMirror` scheduler task (configurable cron) curates each issue via `buildRoadmapItem` (unmappable statuses excluded, not mislabelled) and atomically replaces each org's stored items.
- **Read-only per-org serving** — `GET /api/v1/roadmap/organizations/{organizationUuid}` returns `ApiRoadmapResponse` from the mirror, running stored items through `redactRoadmapItems` as a final defensive checkpoint. Empty list when an org has no mapped customer or no items (richer empty-state UX is CS-19).

### New tables
`roadmap_customer_links` (org ↔ Linear customer, one row per org) and `roadmap_items` (curated items). `organization_uuid` intentionally has no FK — these reference external instances' orgs, not local ones.

### Config
`ROADMAP_ENABLED`, `ROADMAP_SYNC_CRON`, `ROADMAP_LINEAR_API_KEY`, `ROADMAP_LINEAR_API_URL`, `ROADMAP_LINEAR_FEATURE_REQUEST_LABEL`. Disabled by default; sync no-ops without an API key.

### Notes for reviewers
- **Stacked on CS-15** (#24462, in review). This branch merges it in so the contract is available, so the diff currently includes CS-15's 4 `packages/common` files — those drop out once CS-15 lands on main.
- The serving endpoint trusts the calling instance to request its own org's roadmap (v1 server-side-proxy topology — see CS-21 for the air-gapped/browser-direct variant). The instance-side proxy + feature-flag gating is CS-17; the customer-facing page is CS-18.
- `LinearClient`'s GraphQL queries are written against Linear's customer-needs API; unit tests mock the client, so service behaviour (resolution, curation, redaction, empty handling) is covered without a live Linear.

### Tests
`RoadmapService.test.ts` — sync enable/disable gating, curation + unmappable exclusion, ambiguous-customer skipping, empty-org serving, and the redaction checkpoint excluding a leaked internal field. Typecheck/lint/format clean.