### PR TITLE
style(data-apps): refine template picker card animation

### DIFF
--- a/packages/frontend/src/features/apps/AppTemplatePicker.module.css
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.module.css
@@ -64,8 +64,8 @@
 .card:hover,
 .card:focus-visible {
     outline: none;
-    transform: translate(calc(var(--x) - 92px), calc(var(--y) - 28px))
-        rotate(calc(var(--rot) * 0.35)) scale(1.04);
+    transform: translate(calc(var(--x) - 92px), calc(var(--y) - 8px))
+        rotate(calc(var(--rot) * 0.85)) scale(1.02);
     z-index: 10;
 
     @mixin light {
@@ -80,8 +80,8 @@
 
 .cardSelected,
 .cardSelected:hover {
-    transform: translate(calc(var(--x) - 92px), calc(var(--y) - 24px))
-        rotate(calc(var(--rot) * 0.35)) scale(1.04);
+    transform: translate(calc(var(--x) - 92px), var(--y)) rotate(var(--rot))
+        scale(1.06);
     z-index: 9;
 
     @mixin light {
@@ -119,12 +119,6 @@
 }
 .cardTitle {
     line-height: 1.2;
-}
-
-.selectedIndicator {
-    position: absolute;
-    top: var(--mantine-spacing-sm);
-    right: var(--mantine-spacing-sm);
 }
 
 /* Narrow widths can't hold the arch — stack the cards vertically. */

--- a/packages/frontend/src/features/apps/AppTemplatePicker.tsx
+++ b/packages/frontend/src/features/apps/AppTemplatePicker.tsx
@@ -1,6 +1,5 @@
 import { type DataAppTemplate } from '@lightdash/common';
 import { Stack, Text, ThemeIcon } from '@mantine-8/core';
-import { IconCheck } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { PolymorphicPaperButton } from '../../components/common/PolymorphicPaperButton';
 import classes from './AppTemplatePicker.module.css';
@@ -53,16 +52,6 @@ const AppTemplatePicker: FC<Props> = ({ selected, onSelectedChange }) => (
                             </Text>
                         </Stack>
                     </Stack>
-                    {isSelected && (
-                        <ThemeIcon
-                            size={20}
-                            radius="xl"
-                            color="dark"
-                            className={classes.selectedIndicator}
-                        >
-                            <IconCheck size={12} stroke={3} />
-                        </ThemeIcon>
-                    )}
                 </PolymorphicPaperButton>
             );
         })}


### PR DESCRIPTION
## What & why

The data-app builder's first page (**Build a Data App**) shows the four templates as fan-out cards. The selection/hover animation read as odd: selecting a card lifted it up the arch (a positional jump) rather than emphasising it, a checkmark popped in on top, and hovering tilted/expanded the card quite aggressively.

## Changes

- **Removed the selected-state checkmark** (`IconCheck` indicator). Selection is already clear from the dark border + filled icon treatment.
- **Select now enlarges in place** instead of moving — the selected card keeps its resting position and tilt and just scales up (`scale(1.06)`), so it grows around its centre rather than jumping upward.
- **Softened the hover** — smaller lift (28px → 8px), gentler tilt straighten (`rot * 0.35` → `rot * 0.85`), smaller scale (1.04 → 1.02).

Scoped entirely to `AppTemplatePicker.tsx` / `AppTemplatePicker.module.css`. No behaviour change beyond the animation.

## Verification

Verified live (light mode) on the local Jaffle shop project: selecting a card grows it in place with no upward jump and no tick; hover lift/tilt is subtle. Narrow-width fallback (cards stack vertically, transforms disabled) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)