### PR TITLE
fix(health): restore echarts6 flag for older frontend compatibility

### DIFF
--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -118,6 +118,9 @@ export const BaseResponse: HealthState = {
         analyticsDashboardUuid: undefined,
         isAmbientAiEnabled: false,
     },
+    echarts6: {
+        enabled: false,
+    },
     funnelBuilder: {
         enabled: false,
     },

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -264,6 +264,9 @@ export class HealthService extends BaseService {
                     !!this.lightdashConfig.ai.copilot.providers.anthropic
                         ?.apiKey,
             },
+            echarts6: {
+                enabled: false,
+            },
             funnelBuilder: {
                 enabled: this.lightdashConfig.funnelBuilder.enabled,
             },

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -553,6 +553,9 @@ export type HealthState = {
         analyticsDashboardUuid?: string;
         isAmbientAiEnabled: boolean;
     };
+    echarts6: {
+        enabled: boolean;
+    };
     funnelBuilder: {
         enabled: boolean;
     };

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -118,6 +118,9 @@ export default function mockHealthResponse(
             analyticsDashboardUuid: undefined,
             isAmbientAiEnabled: false,
         },
+        echarts6: {
+            enabled: false,
+        },
         funnelBuilder: {
             enabled: false,
         },


### PR DESCRIPTION
## What

Re-adds `echarts6: { enabled: false }` to the `/health` response as a backwards-compatibility shim.

## Why

ECharts v6 was removed in #24594 (first shipped in `0.3217.0`), which also deleted the `echarts6` field from the health endpoint. But older frontend / `@lightdash/sdk` bundles still contain this in `EChartsReactWrapper`:

```tsx
const Component = healthQuery.data?.echarts6.enabled
    ? EChartsReactV6
    : EChartsReactV5;
```

The optional chain guards `data`, **not** `echarts6`. Once a newer backend stops returning `echarts6`, `data.echarts6` is `undefined` and `.enabled` throws:

> `Cannot read properties of undefined (reading 'enabled')`

This fires inside the wrapper used by **every** chart (pie, cartesian, etc.), so any embed/SDK consumer pinned to a pre-`0.3217.0` frontend crashes on chart render against an upgraded backend.

The real fix for consumers is to bump `@lightdash/sdk` to `>= 0.3217.0` (echarts is bundled into the SDK, so the crash only leaves once the SDK build is replaced). But the backend should not hard-break older clients by silently dropping a health field they read unguarded — this shim restores graceful degradation.

## What it does

Returns `echarts6.enabled = false` (hardcoded — there is no v6 anymore), so older frontends resolve to `EChartsReactV5` and render normally instead of throwing. Newer frontends ignore the field.

## Regression analysis

- **Current/newer frontend**: ignores `echarts6` → no change.
- **Older frontend (< 0.3217.0) / pinned SDK**: previously crashed reading `health.echarts6.enabled`; now reads `false` → uses v5 → works. v5 is the only echarts version shipped now, so `false` is correct.
- **No config surface**: the field is hardcoded; the `echarts6` config/env entry removed in #24594 is not reintroduced.

## Notes

`/health` is a plain Express route (`apiV1Router.ts`), not a TSOA controller, so the OpenAPI spec is unaffected and `generate-api` was not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)