### PR TITLE
feat: allow private MCP addresses

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -144,6 +144,7 @@ export const aiCopilotConfigSchema = z
             .max(1)
             .default(0.6),
         mcpConnectionTimeoutMs: z.number().positive().default(20_000),
+        mcpAllowPrivateAddresses: z.boolean().default(false),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -247,6 +247,7 @@ export const lightdashConfigMock: LightdashConfig = {
             },
             verifiedAnswerSimilarityThreshold: 0.6,
             mcpConnectionTimeoutMs: 20_000,
+            mcpAllowPrivateAddresses: false,
             defaultEmbeddingModelProvider: 'openai',
         },
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1169,6 +1169,8 @@ export const getAiConfig = () => ({
     mcpConnectionTimeoutMs:
         getIntegerFromEnvironmentVariable('AI_COPILOT_MCP_TIMEOUT_MS') ||
         20_000,
+    mcpAllowPrivateAddresses:
+        process.env.AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES === 'true',
 });
 
 export type LoggingConfig = {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3014,7 +3014,9 @@ export class AiAgentService extends BaseService {
         const normalizedUrl = (
             await validatePublicHttpUrl(body.url, {
                 allowedProtocols: ['http:', 'https:'],
-                allowPrivateAddresses: process.env.NODE_ENV === 'test',
+                allowPrivateAddresses:
+                    this.lightdashConfig.ai.copilot.mcpAllowPrivateAddresses ||
+                    process.env.NODE_ENV === 'test',
             })
         ).toString();
 

--- a/packages/backend/src/utils/ssrfProtection.test.ts
+++ b/packages/backend/src/utils/ssrfProtection.test.ts
@@ -51,6 +51,18 @@ describe('validatePublicHttpUrl', () => {
         ).rejects.toThrow(privateUrlError);
     });
 
+    it('accepts private IP targets when explicitly allowed', async () => {
+        await expect(
+            validatePublicHttpUrl('http://127.0.0.1:3000/mcp', {
+                allowedProtocols: ['http:', 'https:'],
+                allowPrivateAddresses: true,
+            }),
+        ).resolves.toMatchObject({
+            hostname: '127.0.0.1',
+            protocol: 'http:',
+        });
+    });
+
     it('rejects IPv4-mapped IPv6 private targets', async () => {
         await expect(
             validatePublicHttpUrl('http://[::ffff:127.0.0.1]:3000/mcp', {


### PR DESCRIPTION
### Summary

* Add `AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES` backend config for AI agent MCP server URLs
* Allow self-hosted deployments to opt into private/internal MCP addresses
* Keep private-address blocking as the default behavior

### Testing

* `pnpm -F backend test -- ssrfProtection.test.ts --runInBand`
* `pnpm -F backend typecheck:fast`
* Local Browser verified app loads at `localhost:3022`
* Local API with private `127.0.0.1` MCP URL reaches connection testing instead of private-address rejection

Related: [PROD-8453](https://linear.app/lightdash/issue/PROD-8453/add-self-hosted-mcp-server-troubleshooting-to-mcp-docs)