### PR TITLE
fix(ai): don't throw document upload when summary generation fails

### DIFF
--- a/packages/backend/src/ee/services/AiAgentDocumentService.ts
+++ b/packages/backend/src/ee/services/AiAgentDocumentService.ts
@@ -22,7 +22,10 @@ import { LightdashConfig } from '../../config/parseConfig';
 import { BaseService } from '../../services/BaseService';
 import { AiAgentDocumentModel } from '../models/AiAgentDocumentModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
-import { generateDocumentSummary } from './ai/agents/documentSummaryGenerator';
+import {
+    createFallbackDocumentSummary,
+    generateDocumentSummary,
+} from './ai/agents/documentSummaryGenerator';
 import { getModel } from './ai/models';
 import type { AiAgentService } from './AiAgentService/AiAgentService';
 
@@ -262,11 +265,19 @@ export class AiAgentDocumentService extends BaseService {
             enableReasoning: false,
             useFastModel: true,
         });
-        const summary = await generateDocumentSummary(modelOptions, {
-            name: body.name,
-            content: body.content,
-            projectExplores,
-        });
+        let summary: AiAgentDocument['summary'];
+        try {
+            summary = await generateDocumentSummary(modelOptions, {
+                name: body.name,
+                content: body.content,
+                projectExplores,
+            });
+        } catch (error) {
+            this.logger.error(
+                `Failed to generate summary for document "${body.name}", storing a fallback summary: ${error}`,
+            );
+            summary = createFallbackDocumentSummary(body.name);
+        }
 
         const storageKey = `org/${organizationUuid}/doc/${uuidv4()}.${
             mimeType === 'text/markdown' ? 'md' : 'txt'

--- a/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/documentSummaryGenerator.ts
@@ -7,6 +7,9 @@ import { z } from 'zod';
 import { GeneratorModelOptions } from '../models/types';
 import { renderAvailableExplores } from '../prompts/availableExplores';
 
+const DEFINED_TERMS_LIMIT = 30;
+const RELATED_EXPLORE_NAMES_LIMIT = 20;
+
 const DocumentSummarySchema = z.object({
     description: z
         .string()
@@ -17,16 +20,16 @@ const DocumentSummarySchema = z.object({
         ),
     definedTerms: z
         .array(z.string().min(1).max(60))
-        .max(20)
         .describe(
-            'Up to 20 short, lowercased terms or concepts that this document defines or constrains (e.g. "revenue", "active user", "refund"). Empty array if the document defines no specific terms.',
-        ),
+            `Up to ${DEFINED_TERMS_LIMIT} short, lowercased terms or concepts that this document defines or constrains (e.g. "revenue", "active user", "refund"). Keep only the most important terms if the document defines more. Empty array if the document defines no specific terms.`,
+        )
+        .transform((terms) => terms.slice(0, DEFINED_TERMS_LIMIT)),
     relatedExploreNames: z
         .array(z.string().min(1))
-        .max(20)
         .describe(
-            'Names of explores (from the provided project context) that this document is most relevant to. Use exact names from the project context. Empty array if no explore is clearly relevant or if no project context was provided.',
-        ),
+            `Up to ${RELATED_EXPLORE_NAMES_LIMIT} names of explores (from the provided project context) that this document is most relevant to. Use exact names from the project context. Empty array if no explore is clearly relevant or if no project context was provided.`,
+        )
+        .transform((names) => names.slice(0, RELATED_EXPLORE_NAMES_LIMIT)),
     useWhen: z
         .string()
         .min(1)
@@ -45,6 +48,17 @@ const DocumentSummarySchema = z.object({
         .describe(
             'If relevance is "low" or "none", a brief human-readable warning the agent should heed (e.g. "This document does not appear to relate to the project\'s data — do not use it to answer data questions."). Null when relevance is "high" or "medium".',
         ),
+});
+
+export const createFallbackDocumentSummary = (
+    name: string,
+): AiAgentDocumentStructuredSummary => ({
+    description: `Reference document "${name}". An automatic summary could not be generated.`,
+    definedTerms: [],
+    relatedExploreNames: [],
+    useWhen: `Use when the user asks about topics covered in "${name}".`,
+    relevance: 'medium',
+    warning: null,
 });
 
 const PROJECT_CONTEXT_EXPLORE_LIMIT = 30;


### PR DESCRIPTION
Closes: PROD-8485

### Description:

Uploading a knowledge document to an AI agent returned a **500** when the auto-generated summary contained more `definedTerms` than the output schema's hard cap (20). Field-rich documents make the model produce more terms, so Zod validation rejected the object (`AI_NoObjectGeneratedError: response did not match schema`), the SDK auto-repair pass also failed, and the unhandled error took down the whole upload — the document was never saved.

**Changes**

- **Relax the cap, slice instead of reject.** Replaced the hard `.max()` on `definedTerms` (and `relatedExploreNames`) with a `.transform()` that slices to the limit. The AI SDK validates `generateObject` output by parsing it through the Zod schema (`safeParseAsync`), so the transform runs during validation and the returned object is already capped — over-sized responses degrade gracefully instead of 500ing. The target count is now also surfaced to the model via the field descriptions (it previously wasn't).
- **Non-fatal summary generation.** Wrapped the summary call in a try/catch so any other generation failure stores a neutral fallback summary and the upload still succeeds.
