### PR TITLE
fix: rename tracking chunks

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -10,6 +10,11 @@ const FE_PORT = process.env.FE_PORT ? parseInt(process.env.FE_PORT) : 3000;
 const FE_HOST = process.env.FE_HOST;
 const BE_PORT = process.env.PORT ? parseInt(process.env.PORT) : 8080;
 
+const trackingChunkNames: Record<string, string> = {
+    TrackingProvider: 'interaction-context',
+    useTracking: 'useInteractionContext',
+};
+
 export default defineConfig({
     publicDir: 'public',
     define: {
@@ -80,6 +85,8 @@ export default defineConfig({
 
         rolldownOptions: {
             output: {
+                chunkFileNames: ({ name }) =>
+                    `assets/${trackingChunkNames[name] ?? '[name]'}-[hash].js`,
                 codeSplitting: {
                     groups: [
                         {


### PR DESCRIPTION
### Description
- Renames frontend chunks derived from tracking modules to neutral asset names.
- Keeps chunking behavior unchanged by remapping only emitted chunk filenames.

### Testing
- pnpm -F @lightdash/frontend exec vite build --outDir /tmp/lightdash-frontend-build --emptyOutDir