### PR TITLE
fix(ai): make AI-response dashboard & chart content links clickable

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -87,7 +87,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
         case 'dashboard-link':
             return (
                 <ContentReferenceLink
-                    href={dashboardHref}
+                    to={dashboardHref || undefined}
                     kind="dashboard"
                     onClick={handleDashboardClick}
                     title={title}
@@ -112,9 +112,7 @@ export const ContentLink: FC<ContentLinkProps> = ({
             return (
                 <ContentReferenceLink
                     chartKind={chartTypeKind}
-                    href={
-                        typeof props.href === 'string' ? props.href : undefined
-                    }
+                    to={typeof props.href === 'string' ? props.href : undefined}
                     kind="chart"
                     rel="noreferrer"
                     target="_blank"


### PR DESCRIPTION
## Problem

In AI agent threads, dashboard and chart links that the assistant generates in its markdown responses **rendered correctly but were not clickable** — they came out as plain text chips with no navigation.

## Root cause

`ContentReferenceLink` renders a static, non-clickable `<span>` whenever its `to` prop is missing, and only renders a navigable `<Anchor component={Link} to={to}>` when `to` is set. This `!to → static span` branch was introduced in #24437.

The AI-response link renderer (`ContentLink`) — for the `dashboard-link` and `chart-link` cases — kept passing `href`/`onClick`/`target` but **never `to`**, so every AI-generated content link fell through to the static-span branch. The sibling callers updated in #24437 (`AgentChatUserBubble`, `PinnedContextCard`) already pass `to`, so @-mention reference links were unaffected — only the AI-response links regressed.

## Fix

Pass `to` to `ContentReferenceLink` in both cases so the clickable `<Anchor>` branch is taken:
- `dashboard-link`: `to={dashboardHref || undefined}` (keeps the existing `onClick` for in-app SPA navigation / `onDashboardLinkClick`).
- `chart-link`: `to={...href}` (keeps `target="_blank"` new-tab behaviour).

## Verification

Verified live in a local AI thread: the three revenue dashboard references now render as real `<a>` links with their dashboard URLs and navigate on click (previously static spans).

Closes: #24699
