### PR TITLE
fix: exclude ChartConfiguration validations from Autopilot

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -12,6 +12,7 @@ import {
     ParameterError,
     ProjectType,
     ServiceAccountScope,
+    ValidationErrorType,
     type ChartConfig,
     type ManagedAgentAction,
     type ManagedAgentActionFilters,
@@ -1778,8 +1779,15 @@ export class ManagedAgentService extends BaseService {
         actor: SessionUser,
         projectUuid: string,
     ): Promise<string> {
-        const validations: ValidationResponse[] =
-            await this.validationModel.get(projectUuid);
+        const validations: ValidationResponse[] = (
+            await this.validationModel.get(projectUuid)
+        ).filter(
+            // Exclude advisory "unused field" warnings so Autopilot does not
+            // remove valid fields or table calculations that are merely flagged
+            // as unused. These are the only validations using ChartConfiguration.
+            (validation) =>
+                validation.errorType !== ValidationErrorType.ChartConfiguration,
+        );
         const { canViewChartUuid, canViewDashboardUuid } =
             this.createContentVisibilityChecker(actor);
 


### PR DESCRIPTION
### Description:

Autopilot uses chart validations to determine which fields and table calculations to remove. However, `ChartConfiguration` validation errors are advisory &#34;unused field&#34; warnings that should not trigger removal of valid fields or calculations.

This change filters out `ChartConfiguration` validations when fetching validations for Autopilot processing, ensuring that fields flagged as unused are preserved rather than removed.

**Changes:**
- Import `ValidationErrorType` from common types
- Filter validation results to exclude `ChartConfiguration` error types before Autopilot processes them
- Added explanatory comment documenting why this exclusion is necessary

**Test Plan:**
Existing tests cover the `getValidations` method. This change adds a filter to the validation results, which will be validated through existing test coverage of Autopilot&#39;s validation handling.

https://claude.ai/code/session_01FYtehi8pchMfriM5Zb2JBx

Slack thread: https://lightdash.slack.com/archives/C0AV8LFF3QU/p1782298848822289?thread_ts=1782297280.733209&cid=C0AV8LFF3QU