### PR TITLE
fix(db): add missing org/project foreign keys + clean orphans

### DIFF
--- a/packages/backend/src/database/migrations/20260624120000_add_cached_warehouse_project_foreign_key.ts
+++ b/packages/backend/src/database/migrations/20260624120000_add_cached_warehouse_project_foreign_key.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex';
+
+const TABLE = 'cached_warehouse';
+
+/**
+ * cached_warehouse.project_uuid (NOT NULL) never had a foreign key. Following the
+ * precedent of 20231101164443_add_cache_explores_foreign_key, delete the orphan
+ * cache rows whose project was hard-deleted, then add a validated CASCADE FK.
+ * cached_warehouse is a regenerable per-project cache, so deleting orphans is
+ * non-destructive. project_uuid is already the primary key, so it is indexed.
+ */
+export async function up(knex: Knex): Promise<void> {
+    await knex(TABLE)
+        .whereNotExists(
+            knex('projects')
+                .select('project_id')
+                .whereRaw(
+                    'projects.project_uuid = cached_warehouse.project_uuid',
+                ),
+        )
+        .delete();
+
+    await knex.schema.alterTable(TABLE, (table) => {
+        table
+            .foreign('project_uuid')
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.dropForeign('project_uuid');
+    });
+}

--- a/packages/backend/src/database/migrations/20260624120001_add_jobs_project_foreign_key.ts
+++ b/packages/backend/src/database/migrations/20260624120001_add_jobs_project_foreign_key.ts
@@ -1,0 +1,36 @@
+import { Knex } from 'knex';
+
+const TABLE = 'jobs';
+
+/**
+ * jobs.project_uuid (nullable) never had a foreign key. The FK is ON DELETE CASCADE,
+ * so an orphan — a non-null project_uuid pointing at a hard-deleted project — is a
+ * row that should have been cascade-deleted with its project. Delete those (this
+ * cascades to job_steps via the existing job_steps.job_uuid CASCADE FK). Rows with a
+ * NULL project_uuid are valid and left untouched. Then add a validated CASCADE FK.
+ * jobs.project_uuid already has an index (jobs_project_uuid_index).
+ */
+export async function up(knex: Knex): Promise<void> {
+    await knex(TABLE)
+        .whereNotNull('project_uuid')
+        .whereNotExists(
+            knex('projects')
+                .select('project_id')
+                .whereRaw('projects.project_uuid = jobs.project_uuid'),
+        )
+        .delete();
+
+    await knex.schema.alterTable(TABLE, (table) => {
+        table
+            .foreign('project_uuid')
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.dropForeign('project_uuid');
+    });
+}

--- a/packages/backend/src/database/migrations/20260624120002_add_download_audit_foreign_keys.ts
+++ b/packages/backend/src/database/migrations/20260624120002_add_download_audit_foreign_keys.ts
@@ -1,0 +1,60 @@
+import { Knex } from 'knex';
+
+const TABLE = 'download_audit';
+
+/**
+ * download_audit has two org/project columns that never had foreign keys. Clean up
+ * orphans to match each intended ON DELETE behaviour, then add validated FKs:
+ *
+ * - organization_uuid (NOT NULL) -> CASCADE: an orphan whose org was hard-deleted
+ *   should have been cascade-deleted, so delete the row.
+ * - project_uuid (nullable) -> SET NULL: an orphan should have been nulled when its
+ *   project was deleted, so null it (non-destructive — the audit row still belongs
+ *   to a live org).
+ *
+ * project_uuid is the only FK column here without an index, so add one.
+ */
+export async function up(knex: Knex): Promise<void> {
+    await knex(TABLE)
+        .whereNotExists(
+            knex('organizations')
+                .select('organization_id')
+                .whereRaw(
+                    'organizations.organization_uuid = download_audit.organization_uuid',
+                ),
+        )
+        .delete();
+
+    await knex(TABLE)
+        .whereNotNull('project_uuid')
+        .whereNotExists(
+            knex('projects')
+                .select('project_id')
+                .whereRaw(
+                    'projects.project_uuid = download_audit.project_uuid',
+                ),
+        )
+        .update({ project_uuid: null });
+
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.index(['project_uuid'], 'download_audit_project_uuid_idx');
+        table
+            .foreign('organization_uuid')
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table
+            .foreign('project_uuid')
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.dropForeign('organization_uuid');
+        table.dropForeign('project_uuid');
+        table.dropIndex(['project_uuid'], 'download_audit_project_uuid_idx');
+    });
+}


### PR DESCRIPTION
Adds the missing organization/project foreign keys on three tables that never had them, cleans the orphan rows they accumulated, and adds the one missing index.

> No Linear ticket yet — customer-migration schema-hardening. Add `Closes:` if one exists.

## Why
- `cached_warehouse`, `jobs`, `download_audit` carry org/project columns but **no FK** — deleting a project/org orphaned their rows (tens of thousands in prod) and they couldn't cascade or be scoped per customer.
- `cached_warehouse`/`jobs` predate FK rigor (2022); `download_audit` shipped 2025 with indexes but no FKs. Sibling `cached_explores` got its FK in 2023 — `cached_warehouse` was missed.

## What
Clean orphans per each FK's `ON DELETE` semantics, then add **validated** FKs + one index:
- `cached_warehouse.project_uuid → projects` **CASCADE** — delete orphans
- `jobs.project_uuid → projects` **CASCADE** — delete orphans (cascades to `job_steps`)
- `download_audit.organization_uuid → organizations` **CASCADE** — delete org-orphans
- `download_audit.project_uuid → projects` **SET NULL** — null project-orphans
- new index `download_audit_project_uuid_idx` (the only FK column lacking one)

## Prod orphans handled
```
download_audit.project_uuid    18,283  -> SET NULL (row kept)
download_audit.organization    18,020  -> deleted
jobs.project_uuid               4,299  -> deleted (+ job_steps cascade)
cached_warehouse.project_uuid     254  -> deleted
```
All four tables are small (<=55 MB) so the cleanup, index build, and FK validation are quick.

## Verified on dev (synthetic positive + orphan rows)
- orphans deleted / project-orphans NULL'd; positives + NULL-project rows kept
- orphan job's `job_steps` cascade-deleted
- 4 FKs `convalidated = true`; index created; a fresh orphan insert is rejected

## Test plan
- [x] `pnpm -F backend typecheck:fast`; `migrate` up + `rollback-last` round-trip
- [x] synthetic positive/negative run (above)
- [ ] confirm no export-audit retention requirement on `download_audit` before merge (18k org-orphans deleted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)