### PR TITLE
fix: allow favoriting while building a data app

### DIFF
--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Button, LoadingOverlay, Text } from '@mantine-8/core';
 import { IconFolderShare, IconPlus } from '@tabler/icons-react';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type ReactNode } from 'react';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import Callout from '../Callout';
@@ -19,6 +19,10 @@ type Props<T> = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     items: T;
     isLoading: boolean;
     onConfirm: (spaceUuid: string | null) => void;
+    title?: string;
+    description?: ReactNode;
+    confirmLabel?: string;
+    createSpaceConfirmLabel?: string;
 };
 
 const ItemName = ({ name }: { name: string }) => {
@@ -50,6 +54,10 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
     items,
     onConfirm,
     isLoading,
+    title,
+    description,
+    confirmLabel = 'Confirm',
+    createSpaceConfirmLabel = 'Create space & move',
 }: Props<T>) => {
     // Fetch spaces only when the modal is opened
     const { data: spaces = [], isLoading: isLoadingSpaces } = useSpaceSummaries(
@@ -132,7 +140,7 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
 
     return (
         <MantineModal
-            title={`Move ${getItemsText(items).type}`}
+            title={title ?? `Move ${getItemsText(items).type}`}
             opened={opened}
             onClose={onClose}
             icon={IconFolderShare}
@@ -156,7 +164,7 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                         disabled={newSpaceName.length === 0}
                         onClick={createSpace}
                     >
-                        Create space & move
+                        {createSpaceConfirmLabel}
                     </Button>
                 ) : (
                     <Button
@@ -165,7 +173,7 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                         }
                         onClick={handleConfirm}
                     >
-                        Confirm
+                        {confirmLabel}
                     </Button>
                 )
             }
