### PR TITLE
fix(data-apps): make selected template icon visible in dark mode

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -92,10 +92,10 @@
             0 18px 40px -10px alpha(var(--mantine-color-black), 0.22);
     }
     @mixin dark {
-        border-color: var(--mantine-color-ldGray-0);
+        border-color: var(--mantine-color-ldGray-9);
         background-color: var(--mantine-color-dark-5);
         box-shadow:
-            0 0 0 1px var(--mantine-color-ldGray-0),
+            0 0 0 1px var(--mantine-color-ldGray-9),
             0 18px 40px -10px alpha(var(--mantine-color-black), 0.6);
     }
 }
@@ -106,7 +106,7 @@
         color: var(--mantine-color-white);
     }
     @mixin dark {
-        background-color: var(--mantine-color-ldGray-0);
+        background-color: var(--mantine-color-ldGray-9);
         color: var(--mantine-color-dark-9);
     }
 }


### PR DESCRIPTION
### Description:
The selected-state styles used ldGray-0 assuming it's a light tone, but in dark mode the ldGray scale is inverted (ldGray-0 = #141414). This made the selected icon box (and its dark icon) near-black on near-black, plus an invisible selection ring. Use ldGray-9 (the light end in dark mode) to mirror light mode's emphasis treatment.

Before:
<img width="777" height="620" alt="image" src="https://github.com/user-attachments/assets/c8f98620-6a13-475e-bba0-520acff95c05" />


After:
<img width="777" height="620" alt="image" src="https://github.com/user-attachments/assets/2c5120cd-afde-48e5-b754-2e1503e04bf3" />
