### PR TITLE
perf(pivot): fold anchor CTEs into ranking CTEs for metric sort

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -68,26 +68,28 @@ const { sql, parameterReferences } = builder.getSqlAndReferences();
 
 2. **Dimension sort** (groupByColumns present, sorting by dimension/index columns): `original_query → group_by_query → pivot_query → filtered_rows → total_columns`. `pivot_query` computes `row_index` and `column_index` inline with DENSE_RANK. No anchor CTEs.
 
-3. **Metric sort** (sorting by a value column): Full anchor CTE pipeline:
+3. **Metric sort** (sorting by a value column): anchor windows folded into the ranking CTEs:
 
 ```mermaid
 graph TD
     A[original_query] --> B[group_by_query]
-    B --> C["{ref}_ca (column anchor) — FIRST_VALUE per groupBy value"]
-    C --> D["column_ranking — DENSE_RANK for col_idx"]
-    D --> E["anchor_column — picks col_idx = 1"]
-    E --> F["{ref}_ra (row anchor) — metric value at anchor column via CROSS JOIN"]
-    F --> G["row_ranking — DENSE_RANK for row_index"]
+    B --> D["column_ranking — DENSE_RANK for col_idx; FIRST_VALUE column anchor folded into a nested scan of group_by_query"]
+    D --> E["anchor_column — picks col_idx = 1 (reads column_ranking)"]
+    E --> G["row_ranking — DENSE_RANK for row_index; MAX(CASE) row anchor folded into a nested scan of group_by_query CROSS JOIN anchor_column"]
+    B --> G
     D --> H["pivot_query — JOINs row_ranking + column_ranking"]
     G --> H
+    B --> H
     H --> I[filtered_rows + total_columns]
 ```
 
 **Metric sorting anchor system**: When users sort by a metric, rows are ordered by that metric's value in the _first pivot column only_ (the anchor column), not by MIN/MAX across all columns. The anchor column is determined by `column_ranking` (`col_idx = 1`).
 
-**Precomputed rankings for Databricks/Spark**: Databricks inlines CTEs instead of materializing them. When `pivot_query` had inline DENSE_RANK with anchor column references, Spark couldn't resolve them across the inlined CTE boundary. Fix: `row_ranking` and `column_ranking` are self-contained CTEs with their own JOINs; `pivot_query` just JOINs the precomputed results. This activates automatically when metric sorting + index columns are present.
+**Anchors folded into rankings (PROD-8441)**: The column anchor (`FIRST_VALUE` per groupBy value, aliased `${ref}_ca_value`) and row anchor (`MAX(CASE …)` metric value at the anchor column, aliased `${ref}_ra_value`) are computed inside a nested subquery (aliased `g`) within `column_ranking` / `row_ranking` respectively — not as standalone `{ref}_ca` / `{ref}_ra` CTEs. This keeps `group_by_query` referenced ~3× on the metric-sort path (once per nested anchor scan + once by `pivot_query`) instead of ~6×, which matters on inlining engines like Trino (`query.max-stage-count`). It is also more robust for Databricks/Spark: the anchor value lives in the same scan as the ranking Window, so there is no cross-CTE column reference for an inliner to lose. `anchor_column` (and the per-metric `{ref}_anchor_column` pinned variant) stays its own CTE — it reads `column_ranking`, not `group_by_query`.
 
-**CTE name quoting**: Anchor CTE names are derived from field names (e.g., `revenue_ca` for column anchor, `revenue_ra` for row anchor). The `_ca`/`_ra` suffixes are kept short to stay within Postgres' 63-char identifier limit when field references are long. Since field names can contain spaces, all dynamic CTE names must be quoted with `${q}${cteName}${q}`. Hardcoded CTE names (`row_ranking`, `pivot_query`, etc.) don't need quoting.
+**Precomputed rankings for Databricks/Spark**: Databricks inlines CTEs instead of materializing them. When `pivot_query` had inline DENSE_RANK with anchor column references, Spark couldn't resolve them across the inlined CTE boundary. Fix: `row_ranking` and `column_ranking` are self-contained CTEs (each folding its own anchor scan); `pivot_query` just JOINs the precomputed results. This activates automatically when metric sorting + index columns are present.
+
+**Anchor value aliasing**: The folded anchor value columns keep the `${ref}_ca_value` / `${ref}_ra_value` aliases (resolved against the nested derived table `g`). The `_ca`/`_ra` suffixes are kept short to stay within Postgres' 63-char identifier limit when field references are long. Hardcoded CTE names (`row_ranking`, `pivot_query`, etc.) don't need quoting.
 
 **Two-phase pivot**: PivotQueryBuilder outputs rows tagged with `row_index` + `column_index`. The actual pivot (spreading values into `{field}_{aggregation}_{groupByValue}` columns) happens in `AsyncQueryService.runQueryAndTransformRows` which streams results and pivots on `row_index` changes.
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -479,7 +479,7 @@ describe('PivotQueryBuilder', () => {
             // Metric sort: should create column_ranking CTE to compute column_index per groupBy value
             expect(result).toContain('column_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ca_value" DESC',
             );
 
             // Metric sort: should create anchor_column CTE to identify first pivot column (column_index = 1)
@@ -489,9 +489,10 @@ describe('PivotQueryBuilder', () => {
                 'SELECT cr."category" AS "anchor_category" FROM column_ranking cr WHERE "col_idx" = 1 ORDER BY cr."category" ASC LIMIT 1',
             );
 
-            // Metric sort: row anchor should use CROSS JOIN with anchor_column
-            // (gets metric value at first pivot column only, not MIN/MAX across all columns)
-            expect(result).toContain('"revenue_ra" AS (');
+            // Metric sort: row anchor aggregation is folded into row_ranking,
+            // CROSS JOINing anchor_column to get the metric value at the first
+            // pivot column only (not MIN/MAX across all columns)
+            expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
                 'MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_sum" END)',
             );
@@ -521,29 +522,34 @@ describe('PivotQueryBuilder', () => {
 
             const result = builder.toSql();
 
-            // Should add additional CTEs for metric first values
-            expect(result).toContain('"revenue_ra" AS (');
-            expect(result).toContain('"revenue_ca" AS (');
+            // Anchor windows are folded into the ranking CTEs — no standalone
+            // _ca/_ra CTEs and no cross-CTE join back to them.
+            expect(result).not.toContain('"revenue_ra" AS (');
+            expect(result).not.toContain('"revenue_ca" AS (');
+            expect(result).not.toContain('JOIN "revenue_ra" ON');
+            expect(result).not.toContain('JOIN "revenue_ca" ON');
 
-            // row_ranking CTE should join with row_anchor and compute DENSE_RANK
+            // row_ranking computes DENSE_RANK over a nested scan that aggregates
+            // the row anchor value in a single pass of group_by_query
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL))',
+                'MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_avg" END) AS "revenue_ra_value" FROM group_by_query q CROSS JOIN anchor_column ac GROUP BY q."date"',
             );
 
-            // column_ranking CTE should join with column_anchor and compute DENSE_RANK
+            // column_ranking computes DENSE_RANK over a nested scan that produces
+            // the column anchor FIRST_VALUE in a single pass of group_by_query
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_ca" ON (g."category" = "revenue_ca"."category" OR (g."category" IS NULL AND "revenue_ca"."category" IS NULL))',
+                'FIRST_VALUE("revenue_avg") OVER (PARTITION BY "category" ORDER BY "revenue_avg" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "revenue_ca_value" FROM group_by_query) g',
             );
 
             // Row index should be computed in row_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" DESC, g."date" ASC) AS "row_index"',
             );
 
             // Column index should be computed in column_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ca_value" DESC, g."category" ASC) AS "col_idx"',
             );
 
             // pivot_query should JOIN with precomputed rankings
