### PR TITLE
fix(map): make choropleth tooltip follow the cursor

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -911,7 +911,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                 );
 
                 if (layer instanceof L.Path) {
-                    layer.bindTooltip(tooltipHtml);
+                    layer.bindTooltip(tooltipHtml, { sticky: true });
 
                     // Determine the correct base and hover opacity for this region
                     const baseOpacity = regionEntry


### PR DESCRIPTION
## Problem

On a choropleth (area) map chart, hovering a country whose GeoJSON feature is a multi-polygon spanning a large area (overseas territories — France, USA, etc.) shows the tooltip anchored far from the cursor. Leaflet anchors the tooltip to the feature's centroid; for France (mainland + French Guiana, Réunion, Guadeloupe…) that centroid sits in the Atlantic, so the tooltip renders well below the mainland — and fully off-screen when zoomed into a regional view like Europe.

## Fix

Bind the tooltip with `{ sticky: true }` so it tracks the cursor instead of anchoring to the geometry-derived point.

```diff
-                    layer.bindTooltip(tooltipHtml);
+                    layer.bindTooltip(tooltipHtml, { sticky: true });
```

## Testing

Verified locally on a World choropleth (`world_country_metrics`, colored by revenue):

- The bound tooltip now reports `sticky: true`.
- France's feature bounds span lat −21°→51°, lng −62°→56° (a 21-polygon multi-polygon). The default centroid anchor is ~117px below mainland France even in world view, and leaves the viewport entirely when zoomed to Europe.
- With the fix, hovering mainland France shows the tooltip at the cursor.

Closes: PROD-8468
Closes: #24663