### PR TITLE
fix(ai-agents): backfill missing tool result in agent history

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4043,6 +4043,7 @@ export class AiAgentService extends BaseService {
                     retrieveRelevantArtifacts &&
                     this.getIsVerifiedArtifactsEnabled(),
                 compaction,
+                currentPromptUuid: prompt.promptUuid,
             },
         );
 
@@ -5947,6 +5948,9 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 typeof AiAgentModel.prototype.getToolCallsAndResultsForPrompt
             >
         >,
+        // True only for the prompt being generated/resumed, which legitimately
+        // replays an approved tool-call with no result yet (the resume input).
+        isCurrentPrompt: boolean,
     ): ModelMessage[] {
         return toolCallsAndResults.flatMap(
             ({ toolCall, toolResult, approvalDecision }) => {
@@ -6016,6 +6020,29 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                             },
                         ],
                     } satisfies ToolModelMessage);
+                } else if (
+                    approvalDecision === 'approved' &&
+                    !isCurrentPrompt
+                ) {
+                    // A prior approved tool-call whose result was never
+                    // persisted would dangle (tool-call/approval with no
+                    // tool-result), which the model API rejects on the next
+                    // prompt ("No tool output found" → "Could not finish").
+                    // Backfill a synthetic result so the history stays valid.
+                    toolTurnMessages.push({
+                        role: 'tool',
+                        content: [
+                            {
+                                type: 'tool-result',
+                                toolCallId: toolCall.toolCallId,
+                                toolName: toolCall.toolName,
+                                output: {
+                                    type: 'json',
+                                    value: 'Tool result unavailable.',
+                                },
+                            },
+                        ],
+                    } satisfies ToolModelMessage);
                 }
 
                 return toolTurnMessages;
@@ -6035,6 +6062,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             agentUuid: string;
             retrieveRelevantArtifacts: boolean;
             compaction: ThreadCompaction | null;
