### PR TITLE
refactor(data-apps): share header + actions between builder and viewer

### DIFF
--- a/packages/frontend/src/features/apps/components/AppHeader.module.css
+++ b/packages/frontend/src/features/apps/components/AppHeader.module.css
@@ -1,0 +1,25 @@
+.header {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    padding: var(--mantine-spacing-md);
+    border-bottom: 1px solid;
+
+    @mixin light {
+        background-color: var(--mantine-color-white);
+        border-color: var(--mantine-color-ldGray-2);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-dark-7);
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+    flex: 1;
+}

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -1,0 +1,35 @@
+import { Box, Text, Title } from '@mantine-8/core';
+import { type FC, type ReactNode } from 'react';
+import classes from './AppHeader.module.css';
+
+type Props = {
+    name: string;
+    description: string | null;
+    /** Per-page actions (refresh button, overflow menu, …) rendered on the
+     *  right. The builder and viewer have different actions, so each owns its
+     *  own slot while sharing this header chrome. */
+    rightSection: ReactNode;
+};
+
+/**
+ * Shared header bar for a data app, used by both the builder (`AppGenerate`)
+ * and the standalone viewer (`AppPreviewTest`) so the two surfaces share one
+ * chrome instead of diverging.
+ */
+const AppHeader: FC<Props> = ({ name, description, rightSection }) => (
+    <Box className={classes.header}>
+        <Box className={classes.info}>
+            <Title order={6} fw={600} lineClamp={1}>
+                {name || 'Untitled app'}
+            </Title>
+            {description && (
+                <Text size="xs" c="dimmed" lineClamp={1}>
+                    {description}
+                </Text>
+            )}
+        </Box>
+        {rightSection}
+    </Box>
+);
+
+export default AppHeader;

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,0 +1,361 @@
+import {
+    ContentType,
+    FeatureFlags,
+    ResourceViewItemType,
+    type AppVersionStatus,
+} from '@lightdash/common';
+import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
+import {
+    IconCopy,
+    IconDatabase,
+    IconDatabaseExport,
+    IconDots,
+    IconFolderPlus,
+    IconFolderSymlink,
+    IconPencil,
+    IconRefresh,
+    IconSend,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState, type FC, type ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import AppDeleteModal from '../../../components/common/modal/AppDeleteModal';
+import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
+import TransferItemsModal from '../../../components/common/TransferItemsModal/TransferItemsModal';
+import { useContentAction } from '../../../hooks/useContent';
+import { useProject } from '../../../hooks/useProject';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
+import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
+import { useDuplicateApp } from '../hooks/useDuplicateApp';
+import {
+    DataAppFavoriteMenuItem,
+    FavoritePersonalDataAppModal,
+} from './DataAppFavoriteMenuItem';
+import { PromoteAppModal } from './PromoteAppModal';
+
+type Props = {
+    projectUuid: string;
+    appUuid: string;
+    appName: string;
+    appDescription: string | null;
+    appSpaceUuid: string | null;
+    appCreatedByUserUuid: string | null;
+    /** The latest ready version's number + status — used by the favorite flow
+     *  and to gate the Promote action. */
+    latestVersionNumber: number | null;
+    latestVersionStatus: AppVersionStatus | null;
+    onRefresh: () => void;
+    refreshDisabled: boolean;
+    onViewQueries: () => void;
+    /** Called after a successful delete so the page can navigate away. */
+    onDeleted: () => void;
+    /** The single cross-navigation menu item that differs per surface:
+     *  "Preview latest" in the builder, "Continue building" in the viewer.
+     *  Rendered at the top of the menu; pass null to omit it. */
+    navItem: ReactNode;
+};
+
+/**
+ * The shared right-hand side of a data app's header — a refresh button plus the
+ * overflow menu and every action modal. Used by both the builder
+ * (`AppGenerate`) and the viewer (`AppPreviewTest`) so the two surfaces expose
+ * the same actions; the only per-surface difference is `navItem`.
+ *
+ * Edit-actions are gated by `useCanEditDataApp`, because the viewer can be
+ * opened by users without manage rights.
+ */
+const AppHeaderActions: FC<Props> = ({
+    projectUuid,
+    appUuid,
+    appName,
+    appDescription,
+    appSpaceUuid,
+    appCreatedByUserUuid,
+    latestVersionNumber,
+    latestVersionStatus,
+    onRefresh,
+    refreshDisabled,
+    onViewQueries,
+    onDeleted,
+    navItem,
+}) => {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+
+    const canEdit = useCanEditDataApp(projectUuid, {
+        spaceUuid: appSpaceUuid,
+        createdByUserUuid: appCreatedByUserUuid,
+    });
+
+    const scheduledDeliveriesFlag = useServerFeatureFlag(
+        FeatureFlags.DataAppsScheduledDeliveries,
+    );
+
+    // Promotion is only offered from a preview project linked to an upstream.
+    const { data: project } = useProject(projectUuid);
+    const isPreviewProject = !!project?.upstreamProjectUuid;
+
+    const hasReadyVersion = latestVersionStatus === 'ready';
+
+    const { mutate: duplicateMutate, isLoading: isDuplicating } =
+        useDuplicateApp();
+    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
+        useContentAction(projectUuid);
+
+    const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
+    const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+    const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
+    const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [favoriteSpaceModalOpen, setFavoriteSpaceModalOpen] = useState(false);
+
+    const handleDuplicate = useCallback(() => {
+        duplicateMutate(
+            { projectUuid, appUuid },
+            {
+                onSuccess: ({ appUuid: newAppUuid }) => {
+                    void navigate(
+                        `/projects/${projectUuid}/apps/${newAppUuid}`,
+                    );
+                },
+            },
+        );
+    }, [duplicateMutate, navigate, projectUuid, appUuid]);
+
+    const handleMove = useCallback(
+        async (targetSpaceUuid: string | null) => {
+            if (!targetSpaceUuid) return;
+            await contentAction({
+                action: { type: 'move', targetSpaceUuid },
+                item: { uuid: appUuid, contentType: ContentType.DATA_APP },
+            });
+            await queryClient.invalidateQueries({
+                queryKey: ['app', projectUuid, appUuid],
+            });
+            setIsMoveToSpaceOpen(false);
+        },
+        [contentAction, queryClient, projectUuid, appUuid],
+    );
+
+    return (
+        <>
+            <Tooltip
+                label="Refresh to re-run queries"
+                withArrow
+                position="bottom"
+            >
+                <ActionIcon
+                    variant="subtle"
+                    size="sm"
+                    color="ldGray.6"
+                    disabled={refreshDisabled}
+                    onClick={onRefresh}
+                    aria-label="Refresh"
+                >
+                    <MantineIcon icon={IconRefresh} size={16} />
+                </ActionIcon>
+            </Tooltip>
+            <Menu
+                position="bottom-end"
+                shadow="md"
+                withinPortal
+                withArrow
+                arrowPosition="center"
+            >
+                <Menu.Target>
+                    <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        color="ldGray.6"
+                        aria-label="App actions"
+                    >
+                        <MantineIcon icon={IconDots} size={16} />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    {navItem}
+                    <DataAppFavoriteMenuItem
+                        projectUuid={projectUuid}
+                        appUuid={appUuid}
+                        appSpaceUuid={appSpaceUuid}
+                        onAddPersonalAppToSpace={() =>
+                            setFavoriteSpaceModalOpen(true)
+                        }
+                    />
+                    <Menu.Item
+                        leftSection={
+                            <MantineIcon icon={IconDatabase} size={14} />
+                        }
+                        onClick={onViewQueries}
+                    >
+                        View queries
+                    </Menu.Item>
+                    {canEdit && scheduledDeliveriesFlag.data?.enabled && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconSend} size={14} />
+                            }
+                            onClick={() => setSchedulerModalOpen(true)}
+                        >
+                            Schedule delivery
+                        </Menu.Item>
+                    )}
+                    {canEdit && (
+                        <>
+                            <Menu.Divider />
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon icon={IconPencil} size={14} />
+                                }
+                                onClick={() => setIsUpdateModalOpen(true)}
+                            >
+                                Rename
+                            </Menu.Item>
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon icon={IconCopy} size={14} />
+                                }
+                                disabled={isDuplicating}
+                                onClick={handleDuplicate}
+                            >
+                                Duplicate
+                            </Menu.Item>
+                            <Menu.Item
+                                leftSection={
+                                    <MantineIcon
+                                        icon={
+                                            appSpaceUuid
+                                                ? IconFolderSymlink
+                                                : IconFolderPlus
+                                        }
+                                        size={14}
+                                    />
+                                }
+                                onClick={() => setIsMoveToSpaceOpen(true)}
+                            >
+                                {appSpaceUuid
+                                    ? 'Move to space'
+                                    : 'Add to space'}
+                            </Menu.Item>
+                            {isPreviewProject && hasReadyVersion && (
+                                <Menu.Item
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconDatabaseExport}
+                                            size={14}
+                                        />
+                                    }
+                                    onClick={() => setIsPromoteModalOpen(true)}
+                                >
+                                    Promote
+                                </Menu.Item>
+                            )}
+                            <Menu.Divider />
+                            <Menu.Item
+                                color="red"
+                                leftSection={
+                                    <MantineIcon icon={IconTrash} size={14} />
+                                }
+                                onClick={() => setIsDeleteModalOpen(true)}
+                            >
+                                Delete
+                            </Menu.Item>
+                        </>
+                    )}
+                </Menu.Dropdown>
+            </Menu>
+
+            {isUpdateModalOpen && (
+                <AppUpdateModal
+                    opened
+                    projectUuid={projectUuid}
+                    uuid={appUuid}
+                    initialName={appName}
+                    initialDescription={appDescription ?? ''}
+                    onClose={() => setIsUpdateModalOpen(false)}
+                    onConfirm={() => setIsUpdateModalOpen(false)}
+                />
+            )}
+            {isMoveToSpaceOpen && (
+                <TransferItemsModal
+                    projectUuid={projectUuid}
+                    opened
+                    onClose={() => setIsMoveToSpaceOpen(false)}
+                    items={[
+                        {
+                            type: ResourceViewItemType.DATA_APP,
+                            data: {
+                                uuid: appUuid,
+                                name: appName,
+                                description: appDescription || undefined,
+                                spaceUuid: appSpaceUuid,
+                                createdByUserUuid: appCreatedByUserUuid,
+                                updatedAt: new Date(),
+                                updatedByUser: null,
+                                views: 0,
+                                firstViewedAt: null,
+                                latestVersionNumber: null,
+                                latestVersionStatus: null,
+                                pinnedListUuid: null,
+                                pinnedListOrder: null,
+                            },
+                        },
+                    ]}
+                    isLoading={isMovingToSpace}
+                    onConfirm={handleMove}
+                />
+            )}
+            {schedulerModalOpen && (
+                <AppSchedulersModal
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    name={appName || 'Data app'}
+                    isOpen
+                    onClose={() => setSchedulerModalOpen(false)}
+                />
+            )}
+            {isPromoteModalOpen && (
+                <PromoteAppModal
+                    projectUuid={projectUuid}
+                    appUuid={appUuid}
+                    opened
+                    onClose={() => setIsPromoteModalOpen(false)}
+                />
+            )}
+            {isDeleteModalOpen && (
+                <AppDeleteModal
+                    opened
+                    projectUuid={projectUuid}
+                    uuid={appUuid}
+                    name={appName}
+                    onClose={() => setIsDeleteModalOpen(false)}
+                    onConfirm={() => {
+                        setIsDeleteModalOpen(false);
+                        onDeleted();
+                    }}
+                />
+            )}
+            {favoriteSpaceModalOpen && (
+                <FavoritePersonalDataAppModal
+                    projectUuid={projectUuid}
+                    opened
+                    onClose={() => setFavoriteSpaceModalOpen(false)}
+                    app={{
+                        uuid: appUuid,
+                        name: appName || 'Untitled app',
+                        description: appDescription || undefined,
+                        spaceUuid: appSpaceUuid,
+                        createdByUserUuid: appCreatedByUserUuid,
+                        latestVersionNumber,
+                        latestVersionStatus,
+                    }}
+                />
+            )}
+        </>
+    );
+};
+
+export default AppHeaderActions;

