### PR TITLE
test(api-tests): run pivot query suite across all warehouses

### DIFF
--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -44,6 +44,124 @@ export function hasBigqueryCredentials(): boolean {
     }
 }
 
+/**
+ * Warehouse connection builders + availability predicates, shared across
+ * warehouse-parity suites. Each builder targets the jaffle dataset that mirrors
+ * the local Postgres seed, so the same queries assert the same expectations
+ * across dialects. Predicates report whether the matching credentials are
+ * present (CI provides them; locally most are absent, so suites should skip).
+ */
+export function postgresWarehouseConfig(): Record<string, unknown> {
+    return {
+        host: process.env.PGHOST || 'db-dev',
+        user: process.env.PGUSER || 'postgres',
+        password: process.env.PGPASSWORD || 'password',
+        dbname: process.env.PGDATABASE || 'postgres',
+        schema: 'jaffle',
+        port: Number(process.env.PGPORT) || 5432,
+        sslmode: 'disable',
+        type: WarehouseTypes.POSTGRES,
+    };
+}
+
+export function hasSnowflakeCredentials(): boolean {
+    return Boolean(
+        process.env.SNOWFLAKE_ACCOUNT &&
+        process.env.SNOWFLAKE_USER &&
+        process.env.SNOWFLAKE_PASSWORD,
+    );
+}
+
+export function snowflakeWarehouseConfig(): Record<string, unknown> {
+    return {
+        account: process.env.SNOWFLAKE_ACCOUNT,
+        user: process.env.SNOWFLAKE_USER,
+        password: process.env.SNOWFLAKE_PASSWORD,
+        role: 'SYSADMIN',
+        database: 'SNOWFLAKE_DATABASE_STAGING',
+        warehouse: 'TESTING',
+        schema: 'JAFFLE',
+        type: WarehouseTypes.SNOWFLAKE,
+    };
+}
+
+export function hasDatabricksCredentials(): boolean {
+    return Boolean(
+        process.env.DATABRICKS_HOST &&
+        process.env.DATABRICKS_PATH &&
+        process.env.DATABRICKS_TOKEN,
+    );
+}
+
+export function databricksWarehouseConfig(): Record<string, unknown> {
+    return {
+        type: WarehouseTypes.DATABRICKS,
+        serverHostName: process.env.DATABRICKS_HOST,
+        httpPath: process.env.DATABRICKS_PATH,
+        personalAccessToken: process.env.DATABRICKS_TOKEN,
+        database: 'jaffle',
+    };
+}
+
+export function hasTrinoCredentials(): boolean {
+    return Boolean(
+        process.env.TRINO_HOST &&
+        process.env.TRINO_PORT &&
+        process.env.TRINO_USER &&
+        process.env.TRINO_PASSWORD,
+    );
+}
+
+export function trinoWarehouseConfig(): Record<string, unknown> {
+    return {
+        type: WarehouseTypes.TRINO,
+        host: process.env.TRINO_HOST,
+        port: Number(process.env.TRINO_PORT),
+        user: process.env.TRINO_USER,
+        password: process.env.TRINO_PASSWORD,
+        dbname: 'e2e_jaffle_shop',
+        schema: 'e2e_jaffle_shop',
+        http_scheme: 'https',
+    };
+}
+
+export type WarehouseTestEntry = {
+    name: string;
+    config: Record<string, unknown>;
+};
+
+/**
+ * The warehouses whose credentials are currently available, ready to drive a
+ * parameterized suite. Postgres is always included (seeded locally) unless
+ * `includePostgres: false` — pass that when a suite already covers Postgres via
+ * the seed project.
+ */
+export function getAvailableWarehouseConfigs(
+    options: { includePostgres?: boolean } = {},
+): WarehouseTestEntry[] {
+    const { includePostgres = true } = options;
+    const entries: WarehouseTestEntry[] = [];
+    if (includePostgres) {
+        entries.push({ name: 'postgres', config: postgresWarehouseConfig() });
+    }
+    if (hasSnowflakeCredentials()) {
+        entries.push({ name: 'snowflake', config: snowflakeWarehouseConfig() });
+    }
+    if (hasBigqueryCredentials()) {
+        entries.push({ name: 'bigquery', config: bigqueryWarehouseConfig() });
+    }
+    if (hasDatabricksCredentials()) {
+        entries.push({
+            name: 'databricks',
+            config: databricksWarehouseConfig(),
+        });
+    }
+    if (hasTrinoCredentials()) {
+        entries.push({ name: 'trino', config: trinoWarehouseConfig() });
+    }
+    return entries;
+}
+
 export async function createProject(
     client: ApiClient,
     projectName: string,

--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -119,8 +119,8 @@ export function trinoWarehouseConfig(): Record<string, unknown> {
         port: Number(process.env.TRINO_PORT),
         user: process.env.TRINO_USER,
         password: process.env.TRINO_PASSWORD,
-        dbname: 'e2e_jaffle_shop',
-        schema: 'e2e_jaffle_shop',
+        dbname: 'staging_postgres_trino',
+        schema: 'jaffle',
         http_scheme: 'https',
     };
 }

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -1,7 +1,12 @@
 import { SEED_PROJECT } from '@lightdash/common';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