@@ -585,7 +591,7 @@ describe('PivotQueryBuilder', () => {
 
             // Row index order must follow: revenue anchor ASC, store_id DESC, then date ASC (appended)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -658,7 +664,7 @@ describe('PivotQueryBuilder', () => {
             // row_ranking CTE should compute row_index with DENSE_RANK in a self-contained CTE
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g."date" AS "date", DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index" FROM group_by_query g LEFT JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g."date" AS "date", DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" DESC, g."date" ASC) AS "row_index" FROM (SELECT q."date", MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_sum" END) AS "revenue_ra_value" FROM group_by_query q CROSS JOIN anchor_column ac GROUP BY q."date") g)',
             );
 
             // pivot_query should JOIN with precomputed rankings instead of computing Window functions
@@ -669,6 +675,42 @@ describe('PivotQueryBuilder', () => {
             // pivot_query should NOT contain DENSE_RANK (rankings are precomputed)
             const pivotQueryMatch = result.match(/pivot_query AS \(([^)]+)\)/);
             expect(pivotQueryMatch?.[1]).not.toContain('DENSE_RANK');
+        });
+
+        test('Metric sort: references group_by_query ~3x (anchors folded into the ranking CTEs)', () => {
+            // PROD-8441: each anchor window is folded into its ranking CTE so
+            // group_by_query is scanned once inside column_ranking, once inside
+            // row_ranking, and once by pivot_query — 3 total, not ~6. Keeping
+            // this low is what keeps Trino under its max-stage-count limit.
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // Count references to group_by_query that are NOT its own CTE
+            // definition (`group_by_query AS (`).
+            const totalMatches = (result.match(/group_by_query/g) ?? []).length;
+            const definitionMatches = (
+                result.match(/group_by_query AS \(/g) ?? []
+            ).length;
+            expect(definitionMatches).toBe(1);
+            expect(totalMatches - definitionMatches).toBe(3);
         });
 
         test('No metric sort: should NOT create row_ranking CTE when no anchor CTEs exist', () => {
@@ -999,8 +1041,10 @@ describe('PivotQueryBuilder', () => {
 
             expect(result).toContain('(cr."status") IN (\'completed\')');
             expect(result).toContain('(cr."status") IN (\'shipped\')');
-            expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac');
-            expect(result).toContain('CROSS JOIN "orders_anchor_column" ac');
+            // Both per-metric anchors are CROSS JOINed once inside the single
+            // folded row_ranking scan, with distinct aliases.
+            expect(result).toContain('CROSS JOIN "revenue_anchor_column" ac0');
+            expect(result).toContain('CROSS JOIN "orders_anchor_column" ac1');
         });
 
         test('Pinned sort: partial pin (covers only some groupBy columns) falls back to col_idx = 1', () => {
@@ -2081,7 +2125,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Check that row_index ORDER BY has NULLS LAST
             expect(replaceWhitespace(result)).toContain(
-                '"revenue_ra"."revenue_ra_value" DESC NULLS LAST',
+                'g."revenue_ra_value" DESC NULLS LAST',
             );
 
             // Check column anchor CTE has NULLS LAST
@@ -2119,7 +2163,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Row index should include NULLS FIRST when sorting by value column
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -2152,7 +2196,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Column index should include NULLS LAST in column_ranking CTE
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ca_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
             );
         });
 
@@ -2226,7 +2270,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).not.toContain('NULLS LAST');
         });
 
-        test('Should use LEFT JOIN for anchor CTEs to preserve rows with NULL anchor values', () => {
+        test('Should use LEFT JOIN for precomputed rankings to preserve rows with NULL anchor values', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -2252,12 +2296,14 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // Should use LEFT JOIN for both row and column anchor CTEs
-            expect(result).toContain('LEFT JOIN "revenue_ra" ON');
-            expect(result).toContain('LEFT JOIN "revenue_ca" ON');
-            // Should not use regular JOIN (without LEFT)
-            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ra"/);
-            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ca"/);
+            // Anchor windows are folded into the ranking CTEs; pivot_query
+            // LEFT JOINs the precomputed rankings so rows with NULL anchor
+            // values are preserved.
+            expect(result).toContain('LEFT JOIN row_ranking rr ON');
+            expect(result).toContain('LEFT JOIN column_ranking cr ON');
+            // No standalone anchor CTEs remain to join back to.
+            expect(result).not.toContain('"revenue_ra" AS (');
+            expect(result).not.toContain('"revenue_ca" AS (');
         });
     });
 
@@ -4478,21 +4524,13 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // CTE definitions in the WITH clause must be quoted.
-            expect(result).toContain(`"${fieldWithSpaces}_ca" AS (`);
-            expect(result).toContain(`"${fieldWithSpaces}_ra" AS (`);
-
-            // Every reference of those CTEs (LEFT JOIN, qualified column
-            // accesses) must also be quoted — the original bug was unquoted
-            // names appearing in JOIN clauses, not just CTE definitions.
-            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ra"`);
-            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ca"`);
-            expect(result).toContain(
-                `"${fieldWithSpaces}_ca"."${fieldWithSpaces}_ca_value"`,
-            );
-            expect(result).toContain(
-                `"${fieldWithSpaces}_ra"."${fieldWithSpaces}_ra_value"`,
-            );
+            // Anchor windows are folded into the ranking CTEs, so the
+            // field-with-spaces now appears only in quoted aliases and column
+            // refs — all must be wrapped in the warehouse quote char.
+            expect(result).toContain(`AS "${fieldWithSpaces}_ca_value"`);
+            expect(result).toContain(`AS "${fieldWithSpaces}_ra_value"`);
+            expect(result).toContain(`g."${fieldWithSpaces}_ca_value"`);
+            expect(result).toContain(`g."${fieldWithSpaces}_ra_value"`);
 
             // The bare unquoted form must not appear anywhere — that is what
             // would produce the original `syntax error at or near "TAX"`.
@@ -4548,10 +4586,11 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain('row_ranking AS (');
             expect(result).toContain('column_ranking AS (');
 
-            // row_ranking is self-contained: it owns its JOIN to row_anchor
-            // and produces row_index as a concrete output column.
+            // row_ranking is self-contained: it folds the row-anchor
+            // aggregation into a nested scan of group_by_query and produces
+            // row_index as a concrete output column.
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g.`event_tier` AS `event_tier`, DENSE_RANK() OVER (ORDER BY `count_ra`.`count_ra_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_ra` ON (g.`event_tier` = `count_ra`.`event_tier` OR (g.`event_tier` IS NULL AND `count_ra`.`event_tier` IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g.`event_tier` AS `event_tier`, DENSE_RANK() OVER (ORDER BY g.`count_ra_value` DESC, g.`event_tier` ASC) AS `row_index` FROM (SELECT q.`event_tier`, MAX(CASE WHEN (q.`event` = ac.`anchor_event` OR (q.`event` IS NULL AND ac.`anchor_event` IS NULL)) THEN q.`count_count` END) AS `count_ra_value` FROM group_by_query q CROSS JOIN anchor_column ac GROUP BY q.`event_tier`) g)',
             );
 
             // pivot_query just joins precomputed rankings — no inline
@@ -4677,7 +4716,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // column_ranking ORDER BY echoes the NULLS treatment for the
             // anchor value, then falls back to the groupBy field as tiebreaker.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ca_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
             );
 
             // row_index ORDER BY combines BOTH sort entries with their own
