### PR TITLE
feat(ai-reviews): notification settings UI + deep-link polish [4/4]

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -10,6 +10,30 @@ import { type OrganizationMemberProfileModel } from '../../models/OrganizationMe
 import { type AiAgentReviewClassifierModel } from '../models/AiAgentReviewClassifierModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
 
+// Legacy `/ai-agents/admin/reviews` is a query-stripping redirect; deep-link here.
+export const REVIEWS_BOARD_PATH = '/generalSettings/ai/reviews';
+
+// Drawer needs project+agent+thread+item; falls back to item-only without a finding.
+export const buildReviewDrawerSearchParams = (
+    projectUuid: string,
+    fingerprint: string,
+    reviewItem: Awaited<
+        ReturnType<AiAgentReviewClassifierModel['getReviewItem']>
+    >,
+): string => {
+    const finding = reviewItem?.latestFinding;
+    const agentUuid = finding?.agentUuid ?? reviewItem?.agentUuid ?? null;
+    if (finding?.threadUuid && agentUuid) {
+        return new URLSearchParams({
+            reviewProjectUuid: projectUuid,
+            reviewAgentUuid: agentUuid,
+            reviewThreadUuid: finding.threadUuid,
+            reviewItemUuid: fingerprint,
+        }).toString();
+    }
+    return new URLSearchParams({ reviewItemUuid: fingerprint }).toString();
+};
+
 type AiAgentReviewNotificationServiceArgs = {
     notificationsModel: NotificationsModel;
     schedulerClient: CommercialSchedulerClient;
@@ -79,14 +103,18 @@ export class AiAgentReviewNotificationService {
             rootCause: reviewItem?.primaryRootCause ?? 'unknown',
             projectUuid: args.projectUuid,
             count: 1,
-            searchParams: `reviewItemUuid=${args.fingerprint}`,
+            searchParams: buildReviewDrawerSearchParams(
+                args.projectUuid,
+                args.fingerprint,
+                reviewItem,
+            ),
         };
 
         await this.notificationsModel.createAiReviewNotifications({
             recipients: [{ userUuid: args.assigneeUserUuid }],
             metadata,
             message: `You were assigned: ${metadata.title}`,
-            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+            url: `${REVIEWS_BOARD_PATH}?${metadata.searchParams}`,
         });
 
         await this.schedulerClient.scheduleTask(
@@ -127,14 +155,18 @@ export class AiAgentReviewNotificationService {
             rootCause: reviewItem?.primaryRootCause ?? 'unknown',
             projectUuid: args.projectUuid,
             count: args.fingerprints.length,
-            searchParams: `reviewRunUuid=${args.reviewRunUuid}`,
+            searchParams: buildReviewDrawerSearchParams(
+                args.projectUuid,
+                args.fingerprints[0],
+                reviewItem,
+            ),
         };
 
         await this.notificationsModel.createAiReviewNotifications({
             recipients,
             metadata,
             message: `${args.fingerprints.length} AI context findings need review`,
-            url: `/ai-agents/admin/reviews?${metadata.searchParams}`,
+            url: `${REVIEWS_BOARD_PATH}?${metadata.searchParams}`,
         });
 
         await this.schedulerClient.scheduleTask(

--- a/packages/backend/src/scheduler/tasks/sendReviewNotification.ts
+++ b/packages/backend/src/scheduler/tasks/sendReviewNotification.ts
@@ -14,7 +14,11 @@ import {
 } from '../../clients/Slack/SlackReviewMessageBlocks';
 import { type AiAgentReviewClassifierModel } from '../../ee/models/AiAgentReviewClassifierModel';
 import { type AiAgentReviewNotificationModel } from '../../ee/models/AiAgentReviewNotificationModel';
-import { type AiAgentReviewNotificationService } from '../../ee/services/AiAgentReviewNotificationService';
+import {
+    buildReviewDrawerSearchParams,
+    REVIEWS_BOARD_PATH,
+    type AiAgentReviewNotificationService,
+} from '../../ee/services/AiAgentReviewNotificationService';
 import { type OpenIdIdentityModel } from '../../models/OpenIdIdentitiesModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 
@@ -47,11 +51,11 @@ const getReviewContext = async (
         title: reviewItem?.title ?? 'AI review finding',
         rootCause: reviewItem?.primaryRootCause ?? 'unknown',
         projectName: project.name,
-        reviewUrl: `${deps.siteUrl}/ai-agents/admin/reviews?${
-            payload.reviewRunUuid
-                ? `reviewRunUuid=${payload.reviewRunUuid}`
-                : `reviewItemUuid=${payload.fingerprints[0]}`
-        }`,
+        reviewUrl: `${deps.siteUrl}${REVIEWS_BOARD_PATH}?${buildReviewDrawerSearchParams(
+            payload.projectUuid,
+            payload.fingerprints[0],
+            reviewItem,
+        )}`,
     };
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -34,6 +34,7 @@ import {
     useUpsertAiRouterConfig,
 } from '../../../hooks/useAiRouter';
 import { AiRouterInstructionsCard } from './AiRouterInstructionsCard';
+import { ReviewNotificationsSettings } from './ReviewNotificationsSettings';
 
 export const AiGeneralSettingsPage = () => {
     const { data: settings, isInitialLoading: isSettingsLoading } =
@@ -233,54 +234,60 @@ export const AiGeneralSettingsPage = () => {
                     </SettingsCard>
 
                     <SettingsCard>
-                        <Group
-                            justify="space-between"
-                            wrap="nowrap"
-                            align="flex-start"
-                            gap="md"
-                        >
-                            <Box maw={620}>
-                                <Group gap="xs" mb={4}>
-                                    <Title order={5}>
-                                        Review AI agent turns
-                                    </Title>
-                                    <BetaBadge />
-                                </Group>
-                                <Text c="dimmed" fz="xs">
-                                    Process every agent turn to surface semantic
-                                    layer gaps, project context improvements,
-                                    and admin recommendations. For connected
-                                    projects, Lightdash can suggest pull
-                                    requests that improve context and dbt
-                                    definitions.
-                                    {settings.aiAgentReviewsEnabled && (
-                                        <>
-                                            {' '}
-                                            See findings in{' '}
-                                            <Anchor
-                                                component={Link}
-                                                to="/generalSettings/ai/reviews"
-                                                fz="inherit"
-                                            >
-                                                Ask AI &gt; Reviews
-                                            </Anchor>
-                                            .
-                                        </>
-                                    )}
-                                </Text>
-                            </Box>
-                            <Switch
-                                size="md"
-                                checked={settings.aiAgentReviewsEnabled}
-                                disabled={isUpdatingSettings}
-                                onChange={(event) =>
-                                    updateSettings({
-                                        aiAgentReviewsEnabled:
-                                            event.currentTarget.checked,
-                                    })
-                                }
-                            />
-                        </Group>
+                        <Stack gap="md">
+                            <Group
+                                justify="space-between"
+                                wrap="nowrap"
+                                align="flex-start"
+                                gap="md"
+                            >
+                                <Box maw={620}>
+                                    <Group gap="xs" mb={4}>
+                                        <Title order={5}>
+                                            Review AI agent turns
+                                        </Title>
+                                        <BetaBadge />
+                                    </Group>
+                                    <Text c="dimmed" fz="xs">
+                                        Process every agent turn to surface
+                                        semantic layer gaps, project context
+                                        improvements, and admin recommendations.
+                                        For connected projects, Lightdash can
+                                        suggest pull requests that improve
+                                        context and dbt definitions.
+                                        {settings.aiAgentReviewsEnabled && (
+                                            <>
+                                                {' '}
+                                                See findings in{' '}
+                                                <Anchor
+                                                    component={Link}
+                                                    to="/generalSettings/ai/reviews"
+                                                    fz="inherit"
+                                                >
+                                                    Ask AI &gt; Reviews
+                                                </Anchor>
+                                                .
+                                            </>
+                                        )}
+                                    </Text>
+                                </Box>
+                                <Switch
+                                    size="md"
+                                    checked={settings.aiAgentReviewsEnabled}
+                                    disabled={isUpdatingSettings}
+                                    onChange={(event) =>
+                                        updateSettings({
+                                            aiAgentReviewsEnabled:
+                                                event.currentTarget.checked,
+                                        })
+                                    }
+                                />
+                            </Group>
+
+                            {settings.aiAgentReviewsEnabled && (
+                                <ReviewNotificationsSettings />
+                            )}
+                        </Stack>
                     </SettingsCard>
 
                     <SettingsCard>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/ReviewNotificationsSettings.tsx
@@ -1,0 +1,90 @@
+import {
+    Box,
+    Divider,
+    Group,
+    Loader,
+    Switch,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { SlackChannelSelect } from '../../../../../../components/common/SlackChannelSelect';
+import { useGetSlack } from '../../../../../../hooks/slack/useSlack';
+import useApp from '../../../../../../providers/App/useApp';
+import {
+    useReviewNotificationSettings,
+    useUpdateReviewNotificationSettings,
+} from '../../../hooks/useReviewNotificationSettings';
+
+/**
+ * Slack channel notifications for AI review runs. Rendered inside the
+ * "Review AI agent turns" card, only when reviews are enabled and the org has
+ * a Slack integration. The in-app bell + assignment DMs fire independently.
+ */
+export const ReviewNotificationsSettings = () => {
+    const { user } = useApp();
+    const canEdit = user.data?.ability?.can('manage', 'Organization') ?? false;
+
+    const { data: slackInstallation } = useGetSlack();
+    const hasSlack = !!slackInstallation?.organizationUuid;
+
+    const { data: settings, isInitialLoading } =
+        useReviewNotificationSettings();
+    const { mutate: updateSettings, isLoading: isUpdating } =
+        useUpdateReviewNotificationSettings();
+
+    if (!hasSlack) {
+        return null;
+    }
+
+    return (
+        <>
+            <Divider mx="calc(var(--mantine-spacing-md) * -1)" />
+            <Group
+                justify="space-between"
+                wrap="nowrap"
+                align="flex-start"
+                gap="md"
+            >
+                <Box maw={620}>
+                    <Title order={6} mb={4}>
+                        Slack notifications
+                    </Title>
+                    <Text c="dimmed" fz="xs">
+                        Post to a Slack channel when a review run surfaces
+                        findings that need review. Assignment notifications are
+                        always sent as a direct message and in the in-app bell,
+                        regardless of this setting.
+                    </Text>
+                </Box>
+                {isInitialLoading || !settings ? (
+                    <Loader size="sm" />
+                ) : (
+                    <Switch
+                        size="md"
+                        checked={settings.enabled}
+                        disabled={!canEdit || isUpdating}
+                        onChange={(event) =>
+                            updateSettings({
+                                enabled: event.currentTarget.checked,
+                                slackChannelId: settings.slackChannelId,
+                            })
+                        }
+                    />
+                )}
+            </Group>
+
+            {settings?.enabled && (
+                <SlackChannelSelect
+                    label="Slack channel"
+                    value={settings.slackChannelId}
+                    disabled={!canEdit || isUpdating}
+                    withRefresh
+                    placeholder="Select a channel"
+                    onChange={(slackChannelId) =>
+                        updateSettings({ enabled: true, slackChannelId })
+                    }
+                />
+            )}
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useReviewNotificationSettings.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useReviewNotificationSettings.ts
@@ -1,0 +1,76 @@
+import {
+    type ApiAiReviewNotificationSettingsResponse,
+    type ApiError,
+    type UpdateAiReviewNotificationSettings,
+} from '@lightdash/common';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+    type UseMutationOptions,
+    type UseQueryOptions,
+} from '@tanstack/react-query';
+import { lightdashApi } from '../../../../api';
+import useToaster from '../../../../hooks/toaster/useToaster';
+
+type Settings = ApiAiReviewNotificationSettingsResponse['results'];
+
+const QUERY_KEY = ['ai-review-notification-settings'];
+
+const getReviewNotificationSettings = async () =>
+    lightdashApi<Settings>({
+        url: `/aiAgents/admin/review-notification-settings`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useReviewNotificationSettings = (
+    queryOptions?: UseQueryOptions<Settings, ApiError>,
+) =>
+    useQuery<Settings, ApiError>({
+        queryKey: QUERY_KEY,
+        queryFn: getReviewNotificationSettings,
+        keepPreviousData: true,
+        ...queryOptions,
+    });
+
+const updateReviewNotificationSettings = async (
+    data: UpdateAiReviewNotificationSettings,
+) =>
+    lightdashApi<Settings>({
+        url: `/aiAgents/admin/review-notification-settings`,
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateReviewNotificationSettings = (
+    mutationOptions?: UseMutationOptions<
+        Settings,
+        ApiError,
+        UpdateAiReviewNotificationSettings
+    >,
+) => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<Settings, ApiError, UpdateAiReviewNotificationSettings>({
+        mutationFn: updateReviewNotificationSettings,
+        onSuccess: async (data, variables, context) => {
+            showToastSuccess({
+                title: 'Success! Review notification settings updated',
+            });
+            queryClient.setQueryData<Settings | undefined>(
+                QUERY_KEY,
+                (previous) => (previous ? { ...previous, ...data } : data),
+            );
+            await queryClient.invalidateQueries(QUERY_KEY);
+            mutationOptions?.onSuccess?.(data, variables, context);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update review notification settings',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
+++ b/packages/frontend/src/features/notifications/components/AiReviewNotifications.tsx
@@ -1,12 +1,11 @@
 import { type NotificationAiReview } from '@lightdash/common';
-import { Box, Menu } from '@mantine-8/core';
+import { Group, Menu } from '@mantine-8/core';
 import { Text, Tooltip, useMantineTheme } from '@mantine/core';
 import { IconCircleFilled } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useCallback, type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIcon';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -68,7 +67,7 @@ export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
                 },
             });
 
-            void navigate(notification.url ?? '/ai-agents/admin/reviews');
+            void navigate(notification.url ?? '/generalSettings/ai/reviews');
         },
         [navigate, track, updateNotification],
     );
@@ -79,35 +78,24 @@ export const AiReviewNotifications: FC<Props> = ({ notifications }) => {
                 <Menu.Item
                     p="xs"
                     key={notification.notificationId}
-                    leftSection={
-                        <Box
-                            display="flex"
-                            style={{
-                                alignItems: 'center',
-                                gap: 6,
-                            }}
-                        >
-                            <MantineIcon
-                                size={8}
-                                icon={IconCircleFilled}
-                                style={{
-                                    color: notification.viewed
-                                        ? 'transparent'
-                                        : theme.colors.teal[5],
-                                }}
-                            />
-                            <AiAgentIcon size={16} calm />
-                        </Box>
-                    }
                     onClick={() => handleOnNotificationClick(notification)}
                     fz="xs"
                 >
-                    <>
-                        <NotificationTime createdAt={notification.createdAt} />
+                    <NotificationTime createdAt={notification.createdAt} />
+                    <Group gap={6} wrap="nowrap" align="center">
+                        <MantineIcon
+                            size={8}
+                            icon={IconCircleFilled}
+                            style={{
+                                color: notification.viewed
+                                    ? 'transparent'
+                                    : theme.colors.teal[5],
+                            }}
+                        />
                         <Text className={classes.notificationMessage}>
                             {notification.message}
                         </Text>
-                    </>
+                    </Group>
                 </Menu.Item>
             ))}
         </>


### PR DESCRIPTION
Part 4 — UI + UX polish on the AI review notifications stack (#24641 → #24642 → #24643).

## Summary

- **Settings UI** for review notifications, nested inside the existing "Review AI agent turns" card on **Ask AI → General** — appears only when reviews are enabled **and** the org has a Slack integration (since these settings only govern Slack channel delivery; the in-app bell + assignment DMs are independent). Visible to `manage:AiAgent`, **editable by org-admins** (mirrors the `GET`=manage / `PUT`=admin backend permissions). New `useReviewNotificationSettings` GET/PUT hooks.
- **Bell polish:** drop the redundant agent icon from each notification row and inline-align the unread dot with the message (it previously floated in the vertical center).
- **Deep-links now open the review drawer.** The notification URL targeted `/ai-agents/admin/reviews`, which is a `<Navigate replace>` redirect that **drops the query string**, so the drawer never opened. Notifications (bell + Slack "Open review" button) now point straight at `/generalSettings/ai/reviews?reviewProjectUuid&reviewAgentUuid&reviewThreadUuid&reviewItemUuid`, derived from the item's latest finding. Falls back to item-only when there's no finding (e.g. a manual issue).

## Validation

- `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`
- `pnpm -F backend test:dev:nowatch AiAgentReviewNotificationService sendReviewNotification`
- Verified live: settings toggle + channel picker persist via the endpoints; bell click opens the review drawer; a real `needs_review` Slack post landed in the configured channel.

## Regression analysis

Frontend settings card is gated to review-managers (view) / org-admins (edit) and only renders with Slack connected, so non-AI orgs see nothing new. The deep-link change is a strict fix — the old links were broken (redirect stripped params); no existing working behavior changes. Backend changes only affect the URL string in notifications/Slack messages (no API/schema change).

> Slack note surfaced while testing: assignment **DMs** require the Slack app to have the `im:write` scope; without it the worker logs `missing_scope` to `ai_agent_review_notification` and degrades gracefully (channel posts only need `chat:write`).