### PR TITLE
fix(ai-agents): schedule Slack prompt even if placeholder post fails

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -8416,13 +8416,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 );
                 const reconnectNotice =
                     '⚠️ Lightdash AI cannot reply here yet. A workspace admin needs to reconnect Slack in Lightdash (Integrations → Slack) so the app has the latest permissions.';
-                await this.slackClient.updateMessage({
-                    organizationUuid: slackPrompt.organizationUuid,
-                    text: reconnectNotice,
-                    blocks: getMarkdownBlocks(reconnectNotice),
-                    channelId: slackPrompt.slackChannelId,
-                    messageTs: slackPrompt.response_slack_ts,
-                });
+                await this.editPlaceholderOrPost(slackPrompt, reconnectNotice);
                 return;
             }
             Logger.error('Failed to start Slack modern AI stream', error);
@@ -9006,14 +9000,10 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         }
 
         if (slackPrompt.prompt.trim().length === 0) {
-            const welcomeText = AiAgentService.EMPTY_PROMPT_WELCOME;
-            await this.slackClient.updateMessage({
-                organizationUuid: slackPrompt.organizationUuid,
-                text: welcomeText,
-                blocks: getMarkdownBlocks(welcomeText),
-                channelId: slackPrompt.slackChannelId,
-                messageTs: slackPrompt.response_slack_ts,
-            });
+            await this.editPlaceholderOrPost(
+                slackPrompt,
+                AiAgentService.EMPTY_PROMPT_WELCOME,
+            );
             return;
         }
 
@@ -10333,6 +10323,39 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         return false;
     }
 
+    // Edit the placeholder when it exists; if the placeholder post failed
+    // (no `response_slack_ts`, e.g. Slack rate-limited `say()`) post a fresh
+    // threaded message instead, so the user still gets a reply.
+    private async editPlaceholderOrPost(
+        slackPrompt: Pick<
+            SlackPrompt,
+            | 'organizationUuid'
+            | 'slackChannelId'
+            | 'slackThreadTs'
+            | 'response_slack_ts'
+        >,
+        text: string,
+    ): Promise<void> {
+        const blocks = getMarkdownBlocks(text);
+        if (slackPrompt.response_slack_ts) {
+            await this.slackClient.updateMessage({
+                organizationUuid: slackPrompt.organizationUuid,
+                text,
+                blocks,
+                channelId: slackPrompt.slackChannelId,
+                messageTs: slackPrompt.response_slack_ts,
+            });
+            return;
+        }
+        await this.slackClient.postMessage({
+            organizationUuid: slackPrompt.organizationUuid,
+            channel: slackPrompt.slackChannelId,
+            thread_ts: slackPrompt.slackThreadTs,
+            text,
+            blocks,
+        });
+    }
+
     /**
      * Post initial response message and schedule the AI prompt
      */
@@ -10345,46 +10368,56 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
         createdThread: boolean,
         say: Function,
     ): Promise<void> {
-        const postedMessage = await say({
-            username: agentConfig.name,
-            thread_ts: threadTs,
-            text: createdThread
-                ? `Hi <@${userId}>, working on your request now.`
-                : 'Let me check that for you. One moment.',
-            blocks: [
-                {
-                    type: 'section',
-                    text: {
-                        type: 'mrkdwn',
-                        text: createdThread
-                            ? `Hi <@${userId}>, working on your request now :rocket:`
-                            : `Let me check that for you. One moment! :books:`,
+        // Best-effort placeholder: if `say()` throws (e.g. Slack rate-limiting)
+        // we must still schedule the job, else the prompt is orphaned.
+        try {
+            const postedMessage = await say({
+                username: agentConfig.name,
+                thread_ts: threadTs,
+                text: createdThread
+                    ? `Hi <@${userId}>, working on your request now.`
+                    : 'Let me check that for you. One moment.',
+                blocks: [
+                    {
+                        type: 'section',
+                        text: {
+                            type: 'mrkdwn',
+                            text: createdThread
+                                ? `Hi <@${userId}>, working on your request now :rocket:`
+                                : `Let me check that for you. One moment! :books:`,
+                        },
                     },
-                },
-                {
-                    type: 'divider',
-                },
-                {
-                    type: 'context',
-                    elements: [
-                        {
-                            type: 'plain_text',
-                            text: `It can take up to 15s to get a response.`,
-                        },
-                        {
-                            type: 'plain_text',
-                            text: `Reference: ${slackPromptUuid}`,
-                        },
-                    ],
-                },
-            ],
-        });
-
-        if (postedMessage.ts) {
-            await this.aiAgentModel.updateSlackResponseTs({
-                promptUuid: slackPromptUuid,
-                responseSlackTs: postedMessage.ts,
+                    {
+                        type: 'divider',
+                    },
+                    {
+                        type: 'context',
+                        elements: [
+                            {
+                                type: 'plain_text',
+                                text: `It can take up to 15s to get a response.`,
+                            },
+                            {
+                                type: 'plain_text',
+                                text: `Reference: ${slackPromptUuid}`,
+                            },
+                        ],
+                    },
+                ],
             });
+
+            if (postedMessage.ts) {
+                await this.aiAgentModel.updateSlackResponseTs({
+                    promptUuid: slackPromptUuid,
+                    responseSlackTs: postedMessage.ts,
+                });
+            }
+        } catch (error) {
+            Logger.error(
+                `Failed to post Slack placeholder for prompt ${slackPromptUuid}; scheduling generation anyway`,
+                error,
+            );
+            Sentry.captureException(error);
         }
 
         await this.schedulerClient.slackAiPrompt({


### PR DESCRIPTION
## Summary

PR 1 of 3 for [PROD-8371](https://linear.app/lightdash/issue/PROD-8371). Schedules the AI-agent generation job even when the Slack placeholder post fails, so a prompt is never orphaned.

Closes: PROD-8371

## Root cause

`postInitialResponseAndSchedule` posts a placeholder via `say()`, stores its `ts`, then schedules the generation job. `say()` ran *before* scheduling, so when Slack rate-limited the bot on rapid consecutive messages and `say()` threw, the exception propagated and `schedulerClient.slackAiPrompt(...)` was never reached. The prompt was orphaned — no placeholder, no scheduled job, no response, no error — and sat "Working…" until the 5-minute timeout flipped it to an error.

## Fix

- Wrap the placeholder `say()` + `updateSlackResponseTs` in try/catch (log + Sentry). Scheduling now always runs. The modern stream posts its own message during generation, so a missing placeholder is recoverable.
- A failed placeholder leaves `response_slack_ts` null. Two paths edited that placeholder by `ts` (the empty-prompt welcome and the modern-stream-unsupported notice) and would throw on a null `ts`. New `editPlaceholderOrPost` helper edits when a `ts` exists, otherwise posts a fresh threaded message.

## Flow

```
Before:  say() ──throws──▶ ✗ job never scheduled  (prompt orphaned)

After:   try { say() } ─┬─ ok ───▶ store ts ─┐
                        └─ throws ▶ log+Sentry ┴─▶ schedule job  (always)
```

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `pnpm -F backend` lint (changed files)
- [x] `pnpm -F backend` jest: AiAgent Slack unit suites pass
- [x] Manual smoke (live Slack): agent answers an `@mention` end-to-end

## Notes

Follow-up (not blocking): add a bounded `Retry-After`-honoring retry around `say()` to recover rate-limited placeholders instead of only logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
