### PR TITLE
fix(table): keep bars-in-cells proportional regardless of label width

### DIFF
--- a/packages/frontend/src/components/common/Table/TableProvider.tsx
+++ b/packages/frontend/src/components/common/Table/TableProvider.tsx
@@ -177,6 +177,26 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         return data.slice(start, end);
     }, [data, paginationState]);
 
+    // Widest formatted label per column. "Bars in cells" reserves a label
+    // gutter this wide so every row's bar is sized against the same remaining
+    // track — otherwise wider labels (more digits) shrink the bar (PROD-8457).
+    const barLabelMaxMap = useMemo(() => {
+        if (!minMaxMap) return undefined;
+        const result: Record<string, string> = {};
+        for (const row of data) {
+            for (const columnId of Object.keys(row)) {
+                const formatted = row[columnId]?.value?.formatted;
+                if (
+                    typeof formatted === 'string' &&
+                    formatted.length > (result[columnId]?.length ?? 0)
+                ) {
+                    result[columnId] = formatted;
+                }
+            }
+        }
+        return result;
+    }, [data, minMaxMap]);
+
     const table = useReactTable({
         data: isInfiniteScrollEnabled ? data : pageRows,
         columns: visibleColumns,
@@ -197,6 +217,7 @@ export const TableProvider: FC<React.PropsWithChildren<ProviderProps>> = ({
         meta: {
             columnProperties,
             minMaxMap,
+            barLabelMaxMap,
         },
         enableColumnPinning: true,
         onColumnVisibilityChange: setColumnVisibility,

--- a/packages/frontend/src/hooks/TableCellBar.tsx
+++ b/packages/frontend/src/hooks/TableCellBar.tsx
@@ -3,6 +3,9 @@ import { Box, Text } from '@mantine-8/core';
 type TableCellBarProps = {
     value: number;
     formatted: string;
+    // Widest formatted label in the column; reserves a constant label gutter
+    // so the bar track is the same width on every row.
+    maxLabel: string;
     min: number;
     max: number;
     color?: string;
@@ -11,6 +14,7 @@ type TableCellBarProps = {
 export const TableCellBar = ({
     value,
     formatted,
+    maxLabel,
     min,
     max,
     color = '#5470c6',
@@ -29,12 +33,13 @@ export const TableCellBar = ({
         <Box
             style={{
                 display: 'grid',
+                // Bar track fills the space left after a constant label gutter
                 gridTemplateColumns: '1fr auto',
                 alignItems: 'center',
                 gap: '4px',
             }}
         >
-            {showBar && (
+            {showBar ? (
                 <Box
                     h="20px"
                     w={`${percentage}%`}
@@ -46,10 +51,39 @@ export const TableCellBar = ({
                         borderRadius: '2px',
                     }}
                 />
+            ) : (
+                <Box />
             )}
-            <Text span style={{ whiteSpace: 'nowrap' }} fz="xs">
-                {formatted}
-            </Text>
+            {/* Label gutter: when this row isn't the widest, an invisible
+                sizer holds the column's widest label so the gutter width stays
+                constant across every row. The visible label is right-aligned. */}
+            <Box style={{ display: 'grid' }}>
+                {maxLabel !== formatted && (
+                    <Text
+                        span
+                        aria-hidden
+                        fz="xs"
+                        style={{
+                            gridArea: '1 / 1',
+                            visibility: 'hidden',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {maxLabel}
+                    </Text>
+                )}
+                <Text
+                    span
+                    fz="xs"
+                    style={{
+                        gridArea: '1 / 1',
+                        justifySelf: 'end',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {formatted}
+                </Text>
+            </Box>
         </Box>
     );
 };

--- a/packages/frontend/src/hooks/useColumns.test.tsx
+++ b/packages/frontend/src/hooks/useColumns.test.tsx
@@ -30,12 +30,14 @@ const createMockCellContext = ({
     value,
     minMaxMap,
     columnProperties,
+    barLabelMaxMap,
     item,
 }: {
     columnId: string;
     value: ResultValue;
     minMaxMap?: Record<string, { min: number; max: number }>;
     columnProperties?: Record<string, { displayStyle?: 'text' | 'bar' }>;
+    barLabelMaxMap?: Record<string, string>;
     item?: any;
 }): CellContext<ResultRow, { value: ResultValue }> => {
     return {
@@ -51,6 +53,7 @@ const createMockCellContext = ({
                 meta: {
                     minMaxMap,
                     columnProperties,
+                    barLabelMaxMap,
                 },
             },
         },
@@ -364,6 +367,66 @@ describe('getFormattedValueCell - Bar Chart Display', () => {
         // Should have the default color (#5470c6)
         const style = barElement?.getAttribute('style') || '';
         expect(style).toContain('background');
+    });
+
+    test('reserves a constant label gutter using the widest label in the column (PROD-8457)', () => {
+        // This row is narrower than the column's widest label, so an invisible
+        // sizer holds the widest label to keep the bar track width constant.
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: 998,
+                formatted: '998',
+            },
+            minMaxMap: {
+                revenue: { min: 300, max: 1700 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+            barLabelMaxMap: {
+                revenue: '1,700',
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        renderWithMantine(result as React.ReactElement);
+
+        // The visible label is this row's own value
+        expect(screen.getByText('998')).toBeInTheDocument();
+
+        // An invisible sizer reserves space for the column's widest label
+        const sizer = screen.getByText('1,700');
+        expect(sizer).toBeInTheDocument();
+        expect(sizer.getAttribute('style') || '').toContain(
+            'visibility: hidden',
+        );
+        expect(sizer).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    test('does not duplicate the label when this row is the widest', () => {
+        const context = createMockCellContext({
+            columnId: 'revenue',
+            value: {
+                raw: 1700,
+                formatted: '1,700',
+            },
+            minMaxMap: {
+                revenue: { min: 300, max: 1700 },
+            },
+            columnProperties: {
+                revenue: { displayStyle: 'bar' },
+            },
+            barLabelMaxMap: {
+                revenue: '1,700',
+            },
+        });
+
+        const result = getFormattedValueCell(context);
+        renderWithMantine(result as React.ReactElement);
+
+        // No invisible sizer needed, so the label appears exactly once
+        expect(screen.getAllByText('1,700')).toHaveLength(1);
     });
 });
 

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -216,10 +216,19 @@ const formatBarDisplayCell = (
     const numericConvertedValue =
         typeof convertedValue === 'number' ? convertedValue : value;
 
+    // Widest label in this column, used to reserve a constant label gutter.
+    // Prefer the specific column (pivot-aware), then the base field.
+    const barLabelMaxMap = info.table?.options.meta?.barLabelMaxMap;
+    const maxLabel =
+        barLabelMaxMap?.[columnId] ??
+        barLabelMaxMap?.[baseFieldId] ??
+        formatted;
+
     return (
         <TableCellBar
             value={numericConvertedValue}
             formatted={formatted}
+            maxLabel={maxLabel}
             min={minMax.min}
             max={minMax.max}
             color={color}

--- a/packages/frontend/src/types/@tanstack-react-table.d.ts
+++ b/packages/frontend/src/types/@tanstack-react-table.d.ts
@@ -32,5 +32,8 @@ declare module '@tanstack/react-table' {
     interface TableMeta<_TData extends RowData> {
         columnStats?: ColumnStatsMap;
         columnsConfig?: VizColumnsConfig;
+        // Widest formatted label per column, used to reserve a constant
+        // label gutter so "bars in cells" scale against the same track width
+        barLabelMaxMap?: Record<string, string>;
     }
 }


### PR DESCRIPTION
## Problem

In a Table viz with **Bars in cells** enabled, a higher value could render a *shorter* bar than a lower value when the two labels have different digit counts (e.g. `1,002` vs `998`).

`TableCellBar` used a `1fr auto` CSS grid: the bar sat in the `1fr` track, the number label in `auto`. `1fr` resolves to whatever space is left *after* the label, so a wider label (more digits) shrank the bar track for that row. The bar's percentage was therefore relative to a per-row track, not a constant one.

## Fix

Reserve a **constant label gutter** sized to the column's widest label, and size every bar against the same remaining track.

- The widest formatted label per column is computed once in `TableProvider` (single pass over the already-loaded rows, gated on `minMaxMap` so it's free when no column uses bars) and threaded through table `meta` as `barLabelMaxMap`.
- `TableCellBar` holds that label in an invisible, `aria-hidden` sizer so the gutter is identical on every row. The sizer is only rendered when the row isn't already the widest, so the DOM isn't duplicated for the common case (and there's no overlap of the label onto the bar).

Bar geometry is now purely `(value - min) / range` against a fixed track, so a higher value always renders a wider-or-equal bar.

### Before → After

With a column of `300, 998, 1,002, 1,700`:

- **Before:** `998` rendered a *longer* bar than `1,002` — the wider `1,002` label stole track width.
- **After:** monotonic bars (`300 < 998 ≈ 1,002 < 1,700`); close values correctly produce near-equal bars; labels right-aligned in the reserved gutter with no overlap.

## Testing

- `pnpm -F frontend exec vitest run src/hooks/useColumns.test.tsx` — 24 passed, incl. two new cases covering the reserved gutter (invisible sizer holds the widest label) and the no-duplication path when the row is the widest.
- Lint clean on all changed files.

Closes: PROD-8457
Closes: #24647

🤖 Generated with [Claude Code](https://claude.com/claude-code)