### PR TITLE
feat(ai-reviews): two-mode finding fingerprint (ZAP-537)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewClassifierService.ts
@@ -39,7 +39,7 @@ import { getModel } from './ai/models';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 
 const REVIEW_AGENT_VERSION = 'llm-judge-v1';
-const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v3';
+const JUDGE_PROMPT_HASH = 'ai-agent-review-judge-v10';
 const WRITEBACK_TOOL_NAMES = new Set([
     'editDbtProject',
     'propose_writeback',
@@ -710,6 +710,7 @@ export class AiAgentReviewClassifierService extends BaseService {
             organizationUuid: candidate.subject.organizationUuid,
             projectUuid: candidate.subject.projectUuid,
             agentUuid: candidate.subject.agentUuid,
+            threadUuid: candidate.subject.threadUuid,
             primaryRootCause: judgeOutput.primaryRootCause,
             subcategories: judgeOutput.subcategories,
             fixTargets: judgeOutput.fixTargets,
@@ -1098,6 +1099,8 @@ For targetRefs, return compact refs:
 - key: runtime/product capability key when useful, otherwise null.
 reviewItem.title should be concise and admin-facing.
 reviewItem.description should summarize why this grouping exists.
+
+Always populate targetRefs with every object the fix would touch (model, dimension, metric, join, explore). For semantic_layer and project_context findings these drive how findings collapse into one review item, so name the same object consistently across turns rather than varying the wording.
 
 Set projectContextEntry ONLY when primaryRootCause=project_context and a single durable, project-specific fact (a business definition or acronym, routing/join guidance, or object-scoped context) would prevent this class of failure in future turns. Otherwise set it to null.
 - op: "update" if one of the project context entries already injected into the reviewed turn was present but insufficient (reference its id); otherwise "create".

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -105,6 +105,174 @@ describe('getAiAgentReviewItemFingerprint', () => {
             }),
         ).toThrow('projectUuid is required for semantic_layer fingerprints');
     });