@@ -190,9 +198,14 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                 />
             ) : (
                 <>
-                    <Text fz="sm" fw={500}>
-                        Select a space to move {getItemsText(items).name} to:
-                    </Text>
+                    {description ?? (
+                        <Text fz="sm" fw={500}>
+                            <>
+                                Select a space to move{' '}
+                                {getItemsText(items).name} to:
+                            </>
+                        </Text>
+                    )}
 
                     <SpaceSelector
                         itemType={singleItemType}

--- a/packages/frontend/src/features/apps/components/DataAppFavoriteMenuItem.tsx
+++ b/packages/frontend/src/features/apps/components/DataAppFavoriteMenuItem.tsx
@@ -1,0 +1,151 @@
+import {
+    ContentType,
+    ResourceViewItemType,
+    type ResourceViewDataAppItem,
+} from '@lightdash/common';
+import { Menu, Text } from '@mantine-8/core';
+import { IconStar, IconStarFilled } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import TransferItemsModal from '../../../components/common/TransferItemsModal/TransferItemsModal';
+import { useFavoriteMutation } from '../../../hooks/favorites/useFavoriteMutation';
+import { useFavorites } from '../../../hooks/favorites/useFavorites';
+import { useContentAction } from '../../../hooks/useContent';
+
+type DataAppFavoriteTarget = Pick<
+    ResourceViewDataAppItem['data'],
+    | 'uuid'
+    | 'name'
+    | 'description'
+    | 'spaceUuid'
+    | 'createdByUserUuid'
+    | 'latestVersionNumber'
+    | 'latestVersionStatus'
+>;
+
+type DataAppFavoriteMenuItemProps = {
+    projectUuid: string;
+    appUuid: string;
+    appSpaceUuid: string | null;
+    onAddPersonalAppToSpace: () => void;
+};
+
+export const DataAppFavoriteMenuItem: FC<DataAppFavoriteMenuItemProps> = ({
+    projectUuid,
+    appUuid,
+    appSpaceUuid,
+    onAddPersonalAppToSpace,
+}) => {
+    const { data: favorites } = useFavorites(projectUuid);
+    const favoriteMutation = useFavoriteMutation(projectUuid);
+    const isFavorited =
+        favorites?.some((favorite) => favorite.data.uuid === appUuid) ?? false;
+
+    return (
+        <Menu.Item
+            leftSection={
+                isFavorited ? (
+                    <IconStarFilled size={14} color="orange" />
+                ) : (
+                    <IconStar size={14} />
+                )
+            }
+            disabled={favoriteMutation.isLoading}
+            onClick={() => {
+                if (!isFavorited && !appSpaceUuid) {
+                    onAddPersonalAppToSpace();
+                    return;
+                }
+
+                favoriteMutation.mutate({
+                    contentType: ContentType.DATA_APP,
+                    contentUuid: appUuid,
+                });
+            }}
+        >
+            {isFavorited ? 'Remove from favorites' : 'Add to favorites'}
+        </Menu.Item>
+    );
+};
+
+type FavoritePersonalDataAppModalProps = {
+    projectUuid: string;
+    app: DataAppFavoriteTarget;
+    opened: boolean;
+    onClose: () => void;
+};
+
+export const FavoritePersonalDataAppModal: FC<
+    FavoritePersonalDataAppModalProps
+> = ({ projectUuid, app, opened, onClose }) => {
+    const queryClient = useQueryClient();
+    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
+        useContentAction(projectUuid);
+    const { mutateAsync: toggleFavorite, isLoading: isTogglingFavorite } =
+        useFavoriteMutation(projectUuid);
+
+    return (
+        <TransferItemsModal
+            projectUuid={projectUuid}
+            opened={opened}
+            onClose={onClose}
+            title="Add data app to a space"
+            description={
+                <Callout variant="info">
+                    <Text fz="sm">
+                        Data apps must be in a space to be favorited.
+                    </Text>
+                    <Text fz="sm" mt="xs">
+                        Would you like to move this data app to a space and
+                        favorite it?
+                    </Text>
+                </Callout>
+            }
+            confirmLabel="Move and favorite"
+            createSpaceConfirmLabel="Create space, move and favorite"
+            items={[
+                {
+                    type: ResourceViewItemType.DATA_APP,
+                    data: {
+                        uuid: app.uuid,
+                        name: app.name,
+                        description: app.description,
+                        spaceUuid: app.spaceUuid,
+                        createdByUserUuid: app.createdByUserUuid,
+                        updatedAt: new Date(),
+                        updatedByUser: null,
+                        views: 0,
+                        firstViewedAt: null,
+                        latestVersionNumber: app.latestVersionNumber,
+                        latestVersionStatus: app.latestVersionStatus,
+                        pinnedListUuid: null,
+                        pinnedListOrder: null,
+                    },
+                },
+            ]}
+            isLoading={isMovingToSpace || isTogglingFavorite}
+            onConfirm={async (targetSpaceUuid) => {
+                if (!targetSpaceUuid) return;
+                await contentAction({
+                    action: {
+                        type: 'move',
+                        targetSpaceUuid,
+                    },
+                    item: {
+                        uuid: app.uuid,
+                        contentType: ContentType.DATA_APP,
+                    },
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: ['app', projectUuid, app.uuid],
+                });
+                await toggleFavorite({
+                    contentType: ContentType.DATA_APP,
+                    contentUuid: app.uuid,
+                });
+                onClose();
+            }}
+        />
+    );
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -103,6 +103,10 @@ import {
 import AppTemplatePicker from '../features/apps/AppTemplatePicker';
 import ChatBubbleMeta from '../features/apps/ChatBubbleMeta';
 import ChatMessageContent from '../features/apps/ChatMessageContent';
+import {
+    DataAppFavoriteMenuItem,
+    FavoritePersonalDataAppModal,
+} from '../features/apps/components/DataAppFavoriteMenuItem';
 import { PromoteAppModal } from '../features/apps/components/PromoteAppModal';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
@@ -685,6 +689,8 @@ const AppGenerate: FC = () => {
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
 
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
+    const [isFavoriteSpaceModalOpen, setIsFavoriteSpaceModalOpen] =
+        useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
@@ -2824,6 +2830,16 @@ const AppGenerate: FC = () => {
                                                     Preview latest
                                                 </Menu.Item>
                                             )}
+                                            <DataAppFavoriteMenuItem
+                                                projectUuid={projectUuid}
+                                                appUuid={activeAppUuid}
+                                                appSpaceUuid={appSpaceUuid}
+                                                onAddPersonalAppToSpace={() =>
+                                                    setIsFavoriteSpaceModalOpen(
+                                                        true,
+                                                    )
+                                                }
+                                            />
                                             <Menu.Item
                                                 leftSection={
                                                     <MantineIcon
@@ -2945,6 +2961,27 @@ const AppGenerate: FC = () => {
                                         </Menu.Dropdown>
                                     </Menu>
                                 </Box>
+                            )}
+                            {isFavoriteSpaceModalOpen && activeAppUuid && (
+                                <FavoritePersonalDataAppModal
+                                    projectUuid={projectUuid}
+                                    opened
+                                    onClose={() =>
+                                        setIsFavoriteSpaceModalOpen(false)
+                                    }
+                                    app={{
+                                        uuid: activeAppUuid,
+                                        name: appName || 'Untitled app',
+                                        description:
+                                            appDescription || undefined,
+                                        spaceUuid: appSpaceUuid,
+                                        createdByUserUuid: appCreatedByUserUuid,
+                                        latestVersionNumber:
+                                            latestReadyVersion?.version ?? null,
+                                        latestVersionStatus:
+                                            latestReadyVersion?.status ?? null,
+                                    }}
+                                />
                             )}
                             {isMoveToSpaceOpen && activeAppUuid && (
                                 <TransferItemsModal

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { ContentType, FeatureFlags } from '@lightdash/common';
+import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import {
     IconAppsOff,
@@ -8,8 +8,6 @@ import {
     IconPencil,
     IconRefresh,
     IconSend,
-    IconStar,
-    IconStarFilled,
     IconTrash,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
@@ -19,14 +17,16 @@ import AppDeleteModal from '../components/common/modal/AppDeleteModal';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
+import {
+    DataAppFavoriteMenuItem,
+    FavoritePersonalDataAppModal,
+} from '../features/apps/components/DataAppFavoriteMenuItem';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
 import { AppSchedulersModal } from '../features/scheduler/components/SchedulerModals';
-import { useFavoriteMutation } from '../hooks/favorites/useFavoriteMutation';
-import { useFavorites } from '../hooks/favorites/useFavorites';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
@@ -79,11 +79,6 @@ export default function AppPreviewTest() {
             }),
         ) === true;
 
-    const { data: favorites } = useFavorites(projectUuid);
-    const isFavorited =
-        favorites?.some((favorite) => favorite.data.uuid === appUuid) ?? false;
-    const { mutate: toggleFavorite } = useFavoriteMutation(projectUuid);
-
     const version = explicitVersion ?? latestReadyVersion;
 
     const {
@@ -95,6 +90,7 @@ export default function AppPreviewTest() {
     const [menuOpened, setMenuOpened] = useState(false);
     const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+    const [favoriteSpaceModalOpen, setFavoriteSpaceModalOpen] = useState(false);
     const [queriesPanelHidden, setQueriesPanelHidden] = useState(true);
 
     // Query tracking from the preview iframe. The panel is opt-in (hidden by
@@ -228,25 +224,14 @@ export default function AppPreviewTest() {
                         </ActionIcon>
                     </Menu.Target>
                     <Menu.Dropdown>
-                        <Menu.Item
-                            leftSection={
-                                isFavorited ? (
-                                    <IconStarFilled size={14} color="orange" />
-                                ) : (
-                                    <IconStar size={14} />
-                                )
+                        <DataAppFavoriteMenuItem
+                            projectUuid={projectUuid}
+                            appUuid={appUuid}
+                            appSpaceUuid={appSpaceUuid}
+                            onAddPersonalAppToSpace={() =>
+                                setFavoriteSpaceModalOpen(true)
                             }
-                            onClick={() =>
-                                toggleFavorite({
-                                    contentType: ContentType.DATA_APP,
-                                    contentUuid: appUuid,
-                                })
-                            }
-                        >
-                            {isFavorited
-                                ? 'Remove from favorites'
-                                : 'Add to favorites'}
-                        </Menu.Item>
+                        />
                         {canEditApp && (
                             <Menu.Item
                                 leftSection={<IconPencil size={14} />}
@@ -339,6 +324,25 @@ export default function AppPreviewTest() {
                     onConfirm={() => {
                         setDeleteModalOpen(false);
                         void navigate(`/projects/${projectUuid}/home`);
+                    }}
+                />
+            )}
+            {favoriteSpaceModalOpen && (
+                <FavoritePersonalDataAppModal
+                    projectUuid={projectUuid}
+                    opened
+                    onClose={() => setFavoriteSpaceModalOpen(false)}
+                    app={{
+                        uuid: appUuid,
+                        name: appQuery.data?.pages[0]?.name ?? 'Data app',
+                        description:
+                            appQuery.data?.pages[0]?.description ?? undefined,
+                        spaceUuid: appSpaceUuid,
+                        createdByUserUuid: appCreatedByUserUuid,
+                        latestVersionNumber: latestReadyVersion ?? null,
+                        latestVersionStatus: latestReadyVersion
+                            ? 'ready'
+                            : null,
                     }}
                 />
             )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: PROD-8420/

### Description:

- Can favorite a data app while viewing and building
- If it's not already in a space, you can move it
