### PR TITLE
feat(data-apps): show the app's space in the header

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -5054,6 +5054,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         description: string;
         createdByUserUuid: string;
         spaceUuid: string | null;
+        spaceName: string | null;
         template: Exclude<DataAppTemplate, 'custom'> | null;
         pinnedListUuid: string | null;
         pinnedListOrder: number | null;
@@ -5081,6 +5082,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
+            spaceName,
             template,
             pinnedListUuid,
             pinnedListOrder,
@@ -5101,6 +5103,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             description,
             createdByUserUuid,
             spaceUuid,
+            spaceName,
             template,
             pinnedListUuid,
             pinnedListOrder,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7051,11 +7051,31 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CompiledMetricRelativeDateFilter: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                compiledSql: { dataType: 'string', required: true },
+                fieldId: { dataType: 'string', required: true },
+                id: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CompiledProperties: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                compiledRelativeDateFilters: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'CompiledMetricRelativeDateFilter',
+                    },
+                },
                 compiledDistinctKeys: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -9285,7 +9305,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
         {
             dataType: 'refAlias',
             type: {
@@ -9327,6 +9347,14 @@ const models: TsoaRoute.Models = {
                                 ],
                                 required: true,
                             },
+                            spaceName: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'string' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
+                                required: true,
+                            },
                             spaceUuid: {
                                 dataType: 'union',
                                 subSchemas: [
@@ -9354,7 +9382,7 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
             validators: {},
         },
     },
@@ -11372,8 +11400,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -12006,8 +12034,8 @@ const models: TsoaRoute.Models = {
                     imageUrlSource: {
                         dataType: 'union',
                         subSchemas: [
-                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: ['url'] },
+                            { dataType: 'enum', enums: ['upload'] },
                             { dataType: 'enum', enums: [null] },
                         ],
                         required: true,
@@ -30602,7 +30630,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30612,7 +30640,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -30622,7 +30650,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -30635,7 +30663,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8264,8 +8264,29 @@
                 "type": "object",
                 "description": "Error information stored on a field when compilation fails but\npartial compilation mode is enabled."
             },