+            currentPromptUuid: string;
         },
     ): Promise<ModelMessage[]> {
         const contextMap = await this.aiAgentModel.getContextForPromptUuids(
@@ -6092,16 +6120,19 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     await this.aiAgentModel.getToolCallsAndResultsForPrompt(
                         message.ai_prompt_uuid,
                     );
+                const isCurrentPrompt =
+                    message.ai_prompt_uuid === options.currentPromptUuid;
                 messages.push(
                     ...AiAgentService.buildToolCallTurnMessages(
                         toolCallsAndResults,
+                        isCurrentPrompt,
                     ),
                 );
 
-                // A turn suspended mid SQL-approval has a partial `response`
-                // (text emitted before the runSql call). Replaying it would
-                // leave the runSql tool_use without a following tool_result, so
-                // skip it — the resumed run regenerates from the approval.
+                // The current prompt resuming mid SQL-approval has only a
+                // partial `response`; skip it so the resumed run regenerates.
+                // Prior prompts keep their final response — their tool call is
+                // backfilled above, so the turn is already complete.
                 const hasUnresolvedApproval =
                     AiAgentService.hasUnresolvedSqlApproval(
                         toolCallsAndResults,
@@ -6110,7 +6141,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 if (
                     message.response &&
                     !message.error_message &&
-                    !hasUnresolvedApproval
+                    (!hasUnresolvedApproval || !isCurrentPrompt)
                 ) {
                     messages.push({
                         role: 'assistant',
@@ -9019,6 +9050,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                     // TODO: add Slack compaction support once Slack has an
                     // equivalent persisted marker / summary UX.
                     compaction: null,
+                    currentPromptUuid: promptUuid,
                 });
 
             await this.replyToSlackPromptWithModernBlocks({

--- a/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlApprovalReconstruction.test.ts
@@ -21,13 +21,16 @@ type AnyType = Record<string, unknown> & { type: string };
 
 describe('AiAgentService SQL-approval history reconstruction', () => {
     it('a normal tool call emits assistant(call) + tool(result), no approval parts', () => {
-        const msgs = AiAgentService.buildToolCallTurnMessages([
-            {
-                toolCall: call('tc1', 'SELECT 1'),
-                toolResult: result('tc1', '3 rows'),
-                approvalDecision: null,
-            },
-        ]);
+        const msgs = AiAgentService.buildToolCallTurnMessages(
+            [
+                {
+                    toolCall: call('tc1', 'SELECT 1'),
+                    toolResult: result('tc1', '3 rows'),
+                    approvalDecision: null,
+                },
+            ],
+            false,
+        );
 
         expect(msgs).toHaveLength(2);
         expect(msgs[0].role).toBe('assistant');
@@ -43,14 +46,17 @@ describe('AiAgentService SQL-approval history reconstruction', () => {
         expect(content(msgs[1])[0].type).toBe('tool-result');
     });
 
-    it('approved-but-unexecuted call emits request + response and NO result (the resume input)', () => {
-        const msgs = AiAgentService.buildToolCallTurnMessages([
-            {
-                toolCall: call('tc1', 'SELECT 1'),
-                toolResult: null,
-                approvalDecision: 'approved',
-            },
-        ]);
+    it('approved-but-unexecuted call on the CURRENT prompt emits request + response and NO result (the resume input)', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages(
+            [
+                {
+                    toolCall: call('tc1', 'SELECT 1'),
+                    toolResult: null,
+                    approvalDecision: 'approved',
+                },
+            ],
+            true,
+        );
 
         expect(msgs).toHaveLength(2);
         expect(content(msgs[0])).toEqual([
@@ -76,13 +82,16 @@ describe('AiAgentService SQL-approval history reconstruction', () => {
     });
 
     it('rejected call emits an approval-response with approved=false', () => {
-        const msgs = AiAgentService.buildToolCallTurnMessages([
-            {
-                toolCall: call('tc1', 'SELECT 1'),
-                toolResult: null,
-                approvalDecision: 'rejected',
-            },
-        ]);
+        const msgs = AiAgentService.buildToolCallTurnMessages(
+            [
+                {
+                    toolCall: call('tc1', 'SELECT 1'),
+                    toolResult: null,
+                    approvalDecision: 'rejected',
+                },
+            ],
+            false,
+        );
 
         expect(content(msgs[1])[0]).toEqual({
             type: 'tool-approval-response',
@@ -92,17 +101,42 @@ describe('AiAgentService SQL-approval history reconstruction', () => {
     });
 
     it('a completed approved call emits request + response + result', () => {
-        const msgs = AiAgentService.buildToolCallTurnMessages([
-            {
-                toolCall: call('tc1', 'SELECT 1'),
-                toolResult: result('tc1', '3 rows'),
-                approvalDecision: 'approved',
-            },
-        ]);
+        const msgs = AiAgentService.buildToolCallTurnMessages(
+            [
+                {
+                    toolCall: call('tc1', 'SELECT 1'),
+                    toolResult: result('tc1', '3 rows'),
+                    approvalDecision: 'approved',
+                },
+            ],
+            false,
+        );
 
         expect(msgs).toHaveLength(3);
         expect(content(msgs[1])[0].type).toBe('tool-approval-response');
         expect(content(msgs[2])[0].type).toBe('tool-result');
+    });
+
+    it('a PRIOR approved call whose result was never persisted backfills a synthetic tool-result (no dangling call)', () => {
+        const msgs = AiAgentService.buildToolCallTurnMessages(
+            [
+                {
+                    toolCall: call('tc1', 'SELECT 1'),
+                    toolResult: null,
+                    approvalDecision: 'approved',
+                },
+            ],
+            false,
+        );
+
+        expect(msgs).toHaveLength(3);
+        expect(content(msgs[0])[0].type).toBe('tool-call');
+        expect(content(msgs[1])[0].type).toBe('tool-approval-response');
+        expect(content(msgs[2])[0]).toMatchObject({
+            type: 'tool-result',
+            toolCallId: 'tc1',
+            output: { type: 'json', value: 'Tool result unavailable.' },
+        });
     });
 
     it('hasUnresolvedSqlApproval is true only for a decided, result-less call', () => {


### PR DESCRIPTION
## Summary

PR 2 of 3 for [PROD-8456](https://linear.app/lightdash/issue/PROD-8456). Stops AI-agent Slack threads from failing with "Could not finish" when a prior tool call has no recorded result.

Stacks on PR 1 (PROD-8371 — scheduling resilience).

Closes: PROD-8456

## Root cause

Confirmed via production Sentry (`LIGHTDASH-BACKEND-CXV`) + DB. When a `runSql` goes through the SQL-approval suspend/resume flow, the approval is recorded but in some cases the tool *result* is never persisted. `getToolCallsAndResultsForPrompt` keeps approved calls even without a result, so on a *later* prompt in the thread, `buildToolCallTurnMessages` replays an assistant tool-call + approval with no following tool-result. The model API then rejects the whole request:

- OpenAI: `No tool output found for function call …`
- Anthropic: `tool_use ids were found without tool_result blocks …`

The generic error handler surfaces this to the user as "Could not finish".

## Fix

`buildToolCallTurnMessages` now takes `isCurrentPrompt`. For an approved call with no result:

- **prior prompt** → backfill a synthetic tool-result so the turn is complete;
- **current/resuming prompt** → unchanged (the result-less form is the SDK's resume input).

`currentPromptUuid` is threaded through `getChatHistoryFromThreadMessages` from both callers. The prior prompt's final response is now also kept (its turn is complete once backfilled) rather than being suppressed alongside the resume case.

## Reconstructed history (prior prompt with an unresolved approved call)

```
Before:  user │ assistant[tool-call+approval] │ (no result) │ user(next)   → API rejects
After:   user │ assistant[tool-call+approval] │ tool[result] │ assistant[answer] │ user(next)   → valid
```

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `pnpm -F backend` lint (changed files)
- [x] `sqlApprovalReconstruction.test.ts` — prior-prompt backfill vs current-prompt resume input
- [x] Manual (live Slack): seeded an approved-but-result-less call on a prior prompt — without the fix the next prompt failed with the dangling-tool-result error; with the fix it answered. Counterfactual reproduced both directions.

## Notes

This is a defensive fix at reconstruction time. Follow-up (not blocking): close the upstream persistence gap so the approved `runSql` result is saved during resume — this backfill is the safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
