### PR TITLE
fix(ai-agents): show latest chart image in Slack agent card

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.test.ts
@@ -288,4 +288,90 @@ describe('Slack AI agent blocks', () => {
             },
         ]);
     });
+
+    it('uses the latest visualization attempt image when a single artifact was retried', async () => {
+        const artifact = {
+            artifactUuid: 'artifact-1',
+            threadUuid: 'thread-1',
+            promptUuid: 'prompt-1',
+            artifactType: 'chart' as const,
+            savedQueryUuid: null,
+            savedDashboardUuid: null,
+            createdAt: new Date(),
+            versionNumber: 3,
+            versionUuid: 'version-3',
+            title: 'Orders Over Time',
+            description: null,
+            dashboardConfig: null,
+            versionCreatedAt: new Date(),
+            verifiedByUserUuid: null,
+            verifiedAt: null,
+            chartConfig: {
+                title: 'Orders Over Time',
+                description: 'Orders by month',
+                queryConfig: {
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_month'],
+                    metrics: ['orders_unique_order_count'],
+                    sorts: [],
+                    limit: 500,
+                    customMetrics: [],
+                    tableCalculations: [],
+                    filters: null,
+                },
+                chartConfig: null,
+            },
+        };
+
+        const attempt = (callId: string, url: string) => ({
+            uuid: `result-${callId}`,
+            promptUuid: 'prompt-1',
+            toolCallId: callId,
+            toolType: 'built-in' as const,
+            toolName: 'generateVisualization' as const,
+            result: 'ok',
+            createdAt: new Date(),
+            metadata: {
+                status: 'success',
+                chartImageUrl: url,
+            } as never,
+        });
+
+        const blocks = await getModernArtifactCardBlocks(
+            {
+                promptUuid: 'prompt-1',
+                projectUuid: 'project-1',
+                threadUuid: 'thread-1',
+            } as never,
+            'https://lightdash.example.com',
+            500,
+            async () => 'https://lightdash.example.com/share/chart',
+            async () => ({}) as never,
+            'agent-1',
+            [artifact],
+            [
+                attempt(
+                    'call-1',
+                    'https://files.slack.com/chart-attempt-1.png',
+                ),
+                attempt(
+                    'call-2',
+                    'https://files.slack.com/chart-attempt-2.png',
+                ),
+                attempt(
+                    'call-3',
+                    'https://files.slack.com/chart-attempt-3.png',
+                ),
+            ],
+        );
+
+        expect(blocks).toMatchObject([
+            {
+                type: 'card',
+                hero_image: {
+                    image_url: 'https://files.slack.com/chart-attempt-3.png',
+                },
+            },
+        ]);
+    });
 });

--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -616,14 +616,20 @@ export async function getModernArtifactCardBlocks(
                     vizConfig.metricQuery.metrics.length +
                     additionalMetricsWithSql.length;
                 const dimensionCount = vizConfig.metricQuery.dimensions.length;
+                // A prompt upserts a single artifact, so its retried
+                // visualizations produce several images for that one artifact —
+                // the latest is its current render. Use it for the single-artifact
+                // case; for multiple artifacts fall back to positional matching.
                 const chartImageUrl =
-                    chartImageUrls[
-                        chartArtifacts.findIndex(
-                            (chartArtifact) =>
-                                chartArtifact.artifactUuid ===
-                                artifact.artifactUuid,
-                        )
-                    ];
+                    chartArtifacts.length === 1
+                        ? chartImageUrls[chartImageUrls.length - 1]
+                        : chartImageUrls[
+                              chartArtifacts.findIndex(
+                                  (chartArtifact) =>
+                                      chartArtifact.artifactUuid ===
+                                      artifact.artifactUuid,
+                              )
+                          ];
 
                 return buildSlackCardBlock({
                     blockId: `ai_agent_chart_card_${artifact.artifactUuid}`,


### PR DESCRIPTION
## Summary

PR 3 of 3, surfaced while investigating [PROD-8456](https://linear.app/lightdash/issue/PROD-8456). The Slack agent answer card showed the wrong chart image when the agent retried a visualization.

Stacks on PR 2.

Relates to: PROD-8456

## Root cause

A prompt upserts a single artifact, but each `generateVisualization` retry uploads its own image, so `chartImageUrls` holds several images for one artifact. `getModernArtifactCardBlocks` matched an artifact to its image positionally (`chartImageUrls[findIndex(...)]` → index 0), so it embedded the *first* (stale) attempt's image instead of the final render.

## Fix

For a single chart artifact, use the latest image (`chartImageUrls[length - 1]`), which corresponds to the artifact's current version. Multiple artifacts keep positional matching.

## Image selection (one artifact, three retries)

```
chartImageUrls:  [ img1, img2, img3 ]
before  →  img1   (first / stale attempt)
after   →  img3   (current render)
```

## Test plan

- [x] `pnpm -F backend typecheck:fast`
- [x] `pnpm -F backend` lint (changed files)
- [x] `getSlackBlocks.test.ts` — latest-image-after-retries added; original single-image case unchanged

## Notes

Multi-artifact-per-prompt with retries still uses positional matching. The robust fix is to persist an artifact/version identifier on the tool result so images map by key — out of scope here, since a prompt upserts one artifact today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