+import {
+    createAndRefreshProject,
+    deleteProjectsByName,
+    getAvailableWarehouseConfigs,
+} from '../helpers/projects';
 
 const apiUrl = '/api/v2';
 
@@ -76,15 +81,11 @@ const getRawValues = (
         })
         .filter((value) => value !== undefined && value !== null);
 
-describe('Pivot query API', () => {
-    const projectUuid = SEED_PROJECT.project_uuid;
-    let admin: ApiClient;
+type PivotTestContext = { client: ApiClient; projectUuid: string };
 
-    beforeAll(async () => {
-        admin = await login();
-    });
-
+function registerPivotQueryTests(getContext: () => PivotTestContext) {
     it('excludes a sort-only metric from pivoted results', async () => {
+        const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
             dimensions: ['customers_customer_id', 'orders_is_completed'],
@@ -117,7 +118,7 @@ describe('Pivot query API', () => {
         };
 
         const results = await runPivotQuery(
-            admin,
+            client,
             projectUuid,
             query,
             pivotConfiguration,
@@ -135,6 +136,7 @@ describe('Pivot query API', () => {
     });
 
     it('excludes a sort-only table calculation from pivoted results', async () => {
+        const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
             dimensions: ['customers_customer_id', 'orders_is_completed'],
@@ -173,7 +175,7 @@ describe('Pivot query API', () => {
         };
 
         const results = await runPivotQuery(
-            admin,
+            client,
             projectUuid,
             query,
             pivotConfiguration,
@@ -186,6 +188,7 @@ describe('Pivot query API', () => {
     });
 
     it('keeps a self-sorted x-axis table calculation as an index column', async () => {
+        const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
             dimensions: [
@@ -227,7 +230,7 @@ describe('Pivot query API', () => {
         };
 
         const results = await runPivotQuery(
-            admin,
+            client,
             projectUuid,
             query,
             pivotConfiguration,
@@ -239,6 +242,7 @@ describe('Pivot query API', () => {
     });
 
     it('keeps a self-sorted x-axis metric as an index column', async () => {
+        const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
             dimensions: ['orders_is_completed'],
@@ -268,7 +272,7 @@ describe('Pivot query API', () => {
         };
 
         const results = await runPivotQuery(
-            admin,
+            client,
             projectUuid,
             query,
             pivotConfiguration,
@@ -278,4 +282,53 @@ describe('Pivot query API', () => {
             getRawValues(results.rows, 'orders_unique_order_count').length,
         ).toBeGreaterThan(0);
     });
+}
+
+// Postgres is covered by the seed project below, so exclude it here and run the
+// suite against every other warehouse whose credentials are available.
+const pivotWarehouseEntries = getAvailableWarehouseConfigs({
+    includePostgres: false,
+});
+
+describe('Pivot query API', () => {
+    // Postgres: reuse the already-seeded project (no create/refresh needed).
+    describe('postgres (seed project)', () => {
+        let admin: ApiClient;
+
+        beforeAll(async () => {
+            admin = await login();
+        });
+
+        registerPivotQueryTests(() => ({
+            client: admin,
+            projectUuid: SEED_PROJECT.project_uuid,
+        }));
+    });
+
+    // Every other warehouse: spin up a project against its jaffle dataset and
+    // run the same pivot suite. Skipped automatically when creds are absent.
+    for (const { name, config } of pivotWarehouseEntries) {
+        describe(name, () => {
+            const projectName = `pivot ${name} parity test`;
+            let admin: ApiClient;
+            let projectUuid: string;
+
+            beforeAll(async () => {
+                admin = await login();
+                projectUuid = await createAndRefreshProject(
+                    admin,
+                    projectName,
+                    config,
+                );
+            }, 180_000);
+
+            afterAll(async () => {
+                if (projectUuid) {
+                    await deleteProjectsByName(admin, [projectName]);
+                }
+            });
+
+            registerPivotQueryTests(() => ({ client: admin, projectUuid }));
+        });
+    }
 });

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -87,8 +87,11 @@ const getRawValues = (
 
 type PivotTestContext = { client: ApiClient; projectUuid: string };
 
-function registerPivotQueryTests(getContext: () => PivotTestContext) {
-    it('excludes a sort-only metric from pivoted results', async () => {
+function registerPivotQueryTests(
+    label: string,
+    getContext: () => PivotTestContext,
+) {
+    it(`[${label}] excludes a sort-only metric from pivoted results`, async () => {
         const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
@@ -139,7 +142,7 @@ function registerPivotQueryTests(getContext: () => PivotTestContext) {
         );
     });
 
-    it('excludes a sort-only table calculation from pivoted results', async () => {
+    it(`[${label}] excludes a sort-only table calculation from pivoted results`, async () => {
         const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
@@ -191,7 +194,7 @@ function registerPivotQueryTests(getContext: () => PivotTestContext) {
         );
     });
 
-    it('keeps a self-sorted x-axis table calculation as an index column', async () => {
+    it(`[${label}] keeps a self-sorted x-axis table calculation as an index column`, async () => {
         const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
@@ -245,7 +248,7 @@ function registerPivotQueryTests(getContext: () => PivotTestContext) {
         expect(new Set(labels).size).toBeGreaterThan(1);
     });
 
-    it('keeps a self-sorted x-axis metric as an index column', async () => {
+    it(`[${label}] keeps a self-sorted x-axis metric as an index column`, async () => {
         const { client, projectUuid } = getContext();
         const query = {
             exploreName: 'orders',
@@ -303,7 +306,7 @@ describe('Pivot query API', () => {
             admin = await login();
         });
 
-        registerPivotQueryTests(() => ({
+        registerPivotQueryTests('postgres', () => ({
             client: admin,
             projectUuid: SEED_PROJECT.project_uuid,
         }));
@@ -332,7 +335,10 @@ describe('Pivot query API', () => {
                 }
             });
 
-            registerPivotQueryTests(() => ({ client: admin, projectUuid }));
+            registerPivotQueryTests(name, () => ({
+                client: admin,
+                projectUuid,
+            }));
         });
     }
 });

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -19,7 +19,7 @@ type PivotResults = {
     pivotDetails?: {
         valuesColumns?: Array<{ referenceField: string }>;
     } | null;
-    error?: { message: string } | null;
+    error?: { message: string } | string | null;
 };
 
 /**
@@ -48,7 +48,11 @@ async function runPivotQuery(
         );
         const { results } = resp.body;
         if (results.error) {
-            throw new Error(`Query failed: ${results.error.message}`);
+            const message =
+                typeof results.error === 'string'
+                    ? results.error
+                    : results.error.message;
+            throw new Error(`Query failed: ${message}`);
         }
         if (results.status === 'ready') {
             return results;


### PR DESCRIPTION
Closes: PROD-8482
Relates: lightdash/lightdash#24638

### Description:

The pivoted-chart regression on Snowflake (`__grp_rn` ROW_NUMBER missing an `ORDER BY`) slipped through because the pivot tests only ran against Postgres — which tolerates that SQL — while the unit tests only assert on the generated SQL string and can't catch a runtime dialect rejection. This PR runs the existing pivot scenarios against every warehouse whose credentials are available in CI (Postgres seed project + Snowflake, BigQuery, Databricks, Trino), so a dialect-incompatible pivot query fails CI instead of reaching production. It also extracts reusable warehouse config builders, availability predicates, and `getAvailableWarehouseConfigs` into `helpers/projects.ts` for other warehouse-parity suites to share.