+
+    it('collapses runtime_reliability findings in one thread regardless of targetRefs or subcategories (Mode A)', () => {
+        const firstTurn: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'runtime_reliability',
+            threadUuid: 'thread-1',
+            subcategories: ['query_execution_failure'],
+            targetRefs: [
+                {
+                    type: 'explore',
+                    modelName: 'customers',
+                    exploreName: 'customers',
+                },
+            ],
+        };
+        const laterTurn: AiAgentReviewItemFingerprintInput = {
+            ...firstTurn,
+            subcategories: ['sql_approval_timeout'],
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'payments',
+                    metricName: 'total_revenue',
+                },
+            ],
+        };
+
+        expect(getAiAgentReviewItemFingerprint(laterTurn)).toEqual(
+            getAiAgentReviewItemFingerprint(firstTurn),
+        );
+    });
+
+    it('collapses semantic_layer findings on the same object across different threads, ignoring ref casing (Mode B)', () => {
+        const threadA: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            threadUuid: 'thread-a',
+            subcategories: ['wrong_field_or_domain_term'],
+            fixTargets: ['semantic_yaml_patch'],
+            targetRefs: [
+                {
+                    type: 'dimension',
+                    modelName: 'fanouts_deals',
+                    dimensionName: 'region',
+                },
+            ],
+        };
+        const threadB: AiAgentReviewItemFingerprintInput = {
+            ...threadA,
+            threadUuid: 'thread-b',
+            subcategories: ['missing_default_filter'],
+            fixTargets: ['dbt_modeling_ticket'],
+            targetRefs: [
+                {
+                    type: 'dimension',
+                    modelName: 'Fanouts_Deals',
+                    dimensionName: 'Region',
+                },
+            ],
+        };
+
+        expect(getAiAgentReviewItemFingerprint(threadB)).toEqual(
+            getAiAgentReviewItemFingerprint(threadA),
+        );
+    });
+
+    it('collapses semantic_layer findings on the same field despite model-name and context-ref variance (Mode B)', () => {
+        const turnOne: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            threadUuid: 'thread-1',
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'total_order_amount',
+                },
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'total_completed_order_amount',
+                },
+                { type: 'explore', modelName: 'orders', exploreName: 'orders' },
+            ],
+        };
+        const turnTwo: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            threadUuid: 'thread-2',
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'country_orders',
+                    metricName: 'total_order_amount',
+                },
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'total_completed_order_amount',
+                },
+            ],
+        };
+
+        expect(getAiAgentReviewItemFingerprint(turnTwo)).toEqual(
+            getAiAgentReviewItemFingerprint(turnOne),
+        );
+    });
+
+    it('treats qualified and unqualified field ids as the same object (Mode B)', () => {
+        const qualified: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'orders_total_order_amount',
+                },
+            ],
+        };
+        const unqualified: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            targetRefs: [
+                {
+                    type: 'metric',
+                    modelName: 'orders',
+                    metricName: 'total_order_amount',
+                },
+            ],
+        };
+
+        expect(getAiAgentReviewItemFingerprint(qualified)).toEqual(
+            getAiAgentReviewItemFingerprint(unqualified),
+        );
+    });
+
+    it('keeps runtime_reliability incidents in different threads distinct (Mode A)', () => {
+        const incident: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'runtime_reliability',
+            threadUuid: 'thread-1',
+        };
+
+        expect(
+            getAiAgentReviewItemFingerprint({
+                ...incident,
+                threadUuid: 'thread-2',
+            }),
+        ).not.toEqual(getAiAgentReviewItemFingerprint(incident));
+    });
+
+    it('never collides a Mode A incident with a Mode B object', () => {
+        const incident: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'runtime_reliability',
+            threadUuid: 'thread-1',
+        };
+        const object: AiAgentReviewItemFingerprintInput = {
+            ...baseInput,
+            primaryRootCause: 'semantic_layer',
+            threadUuid: 'thread-1',
+        };
+
+        expect(getAiAgentReviewItemFingerprint(incident)).not.toEqual(
+            getAiAgentReviewItemFingerprint(object),
+        );
+    });
 });
 
 describe('aiAgentJudgeProjectContextEntrySchema', () => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -937,6 +937,7 @@ export type AiAgentReviewItemFingerprintInput = {
     organizationUuid: string;
     projectUuid: string | null;
     agentUuid: string | null;
+    threadUuid?: string | null;
     primaryRootCause: AiAgentRootCause;
     subcategories: string[];
     fixTargets: AiAgentFixTarget[];
@@ -1014,20 +1015,119 @@ export const getAiAgentReviewItemFingerprintScope = (
     }
 };
 
+// Only runtime_reliability is a true per-conversation incident.
+const MODE_A_INCIDENT_ROOT_CAUSES = new Set<AiAgentRootCause>([
+    'runtime_reliability',
+]);
+
+// Durable project objects whose dedup identity is the affected object, across
+// threads. agent_configuration / product_capability already dedup cross-thread
+// on their own scope via the fallback, so they are intentionally excluded.
+const MODE_B_OBJECT_ROOT_CAUSES = new Set<AiAgentRootCause>([
+    'semantic_layer',
+    'project_context',
+]);
+
+// Field-level refs identify the actual broken object; model/explore/join are
+// context the judge names inconsistently across turns. We key on the field leaf
+// names (ignoring modelName) so the same broken field collapses even when the
+// judge varies the model or the surrounding context refs.
+const FIELD_LEVEL_REF_TYPES = new Set<AiAgentTargetRef['type']>([
+    'metric',
+    'dimension',
+    'additional_dimension',
+    'required_filter',
+    'ai_hint',
+]);
+
+// Lightdash field ids are `{model}_{field}`, and the judge uses the qualified
+// and unqualified forms interchangeably. Canonicalize to the unqualified field
+// so `orders_total_order_amount` and `total_order_amount` are one object.
+const stripModelPrefix = (name: string, modelName: string): string =>
+    name.startsWith(`${modelName}_`) ? name.slice(modelName.length + 1) : name;
+
+const getRefLeafName = (ref: AiAgentTargetRef): string | null => {
+    switch (ref.type) {
+        case 'metric':
+            return stripModelPrefix(ref.metricName, ref.modelName);
+        case 'dimension':
+        case 'additional_dimension':
+            return stripModelPrefix(ref.dimensionName, ref.modelName);
+        case 'required_filter':
+            return stripModelPrefix(ref.fieldName, ref.modelName);
+        case 'ai_hint':
+            return ref.targetName;
+        case 'explore':
+            return ref.exploreName;
+        case 'join':
+            return ref.joinName;
+        case 'model':
+            return ref.modelName;
+        default:
+            return null;
+    }
+};
+
+// Identity is the PRIMARY object the finding is about — the first field-level
+// ref. The judge lists the broken object first and varies the rest (related
+// metrics it suggests, surrounding explores), so keying on the whole set splits
+// findings that are really about the same object. Falls back to the first ref
+// of any kind, then empty.
+const getNormalizedObjectKey = (
+    input: AiAgentReviewItemFingerprintInput,
+): string => {
+    const primaryRef =
+        input.targetRefs.find((ref) => FIELD_LEVEL_REF_TYPES.has(ref.type)) ??
+        input.targetRefs[0];
+    const leaf = primaryRef ? getRefLeafName(primaryRef) : null;
+    return leaf ? leaf.trim().toLowerCase() : '';
+};
+
+const getAiAgentReviewItemFingerprintPayload = (
+    input: AiAgentReviewItemFingerprintInput,
+): unknown => {
+    // Mode A — incident: one conversation went sideways. Collapse every
+    // runtime finding in the thread onto one item; which object each retry
+    // touched, and the exact error, are noise.
+    if (
+        MODE_A_INCIDENT_ROOT_CAUSES.has(input.primaryRootCause) &&
+        input.threadUuid
+    ) {
+        return {
+            kind: 'incident',
+            threadUuid: input.threadUuid,
+            primaryRootCause: input.primaryRootCause,
+        };
+    }
+
+    // Mode B — object: a durable project object that recurs across threads.
+    // Identity is the normalized object from targetRefs, not the LLM's phrasing.
+    if (MODE_B_OBJECT_ROOT_CAUSES.has(input.primaryRootCause)) {
+        return {
+            kind: 'object',
+            scope: getAiAgentReviewItemFingerprintScope(input),
+            primaryRootCause: input.primaryRootCause,
+            normalizedObject: getNormalizedObjectKey(input),
+        };
+    }
+
+    return {
+        kind: 'scope',
+        scope: getAiAgentReviewItemFingerprintScope(input),
+        primaryRootCause: input.primaryRootCause,
+        subcategories: input.subcategories,
+        fixTargets: input.fixTargets,
+        targetRefs: input.targetRefs,
+        agentConfigurationSettings: input.agentConfigurationSettings,
+        capabilityKey: input.capabilityKey,
+    };
+};
+
 export const getAiAgentReviewItemFingerprint = (
     input: AiAgentReviewItemFingerprintInput,
 ): string => {
-    const scope = getAiAgentReviewItemFingerprintScope(input);
     const canonicalJson = JSON.stringify(
-        normalizeForHash({
-            scope,
-            primaryRootCause: input.primaryRootCause,
-            subcategories: input.subcategories,
-            fixTargets: input.fixTargets,
-            targetRefs: input.targetRefs,
-            agentConfigurationSettings: input.agentConfigurationSettings,
-            capabilityKey: input.capabilityKey,
-        }),
+        normalizeForHash(getAiAgentReviewItemFingerprintPayload(input)),
     );
 
     return `ai_agent_review_item:${hashCanonicalJson(canonicalJson)}`;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -78,7 +78,6 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
 
     const title = getIssueTitle(item);
     const targetAnchor = getTargetAnchor(item);
-    const isRecurring = item.findingCount > 1;
 
     const startKind = getStartWritebackKind(item);
     const isRetry = isWritebackRetry(item);
@@ -145,22 +144,6 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                             )}
                         </Stack>
                         <Group gap={8} wrap="nowrap" align="center">