+            "CompiledMetricRelativeDateFilter": {
+                "properties": {
+                    "compiledSql": {
+                        "type": "string"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "required": ["compiledSql", "fieldId", "id"],
+                "type": "object"
+            },
             "CompiledProperties": {
                 "properties": {
+                    "compiledRelativeDateFilters": {
+                        "items": {
+                            "$ref": "#/components/schemas/CompiledMetricRelativeDateFilter"
+                        },
+                        "type": "array"
+                    },
                     "compiledDistinctKeys": {
                         "items": {
                             "type": "string"
@@ -10337,7 +10358,7 @@
                 },
                 "required": ["alias", "externalConnectionUuid"],
                 "type": "object",
-                "description": "An external connection attached to a generation request. Linked to the app\n(under `alias`) server-side at creation — before the catalog stage — so the\ngenerated app can call it via `client.externalFetch(alias, …)`. Validated\n(must belong to the app's project) and gated on the external-access flag."
+                "description": "An external connection attached to a generation request. Linked to the app\n(under `alias`) server-side at creation — before the catalog stage — so the\ngenerated app can call it via `client.externalFetch(alias, …)`. Validated\n(must belong to the app's project) before linking."
             },
             "GenerateAppRequestBody": {
                 "properties": {
@@ -10686,7 +10707,7 @@
                 ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -10716,6 +10737,10 @@
                                 ],
                                 "nullable": true
                             },
+                            "spaceName": {
+                                "type": "string",
+                                "nullable": true
+                            },
                             "spaceUuid": {
                                 "type": "string",
                                 "nullable": true
@@ -10739,6 +10764,7 @@
                             "pinnedListOrder",
                             "pinnedListUuid",
                             "template",
+                            "spaceName",
                             "spaceUuid",
                             "createdByUserUuid",
                             "description",
@@ -10757,7 +10783,7 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--spaceName-string-or-null--template-Exclude_DataAppTemplate.custom_-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
             },
             "ApiCancelAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
@@ -12996,7 +13022,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -13618,7 +13644,7 @@
                     },
                     "imageUrlSource": {
                         "type": "string",
-                        "enum": ["upload", "url", null],
+                        "enum": ["url", "upload", null],
                         "nullable": true
                     },
                     "groupAccess": {
@@ -31328,22 +31354,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -41222,7 +41248,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3233.0",
+        "version": "0.3241.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -333,6 +333,7 @@ export class AppModel {
         createdByUserUuid: string;
         organizationUuid: string;
         spaceUuid: string | null;
+        spaceName: string | null;
         template: DbApp['template'];
         pinnedListUuid: string | null;
         pinnedListOrder: number | null;
@@ -374,6 +375,13 @@ export class AppModel {
                 `${PinnedAppTableName}.app_uuid`,
                 `${AppsTableName}.app_id`,
             )
+            .leftJoin(SpaceTableName, function spaceJoin() {
+                void this.on(
+                    `${SpaceTableName}.space_uuid`,
+                    '=',
+                    `${AppsTableName}.space_uuid`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
             .where(`${AppsTableName}.app_id`, appId)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
@@ -383,6 +391,7 @@ export class AppModel {
                 `${AppsTableName}.description`,
                 `${AppsTableName}.created_by_user_uuid`,
                 `${AppsTableName}.space_uuid`,
+                `${SpaceTableName}.name as space_name`,
                 `${AppsTableName}.template`,
                 `${OrganizationTableName}.organization_uuid`,
                 `${PinnedAppTableName}.pinned_list_uuid`,
@@ -406,6 +415,7 @@ export class AppModel {
             description: string;
             created_by_user_uuid: string;
             space_uuid: string | null;
+            space_name: string | null;
             template: DbApp['template'];
             organization_uuid: string;
             pinned_list_uuid: string | null;
@@ -425,6 +435,7 @@ export class AppModel {
             description,
             created_by_user_uuid: createdByUserUuid,
             space_uuid: spaceUuid,
+            space_name: spaceName,
             template,
             organization_uuid: organizationUuid,
             pinned_list_uuid: pinnedListUuid,
@@ -440,6 +451,7 @@ export class AppModel {
                 description: string;
                 created_by_user_uuid: string;
                 space_uuid: string | null;
+                space_name: string | null;
                 template: DbApp['template'];
                 organization_uuid: string;
                 pinned_list_uuid: string | null;
@@ -455,6 +467,7 @@ export class AppModel {
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
+            spaceName,
             template,
             pinnedListUuid,
             pinnedListOrder,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -244,6 +244,7 @@ export type ApiGetAppResponse = ApiSuccess<{
     description: string;
     createdByUserUuid: string;
     spaceUuid: string | null;
+    spaceName: string | null;
     // null when the user picked "Custom" or for apps that pre-date template persistence
     template: Exclude<DataAppTemplate, 'custom'> | null;
     pinnedListUuid: string | null;

--- a/packages/frontend/src/features/apps/components/AppHeader.module.css
+++ b/packages/frontend/src/features/apps/components/AppHeader.module.css
@@ -23,3 +23,25 @@
     min-width: 0;
     flex: 1;
 }
+
+.titleRow {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-xs);
+    min-width: 0;
+}
+
+/* The title is the primary element: it takes the free space and truncates. */
+.title {
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+/* The space chip is secondary context, so it yields width before the title
+   collapses: it can shrink (and its label truncates) on a narrow header. */
+.chipSlot {
+    min-width: 0;
+    flex: 0 1 auto;
+    display: flex;
+    align-items: center;
+}

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -5,6 +5,9 @@ import classes from './AppHeader.module.css';
 type Props = {
     name: string;
     description: string | null;
+    /** Space indicator shown next to the title (folder chip / "Add to space").
+     *  Pass null to omit it (e.g. a brand-new app that isn't persisted yet). */
+    spaceChip: ReactNode;
     /** Per-page actions (refresh button, overflow menu, …) rendered on the
      *  right. The builder and viewer have different actions, so each owns its
      *  own slot while sharing this header chrome. */
@@ -16,12 +19,27 @@ type Props = {
  * and the standalone viewer (`AppPreviewTest`) so the two surfaces share one
  * chrome instead of diverging.
  */
-const AppHeader: FC<Props> = ({ name, description, rightSection }) => (
+const AppHeader: FC<Props> = ({
+    name,
+    description,
+    spaceChip,
+    rightSection,
+}) => (
     <Box className={classes.header}>
         <Box className={classes.info}>
-            <Title order={6} fw={600} lineClamp={1}>
-                {name || 'Untitled app'}
-            </Title>
+            <Box className={classes.titleRow}>
+                {spaceChip && (
+                    <Box className={classes.chipSlot}>{spaceChip}</Box>
+                )}
+                <Title
+                    order={6}
+                    fw={600}
+                    lineClamp={1}
+                    className={classes.title}
+                >
+                    {name || 'Untitled app'}
+                </Title>
+            </Box>
             {description && (
                 <Text size="xs" c="dimmed" lineClamp={1}>
                     {description}

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,9 +1,4 @@
-import {
-    ContentType,
-    FeatureFlags,
-    ResourceViewItemType,
-    type AppVersionStatus,
-} from '@lightdash/common';
+import { FeatureFlags, type AppVersionStatus } from '@lightdash/common';
 import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
 import {
     IconCopy,
@@ -17,14 +12,11 @@ import {
     IconSend,
     IconTrash,
 } from '@tabler/icons-react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState, type FC, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../../components/common/MantineIcon';
 import AppDeleteModal from '../../../components/common/modal/AppDeleteModal';
 import AppUpdateModal from '../../../components/common/modal/AppUpdateModal';
-import TransferItemsModal from '../../../components/common/TransferItemsModal/TransferItemsModal';
-import { useContentAction } from '../../../hooks/useContent';
 import { useProject } from '../../../hooks/useProject';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { AppSchedulersModal } from '../../scheduler/components/SchedulerModals';
@@ -34,6 +26,7 @@ import {
     DataAppFavoriteMenuItem,
     FavoritePersonalDataAppModal,
 } from './DataAppFavoriteMenuItem';
+import { MoveAppToSpaceModal } from './MoveAppToSpaceModal';
 import { PromoteAppModal } from './PromoteAppModal';
 
 type Props = {
@@ -83,7 +76,6 @@ const AppHeaderActions: FC<Props> = ({
     navItem,
 }) => {
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
 
     const canEdit = useCanEditDataApp(projectUuid, {
         spaceUuid: appSpaceUuid,
@@ -102,8 +94,6 @@ const AppHeaderActions: FC<Props> = ({
 
     const { mutate: duplicateMutate, isLoading: isDuplicating } =
         useDuplicateApp();
-    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
-        useContentAction(projectUuid);
 
     const [schedulerModalOpen, setSchedulerModalOpen] = useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
@@ -124,21 +114,6 @@ const AppHeaderActions: FC<Props> = ({
             },
         );
     }, [duplicateMutate, navigate, projectUuid, appUuid]);
-
-    const handleMove = useCallback(
-        async (targetSpaceUuid: string | null) => {
-            if (!targetSpaceUuid) return;
-            await contentAction({
-                action: { type: 'move', targetSpaceUuid },
-                item: { uuid: appUuid, contentType: ContentType.DATA_APP },
-            });
-            await queryClient.invalidateQueries({
-                queryKey: ['app', projectUuid, appUuid],
-            });
-            setIsMoveToSpaceOpen(false);
-        },
-        [contentAction, queryClient, projectUuid, appUuid],
-    );
 
     return (
         <>
@@ -280,32 +255,19 @@ const AppHeaderActions: FC<Props> = ({
                 />
             )}
             {isMoveToSpaceOpen && (
-                <TransferItemsModal
+                <MoveAppToSpaceModal
                     projectUuid={projectUuid}
                     opened
                     onClose={() => setIsMoveToSpaceOpen(false)}
-                    items={[
-                        {
-                            type: ResourceViewItemType.DATA_APP,
-                            data: {
-                                uuid: appUuid,
-                                name: appName,
-                                description: appDescription || undefined,
-                                spaceUuid: appSpaceUuid,
-                                createdByUserUuid: appCreatedByUserUuid,
-                                updatedAt: new Date(),
-                                updatedByUser: null,
-                                views: 0,
-                                firstViewedAt: null,
-                                latestVersionNumber: null,
-                                latestVersionStatus: null,
-                                pinnedListUuid: null,
-                                pinnedListOrder: null,
-                            },
-                        },
-                    ]}
-                    isLoading={isMovingToSpace}
-                    onConfirm={handleMove}
+                    app={{
+                        uuid: appUuid,
+                        name: appName,
+                        description: appDescription ?? undefined,
+                        spaceUuid: appSpaceUuid,
+                        createdByUserUuid: appCreatedByUserUuid,
+                        latestVersionNumber,
+                        latestVersionStatus,
+                    }}
                 />
             )}
             {schedulerModalOpen && (

--- a/packages/frontend/src/features/apps/components/AppSpaceChip.module.css
+++ b/packages/frontend/src/features/apps/components/AppSpaceChip.module.css
@@ -1,0 +1,11 @@
+.clickable {
+    cursor: pointer;
+}
+
+/* Let the chip shrink within the header's title row so a long space name
+   truncates (via the Badge's max-width + ellipsis) instead of pushing the
+   app title out. */
+.chip {
+    min-width: 0;
+    flex-shrink: 1;
+}

--- a/packages/frontend/src/features/apps/components/AppSpaceChip.tsx
+++ b/packages/frontend/src/features/apps/components/AppSpaceChip.tsx
@@ -1,0 +1,119 @@
+import { Badge, Tooltip } from '@mantine-8/core';
+import { IconFolder, IconFolderPlus, IconUser } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { useCanEditDataApp } from '../hooks/useCanEditDataApp';
+import classes from './AppSpaceChip.module.css';
+import {
+    MoveAppToSpaceModal,
+    type DataAppMoveTarget,
+} from './MoveAppToSpaceModal';
+
+type Props = {
+    projectUuid: string;
+    app: DataAppMoveTarget;
+    spaceName: string | null;
+};
+
+const MAX_CHIP_WIDTH_PX = 180;
+
+/**
+ * Header chip telling you which space a data app lives in. When the app is
+ * filed it links to that space; when it's personal (no space) it offers
+ * editors "Add to space" and shows read-only viewers a quiet "Personal" label.
+ * Shared by the builder and the viewer via {@link AppHeader}.
+ */
+const AppSpaceChip: FC<Props> = ({ projectUuid, app, spaceName }) => {
+    const canEdit = useCanEditDataApp(projectUuid, {
+        spaceUuid: app.spaceUuid,
+        createdByUserUuid: app.createdByUserUuid,
+    });
+    const [moveModalOpen, setMoveModalOpen] = useState(false);
+
+    // Filed in a space → a chip linking to that space.
+    if (app.spaceUuid) {
+        return (
+            <Tooltip
+                withinPortal
+                position="bottom"
+                label={`Space: ${spaceName ?? 'Unknown'}`}
+            >
+                <Badge
+                    component={Link}
+                    to={`/projects/${projectUuid}/spaces/${app.spaceUuid}`}
+                    variant="light"
+                    color="gray"
+                    size="md"
+                    tt="none"
+                    maw={MAX_CHIP_WIDTH_PX}
+                    className={`${classes.chip} ${classes.clickable}`}
+                    leftSection={<MantineIcon icon={IconFolder} size={12} />}
+                >
+                    {spaceName ?? 'Space'}
+                </Badge>
+            </Tooltip>
+        );
+    }
+
+    // Personal (no space) + read-only viewer → quiet, non-interactive label.
+    if (!canEdit) {
+        return (
+            <Tooltip
+                withinPortal
+                position="bottom"
+                label="This app isn't in a space"
+            >
+                <Badge
+                    variant="light"
+                    color="gray"
+                    size="md"
+                    tt="none"
+                    className={classes.chip}
+                    leftSection={<MantineIcon icon={IconUser} size={12} />}
+                >
+                    Personal
+                </Badge>
+            </Tooltip>
+        );
+    }
+
+    // Personal (no space) + editor → CTA to file it.
+    return (
+        <>
+            <Tooltip
+                withinPortal
+                multiline
+                maw={260}
+                position="bottom"
+                label="Add the data app to a space to share it with others."
+            >
+                <Badge
+                    component="button"
+                    type="button"
+                    variant="light"
+                    color="gray"
+                    size="md"
+                    tt="none"
+                    className={`${classes.chip} ${classes.clickable}`}
+                    leftSection={
+                        <MantineIcon icon={IconFolderPlus} size={12} />
+                    }
+                    onClick={() => setMoveModalOpen(true)}
+                >
+                    Add to space
+                </Badge>
+            </Tooltip>
+            {moveModalOpen && (
+                <MoveAppToSpaceModal
+                    projectUuid={projectUuid}
+                    app={app}
+                    opened
+                    onClose={() => setMoveModalOpen(false)}
+                />
+            )}
+        </>
+    );
+};
+
+export default AppSpaceChip;

--- a/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
+++ b/packages/frontend/src/features/apps/components/MoveAppToSpaceModal.tsx
@@ -1,0 +1,83 @@
+import {
+    ContentType,
+    ResourceViewItemType,
+    type ResourceViewDataAppItem,
+} from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC } from 'react';
+import TransferItemsModal from '../../../components/common/TransferItemsModal/TransferItemsModal';
+import { useContentAction } from '../../../hooks/useContent';
+
+export type DataAppMoveTarget = Pick<
+    ResourceViewDataAppItem['data'],
+    | 'uuid'
+    | 'name'
+    | 'description'
+    | 'spaceUuid'
+    | 'createdByUserUuid'
+    | 'latestVersionNumber'
+    | 'latestVersionStatus'
+>;
+
+type Props = {
+    projectUuid: string;
+    app: DataAppMoveTarget;
+    opened: boolean;
+    onClose: () => void;
+};
+
+/**
+ * "Move to space" / "Add to space" for a data app. Shared by the header's
+ * overflow menu and its space chip so the move flow — and the app's
+ * ResourceViewItem shape it needs — live in one place.
+ */
+export const MoveAppToSpaceModal: FC<Props> = ({
+    projectUuid,
+    app,
+    opened,
+    onClose,
+}) => {
+    const queryClient = useQueryClient();
+    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
+        useContentAction(projectUuid);
+
+    return (
+        <TransferItemsModal
+            projectUuid={projectUuid}
+            opened={opened}
+            onClose={onClose}
+            items={[
+                {
+                    type: ResourceViewItemType.DATA_APP,
+                    data: {
+                        uuid: app.uuid,
+                        name: app.name,
+                        description: app.description,
+                        spaceUuid: app.spaceUuid,
+                        createdByUserUuid: app.createdByUserUuid,
+                        updatedAt: new Date(),
+                        updatedByUser: null,
+                        views: 0,
+                        firstViewedAt: null,
+                        latestVersionNumber: app.latestVersionNumber,
+                        latestVersionStatus: app.latestVersionStatus,
+                        pinnedListUuid: null,
+                        pinnedListOrder: null,
+                    },
+                },
+            ]}
+            isLoading={isMovingToSpace}
+            onConfirm={async (targetSpaceUuid) => {
+                if (!targetSpaceUuid) return;
+                await contentAction({
+                    action: { type: 'move', targetSpaceUuid },
+                    item: { uuid: app.uuid, contentType: ContentType.DATA_APP },
+                });
+                await queryClient.invalidateQueries({
+                    queryKey: ['app', projectUuid, app.uuid],
+                });
+                onClose();
+            }}
+        />
+    );
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -90,6 +90,7 @@ import ChatBubbleMeta from '../features/apps/ChatBubbleMeta';
 import ChatMessageContent from '../features/apps/ChatMessageContent';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
 import { useAppImageUpload } from '../features/apps/hooks/useAppImageUpload';
 import { useAppImageUrl } from '../features/apps/hooks/useAppImageUrl';
@@ -658,6 +659,7 @@ const AppGenerate: FC = () => {
     const appName = appData?.pages?.[0]?.name ?? '';
     const appDescription = appData?.pages?.[0]?.description ?? '';
     const appSpaceUuid = appData?.pages?.[0]?.spaceUuid ?? null;
+    const appSpaceName = appData?.pages?.[0]?.spaceName ?? null;
     const appCreatedByUserUuid = appData?.pages?.[0]?.createdByUserUuid ?? null;
     const appPersistedTemplate = appData?.pages?.[0]?.template ?? null;
 
@@ -2724,6 +2726,27 @@ const AppGenerate: FC = () => {
                                 <AppHeader
                                     name={appName}
                                     description={appDescription || null}
+                                    spaceChip={
+                                        <AppSpaceChip
+                                            projectUuid={projectUuid}
+                                            spaceName={appSpaceName}
+                                            app={{
+                                                uuid: activeAppUuid,
+                                                name: appName,
+                                                description:
+                                                    appDescription || undefined,
+                                                spaceUuid: appSpaceUuid,
+                                                createdByUserUuid:
+                                                    appCreatedByUserUuid,
+                                                latestVersionNumber:
+                                                    latestReadyVersion?.version ??
+                                                    null,
+                                                latestVersionStatus:
+                                                    latestReadyVersion?.status ??
+                                                    null,
+                                            }}
+                                        />
+                                    }
                                     rightSection={
                                         <AppHeaderActions
                                             projectUuid={projectUuid}

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -9,6 +9,7 @@ import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import AppHeader from '../features/apps/components/AppHeader';
 import AppHeaderActions from '../features/apps/components/AppHeaderActions';
+import AppSpaceChip from '../features/apps/components/AppSpaceChip';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
@@ -46,6 +47,7 @@ export default function AppPreviewTest() {
     const appName = appQuery.data?.pages[0]?.name ?? '';
     const appDescription = appQuery.data?.pages[0]?.description ?? null;
     const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
+    const appSpaceName = appQuery.data?.pages[0]?.spaceName ?? null;
     const appCreatedByUserUuid =
         appQuery.data?.pages[0]?.createdByUserUuid ?? null;
     const canEditApp = useCanEditDataApp(projectUuid, {
@@ -167,6 +169,23 @@ export default function AppPreviewTest() {
             <AppHeader
                 name={appName}
                 description={appDescription}
+                spaceChip={
+                    <AppSpaceChip
+                        projectUuid={projectUuid}
+                        spaceName={appSpaceName}
+                        app={{
+                            uuid: appUuid,
+                            name: appName,
+                            description: appDescription ?? undefined,
+                            spaceUuid: appSpaceUuid,
+                            createdByUserUuid: appCreatedByUserUuid,
+                            latestVersionNumber: latestReadyVersion ?? null,
+                            latestVersionStatus: latestReadyVersion
+                                ? 'ready'
+                                : null,
+                        }}
+                    />
+                }
                 rightSection={
                     <AppHeaderActions
                         projectUuid={projectUuid}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8419/show-containing-space-and-allow-deleting-while-viewing-a-data-app

### Description:
Add a space-indicator chip to the shared data-app header (builder and standalone viewer). When the app is filed it links to its space; when it's personal it offers editors "Add to space" and shows read-only viewers a quiet "Personal" label.

Data app without space:
<img width="731" height="68" alt="space-unset" src="https://github.com/user-attachments/assets/37a369a8-a677-4f8c-9514-8fb87c38f440" />

Data app inside space:
<img width="731" height="68" alt="space-set" src="https://github.com/user-attachments/assets/8f985658-a8fc-413c-be2b-4e6b5fe91254" />