@@ -4685,7 +4724,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // NULLS LAST. A regression that drops the per-entry nulls flag
             // would collapse one of these.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
             );
         });
 
@@ -4784,9 +4823,10 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             const result = builder.toSql();
 
-            // Both sort metrics produce a column_anchor CTE.
-            expect(result).toContain('"revenue_ca" AS (');
-            expect(result).toContain('"orders_ca" AS (');
+            // Both sort metrics produce a FIRST_VALUE column anchor folded
+            // into column_ranking's nested scan.
+            expect(result).toContain('AS "revenue_ca_value"');
+            expect(result).toContain('AS "orders_ca_value"');
 
             // Count is the assertion: every FIRST_VALUE must be paired with a
             // ROWS BETWEEN frame clause. A regression that leaves frames off
@@ -5120,11 +5160,6 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(
                 'LEFT JOIN column_ranking cr ON g."status" <=> cr."status"',
             );
-            // Anchor CTE joins also use `<=>`.
-            expect(result).toContain('g."status" <=> "amount_ca"."status"');
-            expect(result).toContain(
-                'g."order_date" <=> "amount_ra"."order_date"',
-            );
 
             // No JOIN ON falls back to the OR form on ClickHouse.
             expect(result).not.toContain(
@@ -5351,29 +5386,30 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
             const collapsed = replaceWhitespace(result);
 
-            // Slice out the column_anchor CTE body so the assertions are
-            // scoped to just that CTE rather than the whole SQL. Nested
-            // parens inside FIRST_VALUE / OVER (...) make a regex slice
-            // brittle, so use named CTE markers as bounds.
-            const colAnchorStart = collapsed.indexOf('"revenue_ca" AS (');
-            const rowAnchorStart = collapsed.indexOf(
-                '"revenue_ra" AS (',
-                colAnchorStart,
+            // Slice out the column_ranking CTE body (which the column anchor is
+            // folded into) so the assertions are scoped to just that CTE rather
+            // than the whole SQL. Nested parens inside FIRST_VALUE / OVER (...)
+            // make a regex slice brittle, so use named CTE markers as bounds —
+            // anchor_column is the CTE that immediately follows column_ranking.
+            const colRankingStart = collapsed.indexOf('column_ranking AS (');
+            const anchorColumnStart = collapsed.indexOf(
+                'anchor_column AS (',
+                colRankingStart,
             );
-            expect(colAnchorStart).toBeGreaterThanOrEqual(0);
-            expect(rowAnchorStart).toBeGreaterThan(colAnchorStart);
+            expect(colRankingStart).toBeGreaterThanOrEqual(0);
+            expect(anchorColumnStart).toBeGreaterThan(colRankingStart);
             const colAnchorBody = collapsed.slice(
-                colAnchorStart,
-                rowAnchorStart,
+                colRankingStart,
+                anchorColumnStart,
             );
 
             // FIRST_VALUE PARTITION BY <groupBy> ORDER BY <metric>, with the
-            // explicit ROWS BETWEEN frame, lives inside column_anchor.
+            // explicit ROWS BETWEEN frame, lives inside column_ranking.
             expect(colAnchorBody).toContain(
                 'FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category" ORDER BY "revenue_sum" DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
             );
 
-            // Negative: column_anchor must NOT carry row-anchor's
+            // Negative: column_ranking must NOT carry row-anchor's
             // MAX(CASE WHEN…) expression — that is the row-side shape.
             // Mixing them up is the documented regression path.
             expect(colAnchorBody).not.toContain('MAX(CASE WHEN');
@@ -5420,9 +5456,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
             expect(overlong).toEqual([]);
 
-            // Sanity check: anchor CTEs use the short suffixes.
-            expect(result).toContain(`"${longRef}_ca" AS (`);
-            expect(result).toContain(`"${longRef}_ra" AS (`);
+            // Sanity check: the folded anchors use the short _ca/_ra suffixes.
+            expect(result).toContain(`AS "${longRef}_ca_value"`);
+            expect(result).toContain(`AS "${longRef}_ra_value"`);
         });
     });
 
@@ -5729,8 +5765,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
             const result = builder.toSql();
 
-            // Standard metric sort anchor CTEs must still be emitted
-            expect(result).toContain('"revenue_ca" AS (');
+            // Standard metric sort ranking CTEs must still be emitted, with the
+            // column anchor folded into column_ranking.
+            expect(result).toContain('AS "revenue_ca_value"');
             expect(result).toContain('column_ranking AS (');
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -203,6 +203,49 @@ describe('PivotQueryBuilder', () => {
             expect(finalProjection).not.toContain('__grp_rn');
         });
 
