### PR TITLE
feat(date-zoom): support date zoom variable in pie, funnel and gauge labels

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -5,9 +5,11 @@ import {
     formatTooltipValue,
     FunnelChartLabelPosition,
     FunnelChartLegendPosition,
+    getGranularityMapFromItems,
     getLegendStyle,
     getReadableTextColor,
     getTooltipStyle,
+    resolveGranularityInLabel,
     type Metric,
     type ResultRow,
     type ResultValue,
@@ -106,12 +108,19 @@ const useEchartsFunnelConfig = (
             colorDefaults,
         } = chartConfig;
 
+        const granularityMap = getGranularityMapFromItems(itemsMap);
+
         return {
             type: 'funnel',
             gap: 3,
             data: seriesData.map(({ id, name, value, meta }) => {
+                const labelOverride = labelOverrides?.[id] ?? name;
                 return {
-                    name: labelOverrides?.[id] ?? name,
+                    name:
+                        resolveGranularityInLabel(
+                            labelOverride,
+                            granularityMap,
+                        ) ?? labelOverride,
                     value,
                     meta,
                     itemStyle: {
@@ -205,6 +214,7 @@ const useEchartsFunnelConfig = (
         parameters,
         theme.colors.foreground,
         resolvedTimezone,
+        itemsMap,
     ]);
 
     const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -1,6 +1,8 @@
 import {
     formatItemValue,
+    getGranularityMapFromItems,
     getItemLabelWithoutTableName,
+    resolveGranularityInLabel,
     type GaugeSection,
 } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
@@ -116,6 +118,8 @@ const useEchartsGaugeConfig = ({
         const fieldItem = itemsMap?.[selectedField];
         if (!fieldItem) return;
 
+        const granularityMap = getGranularityMapFromItems(itemsMap);
+
         const rawValue = firstRow[selectedField];
         const numericValue = toNumber(rawValue?.value.raw);
 
@@ -131,8 +135,11 @@ const useEchartsGaugeConfig = ({
             }
         }
 
-        const fieldLabel =
+        const rawFieldLabel =
             customLabel || getItemLabelWithoutTableName(fieldItem);
+        const fieldLabel =
+            resolveGranularityInLabel(rawFieldLabel, granularityMap) ??
+            rawFieldLabel;
 
         const sectionColors: [number, string][] = [];
         const defaultGapColor = 'transparent';
@@ -317,9 +324,15 @@ const useEchartsGaugeConfig = ({
                             ((toNumber(value) - min) / (effectiveMax - min)) *
                             100
                         ).toFixed(0)}%`;
-                        const percentageLabel = chartConfig.validConfig
-                            .customPercentageLabel
-                            ? ` ${chartConfig.validConfig.customPercentageLabel}`
+                        const customPercentageLabel =
+                            chartConfig.validConfig.customPercentageLabel;
+                        const percentageLabel = customPercentageLabel
+                            ? ` ${
+                                  resolveGranularityInLabel(
+                                      customPercentageLabel,
+                                      granularityMap,
+                                  ) ?? customPercentageLabel
+                              }`
                             : '';
                         return `{value|${formattedValue}}\n{percentage|${percentageValue}}{percentageLabel|${percentageLabel}}`;
                     }

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -5,6 +5,7 @@ import {
     formatTooltipLabel,
     formatTooltipRow,
     formatTooltipValue,
+    getGranularityMapFromItems,
     getLegendStyle,
     getPieExternalLabelStyle,
     getPieInternalLabelStyle,
@@ -13,6 +14,7 @@ import {
     getTooltipStyle,
     PieChartLegendLabelMaxLengthDefault,
     PieChartTooltipLabelMaxLength,
+    resolveGranularityInLabel,
     type ResultRow,
     type ResultValue,
 } from '@lightdash/common';
@@ -74,6 +76,8 @@ const useEchartsPieConfig = (
 
         if (!selectedMetric) return;
 
+        const granularityMap = getGranularityMapFromItems(itemsMap);
+
         // Calculate total for percentage calculation
         const total = data.reduce((sum, { value }) => sum + value, 0);
 
@@ -106,10 +110,15 @@ const useEchartsPieConfig = (
                 const borderRadius = isDonut
                     ? calculateBorderRadiusForSlice(percent)
                     : 0;
+                const labelOverride = groupLabelOverrides?.[name] ?? name;
                 const config: PieSeriesDataPoint = {
                     id: name,
                     groupId: name,
-                    name: groupLabelOverrides?.[name] ?? name,
+                    name:
+                        resolveGranularityInLabel(
+                            labelOverride,
+                            granularityMap,
+                        ) ?? labelOverride,
                     value: value,
                     itemStyle: {
                         color: itemColor,
@@ -157,7 +166,7 @@ const useEchartsPieConfig = (
 
                 return config;
             });
-    }, [chartConfig, getGroupColor]);
+    }, [chartConfig, getGroupColor, itemsMap]);
 
     const pieSeriesOption: PieSeriesOption | undefined = useMemo(() => {
         if (!chartConfig) return;


### PR DESCRIPTION
## Summary

Completes the "Reference the grain" milestone (GLITCH-194, child of GLITCH-190) by resolving `${field.granularity}` tokens in the remaining chart-type label fields, using the same interpolation as big-number (GLITCH-192) and cartesian (GLITCH-193):

- **Pie** (`useEchartsPieConfig`) — `groupLabelOverrides`
- **Funnel** (`useEchartsFunnelConfig`) — `labelOverrides`
- **Gauge** (`useEchartsGaugeConfig`) — `customLabel` and `customPercentageLabel`

Each hook builds the map once via `getGranularityMapFromItems(itemsMap)` and resolves the label strings with `resolveGranularityInLabel`. The query's returned fields already carry the effective (zoomed) `timeInterval`, so resolution reads straight from `itemsMap` — no date-zoom override needed.

## Testing

- `pnpm -F frontend typecheck` (clean for the 3 hooks)
- `pnpm -F frontend lint` (oxlint 0/0 on the 3 hooks)
- Relies on the shared, already-unit-tested `resolveGranularityInLabel` (`bigNumber.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