--- a/packages/frontend/src/features/apps/hooks/useCanEditDataApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useCanEditDataApp.ts
@@ -1,0 +1,44 @@
+import { subject } from '@casl/ability';
+import { useMemo } from 'react';
+import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import { useAbilityContext } from '../../../providers/Ability/useAbilityContext';
+import useApp from '../../../providers/App/useApp';
+
+/**
+ * Whether the current user can manage (edit) a given data app. Space
+ * editors/admins inherit manage rights on apps in their space, so this resolves
+ * the user's access on the app's space before checking the CASL ability.
+ *
+ * Shared by the builder and the viewer so both gate edit-actions identically.
+ */
+export const useCanEditDataApp = (
+    projectUuid: string | undefined,
+    app: { spaceUuid: string | null; createdByUserUuid: string | null },
+): boolean => {
+    const ability = useAbilityContext();
+    const { user } = useApp();
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+
+    return useMemo(() => {
+        if (!projectUuid) return false;
+        const userSpaceAccess = app.spaceUuid
+            ? spaces.find((s) => s.uuid === app.spaceUuid)?.userAccess
+            : undefined;
+        return ability.can(
+            'manage',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+                access: userSpaceAccess ? [userSpaceAccess] : [],
+                createdByUserUuid: app.createdByUserUuid,
+            }),
+        );
+    }, [
+        ability,
+        user.data?.organizationUuid,
+        projectUuid,
+        spaces,
+        app.spaceUuid,
+        app.createdByUserUuid,
+    ]);
+};

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -382,32 +382,6 @@
     }
 }
 
