### PR TITLE
fix: add ORDER BY to pivot __grp_rn ROW_NUMBER window for Snowflake

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -185,7 +185,7 @@ describe('PivotQueryBuilder', () => {
             // total_columns is computed in a single pass over filtered_rows via
             // the stacked-window count-distinct idiom.
             expect(replaceWhitespace(result)).toContain(
-                'ROW_NUMBER() OVER (PARTITION BY "event_type") AS "__grp_rn" FROM filtered_rows f',
+                'ROW_NUMBER() OVER (PARTITION BY "event_type" ORDER BY "event_type") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
                 'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
@@ -1842,7 +1842,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             );
             // Should calculate total_columns in a single pass over filtered_rows
             expect(replaceWhitespace(result)).toContain(
-                'ROW_NUMBER() OVER (PARTITION BY "category") AS "__grp_rn" FROM filtered_rows f',
+                'ROW_NUMBER() OVER (PARTITION BY "category" ORDER BY "category") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
                 'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
@@ -4952,7 +4952,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // Single-pass shape: both groupBy refs are the raw PARTITION BY keys
             // and total_columns sums the per-group first-row markers.
             expect(replaceWhitespace(result)).toContain(
-                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
+                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method" ORDER BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
                 'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
@@ -5002,7 +5002,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // so each distinct (order_date_year, payment_method) combination is
             // counted once.
             expect(replaceWhitespace(result)).toContain(
-                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
+                'ROW_NUMBER() OVER (PARTITION BY "order_date_year", "payment_method" ORDER BY "order_date_year", "payment_method") AS "__grp_rn" FROM filtered_rows f',
             );
             expect(replaceWhitespace(result)).toContain(
                 'SUM(CASE WHEN p."__grp_rn" = 1 THEN 1 ELSE 0 END) OVER () AS total_columns',
@@ -5067,7 +5067,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // The downstream single-pass count references the bare name the
             // aliases expose (PARTITION BY "status").
             expect(result).toContain(
-                'ROW_NUMBER() OVER (PARTITION BY "status") AS "__grp_rn" FROM filtered_rows f',
+                'ROW_NUMBER() OVER (PARTITION BY "status" ORDER BY "status") AS "__grp_rn" FROM filtered_rows f',
             );
         });
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1710,7 +1710,10 @@ export class PivotQueryBuilder {
             passthroughDimensions,
         ).join(', ');
 
-        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
+        // __grp_rn flags one row per groupBy combination; its value isn't
+        // order-dependent, but Snowflake requires ROW_NUMBER() windows to have a
+        // deterministic ORDER BY. Reuse the partition columns to satisfy this.
+        const finalSelect = `SELECT ${outputColumns}, total_columns FROM (SELECT p.*, SUM(CASE WHEN p.${q}__grp_rn${q} = 1 THEN 1 ELSE 0 END) OVER ()${totalColumnsMultiplier} AS total_columns FROM (SELECT f.*, ROW_NUMBER() OVER (PARTITION BY ${groupByPartition} ORDER BY ${groupByPartition}) AS ${q}__grp_rn${q} FROM filtered_rows f) p) pivoted${columnIndexFilterSql} order by ${q}row_index${q}, ${q}column_index${q}`;
 
         return PivotQueryBuilder.assembleSqlParts([
             PivotQueryBuilder.buildCtesSQL(ctes),


### PR DESCRIPTION
The final-stage total_columns subquery generated a ROW_NUMBER() OVER (PARTITION BY ...) window with no ORDER BY. Snowflake rejects this with 'Window function type [ROW_NUMBER] requires ORDER BY in window specification', breaking every pivoted chart on Snowflake (regression in 0.3226.1's single-pass total_columns collapse).

__grp_rn only flags one row per groupBy combination, so its value isn't order-dependent. Reuse the partition columns as a deterministic ORDER BY to satisfy Snowflake without changing results.

Fixes PROD-8454


Claude-Session: https://claude.ai/code/session_012v3QcMbAkWGpHdjYzz6APA

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