-                            {isRecurring && (
-                                <Tooltip
-                                    variant="xs"
-                                    label={`Seen ${item.findingCount} times`}
-                                    position="top"
-                                >
-                                    <Badge
-                                        size="sm"
-                                        radius="sm"
-                                        variant="default"
-                                        color="gray"
-                                    >
-                                        {item.findingCount}×
-                                    </Badge>
-                                </Tooltip>
-                            )}
                             <Tooltip
                                 variant="xs"
                                 position="top"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -196,6 +196,10 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
     const seenTooltip = selectedReviewItem
         ? `First seen ${formatReviewDate(selectedReviewItem.firstSeenAt)}. Last seen ${formatReviewDate(selectedReviewItem.lastSeenAt)}.`
         : null;
+    const recurrenceValue =
+        selectedReviewItem && selectedReviewItem.findingCount > 1
+            ? `${selectedReviewItem.findingCount} times`
+            : null;
     const [showDetails, setShowDetails] = useState(false);
     const [showWhy, setShowWhy] = useState(false);
     const reasoningText = selectedReviewItem
@@ -423,6 +427,13 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                             seenTooltip ??
                                                             undefined
                                                         }
+                                                    />
+                                                )}
+                                                {recurrenceValue && (
+                                                    <ReviewMetadataField
+                                                        label="Recurrence"
+                                                        value={recurrenceValue}
+                                                        tooltip="Findings grouped into this item across threads"
                                                     />
                                                 )}
                                                 {selectedDetail && (


### PR DESCRIPTION
## What

Findings never deduped — every review item held exactly one finding. The fingerprint keyed on `subcategories + fixTargets + targetRefs`, which the judge phrases differently every turn, so each finding was unique. This splits the fingerprint by root-cause shape and derives grouping **deterministically** from fields the judge already emits.

> ⚠️ An earlier iteration had the judge emit a strict `grouping` object. That **blew past the LLM provider's structured-output grammar limit** ("compiled grammar is too large") and **failed every live review** — verified live. The judge schema has zero headroom, so grouping is now computed, not LLM-emitted.

- **Mode A — incident (thread-scoped):** `runtime_reliability` keys on `thread + rootCause`. A thread's runtime trouble collapses to one item.
- **Mode B — object (cross-thread, project-scoped):** `semantic_layer` / `project_context` key on `project scope + the primary field's canonical name` — lowercased, with the `{model}_` prefix stripped, so judge naming variance (`orders.x` vs `country_orders.x`, qualified vs unqualified) collapses. **No `threadUuid`**, so the same broken object across threads is one item.
- **Unchanged:** `agent_configuration` (agent-scoped), `product_capability` (capability key), fallback — they already dedup cross-thread on their own scope.

The fingerprint is an **identity function, not a threshold**: a single turn creates an item; the key only decides whether the next occurrence collapses onto it.

**UI:** the recurrence count moved off the kanban card (it rendered as an illegible empty square) into the review preview sidebar as a "Recurrence — N times" metadata field.

## Verified live

Re-ran the classifier on real disputed-metric threads. One `total_order_amount` item absorbed **6 findings across 3 separate threads** (cross-thread Mode B collapse). Pipeline confirmed working end-to-end.

**Known ceiling:** the judge sometimes lists a *different* ref first (e.g. the suggested-fix metric), so a minority of same-object findings still split. No deterministic key over `targetRefs` fully fixes this — tracked as a follow-up for catalog/LLM ref-canonicalization.

## Regression analysis

Only changes *which* review item a finding attaches to. `agent_configuration` / `product_capability` / `feedback_quality` / `ambiguous` / `not_a_failure` keep the existing scope-based fingerprint (the `agent_configuration` parity test stays green). Existing rows keep their old fingerprints; new signals get the new ones — no prod backfill here.

## Test plan

- 22 common unit tests (Mode A/B collapse, model + qualified-id canonicalization, A/B non-collision, fallback unchanged)
- 53 backend tests; common + backend + frontend typecheck clean

Closes: ZAP-537
Relates: ZAP-523