### PR TITLE
feat(ai-reviews): reopen a closed review item when its finding recurs (ZAP-538)

### DIFF
--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1034,6 +1034,8 @@ describe('AiAgentReviewClassifierModel', () => {
                     ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID,
                 },
             ]);
+            // No existing item for this fingerprint → nothing to reopen.
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
 
             const result = await model.createTurnSignal({
@@ -1162,6 +1164,10 @@ describe('AiAgentReviewClassifierModel', () => {
                 .responseOnce([
                     { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
                 ]);
+            // Existing item is already open → no reopen.
+            tracker.on
+                .select(AiAgentReviewItemTableName)
+                .responseOnce([{ status: 'open', dismissed_reason: null }]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
 
             await model.createTurnSignal({
@@ -1189,6 +1195,95 @@ describe('AiAgentReviewClassifierModel', () => {
             // fingerprint is stable across the re-review.
             expect(
                 tracker.history.delete.filter((q) =>
+                    q.sql.includes(AiAgentReviewItemTableName),
+                ),
+            ).toHaveLength(0);
+        });
+
+        it('reopens a resolved review item when its finding recurs', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            tracker.on
+                .select(AiAgentReviewItemTableName)
+                .responseOnce([{ status: 'resolved', dismissed_reason: null }]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.update(AiAgentReviewItemTableName).responseOnce(1);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: {
+                    primaryRootCause: 'semantic_layer',
+                    secondaryRootCauses: [],
+                    subcategories: [],
+                    fixTargets: [],
+                    targetRefs: [],
+                    evidenceExcerpts: [],
+                    recommendation: null,
+                    projectContextEntry: null,
+                    reviewItem: {
+                        fingerprint: FINGERPRINT,
+                        title: 'Review airports.country',
+                        description: 'Country needs semantic clarification.',
+                        ownerType: 'semantic_layer_owner',
+                    },
+                },
+            });
+
+            const itemUpdates = tracker.history.update.filter((q) =>
+                q.sql.includes(AiAgentReviewItemTableName),
+            );
+            expect(itemUpdates).toHaveLength(1);
+            expect(itemUpdates[0].bindings).toContain('open');
+            expect(itemUpdates[0].bindings).toContain(FINGERPRINT);
+        });
+
+        it('does not reopen an item dismissed as expected behavior', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([
+                {
+                    status: 'dismissed',
+                    dismissed_reason: 'expected_behavior',
+                },
+            ]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: {
+                    primaryRootCause: 'semantic_layer',
+                    secondaryRootCauses: [],
+                    subcategories: [],
+                    fixTargets: [],
+                    targetRefs: [],
+                    evidenceExcerpts: [],
+                    recommendation: null,
+                    projectContextEntry: null,
+                    reviewItem: {
+                        fingerprint: FINGERPRINT,
+                        title: 'Review airports.country',
+                        description: 'Country needs semantic clarification.',
+                        ownerType: 'semantic_layer_owner',
+                    },
+                },
+            });
+
+            expect(
+                tracker.history.update.filter((q) =>
                     q.sql.includes(AiAgentReviewItemTableName),
                 ),
             ).toHaveLength(0);

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1,4 +1,8 @@
-import { ProjectType, QueryExecutionContext } from '@lightdash/common';
+import {
+    ProjectType,
+    QueryExecutionContext,
+    shouldReopenReviewItem,
+} from '@lightdash/common';
 import type {
     AiAgentConfigSnapshot,
     AiAgentEvidenceExcerpt,
@@ -1959,6 +1963,12 @@ export class AiAgentReviewClassifierModel {
             // Write the review item in the same transaction so a signal and the
             // item it promotes are always created together.
             if (newFingerprint) {
+                const existingItem = await trx<AiAgentReviewItemTable>(
+                    AiAgentReviewItemTableName,
+                )
+                    .where('fingerprint', newFingerprint)
+                    .first('status', 'dismissed_reason');
+
                 await trx<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
                     .insert({
                         fingerprint: newFingerprint,
@@ -1968,6 +1978,25 @@ export class AiAgentReviewClassifierModel {
                     })
                     .onConflict('fingerprint')
                     .merge({ updated_at: trx.fn.now() });
+
+                // The same problem recurring on a closed item reopens it, so the
+                // card carries its "fixed → regressed" history.
+                if (
+                    existingItem &&
+                    shouldReopenReviewItem(
+                        existingItem.status,
+                        existingItem.dismissed_reason,
+                    )
+                ) {
+                    await trx<AiAgentReviewItemTable>(
+                        AiAgentReviewItemTableName,
+                    )
+                        .where('fingerprint', newFingerprint)
+                        .update({
+                            status: 'open',
+                            status_updated_at: trx.fn.now() as never,
+                        });
+                }
             }
 
             // Reconcile: a superseded finding can leave its review item with no

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.test.ts
@@ -4,6 +4,7 @@ import {
     getAiAgentConfigSnapshotHash,
     getAiAgentReviewItemFingerprint,
     getAiAgentReviewItemFingerprintScope,
+    shouldReopenReviewItem,
     type AiAgentConfigSnapshot,
     type AiAgentReviewItemFingerprintInput,
 } from './aiAgentReviewClassifierTypes';
@@ -272,6 +273,30 @@ describe('getAiAgentReviewItemFingerprint', () => {
         expect(getAiAgentReviewItemFingerprint(incident)).not.toEqual(
             getAiAgentReviewItemFingerprint(object),
         );
+    });
+});
+
+describe('shouldReopenReviewItem', () => {
+    it('reopens a resolved item when its finding recurs', () => {
+        expect(shouldReopenReviewItem('resolved', null)).toBe(true);
+    });
+
+    it('reopens a dismissed item unless it was dismissed as expected behavior', () => {
+        expect(shouldReopenReviewItem('dismissed', 'not_actionable')).toBe(
+            true,
+        );
+        expect(shouldReopenReviewItem('dismissed', 'low_confidence')).toBe(
+            true,
+        );
+        expect(shouldReopenReviewItem('dismissed', 'expected_behavior')).toBe(
+            false,
+        );
+    });
+
+    it('leaves non-terminal items untouched', () => {
+        expect(shouldReopenReviewItem('triage', null)).toBe(false);
+        expect(shouldReopenReviewItem('open', null)).toBe(false);
+        expect(shouldReopenReviewItem('in_progress', null)).toBe(false);
     });
 });
 

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -306,6 +306,22 @@ export type AiAgentReviewItemDismissedReason =
     | 'low_confidence'
     | 'other';
 
+// A recurring finding reopens a closed item so its "fixed → regressed" history
+// stays on one card — except items dismissed as expected behavior, which stay
+// dismissed rather than clawing back open on every recurrence.
+export const shouldReopenReviewItem = (
+    status: AiAgentReviewItemStatus,
+    dismissedReason: AiAgentReviewItemDismissedReason | null,
+): boolean => {
+    if (status === 'resolved') {
+        return true;
+    }
+    if (status === 'dismissed') {
+        return dismissedReason !== 'expected_behavior';
+    }
+    return false;
+};
+
 export type AiAgentReviewItemOwnerType =
     | 'semantic_layer_owner'
     | 'agent_admin'


### PR DESCRIPTION
## What

Stacked on #24673 (ZAP-537). Once findings dedup by a stable fingerprint, a recurrence of an already-closed problem should land back on the same card instead of silently attaching to a terminal item.

- `shouldReopenReviewItem(status, dismissedReason)` — pure predicate: `resolved` → reopen; `dismissed` → reopen **unless** the reason is `expected_behavior`; non-terminal → no-op.
- `createTurnSignal` reads the existing item in-transaction (behind the existing per-turn advisory lock) and, after the upsert, flips a terminal item back to `open` (bumping `status_updated_at`).

Keeps the "fixed → regressed" history on one card, and is itself a signal that a fix didn't hold. Items dismissed as expected behavior stay dismissed so they don't claw back open on every recurrence.

## Regression analysis

Reopen only fires when a **new promoted finding's fingerprint matches an existing terminal item**. Non-terminal items (`triage` / `open` / `in_progress`) are untouched, `dismissed: expected_behavior` is explicitly preserved, and the first-seen create path is unchanged.

## Test plan

- 3 common unit tests for the predicate (resolved / dismissed reasons / non-terminal)
- 2 backend model tests: resolved item → reopen `UPDATE` issued; `expected_behavior` → no `UPDATE`
- full model suite (40) + typecheck + lint green

Closes: ZAP-538
Relates: ZAP-537