### PR TITLE
fix(sdk): drop react-dom/server from map tooltips to fix util.TextEncoder crash

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -21,7 +21,6 @@ import {
     type FC,
     type RefObject,
 } from 'react';
-import { renderToString } from 'react-dom/server';
 import {
     CircleMarker,
     GeoJSON,
@@ -140,8 +139,7 @@ type MapContentBaseProps = {
 
 type MapTooltipContentProps = MapContentBaseProps;
 
-// NOTE: Using inline styles because this is rendered via renderToString
-// and Mantine styles won't be applied
+// Inline styles: rendered into a Leaflet tooltip where Mantine styles don't apply
 const MapTooltipContent: FC<MapTooltipContentProps> = ({
     tooltipFields,
     rowData,
@@ -194,6 +192,50 @@ const MapTooltipContent: FC<MapTooltipContentProps> = ({
             )}
         </div>
     );
+};
+
+const escapeHtml = (value: string): string =>
+    value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+// HTML-string twin of MapTooltipContent, for Leaflet's imperative bindTooltip
+const getMapTooltipHtml = ({
+    tooltipFields,
+    rowData,
+    lat,
+    lon,
+    noData,
+}: MapContentBaseProps): string => {
+    if (noData) {
+        return `<div style="padding:4px 6px"><div style="font-size:14px"><strong>${escapeHtml(
+            noData.locationLabel,
+        )}:</strong> ${escapeHtml(
+            noData.locationValue,
+        )}</div><div style="font-size:14px;color:#868e96;font-style:italic">No data</div></div>`;
+    }
+
+    const rows = tooltipFields
+        .filter((f) => f.visible)
+        .map(
+            (field) =>
+                `<div style="font-size:14px"><strong>${escapeHtml(
+                    field.label,
+                )}:</strong> ${escapeHtml(
+                    getFormattedValue(rowData, field.fieldId),
+                )}</div>`,
+        )
+        .join('');
+    const coords =
+        lat !== undefined && lon !== undefined
+            ? `<div style="font-size:12px;color:#868e96;margin-top:8px">Lat: ${lat.toFixed(
+                  4,
+              )}, Lon: ${lon.toFixed(4)}</div>`
+            : '';
+    return `<div style="padding:4px 6px"><div style="display:flex;flex-direction:column;gap:2px">${rows}</div>${coords}</div>`;
 };
 
 // MapMarker component for scatter points with tooltip/context menu behavior
@@ -901,14 +943,11 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                           locationValue: rawPropertyValue.toString(),
                       };
 
-                // eslint-disable-next-line testing-library/render-result-naming-convention
-                const tooltipHtml = renderToString(
-                    <MapTooltipContent
-                        tooltipFields={mapConfig?.tooltipFields || []}
-                        rowData={rowData}
-                        noData={noData}
-                    />,
-                );
+                const tooltipHtml = getMapTooltipHtml({
+                    tooltipFields: mapConfig?.tooltipFields || [],
+                    rowData,
+                    noData,
+                });
 
                 if (layer instanceof L.Path) {
                     layer.bindTooltip(tooltipHtml, { sticky: true });


### PR DESCRIPTION
## Problem

SDK consumers hit `TypeError: util2.TextEncoder is not a constructor` when a map visualization renders, crashing the dashboard via the error boundary.

Root cause: `SimpleMap` imported `renderToString` from `react-dom/server` solely to build the choropleth tooltip HTML for Leaflet's imperative `layer.bindTooltip()`. The SDK build **externalizes** `react-dom/server`, so the consumer's bundler resolves it — and its export map's `default`/`node` condition points at React's **Node** server build (`react-dom-server.node.development.js`), which does `new (require('util').TextEncoder)()`. In a browser bundle `util` is stubbed, so `TextEncoder` is undefined → "not a constructor".

### Who is affected vs not

- **Affected:** SDK consumers whose bundler resolves `react-dom/server` to the `node`/`default` export condition (commonly Vite `optimizeDeps`/esbuild prebundling, or React 19 / SSR-influenced resolution) **and** who render a map. The crash is in the consumer's bundle, not ours — our bundle only ever shipped the bare external import.
- **Not affected:** The main Lightdash frontend app (its bundler resolves the `browser` condition), and consumers who never render a map.

This was latent since **v0.2728.0** (the vite-8/rolldown build transition that began externalizing `react-dom/server`); prior builds inlined React's browser server, so the node build never reached consumers.

## Fix

Remove the `react-dom/server` import entirely. Replace `renderToString(<MapTooltipContent/>)` at the one imperative call site with `getMapTooltipHtml(...)`, a plain HTML-string builder that mirrors the component's markup and escapes data-derived labels/values (`escapeHtml`) to preserve the auto-escaping React was providing.

The react-leaflet `<Tooltip>` JSX path (`MapTooltipContent`) is unchanged — it renders through normal React and never needed the server renderer.

Removing the import (rather than aliasing to `react-dom/server.browser`) fixes the crash at the root for **all** consumers regardless of their bundler config.

### Tradeoff

The tooltip markup now exists in two adjacent forms — the `MapTooltipContent` React component (JSX path) and the `getMapTooltipHtml` string builder (Leaflet path) — which must be kept visually in sync.

## Testing

- `frontend typecheck:fast`: no new errors.
- No `react-dom/server` / `renderToString` references remain in the component.

---

> ⚠️ **Ticket reference pending** — please add the `Closes: PROD-XXXX` (and `Closes: #XXXXX` if a GitHub issue exists) line for the production SDK crash. Left out rather than fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)