### PR TITLE
feat(date-zoom): add control config types

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3264,11 +3264,74 @@ const models: TsoaRoute.Models = {
         ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DateZoomControl: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                granularity: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DateGranularity' },
+                        { dataType: 'string' },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DateZoomTileTarget: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tableName: { dataType: 'string', required: true },
+                fieldId: { dataType: 'string', required: true },
+                controlUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.DateZoomTileTarget_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: { ref: 'DateZoomTileTarget' },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DateZoomConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tileTargets: {
+                    ref: 'Record_string.DateZoomTileTarget_',
+                    required: true,
+                },
+                controls: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'DateZoomControl' },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dateZoomConfig: { ref: 'DateZoomConfig' },
                 defaultDateZoomGranularity: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3357,8 +3357,71 @@
                 ],
                 "type": "string"
             },
+            "DateZoomControl": {
+                "properties": {
+                    "granularity": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/DateGranularity"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["granularity", "name", "uuid"],
+                "type": "object"
+            },
+            "DateZoomTileTarget": {
+                "properties": {
+                    "tableName": {
+                        "type": "string"
+                    },
+                    "fieldId": {
+                        "type": "string"
+                    },
+                    "controlUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["tableName", "fieldId", "controlUuid"],
+                "type": "object"
+            },
+            "Record_string.DateZoomTileTarget_": {
+                "properties": {},
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/DateZoomTileTarget"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "DateZoomConfig": {
+                "properties": {
+                    "tileTargets": {
+                        "$ref": "#/components/schemas/Record_string.DateZoomTileTarget_"
+                    },
+                    "controls": {
+                        "items": {
+                            "$ref": "#/components/schemas/DateZoomControl"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["tileTargets", "controls"],
+                "type": "object"
+            },
             "DashboardConfig": {
                 "properties": {
+                    "dateZoomConfig": {
+                        "$ref": "#/components/schemas/DateZoomConfig"
+                    },
                     "defaultDateZoomGranularity": {
                         "anyOf": [
                             {
@@ -41248,7 +41311,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3241.0",
+        "version": "0.3242.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -95,6 +95,9 @@
         },
         "DashboardConfig": {
             "properties": {
+                "dateZoomConfig": {
+                    "$ref": "#/$defs/DateZoomConfig"
+                },
                 "dateZoomGranularities": {
                     "items": {
                         "anyOf": [
@@ -634,6 +637,58 @@
             ],
             "type": "string"
         },
+        "DateZoomConfig": {
+            "properties": {
+                "controls": {
+                    "items": {
+                        "$ref": "#/$defs/DateZoomControl"
+                    },
+                    "type": "array"
+                },
+                "tileTargets": {
+                    "$ref": "#/$defs/Record_string.DateZoomTileTarget_"
+                }
+            },
+            "required": ["tileTargets", "controls"],
+            "type": "object"
+        },
+        "DateZoomControl": {
+            "properties": {
+                "granularity": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/DateGranularity"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            },
+            "required": ["granularity", "name", "uuid"],
+            "type": "object"
+        },
+        "DateZoomTileTarget": {
+            "properties": {
+                "controlUuid": {
+                    "type": "string"
+                },
+                "fieldId": {
+                    "type": "string"
+                },
+                "tableName": {
+                    "type": "string"
+                }
+            },
+            "required": ["tableName", "fieldId", "controlUuid"],
+            "type": "object"
+        },
         "DimensionType": {
             "enum": ["string", "number", "timestamp", "date", "boolean"],
             "type": "string"
@@ -826,6 +881,14 @@
         "Record_string.DashboardTileTarget_": {
             "additionalProperties": {
                 "$ref": "#/$defs/DashboardTileTarget"
+            },
+            "description": "Construct a type with a set of properties K of type T",
+            "properties": {},
+            "type": "object"
+        },
+        "Record_string.DateZoomTileTarget_": {
+            "additionalProperties": {
+                "$ref": "#/$defs/DateZoomTileTarget"
             },
             "description": "Construct a type with a set of properties K of type T",
             "properties": {},

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -206,6 +206,23 @@ export type DashboardDAO = Omit<
     'inheritsFromOrgOrProject' | 'access'
 >;
 
+export type DateZoomTileTarget = {
+    controlUuid: string;
+    fieldId: string;
+    tableName: string;
+};
+
+export type DateZoomControl = {
+    uuid: string;
+    name: string;
+    granularity: DateGranularity | string;
+};
+
+export type DateZoomConfig = {
+    controls: DateZoomControl[];
+    tileTargets: Record<string, DateZoomTileTarget>;
+};
+
 export type DashboardConfig = {
     isDateZoomDisabled: boolean;
     isAddFilterDisabled?: boolean;
@@ -213,6 +230,7 @@ export type DashboardConfig = {
     parameterOrder?: string[];
     dateZoomGranularities?: (DateGranularity | string)[];
     defaultDateZoomGranularity?: DateGranularity | string;
+    dateZoomConfig?: DateZoomConfig;
 };
 
 export type Dashboard = {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -254,6 +254,14 @@ export enum FeatureFlags {
      * rolled out / disabled per-org at runtime without a deploy.
      */
     RedshiftIamAuth = 'redshift-iam-auth',
+
+    /**
+     * Enable configurable date zoom controls on dashboards: named controls that
+     * each own a granularity, with tiles attached through a tileTargets map and
+     * a per-tile date field. When off, dashboards use only the existing global
+     * date zoom picker and any saved control config is inert.
+     */
+    DateZoomConfiguration = 'date-zoom-configuration',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -7,6 +7,7 @@ import type { MetricQuery } from '../types/metricQuery';
 import { ChartType, type ChartConfig } from '../types/savedCharts';
 import { DateGranularity } from '../types/timeFrames';
 import {
+    copyDateZoomTileTargets,
     EMPTY_DATE_ZOOM_CONFIG,
     getControlActiveGranularity,
     getDateZoomCapabilities,
@@ -16,6 +17,7 @@ import {
     isEmptyDateZoomConfig,
     normalizeDateZoomConfig,
     normalizeGranularityParam,
+    pruneDateZoomConfig,
     resolveBaseDimension,
     resolveTileDateZoom,
 } from './dateZoom';
@@ -455,6 +457,50 @@ describe('normalizeGranularityParam', () => {
         expect(normalizeGranularityParam('orders_custom_period')).toBe(
             'orders_custom_period',
         );
+    });
+});
+
+describe('lifecycle helpers', () => {
+    it('copies a tile target to a duplicated tile, inheriting control + field', () => {
+        const next = copyDateZoomTileTargets(controlConfig(), [
+            { fromTileUuid: 'tileA', toTileUuid: 'tileA-copy' },
+        ]);
+        expect(next.tileTargets['tileA-copy']).toEqual({
+            controlUuid: 'ctrl-1',
+            fieldId: 'orders_fiscal_date',
+            tableName: 'orders',
+        });
+    });
+
+    it('returns the same config when the source tile is unassigned', () => {
+        const cfg = controlConfig();
+        expect(
+            copyDateZoomTileTargets(cfg, [
+                { fromTileUuid: 'tileZ', toTileUuid: 'tileZ-copy' },
+            ]),
+        ).toBe(cfg);
+    });
+
+    it('prunes controls that have no targets', () => {
+        const emptied: DateZoomConfig = {
+            controls: controlConfig().controls,
+            tileTargets: {},
+        };
+        expect(pruneDateZoomConfig(emptied)).toEqual(EMPTY_DATE_ZOOM_CONFIG);
+    });
+
+    it('prunes targets whose control was removed (dangling)', () => {
+        const cfg: DateZoomConfig = {
+            controls: [],
+            tileTargets: {
+                tileA: {
+                    controlUuid: 'ctrl-gone',
+                    fieldId: 'f',
+                    tableName: 't',
+                },
+            },
+        };
+        expect(pruneDateZoomConfig(cfg)).toEqual(EMPTY_DATE_ZOOM_CONFIG);
     });
 });
 

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -1,14 +1,23 @@
+import type { DateZoomConfig, DateZoomControl } from '../types/dashboard';
 import type { Explore } from '../types/explore';
 import { ExploreType } from '../types/explore';
 import { DimensionType, FieldType } from '../types/field';
 import type { CompiledDimension } from '../types/field';
 import type { MetricQuery } from '../types/metricQuery';
 import { ChartType, type ChartConfig } from '../types/savedCharts';
+import { DateGranularity } from '../types/timeFrames';
 import {
+    EMPTY_DATE_ZOOM_CONFIG,
+    getControlActiveGranularity,
     getDateZoomCapabilities,
     getDateZoomXAxisFieldId,
+    getTileControl,
     getTimeDimensionsMap,
+    isEmptyDateZoomConfig,
+    normalizeDateZoomConfig,
+    normalizeGranularityParam,
     resolveBaseDimension,
+    resolveTileDateZoom,
 } from './dateZoom';
 
 const makeDimension = (
@@ -260,6 +269,192 @@ describe('resolveBaseDimension', () => {
         );
 
         expect(result).toBe(dim);
+    });
+});
+
+const controlConfig = (
+    overrides?: Partial<DateZoomControl>,
+): DateZoomConfig => ({
+    controls: [
+        {
+            uuid: 'ctrl-1',
+            name: 'Revenue zoom',
+            granularity: DateGranularity.MONTH,
+            ...overrides,
+        },
+    ],
+    tileTargets: {
+        tileA: {
+            controlUuid: 'ctrl-1',
+            fieldId: 'orders_fiscal_date',
+            tableName: 'orders',
+        },
+    },
+});
+
+describe('normalizeDateZoomConfig', () => {
+    it('returns the empty config when dashboard config is undefined', () => {
+        expect(normalizeDateZoomConfig(undefined)).toEqual(
+            EMPTY_DATE_ZOOM_CONFIG,
+        );
+    });
+
+    it('returns the empty config when dateZoomConfig is absent', () => {
+        expect(normalizeDateZoomConfig({ isDateZoomDisabled: false })).toEqual(
+            EMPTY_DATE_ZOOM_CONFIG,
+        );
+    });
+
+    it('passes through an existing dateZoomConfig', () => {
+        const cfg = controlConfig();
+        expect(
+            normalizeDateZoomConfig({
+                isDateZoomDisabled: false,
+                dateZoomConfig: cfg,
+            }),
+        ).toBe(cfg);
+    });
+});
+
+describe('isEmptyDateZoomConfig', () => {
+    it('is true when there are no controls', () => {
+        expect(isEmptyDateZoomConfig(EMPTY_DATE_ZOOM_CONFIG)).toBe(true);
+    });
+
+    it('is false when a control exists', () => {
+        expect(isEmptyDateZoomConfig(controlConfig())).toBe(false);
+    });
+});
+
+describe('getTileControl', () => {
+    it('finds the control a tile is attached to', () => {
+        expect(getTileControl(controlConfig(), 'tileA')?.uuid).toBe('ctrl-1');
+    });
+
+    it('returns undefined for an unassigned tile', () => {
+        expect(getTileControl(controlConfig(), 'tileZ')).toBeUndefined();
+    });
+
+    it('returns undefined for a dangling controlUuid', () => {
+        const cfg: DateZoomConfig = {
+            controls: [],
+            tileTargets: {
+                tileA: {
+                    controlUuid: 'ctrl-gone',
+                    fieldId: 'f',
+                    tableName: 't',
+                },
+            },
+        };
+        expect(getTileControl(cfg, 'tileA')).toBeUndefined();
+    });
+});
+
+describe('getControlActiveGranularity', () => {
+    const control = controlConfig().controls[0];
+
+    it('uses the persisted granularity when no runtime override exists', () => {
+        expect(getControlActiveGranularity(control, {})).toBe(
+            DateGranularity.MONTH,
+        );
+    });
+
+    it('prefers a runtime override', () => {
+        expect(
+            getControlActiveGranularity(control, {
+                'ctrl-1': DateGranularity.WEEK,
+            }),
+        ).toBe(DateGranularity.WEEK);
+    });
+});
+
+describe('resolveTileDateZoom', () => {
+    const base = {
+        config: controlConfig(),
+        runtimeGranularities: {},
+        globalGranularity: DateGranularity.YEAR as
+            | DateGranularity
+            | string
+            | undefined,
+        defaultXAxisFieldId: 'orders_order_date_year' as string | undefined,
+    };
+
+    it('zooms an attached tile on its field at the control grain', () => {
+        expect(resolveTileDateZoom({ ...base, tileUuid: 'tileA' })).toEqual({
+            granularity: DateGranularity.MONTH,
+            xAxisFieldId: 'orders_fiscal_date',
+        });
+    });
+
+    it('applies a runtime control-grain override', () => {
+        expect(
+            resolveTileDateZoom({
+                ...base,
+                tileUuid: 'tileA',
+                runtimeGranularities: { 'ctrl-1': DateGranularity.WEEK },
+            }),
+        ).toEqual({
+            granularity: DateGranularity.WEEK,
+            xAxisFieldId: 'orders_fiscal_date',
+        });
+    });
+
+    it('falls through to the Default for an unassigned tile (preserves x-axis baseline)', () => {
+        expect(resolveTileDateZoom({ ...base, tileUuid: 'tileZ' })).toEqual({
+            granularity: DateGranularity.YEAR,
+            xAxisFieldId: 'orders_order_date_year',
+        });
+    });
+
+    it('falls through to the Default for a dangling target', () => {
+        const cfg: DateZoomConfig = {
+            controls: [],
+            tileTargets: {
+                tileA: {
+                    controlUuid: 'ctrl-gone',
+                    fieldId: 'f',
+                    tableName: 't',
+                },
+            },
+        };
+        expect(
+            resolveTileDateZoom({ ...base, config: cfg, tileUuid: 'tileA' }),
+        ).toEqual({
+            granularity: DateGranularity.YEAR,
+            xAxisFieldId: 'orders_order_date_year',
+        });
+    });
+
+    it('returns undefined for an unassigned tile when the Default grain is unset', () => {
+        expect(
+            resolveTileDateZoom({
+                ...base,
+                tileUuid: 'tileZ',
+                globalGranularity: undefined,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('returns grain-only for an unassigned tile with no x-axis target', () => {
+        expect(
+            resolveTileDateZoom({
+                ...base,
+                tileUuid: 'tileZ',
+                defaultXAxisFieldId: undefined,
+            }),
+        ).toEqual({ granularity: DateGranularity.YEAR });
+    });
+});
+
+describe('normalizeGranularityParam', () => {
+    it('normalizes a lowercased standard grain to canonical case', () => {
+        expect(normalizeGranularityParam('week')).toBe(DateGranularity.WEEK);
+    });
+
+    it('passes through a non-standard (custom interval) value as-is', () => {
+        expect(normalizeGranularityParam('orders_custom_period')).toBe(
+            'orders_custom_period',
+        );
     });
 });
 

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -1,7 +1,14 @@
+import { type DateZoom } from '../types/api/paginatedQuery';
+import {
+    type DashboardConfig,
+    type DateZoomConfig,
+    type DateZoomControl,
+} from '../types/dashboard';
 import type { Explore } from '../types/explore';
 import { DimensionType, type CompiledDimension } from '../types/field';
 import type { MetricQuery } from '../types/metricQuery';
 import { isCartesianChartConfig, type ChartConfig } from '../types/savedCharts';
+import { DateGranularity } from '../types/timeFrames';
 import { getItemId } from './item';
 import { getDateDimension } from './timeFrames';
 
@@ -183,3 +190,78 @@ export const getDateZoomXAxisFieldId = (
     );
     return baseTimeDimension ? xFieldId : undefined;
 };
+
+export const EMPTY_DATE_ZOOM_CONFIG: DateZoomConfig = {
+    controls: [],
+    tileTargets: {},
+};
+
+export const normalizeDateZoomConfig = (
+    config: DashboardConfig | undefined,
+): DateZoomConfig => config?.dateZoomConfig ?? EMPTY_DATE_ZOOM_CONFIG;
+
+export const isEmptyDateZoomConfig = (config: DateZoomConfig): boolean =>
+    config.controls.length === 0;
+
+export const getTileControl = (
+    config: DateZoomConfig,
+    tileUuid: string,
+): DateZoomControl | undefined => {
+    const target = config.tileTargets[tileUuid];
+    return target
+        ? config.controls.find((control) => control.uuid === target.controlUuid)
+        : undefined;
+};
+
+export const getControlActiveGranularity = (
+    control: DateZoomControl,
+    runtimeGranularities: Record<string, DateGranularity | string>,
+): DateGranularity | string =>
+    runtimeGranularities[control.uuid] ?? control.granularity;
+
+export type ResolveTileDateZoomArgs = {
+    config: DateZoomConfig;
+    tileUuid: string;
+    runtimeGranularities: Record<string, DateGranularity | string>;
+    globalGranularity: DateGranularity | string | undefined;
+    defaultXAxisFieldId: string | undefined;
+};
+
+export const resolveTileDateZoom = ({
+    config,
+    tileUuid,
+    runtimeGranularities,
+    globalGranularity,
+    defaultXAxisFieldId,
+}: ResolveTileDateZoomArgs): DateZoom | undefined => {
+    const target = config.tileTargets[tileUuid];
+    const control = target
+        ? config.controls.find((c) => c.uuid === target.controlUuid)
+        : undefined;
+
+    if (target && control) {
+        const granularity = getControlActiveGranularity(
+            control,
+            runtimeGranularities,
+        );
+        return { granularity, xAxisFieldId: target.fieldId };
+    }
+
+    // Unassigned (or dangling target) -> Default = today's behavior.
+    if (globalGranularity === undefined) {
+        return undefined;
+    }
+    return {
+        granularity: globalGranularity,
+        ...(defaultXAxisFieldId ? { xAxisFieldId: defaultXAxisFieldId } : {}),
+    };
+};
+
+// Match the existing global `?dateZoom` read: a standard grain round-trips to
+// its canonical `DateGranularity` case; a custom-interval value is kept as-is.
+export const normalizeGranularityParam = (
+    param: string,
+): DateGranularity | string =>
+    Object.values(DateGranularity).find(
+        (grain) => grain.toLowerCase() === param.toLowerCase(),
+    ) ?? param;

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -265,3 +265,33 @@ export const normalizeGranularityParam = (
     Object.values(DateGranularity).find(
         (grain) => grain.toLowerCase() === param.toLowerCase(),
     ) ?? param;
+
+export const copyDateZoomTileTargets = (
+    config: DateZoomConfig,
+    mapping: Array<{ fromTileUuid: string; toTileUuid: string }>,
+): DateZoomConfig => {
+    const tileTargets = { ...config.tileTargets };
+    let changed = false;
+    mapping.forEach(({ fromTileUuid, toTileUuid }) => {
+        const source = config.tileTargets[fromTileUuid];
+        if (source) {
+            tileTargets[toTileUuid] = { ...source };
+            changed = true;
+        }
+    });
+    return changed ? { ...config, tileTargets } : config;
+};
+
+export const pruneDateZoomConfig = (config: DateZoomConfig): DateZoomConfig => {
+    const validControlUuids = new Set(config.controls.map((c) => c.uuid));
+    const liveTargets = Object.entries(config.tileTargets).filter(
+        ([, target]) => validControlUuids.has(target.controlUuid),
+    );
+    const referenced = new Set(
+        liveTargets.map(([, target]) => target.controlUuid),
+    );
+    return {
+        controls: config.controls.filter((c) => referenced.has(c.uuid)),
+        tileTargets: Object.fromEntries(liveTargets),
+    };
+};


### PR DESCRIPTION
Part 1/3 of making date zoom configurable like dashboard filters.

Adds the date-zoom control config types, the per-tile zoom resolver and tile-target lifecycle/prune helpers, the `date-zoom-configuration` feature flag, and the dashboard-as-code schema. Behind the flag; no UI yet.

Relates to [GLITCH-225](https://linear.app/lightdash/issue/GLITCH-225/make-date-zoom-more-configurable-like-dashboard-filters)