-.previewHeader {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    gap: var(--mantine-spacing-sm);
-    padding: var(--mantine-spacing-md);
-    border-bottom: 1px solid;
-
-    @mixin light {
-        background-color: var(--mantine-color-white);
-        border-color: var(--mantine-color-ldGray-2);
-    }
-    @mixin dark {
-        background-color: var(--mantine-color-dark-7);
-        border-color: var(--mantine-color-ldDark-4);
-    }
-}
-
-.previewHeaderInfo {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-    flex: 1;
-}
-
 .previewContent {
     flex: 1;
     overflow: hidden;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1,11 +1,9 @@
 import { subject } from '@casl/ability';
 import {
     ChartKind,
-    ContentType,
     DEFAULT_DATA_APP_CLAUDE_MODEL,
     FeatureFlags,
     isAppVersionInProgress,
-    ResourceViewItemType,
     type ApiAppVersionSummary,
     type AppChartReference,
     type AppClarification,
@@ -26,7 +24,6 @@ import {
     Stack,
     Text,
     Textarea,
-    Title,
     Tooltip,
 } from '@mantine-8/core';
 import {
@@ -34,21 +31,12 @@ import {
     IconAppWindow,
     IconCheck,
     IconArrowUp,
-    IconCopy,
-    IconDatabase,
-    IconDatabaseExport,
     IconBrush,
-    IconDots,
     IconExternalLink,
     IconArrowBackUp,
-    IconFolderPlus,
-    IconFolderSymlink,
-    IconPencil,
     IconLayoutDashboard,
     IconPlayerStop,
-    IconRefresh,
     IconRestore,
-    IconTrash,
     IconPlugConnected,
     IconX,
 } from '@tabler/icons-react';
@@ -76,11 +64,8 @@ import { AiMarkdown } from '../components/common/AiMarkdown';
 import Callout from '../components/common/Callout';
 import MantineIcon from '../components/common/MantineIcon';
 import MantineModal from '../components/common/MantineModal';
-import AppDeleteModal from '../components/common/modal/AppDeleteModal';
-import AppUpdateModal from '../components/common/modal/AppUpdateModal';
 import { getChartIcon } from '../components/common/ResourceIcon/utils';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import TransferItemsModal from '../components/common/TransferItemsModal/TransferItemsModal';
 import AppIframePreview, {
     type AppIframePreviewHandle,
 } from '../features/apps/AppIframePreview';
@@ -103,11 +88,8 @@ import {
 import AppTemplatePicker from '../features/apps/AppTemplatePicker';
 import ChatBubbleMeta from '../features/apps/ChatBubbleMeta';
 import ChatMessageContent from '../features/apps/ChatMessageContent';
-import {
-    DataAppFavoriteMenuItem,
-    FavoritePersonalDataAppModal,
-} from '../features/apps/components/DataAppFavoriteMenuItem';
-import { PromoteAppModal } from '../features/apps/components/PromoteAppModal';
+import AppHeader from '../features/apps/components/AppHeader';
+import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -116,7 +98,6 @@ import type { QueryEvent } from '../features/apps/hooks/useAppSdkBridge';
 import { useBuildNotification } from '../features/apps/hooks/useBuildNotification';
 import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
 import { useClarifyApp } from '../features/apps/hooks/useClarifyApp';
-import { useDuplicateApp } from '../features/apps/hooks/useDuplicateApp';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -135,8 +116,6 @@ import { useAppExternalConnections } from '../features/externalConnections/hooks
 import { ThemePicker } from '../features/organizationDesigns/components/ThemePicker';
 import { useOrganizationDesigns } from '../features/organizationDesigns/hooks/useOrganizationDesigns';
 import useToaster from '../hooks/toaster/useToaster';
-import { useContentAction } from '../hooks/useContent';
-import { useProject } from '../hooks/useProject';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
@@ -646,8 +625,6 @@ const AppGenerate: FC = () => {
         useClarifyApp();
     const { mutate: cancelMutate, isLoading: isCancelling } =
         useCancelAppVersion();
-    const { mutate: duplicateMutate, isLoading: isDuplicating } =
-        useDuplicateApp();
     const {
         mutate: restoreVersionMutate,
         isLoading: isRestoringVersion,
@@ -687,19 +664,6 @@ const AppGenerate: FC = () => {
     // Used to resolve the user's space role when checking manage rights for
     // an existing app — space editors/admins inherit manage on its data app.
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
-
-    const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
-    const [isFavoriteSpaceModalOpen, setIsFavoriteSpaceModalOpen] =
-        useState(false);
-    const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
-    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-    const [isPromoteModalOpen, setIsPromoteModalOpen] = useState(false);
-
-    // Promotion is only offered from a preview project linked to an upstream.
-    const { data: project } = useProject(projectUuid);
-    const isPreviewProject = !!project?.upstreamProjectUuid;
-    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
-        useContentAction(projectUuid);
 
     // Accumulate all versions ever seen in this session. Refetches may lose
     // older versions when new ones shift pagination boundaries, but we keep
@@ -2757,318 +2721,60 @@ const AppGenerate: FC = () => {
                     <Panel minSize={40}>
                         <Box className={classes.previewPanel}>
                             {activeAppUuid && (
-                                <Box className={classes.previewHeader}>
-                                    <Box className={classes.previewHeaderInfo}>
-                                        <Title order={6} fw={600} lineClamp={1}>
-                                            {appName || 'Untitled app'}
-                                        </Title>
-                                        {appDescription && (
-                                            <Text
-                                                size="xs"
-                                                c="dimmed"
-                                                lineClamp={1}
-                                            >
-                                                {appDescription}
-                                            </Text>
-                                        )}
-                                    </Box>
-                                    <Tooltip
-                                        label="Refresh preview to re-run queries"
-                                        withArrow
-                                        position="bottom"
-                                    >
-                                        <ActionIcon
-                                            variant="subtle"
-                                            size="sm"
-                                            color="ldGray.6"
-                                            ml="auto"
-                                            disabled={!previewApp}
-                                            onClick={handleRefreshPreview}
-                                            aria-label="Refresh preview"
-                                        >
-                                            <MantineIcon
-                                                icon={IconRefresh}
-                                                size={16}
-                                            />
-                                        </ActionIcon>
-                                    </Tooltip>
-                                    <Menu
-                                        position="bottom-end"
-                                        shadow="md"
-                                        withinPortal
-                                        withArrow
-                                        arrowPosition="center"
-                                    >
-                                        <Menu.Target>
-                                            <ActionIcon
-                                                variant="subtle"
-                                                size="sm"
-                                                color="ldGray.6"
-                                                aria-label="App actions"
-                                            >
-                                                <MantineIcon
-                                                    icon={IconDots}
-                                                    size={16}
-                                                />
-                                            </ActionIcon>
-                                        </Menu.Target>
-                                        <Menu.Dropdown>
-                                            {previewApp && (
-                                                <Menu.Item
-                                                    component={Link}
-                                                    to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
-                                                    target="_blank"
-                                                    leftSection={
-                                                        <MantineIcon
-                                                            icon={
-                                                                IconExternalLink
-                                                            }
-                                                            size={14}
-                                                        />
-                                                    }
-                                                >
-                                                    Preview latest
-                                                </Menu.Item>
-                                            )}
-                                            <DataAppFavoriteMenuItem
-                                                projectUuid={projectUuid}
-                                                appUuid={activeAppUuid}
-                                                appSpaceUuid={appSpaceUuid}
-                                                onAddPersonalAppToSpace={() =>
-                                                    setIsFavoriteSpaceModalOpen(
-                                                        true,
-                                                    )
-                                                }
-                                            />
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconDatabase}
-                                                        size={14}
-                                                    />
-                                                }
-                                                onClick={() =>
-                                                    setQueriesPanelHidden(false)
-                                                }
-                                            >
-                                                View queries
-                                            </Menu.Item>
-                                            <Menu.Divider />
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconCopy}
-                                                        size={14}
-                                                    />
-                                                }
-                                                disabled={
-                                                    isDuplicating ||
-                                                    !activeAppUuid
-                                                }
-                                                onClick={() => {
-                                                    if (!activeAppUuid) return;
-                                                    duplicateMutate(
-                                                        {
-                                                            projectUuid,
-                                                            appUuid:
-                                                                activeAppUuid,
-                                                        },
-                                                        {
-                                                            onSuccess: ({
-                                                                appUuid:
-                                                                    newAppUuid,
-                                                            }) => {
-                                                                void navigate(
-                                                                    `/projects/${projectUuid}/apps/${newAppUuid}`,
-                                                                );
-                                                            },
-                                                        },
-                                                    );
-                                                }}
-                                            >
-                                                Duplicate
-                                            </Menu.Item>
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconPencil}
-                                                        size={14}
-                                                    />
-                                                }
-                                                onClick={() =>
-                                                    setIsUpdateModalOpen(true)
-                                                }
-                                            >
-                                                Rename
-                                            </Menu.Item>
-                                            <Menu.Item
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={
-                                                            appSpaceUuid
-                                                                ? IconFolderSymlink
-                                                                : IconFolderPlus
-                                                        }
-                                                        size={14}
-                                                    />
-                                                }
-                                                onClick={() =>
-                                                    setIsMoveToSpaceOpen(true)
-                                                }
-                                            >
-                                                {appSpaceUuid
-                                                    ? 'Move to space'
-                                                    : 'Add to space'}
-                                            </Menu.Item>
-                                            {isPreviewProject &&
-                                                latestReadyVersion && (
+                                <AppHeader
+                                    name={appName}
+                                    description={appDescription || null}
+                                    rightSection={
+                                        <AppHeaderActions
+                                            projectUuid={projectUuid}
+                                            appUuid={activeAppUuid}
+                                            appName={appName}
+                                            appDescription={
+                                                appDescription || null
+                                            }
+                                            appSpaceUuid={appSpaceUuid}
+                                            appCreatedByUserUuid={
+                                                appCreatedByUserUuid
+                                            }
+                                            latestVersionNumber={
+                                                latestReadyVersion?.version ??
+                                                null
+                                            }
+                                            latestVersionStatus={
+                                                latestReadyVersion?.status ??
+                                                null
+                                            }
+                                            onRefresh={handleRefreshPreview}
+                                            refreshDisabled={!previewApp}
+                                            onViewQueries={() =>
+                                                setQueriesPanelHidden(false)
+                                            }
+                                            onDeleted={() =>
+                                                void navigate(
+                                                    `/projects/${projectUuid}/apps/generate`,
+                                                )
+                                            }
+                                            navItem={
+                                                previewApp ? (
                                                     <Menu.Item
+                                                        component={Link}
+                                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
+                                                        target="_blank"
                                                         leftSection={
                                                             <MantineIcon
                                                                 icon={
-                                                                    IconDatabaseExport
+                                                                    IconExternalLink
                                                                 }
                                                                 size={14}
                                                             />
                                                         }
-                                                        disabled={
-                                                            !activeAppUuid
-                                                        }
-                                                        onClick={() =>
-                                                            setIsPromoteModalOpen(
-                                                                true,
-                                                            )
-                                                        }
                                                     >
-                                                        Promote
+                                                        Preview latest
                                                     </Menu.Item>
-                                                )}
-                                            <Menu.Divider />
-                                            <Menu.Item
-                                                color="red"
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconTrash}
-                                                        size={14}
-                                                    />
-                                                }
-                                                onClick={() =>
-                                                    setIsDeleteModalOpen(true)
-                                                }
-                                            >
-                                                Delete
-                                            </Menu.Item>
-                                        </Menu.Dropdown>
-                                    </Menu>
-                                </Box>
-                            )}
-                            {isFavoriteSpaceModalOpen && activeAppUuid && (
-                                <FavoritePersonalDataAppModal
-                                    projectUuid={projectUuid}
-                                    opened
-                                    onClose={() =>
-                                        setIsFavoriteSpaceModalOpen(false)
+                                                ) : null
+                                            }
+                                        />
                                     }
-                                    app={{
-                                        uuid: activeAppUuid,
-                                        name: appName || 'Untitled app',
-                                        description:
-                                            appDescription || undefined,
-                                        spaceUuid: appSpaceUuid,
-                                        createdByUserUuid: appCreatedByUserUuid,
-                                        latestVersionNumber:
-                                            latestReadyVersion?.version ?? null,
-                                        latestVersionStatus:
-                                            latestReadyVersion?.status ?? null,
-                                    }}
-                                />
-                            )}
-                            {isMoveToSpaceOpen && activeAppUuid && (
-                                <TransferItemsModal
-                                    projectUuid={projectUuid}
-                                    opened
-                                    onClose={() => setIsMoveToSpaceOpen(false)}
-                                    items={[
-                                        {
-                                            type: ResourceViewItemType.DATA_APP,
-                                            data: {
-                                                uuid: activeAppUuid,
-                                                name: appName,
-                                                description:
-                                                    appDescription || undefined,
-                                                spaceUuid: appSpaceUuid,
-                                                createdByUserUuid:
-                                                    appCreatedByUserUuid,
-                                                updatedAt: new Date(),
-                                                updatedByUser: null,
-                                                views: 0,
-                                                firstViewedAt: null,
-                                                latestVersionNumber: null,
-                                                latestVersionStatus: null,
-                                                pinnedListUuid: null,
-                                                pinnedListOrder: null,
-                                            },
-                                        },
-                                    ]}
-                                    isLoading={isMovingToSpace}
-                                    onConfirm={async (targetSpaceUuid) => {
-                                        if (!targetSpaceUuid) return;
-                                        await contentAction({
-                                            action: {
-                                                type: 'move',
-                                                targetSpaceUuid,
-                                            },
-                                            item: {
-                                                uuid: activeAppUuid,
-                                                contentType:
-                                                    ContentType.DATA_APP,
-                                            },
-                                        });
-                                        await queryClient.invalidateQueries({
-                                            queryKey: [
-                                                'app',
-                                                projectUuid,
-                                                activeAppUuid,
-                                            ],
-                                        });
-                                        setIsMoveToSpaceOpen(false);
-                                    }}
-                                />
-                            )}
-                            {isUpdateModalOpen && activeAppUuid && (
-                                <AppUpdateModal
-                                    opened
-                                    projectUuid={projectUuid}
-                                    uuid={activeAppUuid}
-                                    initialName={appName}
-                                    initialDescription={appDescription}
-                                    onClose={() => setIsUpdateModalOpen(false)}
-                                    onConfirm={() =>
-                                        setIsUpdateModalOpen(false)
-                                    }
-                                />
-                            )}
-                            {isPromoteModalOpen && activeAppUuid && (
-                                <PromoteAppModal
-                                    projectUuid={projectUuid}
-                                    appUuid={activeAppUuid}
-                                    opened
-                                    onClose={() => setIsPromoteModalOpen(false)}
-                                />
-                            )}
-                            {isDeleteModalOpen && activeAppUuid && (
-                                <AppDeleteModal
-                                    opened
-                                    projectUuid={projectUuid}
-                                    uuid={activeAppUuid}
-                                    name={appName}
-                                    onClose={() => setIsDeleteModalOpen(false)}
-                                    onConfirm={() => {
-                                        setIsDeleteModalOpen(false);
-                                        void navigate(
-                                            `/projects/${projectUuid}/apps/generate`,
-                                        );
-                                    }}
                                 />
                             )}
                             {restoreTargetVersion !== null && activeAppUuid && (

--- a/packages/frontend/src/pages/AppPreviewTest.module.css
+++ b/packages/frontend/src/pages/AppPreviewTest.module.css
@@ -1,7 +1,9 @@
 .previewContainer {
-    position: relative;
+    display: flex;
+    flex-direction: column;
     height: calc(100vh - 50px);
     width: 100%;
+    overflow: hidden;
 }
 
 /* A fixed NavBar banner (preview / impersonation) reserves an extra 35px at
@@ -12,9 +14,9 @@
     height: calc(100vh - 50px - 35px);
 }
 
-.menuOverlay {
-    position: absolute;
-    top: var(--mantine-spacing-sm);
-    right: var(--mantine-spacing-xl);
-    z-index: 10;
+.previewBody {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+    overflow: hidden;
 }

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,35 +1,21 @@
-import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
-import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
-import {
-    IconAppsOff,
-    IconDatabase,
-    IconDots,
-    IconPencil,
-    IconRefresh,
-    IconSend,
-    IconTrash,
-} from '@tabler/icons-react';
-import { useCallback, useEffect, useState } from 'react';
+import { Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
+import { IconAppsOff, IconPencil } from '@tabler/icons-react';
+import { useCallback, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
-import AppDeleteModal from '../components/common/modal/AppDeleteModal';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
-import {
-    DataAppFavoriteMenuItem,
-    FavoritePersonalDataAppModal,
-} from '../features/apps/components/DataAppFavoriteMenuItem';
+import AppHeader from '../features/apps/components/AppHeader';
+import AppHeaderActions from '../features/apps/components/AppHeaderActions';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
+import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useTrackedAppQueries } from '../features/apps/hooks/useTrackedAppQueries';
 import { usePreviewOrigin } from '../features/apps/previewOrigin';
 import QueryInspector from '../features/apps/QueryInspector';
-import { AppSchedulersModal } from '../features/scheduler/components/SchedulerModals';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
-import { useSpaceSummaries } from '../hooks/useSpaces';
-import useApp from '../providers/App/useApp';
 import classes from './AppPreviewTest.module.css';
 
 export default function AppPreviewTest() {
@@ -47,10 +33,6 @@ export default function AppPreviewTest() {
     const explicitVersion = versionParam ? Number(versionParam) : undefined;
 
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
-    const scheduledDeliveriesFlag = useServerFeatureFlag(
-        FeatureFlags.DataAppsScheduledDeliveries,
-    );
-    const { user } = useApp();
 
     // Always fetch app to get creator info + latest ready version when needed.
     // The backend enforces space-aware view permissions and will 403 if the
@@ -61,23 +43,15 @@ export default function AppPreviewTest() {
         (v) => v.status === 'ready',
     )?.version;
 
+    const appName = appQuery.data?.pages[0]?.name ?? '';
+    const appDescription = appQuery.data?.pages[0]?.description ?? null;
     const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
     const appCreatedByUserUuid =
         appQuery.data?.pages[0]?.createdByUserUuid ?? null;
-    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
-    const userSpaceAccess = appSpaceUuid
-        ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
-        : undefined;
-    const canEditApp =
-        user.data?.ability?.can(
-            'manage',
-            subject('DataApp', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-                access: userSpaceAccess ? [userSpaceAccess] : [],
-                createdByUserUuid: appCreatedByUserUuid,
-            }),
-        ) === true;
+    const canEditApp = useCanEditDataApp(projectUuid, {
+        spaceUuid: appSpaceUuid,
+        createdByUserUuid: appCreatedByUserUuid,
+    });
 
     const version = explicitVersion ?? latestReadyVersion;
 
@@ -87,10 +61,6 @@ export default function AppPreviewTest() {
         error: tokenError,
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
-    const [menuOpened, setMenuOpened] = useState(false);
-    const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
-    const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-    const [favoriteSpaceModalOpen, setFavoriteSpaceModalOpen] = useState(false);
     const [queriesPanelHidden, setQueriesPanelHidden] = useState(true);
 
     // Query tracking from the preview iframe. The panel is opt-in (hidden by
@@ -110,18 +80,6 @@ export default function AppPreviewTest() {
         setInvalidateCache(true);
         clearQueries();
     }, [clearQueries]);
-
-    // Close menu when the iframe receives focus (i.e. user clicked on it)
-    const handleBlur = useCallback(() => {
-        if (menuOpened) {
-            setMenuOpened(false);
-        }
-    }, [menuOpened]);
-
-    useEffect(() => {
-        window.addEventListener('blur', handleBlur);
-        return () => window.removeEventListener('blur', handleBlur);
-    }, [handleBlur]);
 
     const previewOrigin = usePreviewOrigin();
 
@@ -206,146 +164,71 @@ export default function AppPreviewTest() {
 
     return (
         <Box className={classes.previewContainer}>
-            <Box className={classes.menuOverlay}>
-                <Menu
-                    position="bottom-end"
-                    withinPortal
-                    opened={menuOpened}
-                    onChange={setMenuOpened}
-                >
-                    <Menu.Target>
-                        <ActionIcon
-                            variant="filled"
-                            color="gray"
-                            size="lg"
-                            radius="xl"
-                        >
-                            <MantineIcon icon={IconDots} size={18} />
-                        </ActionIcon>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                        <DataAppFavoriteMenuItem
-                            projectUuid={projectUuid}
-                            appUuid={appUuid}
-                            appSpaceUuid={appSpaceUuid}
-                            onAddPersonalAppToSpace={() =>
-                                setFavoriteSpaceModalOpen(true)
-                            }
-                        />
-                        {canEditApp && (
-                            <Menu.Item
-                                leftSection={<IconPencil size={14} />}
-                                onClick={() =>
-                                    navigate(
-                                        `/projects/${projectUuid}/apps/${appUuid}`,
-                                    )
-                                }
-                            >
-                                Continue building
-                            </Menu.Item>
-                        )}
-                        <Menu.Item
-                            leftSection={<MantineIcon icon={IconRefresh} />}
-                            onClick={handleRefresh}
-                        >
-                            Refresh
-                        </Menu.Item>
-                        {canEditApp &&
-                            scheduledDeliveriesFlag.data?.enabled && (
+            <AppHeader
+                name={appName}
+                description={appDescription}
+                rightSection={
+                    <AppHeaderActions
+                        projectUuid={projectUuid}
+                        appUuid={appUuid}
+                        appName={appName}
+                        appDescription={appDescription}
+                        appSpaceUuid={appSpaceUuid}
+                        appCreatedByUserUuid={appCreatedByUserUuid}
+                        latestVersionNumber={latestReadyVersion ?? null}
+                        latestVersionStatus={
+                            latestReadyVersion ? 'ready' : null
+                        }
+                        onRefresh={handleRefresh}
+                        refreshDisabled={false}
+                        onViewQueries={() => setQueriesPanelHidden(false)}
+                        onDeleted={() => {
+                            void navigate(`/projects/${projectUuid}/home`);
+                        }}
+                        navItem={
+                            canEditApp ? (
                                 <Menu.Item
-                                    leftSection={<IconSend size={14} />}
-                                    onClick={() => setSchedulerModalOpen(true)}
-                                >
-                                    Schedule delivery
-                                </Menu.Item>
-                            )}
-                        <Menu.Item
-                            leftSection={<IconDatabase size={14} />}
-                            onClick={() => setQueriesPanelHidden(false)}
-                        >
-                            View queries
-                        </Menu.Item>
-                        {canEditApp && (
-                            <>
-                                <Menu.Divider />
-                                <Menu.Item
-                                    color="red"
                                     leftSection={
                                         <MantineIcon
-                                            icon={IconTrash}
+                                            icon={IconPencil}
                                             size={14}
                                         />
                                     }
-                                    onClick={() => setDeleteModalOpen(true)}
+                                    onClick={() =>
+                                        navigate(
+                                            `/projects/${projectUuid}/apps/${appUuid}`,
+                                        )
+                                    }
                                 >
-                                    Delete app
+                                    Continue building
                                 </Menu.Item>
-                            </>
-                        )}
-                    </Menu.Dropdown>
-                </Menu>
-            </Box>
-            <AppIframePreview
-                src={previewUrl}
-                expectedPreviewOrigin={previewOrigin}
-                projectUuid={projectUuid}
-                appUuid={appUuid}
-                identityKey={`${appUuid}:${version}`}
-                invalidateCache={invalidateCache}
-                onQueryEvent={handleQueryEvent}
-                capabilities={{ gsheetExport: true }}
+                            ) : null
+                        }
+                    />
+                }
             />
-            {!queriesPanelHidden && (
-                <QueryInspector
-                    queries={queries}
-                    projectUuid={projectUuid}
-                    onClear={clearQueries}
-                    defaultCollapsed={false}
-                    hideWhenEmpty={false}
-                    onDismiss={() => setQueriesPanelHidden(true)}
-                />
-            )}
-            {schedulerModalOpen && (
-                <AppSchedulersModal
+            <Box className={classes.previewBody}>
+                <AppIframePreview
+                    src={previewUrl}
+                    expectedPreviewOrigin={previewOrigin}
                     projectUuid={projectUuid}
                     appUuid={appUuid}
-                    name={appQuery.data?.pages[0]?.name ?? 'Data app'}
-                    isOpen
-                    onClose={() => setSchedulerModalOpen(false)}
+                    identityKey={`${appUuid}:${version}`}
+                    invalidateCache={invalidateCache}
+                    onQueryEvent={handleQueryEvent}
+                    capabilities={{ gsheetExport: true }}
                 />
-            )}
-            {deleteModalOpen && (
-                <AppDeleteModal
-                    opened
-                    projectUuid={projectUuid}
-                    uuid={appUuid}
-                    name={appQuery.data?.pages[0]?.name ?? 'Data app'}
-                    onClose={() => setDeleteModalOpen(false)}
-                    onConfirm={() => {
-                        setDeleteModalOpen(false);
-                        void navigate(`/projects/${projectUuid}/home`);
-                    }}
-                />
-            )}
-            {favoriteSpaceModalOpen && (
-                <FavoritePersonalDataAppModal
-                    projectUuid={projectUuid}
-                    opened
-                    onClose={() => setFavoriteSpaceModalOpen(false)}
-                    app={{
-                        uuid: appUuid,
-                        name: appQuery.data?.pages[0]?.name ?? 'Data app',
-                        description:
-                            appQuery.data?.pages[0]?.description ?? undefined,
-                        spaceUuid: appSpaceUuid,
-                        createdByUserUuid: appCreatedByUserUuid,
-                        latestVersionNumber: latestReadyVersion ?? null,
-                        latestVersionStatus: latestReadyVersion
-                            ? 'ready'
-                            : null,
-                    }}
-                />
-            )}
+                {!queriesPanelHidden && (
+                    <QueryInspector
+                        queries={queries}
+                        projectUuid={projectUuid}
+                        onClear={clearQueries}
+                        defaultCollapsed={false}
+                        hideWhenEmpty={false}
+                        onDismiss={() => setQueriesPanelHidden(true)}
+                    />
+                )}
+            </Box>
         </Box>
     );
 }


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-8419/show-containing-space-and-allow-deleting-while-viewing-a-data-app

### Description:
Extract a shared AppHeader shell and AppHeaderActions (refresh button + overflow menu + all action modals) so the builder (AppGenerate) and the standalone viewer (AppPreviewTest) render the same header chrome and the same actions. The only per-surface difference is the cross-nav item (Preview latest vs Continue building).

The viewer gains a real header bar instead of a floating menu that overlapped content, and the two menus no longer drift. Edit-actions are gated by a new useCanEditDataApp hook so a read-only viewer sees a collapsed menu.


Preview page:
<img width="2565" height="1037" alt="preview" src="https://github.com/user-attachments/assets/14a1d542-c529-4ee9-85d7-d9ba4db202c1" />



Builder page:
<img width="2565" height="1037" alt="builder" src="https://github.com/user-attachments/assets/4b9e4acd-639c-41bd-aa51-86672f29c8b1" />