+        test.each([SupportedDbtAdapter.TRINO, SupportedDbtAdapter.ATHENA])(
+            'Omits the __grp_rn window ORDER BY on %s (it throws "Could not instantiate sink" otherwise)',
+            (adapterType) => {
+                const pivotConfiguration = {
+                    indexColumn: [
+                        { reference: 'date', type: VizIndexType.TIME },
+                    ],
+                    valuesColumns: [
+                        {
+                            reference: 'event_id',
+                            aggregation: VizAggregationOptions.SUM,
+                        },
+                    ],
+                    groupByColumns: [{ reference: 'event_type' }],
+                    sortBy: [
+                        { reference: 'date', direction: SortByDirection.ASC },
+                    ],
+                };
+
+                const builder = new PivotQueryBuilder(
+                    baseSql,
+                    pivotConfiguration,
+                    {
+                        ...mockWarehouseSqlBuilder,
+                        getAdapterType: () => adapterType,
+                    } as unknown as WarehouseSqlBuilder,
+                    100,
+                );
+
+                const result = replaceWhitespace(
+                    builder.toSql({ columnLimit: 100 }),
+                );
+
+                // Presto-family engines reject any ORDER BY in this nested window.
+                expect(result).toContain(
+                    'ROW_NUMBER() OVER (PARTITION BY "event_type") AS "__grp_rn" FROM filtered_rows f',
+                );
+                expect(result).not.toContain(
+                    'PARTITION BY "event_type" ORDER BY',
+                );
+            },
+        );
+
         test('Should handle multiple group by columns', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -411,9 +411,6 @@ describe('PivotQueryBuilder', () => {
             // (these are only needed for metric-based sorting)
             expect(result).not.toContain('column_ranking AS (');
             expect(result).not.toContain('anchor_column AS (');
-
-            // Should NOT create row anchor CTEs for revenue
-            expect(result).not.toContain('"revenue_ra" AS (');
         });
 
         test('Dimension sort: should NOT create metric anchor CTEs when sorting by groupBy column', () => {
@@ -447,10 +444,6 @@ describe('PivotQueryBuilder', () => {
             // Should NOT create column_ranking or anchor_column CTEs
             expect(result).not.toContain('column_ranking AS (');
             expect(result).not.toContain('anchor_column AS (');
-
-            // Should NOT create metric anchor CTEs
-            expect(result).not.toContain('"revenue_ra" AS (');
-            expect(result).not.toContain('"revenue_ca" AS (');
         });
 
         test('Metric sort: should create column_ranking and anchor_column CTEs when sorting by value column', () => {
@@ -499,7 +492,7 @@ describe('PivotQueryBuilder', () => {
             expect(result).toContain('CROSS JOIN anchor_column ac');
         });
 
-        test('Should include anchor CTEs and joins when sorting by a value column in pivot queries', () => {
+        test('Should fold anchor windows into the ranking CTEs when sorting by a value column in pivot queries', () => {
             const pivotConfiguration = {
                 indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
                 valuesColumns: [
@@ -521,13 +514,6 @@ describe('PivotQueryBuilder', () => {
             );
 
             const result = builder.toSql();
-
-            // Anchor windows are folded into the ranking CTEs — no standalone
-            // _ca/_ra CTEs and no cross-CTE join back to them.
-            expect(result).not.toContain('"revenue_ra" AS (');
-            expect(result).not.toContain('"revenue_ca" AS (');
-            expect(result).not.toContain('JOIN "revenue_ra" ON');
-            expect(result).not.toContain('JOIN "revenue_ca" ON');
 
             // row_ranking computes DENSE_RANK over a nested scan that aggregates
             // the row anchor value in a single pass of group_by_query
@@ -2301,9 +2287,6 @@ SELECT * FROM group_by_query LIMIT 50`);
             // values are preserved.
             expect(result).toContain('LEFT JOIN row_ranking rr ON');
             expect(result).toContain('LEFT JOIN column_ranking cr ON');
-            // No standalone anchor CTEs remain to join back to.
-            expect(result).not.toContain('"revenue_ra" AS (');
-            expect(result).not.toContain('"revenue_ca" AS (');
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -586,8 +586,10 @@ export class PivotQueryBuilder {
                     );
                     const colAnchorCteName = `${sort.reference}_ca`;
                     if (metricFirstValueQueries[colAnchorCteName]) {
+                        // The anchor value is folded into column_ranking's nested
+                        // derived table (aliased `g`), so resolve against it.
                         acc.push(
-                            `${q}${colAnchorCteName}${q}.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                            `g.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                         );
                     }
                     return acc;
@@ -711,14 +713,15 @@ export class PivotQueryBuilder {
             );
 
             if (isValueColumn) {
-                // Use the anchor value from the row anchor CTE
+                // Use the anchor value folded into row_ranking's nested
+                // derived table (aliased `g`).
                 const rowAnchorCteName = `${sort.reference}_ra`;
                 if (metricFirstValueQueries[rowAnchorCteName]) {
                     const nullsClause = PivotQueryBuilder.getNullsFirstLast(
                         sort.nullsFirst,
                     );
                     orderByParts.push(
-                        `${q}${rowAnchorCteName}${q}.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                        `g.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                     );
                 }
             } else if (isIndexColumn) {
@@ -858,27 +861,91 @@ export class PivotQueryBuilder {
             sortOnlyDimensions,
         );
 
-        // Build JOINs for column anchor CTEs
-        let fromClause = 'group_by_query g';
-        const joins: string[] = [];
-
-        Object.values(columnAnchorCTEs).forEach(({ cteName }) => {
-            const joinConditions = groupByColumns
-                .map((col) =>
-                    this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                        `g.${q}${col.reference}${q}`,
-                        `${q}${cteName}${q}.${q}${col.reference}${q}`,
-                    ),
-                )
-                .join(' AND ');
-            joins.push(`LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`);
-        });
-
-        if (joins.length > 0) {
-            fromClause += ` ${joins.join(' ')}`;
-        }
+        // When sorting by a metric, the FIRST_VALUE anchor windows are folded
+        // into a nested derived table (aliased `g`) so group_by_query is scanned
+        // once. Without metric sort there are no anchors — read group_by_query
+        // directly (dimension-sort path).
+        const fromClause =
+            Object.keys(columnAnchorCTEs).length > 0
+                ? `(${this.buildColumnAnchorSubquerySQL(
+                      valuesColumns,
+                      groupByColumns,
+                      sortBy,
+                      sortOnlyDimensions,
+                  )}) g`
+                : 'group_by_query g';
 
         return `SELECT DISTINCT ${groupByRefs}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}col_idx${q} FROM ${fromClause}`;
+    }
+
+    /**
+     * Builds the nested derived table for column_ranking: a single DISTINCT scan
+     * of group_by_query that produces the groupBy columns (plus any sort-only
+     * dims / _order companions needed by the outer ORDER BY) and one
+     * FIRST_VALUE `${ref}_ca_value` column per sorted value column. Folding the
+     * anchor windows here keeps group_by_query referenced once and avoids a
+     * cross-CTE window reference that Databricks/Spark can't resolve.
+     */
+    private buildColumnAnchorSubquerySQL(
+        valuesColumns: PivotConfiguration['valuesColumns'],
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+        sortBy: PivotConfiguration['sortBy'],
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+
+        const groupColumnReferences = groupByColumns
+            .map((col) => `${q}${col.reference}${q}`)
+            .join(', ');
+
+        // Dims the outer ORDER BY references: visible groupBys, sort-only dims,
+        // and the _order companion of any sorted custom-bin dim among them.
+        const dimSelects = [
+            ...groupByColumns.map((col) => `${q}${col.reference}${q}`),
+            ...(sortOnlyDimensions || []).map(
+                (col) => `${q}${col.reference}${q}`,
+            ),
+        ];
+        const sortedBinRefs = this.getSortedBinDimensionReferences([
+            ...groupByColumns,
+            ...(sortOnlyDimensions || []),
+        ]);
+        for (const ref of sortedBinRefs) {
+            dimSelects.push(`${q}${ref}_order${q}`);
+        }
+
+        const firstValueSelects = (valuesColumns ?? []).reduce<string[]>(
+            (acc, valCol) => {
+                const sortConfig = sortBy?.find(
+                    (sort) => sort.reference === valCol.reference,
+                );
+                if (!sortConfig) return acc;
+
+                const fieldName = PivotQueryBuilder.getValueColumnFieldName(
+                    valCol.reference,
+                    valCol.aggregation,
+                );
+                const sortDirection =
+                    sortConfig.direction === SortByDirection.DESC
+                        ? 'DESC'
+                        : 'ASC';
+                const nullsClause = PivotQueryBuilder.getNullsFirstLast(
+                    sortConfig.nullsFirst,
+                );
+                const colAnchorCteName = `${valCol.reference}_ca`;
+                acc.push(
+                    `FIRST_VALUE(${q}${fieldName}${q}) OVER (PARTITION BY ${groupColumnReferences} ORDER BY ${q}${fieldName}${q} ${sortDirection}${nullsClause} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS ${q}${colAnchorCteName}_value${q}`,
+                );
+                return acc;
+            },
+            [],
+        );
+
+        const selectParts = [...new Set(dimSelects), ...firstValueSelects].join(
+            ', ',
+        );
+
+        return `SELECT DISTINCT ${selectParts} FROM group_by_query`;
     }
 
     /**
@@ -1102,16 +1169,18 @@ export class PivotQueryBuilder {
         sortBy: PivotConfiguration['sortBy'],
         sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
     ): {
-        columnAnchorCTEs: string[];
         columnRankingCTE: string | null;
         anchorColumnCTEs: string[];
-        rowAnchorCTEs: string[];
         metricFirstValueQueries: Record<
             string,
             { cteName: string; sql: string }
         >;
+        rowAnchorQueries: Record<string, { cteName: string; sql: string }>;
+        perMetricAnchorCte: Map<string, string>;
     } {
-        // Get column anchor CTEs (for column ordering)
+        // Get column anchor metadata (for column ordering). These are no longer
+        // emitted as standalone CTEs — they are folded into column_ranking — but
+        // the map's keys still gate the ORDER BY value parts.
         const columnAnchorQueries = this.getColumnAnchorCTEs(
             valuesColumns,
             groupByColumns,
@@ -1119,9 +1188,6 @@ export class PivotQueryBuilder {
         );
 
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-        const columnAnchorCTEs = Object.values(columnAnchorQueries).map(
-            ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
-        );
 
         // When sorting by a metric value, we need the column_ranking CTE so
         // that pivot_query can read col_idx from a precomputed scope instead
@@ -1147,9 +1213,9 @@ export class PivotQueryBuilder {
 
         let columnRankingCTE: string | null = null;
         let anchorColumnCTEs: string[] = [];
-        let rowAnchorCTEs: string[] = [];
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
+        const perMetricAnchorCte = new Map<string, string>();
 
         if (needsColumnRanking) {
             const columnRankingSQL = this.getColumnRankingSQL(
@@ -1166,8 +1232,6 @@ export class PivotQueryBuilder {
                 // anchors so two metrics can pin different columns independently.
                 const hasAnyPin =
                     sortBy?.some((s) => s.pivotValues?.length) ?? false;
-
-                const perMetricAnchorCte = new Map<string, string>();
 
                 if (hasAnyPin && valuesColumns) {
                     valuesColumns.forEach((valCol) => {
@@ -1203,9 +1267,6 @@ export class PivotQueryBuilder {
                     sortBy,
                     hasAnyPin ? perMetricAnchorCte : undefined,
                 );
-                rowAnchorCTEs = Object.values(rowAnchorQueries).map(
-                    ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
-                );
             }
         }
 
@@ -1216,11 +1277,11 @@ export class PivotQueryBuilder {
         };
 
         return {
-            columnAnchorCTEs,
             columnRankingCTE,
             anchorColumnCTEs,
-            rowAnchorCTEs,
             metricFirstValueQueries,
+            rowAnchorQueries,
+            perMetricAnchorCte,
         };
     }
 
@@ -1242,15 +1303,20 @@ export class PivotQueryBuilder {
      *
      * @param indexColumns - Index columns for row identification
      * @param valuesColumns - Value columns configuration
+     * @param groupByColumns - Group by columns (used to match the anchor column)
      * @param sortBy - Sort configuration
-     * @param rowAnchorQueries - Row anchor CTEs to join with
+     * @param rowAnchorQueries - Row anchor map (presence drives whether the
+     *   anchor aggregation is folded into a nested subquery)
+     * @param perMetricAnchorCte - Optional metric → anchor CTE map for pinned sorts
      * @returns SQL for the row_ranking CTE
      */
     private getRowRankingSQL(
         indexColumns: ReturnType<typeof normalizeIndexColumns>,
         valuesColumns: PivotConfiguration['valuesColumns'],
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
         sortBy: PivotConfiguration['sortBy'],
         rowAnchorQueries: Record<string, { cteName: string; sql: string }>,
+        perMetricAnchorCte?: Map<string, string>,
     ): string {
         const q = this.warehouseSqlBuilder.getFieldQuoteChar();
 
@@ -1271,27 +1337,104 @@ export class PivotQueryBuilder {
             q,
         );
 
-        // Build FROM clause with JOINs for row anchor CTEs
-        let fromClause = 'group_by_query g';
-        const joins: string[] = [];
+        // With metric sort, fold the anchor aggregation into a nested derived
+        // table (aliased `g`) scanned once. Without row anchors (dimension-sort
+        // path), read group_by_query directly.
+        const fromClause =
+            Object.keys(rowAnchorQueries).length > 0
+                ? `(${this.buildRowAnchorSubquerySQL(
+                      indexColumns,
+                      valuesColumns,
+                      groupByColumns,
+                      sortBy,
+                      perMetricAnchorCte,
+                  )}) g`
+                : 'group_by_query g';
 
-        Object.values(rowAnchorQueries).forEach(({ cteName }) => {
-            const joinConditions = indexColumns
+        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q} FROM ${fromClause}`;
+    }
+
+    /**
+     * Builds the nested derived table for row_ranking: a single scan of
+     * group_by_query grouped by the index columns that produces one
+     * MAX(CASE …) `${ref}_ra_value` column per sorted value column — the metric
+     * value at that metric's anchor column. Each distinct anchor CTE is
+     * CROSS JOINed once (multiple when different metrics pin different columns).
+     */
+    private buildRowAnchorSubquerySQL(
+        indexColumns: ReturnType<typeof normalizeIndexColumns>,
+        valuesColumns: PivotConfiguration['valuesColumns'],
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+        sortBy: PivotConfiguration['sortBy'],
+        perMetricAnchorCte?: Map<string, string>,
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+
+        // Index columns (and the _order companion of any sorted custom-bin index
+        // dim) carried through both SELECT and GROUP BY.
+        const indexRefs = indexColumns.map(
+            (col) => `q.${q}${col.reference}${q}`,
+        );
+        const sortedBinRefs =
+            this.getSortedBinDimensionReferences(indexColumns);
+        for (const ref of sortedBinRefs) {
+            indexRefs.push(`q.${q}${ref}_order${q}`);
+        }
+        const indexSelect = indexRefs.join(', ');
+
+        const sortedValueColumns = (valuesColumns ?? []).filter((valCol) =>
+            sortBy?.some((sort) => sort.reference === valCol.reference),
+        );
+
+        // Each value column's anchor column (shared `anchor_column` or, for
+        // pinned sorts, a per-metric `${ref}_anchor_column`). Distinct anchors
+        // are CROSS JOINed once; a single anchor keeps the `ac` alias.
+        const anchorByValCol = new Map<string, string>(
+            sortedValueColumns.map((valCol) => [
+                valCol.reference,
+                perMetricAnchorCte?.get(valCol.reference) ?? 'anchor_column',
+            ]),
+        );
+        const distinctAnchors = [...new Set(anchorByValCol.values())];
+        const aliasByAnchor = new Map<string, string>(
+            distinctAnchors.map((name, i) => [
+                name,
+                distinctAnchors.length === 1 ? 'ac' : `ac${i}`,
+            ]),
+        );
+
+        const crossJoins = distinctAnchors
+            .map((name) => {
+                const ref =
+                    name === 'anchor_column'
+                        ? 'anchor_column'
+                        : `${q}${name}${q}`;
+                return `CROSS JOIN ${ref} ${aliasByAnchor.get(name)}`;
+            })
+            .join(' ');
+
+        const maxCaseSelects = sortedValueColumns.map((valCol) => {
+            const fieldName = PivotQueryBuilder.getValueColumnFieldName(
+                valCol.reference,
+                valCol.aggregation,
+            );
+            const alias = aliasByAnchor.get(
+                anchorByValCol.get(valCol.reference)!,
+            )!;
+            const anchorMatch = groupByColumns
                 .map((col) =>
-                    this.warehouseSqlBuilder.getNullSafeEqualJoinSql(
-                        `g.${q}${col.reference}${q}`,
-                        `${q}${cteName}${q}.${q}${col.reference}${q}`,
+                    this.warehouseSqlBuilder.getNullSafeEqualSql(
+                        `q.${q}${col.reference}${q}`,
+                        `${alias}.${q}anchor_${col.reference}${q}`,
                     ),
                 )
                 .join(' AND ');
-            joins.push(`LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`);
+            return `MAX(CASE WHEN ${anchorMatch} THEN q.${q}${fieldName}${q} END) AS ${q}${valCol.reference}_ra_value${q}`;
         });
 
-        if (joins.length > 0) {
-            fromClause += ` ${joins.join(' ')}`;
-        }
-
-        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q} FROM ${fromClause}`;
+        return `SELECT ${indexSelect}, ${maxCaseSelects.join(
+            ', ',
+        )} FROM group_by_query q ${crossJoins} GROUP BY ${indexSelect}`;
     }
 
     private getPivotQuerySQL(
@@ -1589,13 +1732,15 @@ export class PivotQueryBuilder {
             (col) => !this.pivotTableCalculations[col.reference],
         );
 
-        // Get all metric anchor CTEs in the correct order
+        // Get all metric anchor CTEs in the correct order. The column/row anchor
+        // windows are folded into column_ranking / row_ranking, so they are no
+        // longer standalone CTEs.
         const {
-            columnAnchorCTEs,
             columnRankingCTE,
             anchorColumnCTEs,
-            rowAnchorCTEs,
             metricFirstValueQueries,
+            rowAnchorQueries,
+            perMetricAnchorCte,
         } = this.getMetricAnchorCTEs(
             indexColumns,
             valuesColumnsWithoutPivotTableCalculations,
@@ -1615,17 +1760,13 @@ export class PivotQueryBuilder {
 
         let rowRankingCTE: string | null = null;
         if (needsPrecomputedRankings && indexColumns.length > 0) {
-            // Extract only row anchor queries for the row_ranking CTE
-            const rowAnchorQueries = Object.fromEntries(
-                Object.entries(metricFirstValueQueries).filter(([key]) =>
-                    key.endsWith('_ra'),
-                ),
-            );
             const rowRankingSQL = this.getRowRankingSQL(
                 indexColumns,
                 valuesColumnsWithoutPivotTableCalculations,
+                groupByColumns,
                 sortBy,
                 rowAnchorQueries,
+                perMetricAnchorCte,
             );
             rowRankingCTE = `row_ranking AS (${rowRankingSQL})`;
         }
@@ -1656,19 +1797,19 @@ export class PivotQueryBuilder {
 
         // Build CTEs in correct dependency order:
         // 1. original_query, group_by_query (base data)
-        // 2. column anchor CTEs (for column ordering)
-        // 3. column_ranking, anchor_column (for metric-based row sorting - identifies first pivot column)
-        // 4. row anchor CTEs (uses anchor_column to get metric value at first column only)
-        // 5. row_ranking (when precomputed rankings are used)
-        // 6. pivot_query, filtered_rows
-        // 7. pivot_table_calculations (if there are any pivot table calculations)
+        // 2. column_ranking (folds the column-anchor FIRST_VALUE windows into a
+        //    nested scan of group_by_query)
+        // 3. anchor_column (identifies the first pivot column — reads column_ranking)
+        // 4. row_ranking (folds the row-anchor MAX(CASE) aggregation into a nested
+        //    scan of group_by_query, cross-joined to anchor_column)
+        // 5. pivot_query, filtered_rows (total_columns is computed in the final
+        //    SELECT in a single pass over filtered_rows)
+        // 6. pivot_table_calculations (if there are any pivot table calculations)
         const ctes = [
             `original_query AS (${userSql})`,
             `group_by_query AS (${groupByQuery})`,
-            ...columnAnchorCTEs,
             ...(columnRankingCTE ? [columnRankingCTE] : []),
             ...anchorColumnCTEs,
-            ...rowAnchorCTEs,
             ...(rowRankingCTE ? [rowRankingCTE] : []),
             `pivot_query AS (${pivotQuery})`,
         ];

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -16,6 +16,7 @@ import {
     parseTableCalculationFunctions,
     renderFilterRuleSql,
     SortByDirection,
+    SupportedDbtAdapter,
     TableCalculationFunctionCompiler,
     TimeFrames,
     VizAggregationOptions,
@@ -1855,9 +1856,19 @@ export class PivotQueryBuilder {
         ).join(', ');
 
         // __grp_rn flags one row per groupBy combination; its value isn't
-        // order-dependent, but Snowflake requires ROW_NUMBER() windows to have a
-        // deterministic ORDER BY. Reuse the partition columns to satisfy this.
-        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition} ORDER BY ${groupByPartition}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
+        // order-dependent, but warehouses disagree on the window's ORDER BY:
+        // Snowflake (and other strict engines) reject ROW_NUMBER() without one,
+        // while Trino/Athena throw GENERIC_INTERNAL_ERROR "Could not instantiate
+        // sink" when this nested window carries any ORDER BY. So emit it
+        // everywhere except the Presto-family engines, which neither need nor
+        // tolerate it here.
+        const adapterType = this.warehouseSqlBuilder.getAdapterType();
+        const grpRnOrderBy =
+            adapterType === SupportedDbtAdapter.TRINO ||
+            adapterType === SupportedDbtAdapter.ATHENA
+                ? ''
+                : ` ORDER BY ${groupByPartition}`;
+        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition}${grpRnOrderBy}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
 
         return PivotQueryBuilder.assembleSqlParts([
             PivotQueryBuilder.buildCtesSQL(ctes),

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -816,69 +816,6 @@ export class PivotQueryBuilder {
     }
 
     /**
-     * Generates the column_ranking CTE that computes column_index for each distinct groupBy combination.
-     * This is needed to identify the anchor column (column_index = 1) for row sorting.
-     *
-     * @param groupByColumns - Group by columns (visible pivot-column dims)
-     * @param valuesColumns - Value columns configuration
-     * @param sortBy - Sort configuration
-     * @param columnAnchorCTEs - Column anchor CTEs for metric-based column sorting
-     * @param sortOnlyDimensions - Hidden pivot-column dims available in group_by_query
-     *   that should influence the ORDER BY of column_ranking (and thus column order)
-     *   but should NOT appear in the DISTINCT SELECT (so they don't create extra groups).
-     * @returns SQL for the column_ranking CTE
-     */
-    private getColumnRankingSQL(
-        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
-        valuesColumns: PivotConfiguration['valuesColumns'],
-        sortBy: PivotConfiguration['sortBy'],
-        columnAnchorCTEs: Record<string, { cteName: string; sql: string }>,
-        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
-    ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
-        // DISTINCT SELECT contains only visible groupBy columns so that each
-        // pivot column header combination maps to exactly one col_idx.
-        // sortOnlyDimensions are NOT included here — they are helper dims that
-        // only drive the ORDER BY, not the column identity.
-        // Alias to bare names for downstream resolution (ClickHouse multi-join scoping).
-        const groupByRefs = groupByColumns
-            .map(
-                (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
-            )
-            .join(', ');
-
-        // Build ORDER BY clause for column_index.
-        // sortOnlyDimensions participate in the ORDER BY so they influence which
-        // groupBy combination gets col_idx = 1, 2, 3, …
-        const groupByOrderBy = this.buildGroupByOrderBy(
-            groupByColumns,
-            valuesColumns,
-            sortBy,
-            columnAnchorCTEs,
-            q,
-            sortOnlyDimensions,
-        );
-
-        // When sorting by a metric, the FIRST_VALUE anchor windows are folded
-        // into a nested derived table (aliased `g`) so group_by_query is scanned
-        // once. Without metric sort there are no anchors — read group_by_query
-        // directly (dimension-sort path).
-        const fromClause =
-            Object.keys(columnAnchorCTEs).length > 0
-                ? `(${this.buildColumnAnchorSubquerySQL(
-                      valuesColumns,
-                      groupByColumns,
-                      sortBy,
-                      sortOnlyDimensions,
-                  )}) g`
-                : 'group_by_query g';
-
-        return `SELECT DISTINCT ${groupByRefs}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}col_idx${q} FROM ${fromClause}`;
-    }
-
-    /**
      * Builds the nested derived table for column_ranking: a single DISTINCT scan
      * of group_by_query that produces the groupBy columns (plus any sort-only
      * dims / _order companions needed by the outer ORDER BY) and one
@@ -946,6 +883,70 @@ export class PivotQueryBuilder {
         );
 
         return `SELECT DISTINCT ${selectParts} FROM group_by_query`;
+    }
+
+    /**
+     * Generates the column_ranking CTE that computes column_index for each distinct groupBy combination.
+     * This is needed to identify the anchor column (column_index = 1) for row sorting.
+     *
+     * @param groupByColumns - Group by columns (visible pivot-column dims)
+     * @param valuesColumns - Value columns configuration
+     * @param sortBy - Sort configuration
+     * @param columnAnchorCTEs - Column anchor CTEs for metric-based column sorting
+     * @param sortOnlyDimensions - Hidden pivot-column dims available in group_by_query
+     *   that should influence the ORDER BY of column_ranking (and thus column order)
+     *   but should NOT appear in the DISTINCT SELECT (so they don't create extra groups).
+     * @returns SQL for the column_ranking CTE
+     */
+    private getColumnRankingSQL(
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+        valuesColumns: PivotConfiguration['valuesColumns'],
+        sortBy: PivotConfiguration['sortBy'],
+        columnAnchorCTEs: Record<string, { cteName: string; sql: string }>,
+        sortOnlyDimensions?: PivotConfiguration['sortOnlyDimensions'],
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+
+        // DISTINCT SELECT contains only visible groupBy columns so that each
+        // pivot column header combination maps to exactly one col_idx.
+        // sortOnlyDimensions are NOT included here — they are helper dims that
+        // only drive the ORDER BY, not the column identity.
+        // Alias to bare names for downstream resolution (ClickHouse multi-join scoping).
+        const groupByRefs = groupByColumns
+            .map(
+                (col) =>
+                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+            )
+            .join(', ');
+
+        // Build ORDER BY clause for column_index.
+        // sortOnlyDimensions participate in the ORDER BY so they influence which
+        // groupBy combination gets col_idx = 1, 2, 3, …
+        const groupByOrderBy = this.buildGroupByOrderBy(
+            groupByColumns,
+            valuesColumns,
+            sortBy,
+            columnAnchorCTEs,
+            q,
+            sortOnlyDimensions,
+        );
+
+        // The row source is aliased `g` — the same alias group_by_query carries
+        // everywhere else — so the shared ORDER BY builders resolve their
+        // `g.`-qualified columns identically. With a metric sort it is the folded
+        // anchor subquery (group_by_query scanned once); otherwise it is
+        // group_by_query directly (dimension-sort path).
+        const fromClause =
+            Object.keys(columnAnchorCTEs).length > 0
+                ? `(${this.buildColumnAnchorSubquerySQL(
+                      valuesColumns,
+                      groupByColumns,
+                      sortBy,
+                      sortOnlyDimensions,
+                  )}) g`
+                : 'group_by_query g';
+
+        return `SELECT DISTINCT ${groupByRefs}, DENSE_RANK() OVER (ORDER BY ${groupByOrderBy}) AS ${q}col_idx${q} FROM ${fromClause}`;
     }
 
     /**
@@ -1178,9 +1179,9 @@ export class PivotQueryBuilder {
         rowAnchorQueries: Record<string, { cteName: string; sql: string }>;
         perMetricAnchorCte: Map<string, string>;
     } {
-        // Get column anchor metadata (for column ordering). These are no longer
-        // emitted as standalone CTEs — they are folded into column_ranking — but
-        // the map's keys still gate the ORDER BY value parts.
+        // Column anchor metadata (for column ordering). The map's keys gate which
+        // ORDER BY value parts are emitted; the FIRST_VALUE windows themselves are
+        // folded into column_ranking's nested scan.
         const columnAnchorQueries = this.getColumnAnchorCTEs(
             valuesColumns,
             groupByColumns,
@@ -1297,64 +1298,6 @@ export class PivotQueryBuilder {
      */
 
     /**
-     * Generates the row_ranking CTE that computes row_index for each distinct
-     * index column combination. Isolates Window function + anchor value references
-     * in a self-contained CTE so Databricks/Spark can resolve them when inlining.
-     *
-     * @param indexColumns - Index columns for row identification
-     * @param valuesColumns - Value columns configuration
-     * @param groupByColumns - Group by columns (used to match the anchor column)
-     * @param sortBy - Sort configuration
-     * @param rowAnchorQueries - Row anchor map (presence drives whether the
-     *   anchor aggregation is folded into a nested subquery)
-     * @param perMetricAnchorCte - Optional metric → anchor CTE map for pinned sorts
-     * @returns SQL for the row_ranking CTE
-     */
-    private getRowRankingSQL(
-        indexColumns: ReturnType<typeof normalizeIndexColumns>,
-        valuesColumns: PivotConfiguration['valuesColumns'],
-        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
-        sortBy: PivotConfiguration['sortBy'],
-        rowAnchorQueries: Record<string, { cteName: string; sql: string }>,
-        perMetricAnchorCte?: Map<string, string>,
-    ): string {
-        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
-
-        // Alias to bare names for downstream resolution (ClickHouse multi-join scoping).
-        const indexRefs = indexColumns
-            .map(
-                (col) =>
-                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
-            )
-            .join(', ');
-
-        // Reuse buildRowIndexOrderBy to get the same ORDER BY logic
-        const rowIndexOrderBy = this.buildRowIndexOrderBy(
-            indexColumns,
-            valuesColumns,
-            sortBy,
-            rowAnchorQueries,
-            q,
-        );
-
-        // With metric sort, fold the anchor aggregation into a nested derived
-        // table (aliased `g`) scanned once. Without row anchors (dimension-sort
-        // path), read group_by_query directly.
-        const fromClause =
-            Object.keys(rowAnchorQueries).length > 0
-                ? `(${this.buildRowAnchorSubquerySQL(
-                      indexColumns,
-                      valuesColumns,
-                      groupByColumns,
-                      sortBy,
-                      perMetricAnchorCte,
-                  )}) g`
-                : 'group_by_query g';
-
-        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q} FROM ${fromClause}`;
-    }
-
-    /**
      * Builds the nested derived table for row_ranking: a single scan of
      * group_by_query grouped by the index columns that produces one
      * MAX(CASE …) `${ref}_ra_value` column per sorted value column — the metric
@@ -1435,6 +1378,66 @@ export class PivotQueryBuilder {
         return `SELECT ${indexSelect}, ${maxCaseSelects.join(
             ', ',
         )} FROM group_by_query q ${crossJoins} GROUP BY ${indexSelect}`;
+    }
+
+    /**
+     * Generates the row_ranking CTE that computes row_index for each distinct
+     * index column combination. Isolates Window function + anchor value references
+     * in a self-contained CTE so Databricks/Spark can resolve them when inlining.
+     *
+     * @param indexColumns - Index columns for row identification
+     * @param valuesColumns - Value columns configuration
+     * @param groupByColumns - Group by columns (used to match the anchor column)
+     * @param sortBy - Sort configuration
+     * @param rowAnchorQueries - Row anchor map (presence drives whether the
+     *   anchor aggregation is folded into a nested subquery)
+     * @param perMetricAnchorCte - Optional metric → anchor CTE map for pinned sorts
+     * @returns SQL for the row_ranking CTE
+     */
+    private getRowRankingSQL(
+        indexColumns: ReturnType<typeof normalizeIndexColumns>,
+        valuesColumns: PivotConfiguration['valuesColumns'],
+        groupByColumns: NonNullable<PivotConfiguration['groupByColumns']>,
+        sortBy: PivotConfiguration['sortBy'],
+        rowAnchorQueries: Record<string, { cteName: string; sql: string }>,
+        perMetricAnchorCte?: Map<string, string>,
+    ): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+
+        // Alias to bare names for downstream resolution (ClickHouse multi-join scoping).
+        const indexRefs = indexColumns
+            .map(
+                (col) =>
+                    `g.${q}${col.reference}${q} AS ${q}${col.reference}${q}`,
+            )
+            .join(', ');
+
+        // Reuse buildRowIndexOrderBy to get the same ORDER BY logic
+        const rowIndexOrderBy = this.buildRowIndexOrderBy(
+            indexColumns,
+            valuesColumns,
+            sortBy,
+            rowAnchorQueries,
+            q,
+        );
+
+        // The row source is aliased `g` — the same alias group_by_query carries
+        // everywhere else — so the shared ORDER BY builder resolves its
+        // `g.`-qualified columns identically. With a metric sort it is the folded
+        // anchor subquery (group_by_query scanned once); otherwise it is
+        // group_by_query directly (dimension-sort path).
+        const fromClause =
+            Object.keys(rowAnchorQueries).length > 0
+                ? `(${this.buildRowAnchorSubquerySQL(
+                      indexColumns,
+                      valuesColumns,
+                      groupByColumns,
+                      sortBy,
+                      perMetricAnchorCte,
+                  )}) g`
+                : 'group_by_query g';
+
+        return `SELECT DISTINCT ${indexRefs}, DENSE_RANK() OVER (ORDER BY ${rowIndexOrderBy}) AS ${q}row_index${q} FROM ${fromClause}`;
     }
 
     private getPivotQuerySQL(


### PR DESCRIPTION
## Problem

On the **metric-sort path** (sorting a pivot table by a metric value), the generated SQL produced two extra CTEs per sorted value column:

- `{ref}_ca` (column anchor) — a `FIRST_VALUE` window over `group_by_query`, later LEFT JOINed back into `column_ranking`.
- `{ref}_ra` (row anchor) — a `MAX(CASE …)` aggregation over `group_by_query`, later LEFT JOINed back into `row_ranking`.

Each of those scanned `group_by_query`, and so did `column_ranking`, `row_ranking`, and `pivot_query`. On engines that **inline** CTEs instead of materializing them (Trino, Databricks/Spark), `group_by_query` got re-expanded **~6×**, which pushes Trino past its `query.max-stage-count` limit. The cross-CTE window reference (a ranking CTE reading a value from a sibling `_ca`/`_ra` CTE) was also historically fragile on Databricks/Spark.

## Change

Fold each anchor's window/aggregation into a **nested subquery inside its own ranking CTE**, so the anchor value is produced in the same single scan of `group_by_query`. The standalone `_ca`/`_ra` CTEs are dropped and the metric-sort path now references `group_by_query` **~3×** (once per nested anchor scan + once by `pivot_query`).

**Column anchor → `column_ranking`:**
```sql
column_ranking AS (
  SELECT DISTINCT g."category" AS "category",
         DENSE_RANK() OVER (ORDER BY g."revenue_ca_value" DESC, g."category" ASC) AS "col_idx"
  FROM (
    SELECT DISTINCT "category",
           FIRST_VALUE("revenue_sum") OVER (PARTITION BY "category"
             ORDER BY "revenue_sum" DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "revenue_ca_value"
    FROM group_by_query
  ) g
)
```

**Row anchor → `row_ranking`:**
```sql
row_ranking AS (
  SELECT DISTINCT g."date" AS "date",
         DENSE_RANK() OVER (ORDER BY g."revenue_ra_value" DESC, g."date" ASC) AS "row_index"
  FROM (
    SELECT q."date",
           MAX(CASE WHEN <anchorMatch> THEN q."revenue_sum" END) AS "revenue_ra_value"
    FROM group_by_query q CROSS JOIN anchor_column ac
    GROUP BY q."date"
  ) g
)
```

**Assembly:** `getMetricAnchorCTEs` no longer emits the standalone anchor CTE strings; it threads `perMetricAnchorCte` / `rowAnchorQueries` into the folded ranking CTEs, and `getFullPivotSQL` drops them from the CTE list.

## What stays the same

- `anchor_column` (and the per-metric `{ref}_anchor_column` pinned variant) remains its own CTE — it reads `column_ranking`, not `group_by_query`.
- The **multi-pin path** is preserved: when two metrics pin different anchor columns, each distinct anchor is `CROSS JOIN`ed once inside the single folded `row_ranking` scan (aliases `ac0`, `ac1`, …); a single shared anchor keeps the `ac` alias.
- Alias names `{ref}_ca_value` / `{ref}_ra_value` and the **final output schema** are unchanged. `pivot_query` still LEFT JOINs `row_ranking` / `column_ranking`.
- `_order` companions (sorted custom-bin dims) and `sortOnlyDimensions` are carried into the nested subqueries so the outer ORDER BY still resolves.

## More robust for Databricks/Spark

The anchor value now lives in the same scan as the ranking Window, so there is no cross-CTE column reference for an inliner to lose.

## Cross-warehouse `__grp_rn` window fix (Trino/Athena)

The final-stage `__grp_rn` `ROW_NUMBER()` window carried an unconditional `ORDER BY <partition cols>` (added so Snowflake — which rejects `ROW_NUMBER()` without `ORDER BY` — compiles). Trino/Athena throw `GENERIC_INTERNAL_ERROR "Could not instantiate sink"` when this nested window has **any** `ORDER BY` (verified directly against Trino: every variant fails, only no `ORDER BY` succeeds). The window value is order-independent, so the `ORDER BY` is now emitted everywhere **except** the Presto-family engines, which neither need nor tolerate it here.

## Tests

- Updated the metric-sort, NULLS FIRST/LAST, ClickHouse (#23711), Databricks, regression (#18064/#19509/#21401), sortOnly, and pinned-sort assertions to the folded shape.
- Added a test asserting `group_by_query` is referenced exactly **3×** on the metric-sort path, plus Trino/Athena tests asserting the `__grp_rn` window omits the `ORDER BY`.
- Pivot unit suite: **140/140 pass**; `typecheck:fast` and `lint` clean.
- Updated the CTE-pipeline diagram in `QueryBuilder/CLAUDE.md`.

### Cross-warehouse validation

Ran the pivot-parity api-test (`pivotQuery.test.ts` — 4 metric-sort/pivot scenarios each: sort-only metric, sort-only table calc, self-sorted x-axis TC, self-sorted x-axis metric) against live warehouses on this branch:

| Warehouse | Pivot scenarios | Notes |
|-----------|:---------------:|-------|
| Postgres   | ✅ 4/4 | seed project |
| Snowflake  | ✅ 4/4 | run directly via API (suite skips it — cred is a private key, not a password) |
| BigQuery   | ✅ 4/4 | |
| Databricks | ✅ 4/4 | |
| Trino      | ✅ 4/4 | fails on the pre-change baseline with `Could not instantiate sink`; fixed by the `__grp_rn` change above |
| ClickHouse | n/a | excluded — pre-existing base-query/adapter issue (`Unknown table 'default.customers'`), unrelated to this change |

Closes: PROD-8441
