### PR TITLE
feat(date-zoom): expose control config edit state

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -152,12 +152,37 @@ export class DashboardModel {
         dashboardId: number,
         version: DashboardVersionedFields,
     ): Promise<void> {
+        // Narrow date-zoom control tileTargets to tiles present in this version,
+        // mirroring the filter tileTargets narrowing below. This drops targets
+        // for tiles removed on any deletion path (tile/tab/batch delete) without
+        // any frontend wiring. Control-level pruning stays a frontend concern.
+        const savedTileUuids = new Set(
+            version.tiles
+                .map((tile) => tile.uuid)
+                .filter((uuid): uuid is string => !!uuid),
+        );
+        const config = version.config?.dateZoomConfig
+            ? {
+                  ...version.config,
+                  dateZoomConfig: {
+                      ...version.config.dateZoomConfig,
+                      tileTargets: Object.fromEntries(
+                          Object.entries(
+                              version.config.dateZoomConfig.tileTargets,
+                          ).filter(([tileUuid]) =>
+                              savedTileUuids.has(tileUuid),
+                          ),
+                      ),
+                  },
+              }
+            : version.config;
+
         const [versionId] = await trx(DashboardVersionsTableName).insert(
             {
                 dashboard_id: dashboardId,
                 dashboard_version_uuid: uuidv4(),
                 updated_by_user_uuid: version.updatedByUser?.userUuid,
-                config: version.config,
+                config,
             },
             ['dashboard_version_id', 'updated_by_user_uuid'],
         );

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -448,6 +448,79 @@ describe('resolveTileDateZoom', () => {
     });
 });
 
+// Locks the backwards-compatibility contract the config read path relies on:
+// with no config (existing dashboards) or the flag-off swap to
+// EMPTY_DATE_ZOOM_CONFIG in useDashboardChartReadyQuery, every tile resolves to
+// the single global date-zoom setting exactly as it did before configs existed.
+// This is what must hold before the DateZoomConfiguration flag can be removed.
+describe('resolveTileDateZoom — legacy single-setting backwards compatibility', () => {
+    const legacyBase = {
+        config: EMPTY_DATE_ZOOM_CONFIG,
+        runtimeGranularities: {},
+        defaultXAxisFieldId: 'orders_order_date_year' as string | undefined,
+    };
+
+    it('applies the global granularity to every tile on its x-axis baseline', () => {
+        const expected = {
+            granularity: DateGranularity.YEAR,
+            xAxisFieldId: 'orders_order_date_year',
+        };
+        // No per-tile config exists, so the result is identical across tiles.
+        expect(
+            resolveTileDateZoom({
+                ...legacyBase,
+                tileUuid: 'tile-1',
+                globalGranularity: DateGranularity.YEAR,
+            }),
+        ).toEqual(expected);
+        expect(
+            resolveTileDateZoom({
+                ...legacyBase,
+                tileUuid: 'tile-2',
+                globalGranularity: DateGranularity.YEAR,
+            }),
+        ).toEqual(expected);
+    });
+
+    it('applies no zoom when the global setting is unset (chart keeps its own grain)', () => {
+        expect(
+            resolveTileDateZoom({
+                ...legacyBase,
+                tileUuid: 'tile-1',
+                globalGranularity: undefined,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('zooms grain-only for a tile with no date x-axis field', () => {
+        expect(
+            resolveTileDateZoom({
+                ...legacyBase,
+                tileUuid: 'tile-1',
+                globalGranularity: DateGranularity.WEEK,
+                defaultXAxisFieldId: undefined,
+            }),
+        ).toEqual({ granularity: DateGranularity.WEEK });
+    });
+
+    it('flag-off swap makes saved controls inert: a would-be-attached tile falls back to the global setting', () => {
+        // useDashboardChartReadyQuery substitutes EMPTY_DATE_ZOOM_CONFIG when the
+        // flag is off, so 'tileA' (attached to ctrl-1 under controlConfig()) and
+        // its runtime override are ignored, resolving to the legacy global grain.
+        expect(
+            resolveTileDateZoom({
+                ...legacyBase,
+                tileUuid: 'tileA',
+                globalGranularity: DateGranularity.MONTH,
+                runtimeGranularities: { 'ctrl-1': DateGranularity.DAY },
+            }),
+        ).toEqual({
+            granularity: DateGranularity.MONTH,
+            xAxisFieldId: 'orders_order_date_year',
+        });
+    });
+});
+
 describe('normalizeGranularityParam', () => {
     it('normalizes a lowercased standard grain to canonical case', () => {
         expect(normalizeGranularityParam('week')).toBe(DateGranularity.WEEK);

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -22,7 +22,6 @@ import {
     type ApiChartAndResults,
     type ApiError,
     type Dashboard,
-    type DateZoom,
     type QueryExecutionContext,
     type DashboardFilterRule,
     type EChartsSeries,
@@ -73,6 +72,10 @@ import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { useProjectColorPalette } from '../../hooks/appearance/useProjectColorPalette';
 import { type EChartsReact } from '../EChartsReactWrapper';
+import {
+    getAppliedTileDateZoom,
+    type AppliedTileDateZoomArgs,
+} from './getAppliedTileDateZoom';
 import { getDashboardChartColorPalette } from './getDashboardChartColorPalette';
 
 type ClientSideError = {
@@ -84,40 +87,21 @@ type ClientSideError = {
 
 type DashboardTileError = ApiError | ClientSideError | Error;
 
-type TileDateZoomArgs = {
-    tileUuid: string;
-    tilesWithDateZoomApplied: Set<string> | undefined;
-    dateZoom: DateZoom | undefined;
-};
-
-// Narrows the resolved tile zoom to what was actually applied: the backend only
-// re-grains the targeted x-axis field when zoom took effect for this tile, so
-// drop xAxisFieldId until the applied-state set confirms it.
-const getAppliedTileDateZoom = ({
-    tileUuid,
-    tilesWithDateZoomApplied,
-    dateZoom,
-}: TileDateZoomArgs): DateZoom | undefined => {
-    if (!dateZoom) return undefined;
-    if (!dateZoom.xAxisFieldId) return dateZoom;
-    return tilesWithDateZoomApplied?.has(tileUuid)
-        ? dateZoom
-        : { granularity: dateZoom.granularity };
-};
-
 const useAppliedTileDateZoom = ({
     tileUuid,
     tilesWithDateZoomApplied,
     dateZoom,
-}: TileDateZoomArgs) =>
+    dateDimension,
+}: AppliedTileDateZoomArgs) =>
     useMemo(
         () =>
             getAppliedTileDateZoom({
                 tileUuid,
                 tilesWithDateZoomApplied,
                 dateZoom,
+                dateDimension,
             }),
-        [tileUuid, tilesWithDateZoomApplied, dateZoom],
+        [tileUuid, tilesWithDateZoomApplied, dateZoom, dateDimension],
     );
 
 const getDashboardTileErrorMessage = (
@@ -339,6 +323,7 @@ const ValidDashboardChartTile: FC<{
             tileUuid,
             tilesWithDateZoomApplied,
             dateZoom: dashboardChartReadyQuery.dateZoom,
+            dateDimension: metricQuery.metadata?.hasADateDimension,
         });
 
         useEffect(() => {
@@ -489,6 +474,9 @@ const ValidDashboardChartTileMinimal: FC<{
         tileUuid,
         tilesWithDateZoomApplied,
         dateZoom: dashboardChartReadyQuery.dateZoom,
+        dateDimension:
+            dashboardChartReadyQuery.executeQueryResponse.metricQuery.metadata
+                ?.hasADateDimension,
     });
 
     const computedSeries: Series[] = useMemo(() => {
@@ -792,6 +780,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                 tileUuid,
                 tilesWithDateZoomApplied,
                 dateZoom: dashboardChartReadyQuery.dateZoom,
+                dateDimension: metricQuery?.metadata?.hasADateDimension,
             });
 
             openUnderlyingDataModal({
@@ -804,6 +793,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             tileUuid,
             tilesWithDateZoomApplied,
             dashboardChartReadyQuery.dateZoom,
+            metricQuery?.metadata?.hasADateDimension,
         ]);
 
         const handleCopyToClipboard = useCallback(() => {
@@ -1928,6 +1918,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
             tileUuid,
             tilesWithDateZoomApplied,
             dateZoom: dashboardChartReadyQuery.dateZoom,
+            dateDimension: metricQuery?.metadata?.hasADateDimension,
         });
 
         openUnderlyingDataModal({
@@ -1940,6 +1931,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         tileUuid,
         tilesWithDateZoomApplied,
         dashboardChartReadyQuery.dateZoom,
+        metricQuery?.metadata?.hasADateDimension,
     ]);
 
     const handleCancelContextMenu = useCallback(

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -86,14 +86,14 @@ type DashboardTileError = ApiError | ClientSideError | Error;
 
 type ChartDateZoomArgs = {
     chartUuid: string | null | undefined;
-    chartsWithDateZoomApplied: Set<string> | undefined;
+    tilesWithDateZoomApplied: Set<string> | undefined;
     dateDimension: { table: string; name: string } | undefined;
     dateZoomGranularity: DateZoom['granularity'];
 };
 
 const getChartDateZoom = ({
     chartUuid,
-    chartsWithDateZoomApplied,
+    tilesWithDateZoomApplied,
     dateDimension,
     dateZoomGranularity,
 }: ChartDateZoomArgs): DateZoom => ({
@@ -101,7 +101,7 @@ const getChartDateZoom = ({
     ...(dateZoomGranularity &&
     dateDimension &&
     chartUuid &&
-    chartsWithDateZoomApplied?.has(chartUuid)
+    tilesWithDateZoomApplied?.has(chartUuid)
         ? {
               xAxisFieldId: `${dateDimension.table}_${dateDimension.name}`,
           }
@@ -110,7 +110,7 @@ const getChartDateZoom = ({
 
 const useChartDateZoom = ({
     chartUuid,
-    chartsWithDateZoomApplied,
+    tilesWithDateZoomApplied,
     dateDimension,
     dateZoomGranularity,
 }: ChartDateZoomArgs) =>
@@ -118,13 +118,13 @@ const useChartDateZoom = ({
         () =>
             getChartDateZoom({
                 chartUuid,
-                chartsWithDateZoomApplied,
+                tilesWithDateZoomApplied,
                 dateDimension,
                 dateZoomGranularity,
             }),
         [
             chartUuid,
-            chartsWithDateZoomApplied,
+            tilesWithDateZoomApplied,
             dateDimension,
             dateZoomGranularity,
         ],
@@ -330,8 +330,8 @@ const ValidDashboardChartTile: FC<{
         const dateZoomGranularity = useDashboardContext(
             (c) => c.dateZoomGranularity,
         );
-        const chartsWithDateZoomApplied = useDashboardContext(
-            (c) => c.chartsWithDateZoomApplied,
+        const tilesWithDateZoomApplied = useDashboardContext(
+            (c) => c.tilesWithDateZoomApplied,
         );
 
         const { health } = useApp();
@@ -350,7 +350,7 @@ const ValidDashboardChartTile: FC<{
         } = dashboardChartReadyQuery;
         const chartDateZoom = useChartDateZoom({
             chartUuid: chart.uuid,
-            chartsWithDateZoomApplied,
+            tilesWithDateZoomApplied,
             dateDimension: metricQuery.metadata?.hasADateDimension,
             dateZoomGranularity,
         });
@@ -485,8 +485,8 @@ const ValidDashboardChartTileMinimal: FC<{
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
     );
-    const chartsWithDateZoomApplied = useDashboardContext(
-        (c) => c.chartsWithDateZoomApplied,
+    const tilesWithDateZoomApplied = useDashboardContext(
+        (c) => c.tilesWithDateZoomApplied,
     );
     const markTileScreenshotReady = useDashboardTileStatusContext(
         (c) => c.markTileScreenshotReady,
@@ -504,7 +504,7 @@ const ValidDashboardChartTileMinimal: FC<{
     );
     const chartDateZoom = useChartDateZoom({
         chartUuid: chart.uuid,
-        chartsWithDateZoomApplied,
+        tilesWithDateZoomApplied,
         dateDimension:
             dashboardChartReadyQuery.executeQueryResponse.metricQuery.metadata
                 ?.hasADateDimension,
@@ -776,8 +776,8 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
         const dateZoomGranularity = useDashboardContext(
             (c) => c.dateZoomGranularity,
         );
-        const chartsWithDateZoomApplied = useDashboardContext(
-            (c) => c.chartsWithDateZoomApplied,
+        const tilesWithDateZoomApplied = useDashboardContext(
+            (c) => c.tilesWithDateZoomApplied,
         );
 
         const parameterDefinitions = useDashboardContext(
@@ -813,7 +813,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
 
             const dateZoom = getChartDateZoom({
                 chartUuid: savedChartUuid,
-                chartsWithDateZoomApplied,
+                tilesWithDateZoomApplied,
                 dateDimension: metricQuery?.metadata?.hasADateDimension,
                 dateZoomGranularity,
             });
@@ -828,7 +828,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             openUnderlyingDataModal,
             metricQuery?.metadata?.hasADateDimension,
             savedChartUuid,
-            chartsWithDateZoomApplied,
+            tilesWithDateZoomApplied,
         ]);
 
         const handleCopyToClipboard = useCallback(() => {
@@ -1533,7 +1533,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                             {metricQuery?.metadata?.hasADateDimension &&
                             savedChartUuid &&
                             dateZoomGranularity &&
-                            chartsWithDateZoomApplied?.has(savedChartUuid) ? (
+                            tilesWithDateZoomApplied?.has(savedChartUuid) ? (
                                 <DateZoomInfoOnTile
                                     dateDimension={
                                         metricQuery.metadata.hasADateDimension
@@ -1933,8 +1933,8 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
     const dateZoomGranularity = useDashboardContext(
         (c) => c.dateZoomGranularity,
     );
-    const chartsWithDateZoomApplied = useDashboardContext(
-        (c) => c.chartsWithDateZoomApplied,
+    const tilesWithDateZoomApplied = useDashboardContext(
+        (c) => c.tilesWithDateZoomApplied,
     );
 
     const { openUnderlyingDataModal } = useMetricQueryDataContext();
@@ -1952,7 +1952,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
 
         const dateZoom = getChartDateZoom({
             chartUuid: savedChartUuid,
-            chartsWithDateZoomApplied,
+            tilesWithDateZoomApplied,
             dateDimension: metricQuery?.metadata?.hasADateDimension,
             dateZoomGranularity,
         });
@@ -1967,7 +1967,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         openUnderlyingDataModal,
         metricQuery?.metadata?.hasADateDimension,
         savedChartUuid,
-        chartsWithDateZoomApplied,
+        tilesWithDateZoomApplied,
     ]);
 
     const handleCancelContextMenu = useCallback(

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -84,50 +84,40 @@ type ClientSideError = {
 
 type DashboardTileError = ApiError | ClientSideError | Error;
 
-type ChartDateZoomArgs = {
-    chartUuid: string | null | undefined;
+type TileDateZoomArgs = {
+    tileUuid: string;
     tilesWithDateZoomApplied: Set<string> | undefined;
-    dateDimension: { table: string; name: string } | undefined;
-    dateZoomGranularity: DateZoom['granularity'];
+    dateZoom: DateZoom | undefined;
 };
 
-const getChartDateZoom = ({
-    chartUuid,
+// Narrows the resolved tile zoom to what was actually applied: the backend only
+// re-grains the targeted x-axis field when zoom took effect for this tile, so
+// drop xAxisFieldId until the applied-state set confirms it.
+const getAppliedTileDateZoom = ({
+    tileUuid,
     tilesWithDateZoomApplied,
-    dateDimension,
-    dateZoomGranularity,
-}: ChartDateZoomArgs): DateZoom => ({
-    granularity: dateZoomGranularity,
-    ...(dateZoomGranularity &&
-    dateDimension &&
-    chartUuid &&
-    tilesWithDateZoomApplied?.has(chartUuid)
-        ? {
-              xAxisFieldId: `${dateDimension.table}_${dateDimension.name}`,
-          }
-        : {}),
-});
+    dateZoom,
+}: TileDateZoomArgs): DateZoom | undefined => {
+    if (!dateZoom) return undefined;
+    if (!dateZoom.xAxisFieldId) return dateZoom;
+    return tilesWithDateZoomApplied?.has(tileUuid)
+        ? dateZoom
+        : { granularity: dateZoom.granularity };
+};
 
-const useChartDateZoom = ({
-    chartUuid,
+const useAppliedTileDateZoom = ({
+    tileUuid,
     tilesWithDateZoomApplied,
-    dateDimension,
-    dateZoomGranularity,
-}: ChartDateZoomArgs) =>
+    dateZoom,
+}: TileDateZoomArgs) =>
     useMemo(
         () =>
-            getChartDateZoom({
-                chartUuid,
+            getAppliedTileDateZoom({
+                tileUuid,
                 tilesWithDateZoomApplied,
-                dateDimension,
-                dateZoomGranularity,
+                dateZoom,
             }),
-        [
-            chartUuid,
-            tilesWithDateZoomApplied,
-            dateDimension,
-            dateZoomGranularity,
-        ],
+        [tileUuid, tilesWithDateZoomApplied, dateZoom],
     );
 
 const getDashboardTileErrorMessage = (
@@ -327,9 +317,6 @@ const ValidDashboardChartTile: FC<{
         const invalidateCache = useDashboardTileStatusContext(
             (c) => c.invalidateCache,
         );
-        const dateZoomGranularity = useDashboardContext(
-            (c) => c.dateZoomGranularity,
-        );
         const tilesWithDateZoomApplied = useDashboardContext(
             (c) => c.tilesWithDateZoomApplied,
         );
@@ -348,11 +335,10 @@ const ValidDashboardChartTile: FC<{
             executeQueryResponse: { cacheMetadata, metricQuery, fields },
             chart,
         } = dashboardChartReadyQuery;
-        const chartDateZoom = useChartDateZoom({
-            chartUuid: chart.uuid,
+        const chartDateZoom = useAppliedTileDateZoom({
+            tileUuid,
             tilesWithDateZoomApplied,
-            dateDimension: metricQuery.metadata?.hasADateDimension,
-            dateZoomGranularity,
+            dateZoom: dashboardChartReadyQuery.dateZoom,
         });
 
         useEffect(() => {
@@ -482,9 +468,6 @@ const ValidDashboardChartTileMinimal: FC<{
     const { colorScheme } = useMantineColorScheme();
 
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
-    );
     const tilesWithDateZoomApplied = useDashboardContext(
         (c) => c.tilesWithDateZoomApplied,
     );
@@ -502,13 +485,10 @@ const ValidDashboardChartTileMinimal: FC<{
         chart.pivotConfig?.columns,
         dashboardChartReadyQuery.executeQueryResponse.metricQuery,
     );
-    const chartDateZoom = useChartDateZoom({
-        chartUuid: chart.uuid,
+    const chartDateZoom = useAppliedTileDateZoom({
+        tileUuid,
         tilesWithDateZoomApplied,
-        dateDimension:
-            dashboardChartReadyQuery.executeQueryResponse.metricQuery.metadata
-                ?.hasADateDimension,
-        dateZoomGranularity,
+        dateZoom: dashboardChartReadyQuery.dateZoom,
     });
 
     const computedSeries: Series[] = useMemo(() => {
@@ -773,9 +753,6 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             }),
         );
 
-        const dateZoomGranularity = useDashboardContext(
-            (c) => c.dateZoomGranularity,
-        );
         const tilesWithDateZoomApplied = useDashboardContext(
             (c) => c.tilesWithDateZoomApplied,
         );
@@ -811,24 +788,22 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
         const handleViewUnderlyingData = useCallback(() => {
             if (!viewUnderlyingDataOptions) return;
 
-            const dateZoom = getChartDateZoom({
-                chartUuid: savedChartUuid,
+            const dateZoom = getAppliedTileDateZoom({
+                tileUuid,
                 tilesWithDateZoomApplied,
-                dateDimension: metricQuery?.metadata?.hasADateDimension,
-                dateZoomGranularity,
+                dateZoom: dashboardChartReadyQuery.dateZoom,
             });
 
             openUnderlyingDataModal({
                 ...viewUnderlyingDataOptions,
-                ...(dateZoom.xAxisFieldId && { dateZoom }),
+                ...(dateZoom?.xAxisFieldId && { dateZoom }),
             });
         }, [
             viewUnderlyingDataOptions,
-            dateZoomGranularity,
             openUnderlyingDataModal,
-            metricQuery?.metadata?.hasADateDimension,
-            savedChartUuid,
+            tileUuid,
             tilesWithDateZoomApplied,
+            dashboardChartReadyQuery.dateZoom,
         ]);
 
         const handleCopyToClipboard = useCallback(() => {
@@ -1139,7 +1114,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             dashboardUuid,
             dashboardChartReadyQuery.executeQueryResponse.queryUuid,
             !!downloadPivotConfig,
-            dashboardChartReadyQuery.dateZoomXAxisFieldId,
+            dashboardChartReadyQuery.dateZoom,
         );
 
         const closeDataExportModal = useCallback(
@@ -1531,14 +1506,16 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                                 clickedFrom="dashboard_chart_tile"
                             />
                             {metricQuery?.metadata?.hasADateDimension &&
-                            savedChartUuid &&
-                            dateZoomGranularity &&
-                            tilesWithDateZoomApplied?.has(savedChartUuid) ? (
+                            dashboardChartReadyQuery.dateZoom?.granularity &&
+                            tilesWithDateZoomApplied?.has(tileUuid) ? (
                                 <DateZoomInfoOnTile
                                     dateDimension={
                                         metricQuery.metadata.hasADateDimension
                                     }
-                                    dateZoomGranularity={dateZoomGranularity}
+                                    dateZoomGranularity={
+                                        dashboardChartReadyQuery.dateZoom
+                                            .granularity
+                                    }
                                 />
                             ) : null}
                         </>
@@ -1930,9 +1907,6 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
 
     const canExplore = canViewExploreOverride ?? canViewExplore;
 
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
-    );
     const tilesWithDateZoomApplied = useDashboardContext(
         (c) => c.tilesWithDateZoomApplied,
     );
@@ -1950,24 +1924,22 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
     const handleViewUnderlyingData = useCallback(() => {
         if (!viewUnderlyingDataOptions) return;
 
-        const dateZoom = getChartDateZoom({
-            chartUuid: savedChartUuid,
+        const dateZoom = getAppliedTileDateZoom({
+            tileUuid,
             tilesWithDateZoomApplied,
-            dateDimension: metricQuery?.metadata?.hasADateDimension,
-            dateZoomGranularity,
+            dateZoom: dashboardChartReadyQuery.dateZoom,
         });
 
         openUnderlyingDataModal({
             ...viewUnderlyingDataOptions,
-            ...(dateZoom.xAxisFieldId && { dateZoom }),
+            ...(dateZoom?.xAxisFieldId && { dateZoom }),
         });
     }, [
         viewUnderlyingDataOptions,
-        dateZoomGranularity,
         openUnderlyingDataModal,
-        metricQuery?.metadata?.hasADateDimension,
-        savedChartUuid,
+        tileUuid,
         tilesWithDateZoomApplied,
+        dashboardChartReadyQuery.dateZoom,
     ]);
 
     const handleCancelContextMenu = useCallback(
@@ -2021,7 +1993,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         projectUuid,
         dashboardChartReadyQuery.executeQueryResponse.queryUuid,
         !!downloadPivotConfig,
-        dashboardChartReadyQuery.dateZoomXAxisFieldId,
+        dashboardChartReadyQuery.dateZoom,
     );
 
     const chartKind = useMemo(

--- a/packages/frontend/src/components/DashboardTiles/getAppliedTileDateZoom.test.ts
+++ b/packages/frontend/src/components/DashboardTiles/getAppliedTileDateZoom.test.ts
@@ -1,0 +1,88 @@
+import { DateGranularity } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getAppliedTileDateZoom } from './getAppliedTileDateZoom';
+
+const dateDimension = { table: 'orders', name: 'order_date' };
+
+describe('getAppliedTileDateZoom', () => {
+    it('returns undefined when there is no resolved zoom', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['tile-1']),
+                dateZoom: undefined,
+                dateDimension,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('keeps the resolved cartesian xAxisFieldId when the tile is applied', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['tile-1']),
+                dateZoom: {
+                    granularity: DateGranularity.WEEK,
+                    xAxisFieldId: 'orders_order_date',
+                },
+                dateDimension,
+            }),
+        ).toEqual({
+            granularity: DateGranularity.WEEK,
+            xAxisFieldId: 'orders_order_date',
+        });
+    });
+
+    it('drops xAxisFieldId when the tile is not in the applied set', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['other-tile']),
+                dateZoom: {
+                    granularity: DateGranularity.WEEK,
+                    xAxisFieldId: 'orders_order_date',
+                },
+                dateDimension,
+            }),
+        ).toEqual({ granularity: DateGranularity.WEEK });
+    });
+
+    // Regression: legacy date-zoomed TABLE tiles resolve to a grain-only zoom
+    // (getDateZoomXAxisFieldId is cartesian-only). The drill-through range filter
+    // needs the backend-truncated field, so fall back to hasADateDimension.
+    it('falls back to the backend date dimension when the resolved zoom has no xAxisFieldId', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['tile-1']),
+                dateZoom: { granularity: DateGranularity.MONTH },
+                dateDimension,
+            }),
+        ).toEqual({
+            granularity: DateGranularity.MONTH,
+            xAxisFieldId: 'orders_order_date',
+        });
+    });
+
+    it('does not invent a field for a grain-only zoom when no date dimension exists', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['tile-1']),
+                dateZoom: { granularity: DateGranularity.MONTH },
+                dateDimension: undefined,
+            }),
+        ).toEqual({ granularity: DateGranularity.MONTH });
+    });
+
+    it('drops the fallback field when the tile is not applied', () => {
+        expect(
+            getAppliedTileDateZoom({
+                tileUuid: 'tile-1',
+                tilesWithDateZoomApplied: new Set(['other-tile']),
+                dateZoom: { granularity: DateGranularity.MONTH },
+                dateDimension,
+            }),
+        ).toEqual({ granularity: DateGranularity.MONTH });
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/getAppliedTileDateZoom.ts
+++ b/packages/frontend/src/components/DashboardTiles/getAppliedTileDateZoom.ts
@@ -1,0 +1,34 @@
+import { type DateZoom } from '@lightdash/common';
+
+export type AppliedTileDateZoomArgs = {
+    tileUuid: string;
+    tilesWithDateZoomApplied: Set<string> | undefined;
+    dateZoom: DateZoom | undefined;
+    dateDimension: { table: string; name: string } | undefined;
+};
+
+// Narrows the resolved tile zoom to what was actually applied: the backend only
+// re-grains the targeted x-axis field when zoom took effect for this tile, so
+// drop xAxisFieldId until the applied-state set confirms it.
+//
+// The drill-through range filter needs the field the backend actually
+// truncated. Cartesian tiles carry it as xAxisFieldId; non-cartesian (table)
+// tiles zoom the backend-picked date dimension, which the resolver can't name,
+// so fall back to it here to keep the underlying-data drill working.
+export const getAppliedTileDateZoom = ({
+    tileUuid,
+    tilesWithDateZoomApplied,
+    dateZoom,
+    dateDimension,
+}: AppliedTileDateZoomArgs): DateZoom | undefined => {
+    if (!dateZoom) return undefined;
+    const xAxisFieldId =
+        dateZoom.xAxisFieldId ??
+        (dateDimension
+            ? `${dateDimension.table}_${dateDimension.name}`
+            : undefined);
+    if (!xAxisFieldId) return dateZoom;
+    return tilesWithDateZoomApplied?.has(tileUuid)
+        ? { ...dateZoom, xAxisFieldId }
+        : { granularity: dateZoom.granularity };
+};

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -1,5 +1,6 @@
 import { DragDropContext, Droppable } from '@hello-pangea/dnd';
 import {
+    copyDateZoomTileTargets,
     FeatureFlags,
     type DashboardTab,
     type DashboardTile,
@@ -329,6 +330,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     const setHaveFiltersChanged = useDashboardContext(
         (c) => c.setHaveFiltersChanged,
     );
+    const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
+    const setDateZoomConfig = useDashboardContext((c) => c.setDateZoomConfig);
     const requiredDashboardFilters = useDashboardContext(
         (c) => c.requiredDashboardFilters,
     );
@@ -879,6 +882,22 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                     dimensions: updatedFilters,
                 });
                 setHaveFiltersChanged(true);
+
+                // Mirror the filter remap for date-zoom controls. The tab map is
+                // Map<oldUuid, newUuid>, so old=from and new=to.
+                const dateZoomMapping = [...tileUuidMapping].map(
+                    ([fromTileUuid, toTileUuid]) => ({
+                        fromTileUuid,
+                        toTileUuid,
+                    }),
+                );
+                const nextDateZoomConfig = copyDateZoomTileTargets(
+                    dateZoomConfig,
+                    dateZoomMapping,
+                );
+                if (nextDateZoomConfig !== dateZoomConfig) {
+                    setDateZoomConfig(nextDateZoomConfig);
+                }
             }
         }
         setDuplicatingTab(false);

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartDownload.ts
@@ -2,6 +2,7 @@ import {
     QueryExecutionContext,
     QueryHistoryStatus,
     type ApiExecuteAsyncDashboardChartQueryResults,
+    type DateZoom,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import { lightdashApi } from '../../api';
@@ -17,7 +18,7 @@ export const useDashboardChartDownload = (
     dashboardUuid: string | undefined,
     originalQueryUuid: string,
     canExportPivotedData: boolean,
-    dateZoomXAxisFieldId?: string,
+    dateZoom?: DateZoom,
 ) => {
     // Get dashboard filters and sorts for this tile
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
@@ -26,9 +27,6 @@ export const useDashboardChartDownload = (
     const dashboardSorts = useMemo(
         () => chartSort[tileUuid] || [],
         [chartSort, tileUuid],
-    );
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
     );
 
     const getDownloadQueryUuid = useCallback(
@@ -66,14 +64,7 @@ export const useDashboardChartDownload = (
                         dashboardUuid,
                         dashboardFilters: dashboardFilters || {},
                         dashboardSorts: dashboardSorts || [],
-                        dateZoom: dateZoomGranularity
-                            ? {
-                                  granularity: dateZoomGranularity,
-                                  ...(dateZoomXAxisFieldId
-                                      ? { xAxisFieldId: dateZoomXAxisFieldId }
-                                      : {}),
-                              }
-                            : undefined,
+                        dateZoom,
                         limit,
                         invalidateCache: false,
                         parameters,
@@ -107,8 +98,7 @@ export const useDashboardChartDownload = (
             chartUuid,
             dashboardFilters,
             dashboardSorts,
-            dateZoomGranularity,
-            dateZoomXAxisFieldId,
+            dateZoom,
             parameters,
             canExportPivotedData,
             originalQueryUuid,

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -1,12 +1,16 @@
 import {
+    EMPTY_DATE_ZOOM_CONFIG,
+    FeatureFlags,
     getAvailableParametersFromTables,
     getDateZoomCapabilities,
     getDateZoomXAxisFieldId,
     hasReservedParameterReference,
     QueryExecutionContext,
+    resolveTileDateZoom,
     type ApiError,
     type ApiExecuteAsyncDashboardChartQueryResults,
     type ApiExploreResults,
+    type DateZoom,
     type ExecuteAsyncDashboardChartRequestParams,
     type SavedChart,
 } from '@lightdash/common';
@@ -20,6 +24,7 @@ import { useExplore } from '../useExplore';
 import { useQueryRetryConfig } from '../useQueryRetry';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
+import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { useSessionTimezone } from '../useSessionTimezone';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
@@ -60,6 +65,10 @@ export type DashboardChartReadyQuery = {
     executeQueryResponse: ApiExecuteAsyncDashboardChartQueryResults;
     chart: SavedChart;
     explore: ApiExploreResults;
+    // The resolved date zoom for this tile (control grain + field, or the
+    // Default). Downstream consumers reuse it so visualization, downloads, and
+    // underlying data agree with the query that was executed.
+    dateZoom: DateZoom | undefined;
     // The date-zoom target field for this chart, so downstream re-executions
     // (e.g. downloads) zoom the same x-axis field as the displayed query.
     dateZoomXAxisFieldId: string | undefined;
@@ -97,6 +106,22 @@ export const useDashboardChartReadyQuery = (
         useSearchParams<QueryExecutionContext>('context') || undefined;
     const setChartsWithDateZoomApplied = useDashboardContext(
         (c) => c.setChartsWithDateZoomApplied,
+    );
+
+    // Date zoom controls (gated): when the flag is off, resolve against the
+    // empty config so every tile takes the Default branch and any saved controls
+    // are inert, keeping flag-off byte-for-byte identical to today.
+    const { data: dateZoomConfigFlag } = useServerFeatureFlag(
+        FeatureFlags.DateZoomConfiguration,
+    );
+    const isDateZoomConfigEnabled =
+        dateZoomConfigFlag?.enabled ?? import.meta.env.DEV;
+    const savedDateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
+    const dateZoomConfig = isDateZoomConfigEnabled
+        ? savedDateZoomConfig
+        : EMPTY_DATE_ZOOM_CONFIG;
+    const controlGranularities = useDashboardContext(
+        (c) => c.controlGranularities,
     );
     const addParameterDefinitions = useDashboardContext(
         (c) => c.addParameterDefinitions,
@@ -144,6 +169,27 @@ export const useDashboardChartReadyQuery = (
                 ? getDateZoomXAxisFieldId(chartQuery.data.chartConfig, explore)
                 : undefined,
         [chartQuery.data, explore],
+    );
+
+    // Single source of truth for this tile's wire date zoom. Attached tiles zoom
+    // their control's grain on the target field; unassigned tiles fall through to
+    // the Default (the existing global picker + x-axis baseline).
+    const tileDateZoom = useMemo(
+        () =>
+            resolveTileDateZoom({
+                config: dateZoomConfig,
+                tileUuid,
+                runtimeGranularities: controlGranularities,
+                globalGranularity: granularity,
+                defaultXAxisFieldId: dateZoomXAxisFieldId,
+            }),
+        [
+            dateZoomConfig,
+            tileUuid,
+            controlGranularities,
+            granularity,
+            dateZoomXAxisFieldId,
+        ],
     );
 
     useEffect(() => {
@@ -194,7 +240,8 @@ export const useDashboardChartReadyQuery = (
     // single source of truth for whether zoom was actually applied.
     // We still need a pre-query estimate for the query key so we avoid
     // unnecessary refetches when zoom won't have an effect.
-    const isZoomLikelyApplied = isAffectedByDateZoom && !!granularity;
+    const isZoomLikelyApplied =
+        isAffectedByDateZoom && tileDateZoom !== undefined;
 
     const queryKey = useMemo(
         () => [
@@ -207,8 +254,8 @@ export const useDashboardChartReadyQuery = (
             sortKey,
             contextOverride || context,
             autoRefresh,
-            isZoomLikelyApplied ? granularity : null,
-            isZoomLikelyApplied ? dateZoomXAxisFieldId : null,
+            isZoomLikelyApplied ? (tileDateZoom?.granularity ?? null) : null,
+            isZoomLikelyApplied ? (tileDateZoom?.xAxisFieldId ?? null) : null,
             invalidateCache,
             chartParameterValues,
             sessionTimezone,
@@ -224,8 +271,7 @@ export const useDashboardChartReadyQuery = (
             context,
             autoRefresh,
             isZoomLikelyApplied,
-            granularity,
-            dateZoomXAxisFieldId,
+            tileDateZoom,
             invalidateCache,
             chartParameterValues,
             sessionTimezone,
@@ -248,12 +294,7 @@ export const useDashboardChartReadyQuery = (
             const isEmbedContext =
                 requestedContext === QueryExecutionContext.EMBED;
 
-            const dateZoom = {
-                granularity,
-                ...(dateZoomXAxisFieldId
-                    ? { xAxisFieldId: dateZoomXAxisFieldId }
-                    : {}),
-            };
+            const dateZoom = tileDateZoom;
 
             const executeQueryResponse = isEmbedContext
                 ? await postEmbedDashboardTileQuery(
@@ -289,7 +330,8 @@ export const useDashboardChartReadyQuery = (
                 chart: chartQuery.data,
                 explore,
                 executeQueryResponse,
-                dateZoomXAxisFieldId,
+                dateZoom: tileDateZoom,
+                dateZoomXAxisFieldId: tileDateZoom?.xAxisFieldId,
             };
         },
         enabled: Boolean(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -104,8 +104,8 @@ export const useDashboardChartReadyQuery = (
     const autoRefresh = useDashboardTileStatusContext((c) => c.isAutoRefresh);
     const context =
         useSearchParams<QueryExecutionContext>('context') || undefined;
-    const setChartsWithDateZoomApplied = useDashboardContext(
-        (c) => c.setChartsWithDateZoomApplied,
+    const setTilesWithDateZoomApplied = useDashboardContext(
+        (c) => c.setTilesWithDateZoomApplied,
     );
 
     // Date zoom controls (gated): when the flag is off, resolve against the
@@ -348,22 +348,24 @@ export const useDashboardChartReadyQuery = (
         (referencesDateZoomReservedParam && !!granularity);
 
     useEffect(() => {
-        if (!chartUuid || !isAffectedByDateZoom) return;
+        if (!isAffectedByDateZoom) return;
 
-        setChartsWithDateZoomApplied((prev) => {
+        // Keyed by tileUuid: a duplicated saved chart shares its chartUuid across
+        // tiles, but each tile needs its own applied state.
+        setTilesWithDateZoomApplied((prev) => {
             const nextSet = new Set(prev ?? []);
             if (dateZoomApplied) {
-                nextSet.add(chartUuid);
+                nextSet.add(tileUuid);
             } else {
-                nextSet.delete(chartUuid);
+                nextSet.delete(tileUuid);
             }
             return nextSet;
         });
     }, [
         dateZoomApplied,
         isAffectedByDateZoom,
-        chartUuid,
-        setChartsWithDateZoomApplied,
+        tileUuid,
+        setTilesWithDateZoomApplied,
     ]);
 
     useEffect(() => {

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -69,9 +69,6 @@ export type DashboardChartReadyQuery = {
     // Default). Downstream consumers reuse it so visualization, downloads, and
     // underlying data agree with the query that was executed.
     dateZoom: DateZoom | undefined;
-    // The date-zoom target field for this chart, so downstream re-executions
-    // (e.g. downloads) zoom the same x-axis field as the displayed query.
-    dateZoomXAxisFieldId: string | undefined;
 };
 
 export const useDashboardChartReadyQuery = (
@@ -331,7 +328,6 @@ export const useDashboardChartReadyQuery = (
                 explore,
                 executeQueryResponse,
                 dateZoom: tileDateZoom,
-                dateZoomXAxisFieldId: tileDateZoom?.xAxisFieldId,
             };
         },
         enabled: Boolean(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -337,11 +337,12 @@ export const useDashboardChartReadyQuery = (
         refetchOnMount: false,
     });
 
-    // Backend reports it for overridden date dimensions; param-only charts are in effect
-    // whenever a grain is selected.
+    // Backend reports it for overridden date dimensions; charts that only
+    // reference the reserved date-zoom param are in effect whenever the resolved
+    // tile grain is set (the same value substituted into their SQL on the wire).
     const dateZoomApplied =
         (queryResult.data?.executeQueryResponse?.dateZoomApplied ?? false) ||
-        (referencesDateZoomReservedParam && !!granularity);
+        (referencesDateZoomReservedParam && !!tileDateZoom?.granularity);
 
     useEffect(() => {
         if (!isAffectedByDateZoom) return;

--- a/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
@@ -1,6 +1,7 @@
 import {
     QueryHistoryStatus,
     type ApiExecuteAsyncDashboardChartQueryResults,
+    type DateZoom,
 } from '@lightdash/common';
 import { useCallback, useMemo } from 'react';
 import { lightdashApi } from '../../api';
@@ -14,7 +15,7 @@ export const useEmbedDashboardChartDownload = (
     projectUuid: string | undefined,
     originalQueryUuid: string,
     canExportPivotedData: boolean,
-    dateZoomXAxisFieldId?: string,
+    dateZoom?: DateZoom,
 ) => {
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
     const chartSort = useDashboardContext((c) => c.chartSort);
@@ -22,9 +23,6 @@ export const useEmbedDashboardChartDownload = (
     const dashboardSorts = useMemo(
         () => chartSort[tileUuid] || [],
         [chartSort, tileUuid],
-    );
-    const dateZoomGranularity = useDashboardContext(
-        (c) => c.dateZoomGranularity,
     );
 
     const getDownloadQueryUuid = useCallback(
@@ -58,14 +56,7 @@ export const useEmbedDashboardChartDownload = (
                         tileUuid,
                         dashboardFilters: dashboardFilters || {},
                         dashboardSorts: dashboardSorts || [],
-                        dateZoom: dateZoomGranularity
-                            ? {
-                                  granularity: dateZoomGranularity,
-                                  ...(dateZoomXAxisFieldId
-                                      ? { xAxisFieldId: dateZoomXAxisFieldId }
-                                      : {}),
-                              }
-                            : undefined,
+                        dateZoom,
                         limit,
                         invalidateCache: false,
                         parameters,
@@ -96,8 +87,7 @@ export const useEmbedDashboardChartDownload = (
             tileUuid,
             dashboardFilters,
             dashboardSorts,
-            dateZoomGranularity,
-            dateZoomXAxisFieldId,
+            dateZoom,
             parameters,
             canExportPivotedData,
             originalQueryUuid,

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    copyDateZoomTileTargets,
     getShadowedReservedNames,
     ContentType,
     DateGranularity,
@@ -83,6 +84,8 @@ const Dashboard: FC = () => {
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
+    const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
+    const setDateZoomConfig = useDashboardContext((c) => c.setDateZoomConfig);
     const resetDashboardFilters = useDashboardContext(
         (c) => c.resetDashboardFilters,
     );
@@ -494,6 +497,22 @@ const Dashboard: FC = () => {
                     return { ...prev, dimensions: updatedDimensions };
                 });
                 setHaveFiltersChanged(true);
+
+                // Mirror the filter remap for date-zoom controls: copy each
+                // source tile's target onto its duplicate.
+                const mapping = Object.entries(tileUuidMapping).map(
+                    ([toTileUuid, fromTileUuid]) => ({
+                        fromTileUuid,
+                        toTileUuid,
+                    }),
+                );
+                const nextDateZoomConfig = copyDateZoomTileTargets(
+                    dateZoomConfig,
+                    mapping,
+                );
+                if (nextDateZoomConfig !== dateZoomConfig) {
+                    setDateZoomConfig(nextDateZoomConfig);
+                }
             }
         },
         [
@@ -505,6 +524,8 @@ const Dashboard: FC = () => {
             setHaveTabsChanged,
             setDashboardFilters,
             setHaveFiltersChanged,
+            dateZoomConfig,
+            setDateZoomConfig,
         ],
     );
 

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -313,6 +313,28 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setHasDateZoomConfigChanged(true);
     }, []);
 
+    // Per-control runtime grain overrides only; an absent entry means "use the
+    // control's persisted default" (the resolver applies `?? control.granularity`).
+    const [controlGranularities, setControlGranularities] = useState<
+        Record<string, DateGranularity | string>
+    >({});
+
+    const setControlGranularity = useCallback(
+        (
+            controlUuid: string,
+            granularity: DateGranularity | string | undefined,
+        ) => {
+            setControlGranularities((prev) => {
+                if (granularity === undefined) {
+                    const { [controlUuid]: _removed, ...rest } = prev;
+                    return rest;
+                }
+                return { ...prev, [controlUuid]: granularity };
+            });
+        },
+        [],
+    );
+
     // Set parameters to saved parameters when they are loaded
     useEffect(() => {
         if (savedParameters) {
@@ -367,6 +389,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setDateZoomConfigState(normalizeDateZoomConfig(dashboard?.config));
         setHasDateZoomConfigChanged(false);
     }, [dashboard?.uuid, dashboard?.config]);
+
+    // Reset per-control runtime overrides when the dashboard identity changes;
+    // each control's default comes from its persisted granularity.
+    useEffect(() => {
+        setControlGranularities({});
+    }, [dashboard?.uuid]);
 
     // Set active tab when dashboard and tabs are loaded.
     // In view mode, hidden tabs are not selectable — fall back to the first
@@ -1592,6 +1620,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setDateZoomConfig,
         hasDateZoomConfigChanged,
         setHasDateZoomConfigChanged,
+        controlGranularities,
+        setControlGranularity,
         dashboardCommentsCheck,
         dashboardComments,
         hasTileComments,

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -4,6 +4,7 @@ import {
     convertDashboardFiltersParamToDashboardFilters,
     DashboardTileTypes,
     DateGranularity,
+    EMPTY_DATE_ZOOM_CONFIG,
     FilterInteractivityValues,
     getFilterInteractivityValue,
     getItemId,
@@ -12,12 +13,14 @@ import {
     isFilterLockedOnTab,
     isStandardDateGranularity,
     isSubDayGranularity,
+    normalizeDateZoomConfig,
     stripOverridesForLockedFiltersOnTab,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
     type DashboardFilters,
     type DashboardParameters,
+    type DateZoomConfig,
     type FilterableDimension,
     type InteractivityOptions,
     type Metric,
@@ -298,6 +301,18 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setHasDefaultDateZoomGranularityChanged,
     ] = useState<boolean>(false);
 
+    // Configurable date zoom controls (named controls + per-tile targets).
+    const [dateZoomConfig, setDateZoomConfigState] = useState<DateZoomConfig>(
+        EMPTY_DATE_ZOOM_CONFIG,
+    );
+    const [hasDateZoomConfigChanged, setHasDateZoomConfigChanged] =
+        useState(false);
+
+    const setDateZoomConfig = useCallback((config: DateZoomConfig) => {
+        setDateZoomConfigState(config);
+        setHasDateZoomConfigChanged(true);
+    }, []);
+
     // Set parameters to saved parameters when they are loaded
     useEffect(() => {
         if (savedParameters) {
@@ -345,6 +360,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             dashboard?.config?.defaultDateZoomGranularity,
         );
     }, [dashboard?.config?.defaultDateZoomGranularity]);
+
+    // Sync date zoom control config from dashboard config (normalizing an
+    // absent config to the empty controls/tileTargets shape).
+    useEffect(() => {
+        setDateZoomConfigState(normalizeDateZoomConfig(dashboard?.config));
+        setHasDateZoomConfigChanged(false);
+    }, [dashboard?.uuid, dashboard?.config]);
 
     // Set active tab when dashboard and tabs are loaded.
     // In view mode, hidden tabs are not selectable — fall back to the first
@@ -1566,6 +1588,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setDateZoomGranularity,
         chartsWithDateZoomApplied,
         setChartsWithDateZoomApplied,
+        dateZoomConfig,
+        setDateZoomConfig,
+        hasDateZoomConfigChanged,
+        setHasDateZoomConfigChanged,
         dashboardCommentsCheck,
         dashboardComments,
         hasTileComments,

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -14,6 +14,7 @@ import {
     isStandardDateGranularity,
     isSubDayGranularity,
     normalizeDateZoomConfig,
+    normalizeGranularityParam,
     stripOverridesForLockedFiltersOnTab,
     type Dashboard,
     type DashboardFilterableField,
@@ -639,6 +640,34 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     }, [dateZoomGranularity, search, navigate, pathname, embed.mode]);
 
+    // Sync per-control runtime grain overrides to `dateZoom.<controlUuid>` URL
+    // params (the global `?dateZoom` above is unchanged and drives the Default).
+    // Written lowercased to match the global write; normalized back to canonical
+    // DateGranularity case on read.
+    useEffect(() => {
+        if (embed.mode === 'sdk') {
+            return;
+        }
+
+        const currentParams = new URLSearchParams(search);
+        const newParams = new URLSearchParams(search);
+
+        [...newParams.keys()]
+            .filter((key) => key.startsWith('dateZoom.'))
+            .forEach((key) => newParams.delete(key));
+
+        Object.entries(controlGranularities).forEach(([uuid, grain]) => {
+            newParams.set(`dateZoom.${uuid}`, grain.toString().toLowerCase());
+        });
+
+        if (currentParams.toString() !== newParams.toString()) {
+            void navigate(
+                { pathname, search: newParams.toString() },
+                { replace: true },
+            );
+        }
+    }, [controlGranularities, search, navigate, pathname, embed.mode]);
+
     const {
         overridesForSavedDashboardFilters,
         addSavedFilterOverride,
@@ -1090,6 +1119,20 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 // Custom granularity — use the param value directly
                 setDateZoomGranularity(dateZoomParam);
             }
+        }
+
+        // Per-control date zoom grain overrides (`dateZoom.<controlUuid>`),
+        // normalized back to canonical DateGranularity case so the runtime grain
+        // that reaches the wire is e.g. 'Week', never a lowercased 'week'.
+        const controlOverrides: Record<string, DateGranularity | string> = {};
+        searchParams.forEach((value, key) => {
+            if (key.startsWith('dateZoom.')) {
+                controlOverrides[key.slice('dateZoom.'.length)] =
+                    normalizeGranularityParam(value);
+            }
+        });
+        if (Object.keys(controlOverrides).length > 0) {
+            setControlGranularities(controlOverrides);
         }
 
         // Temp filters

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -608,7 +608,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         );
     }, [dashboardParameterReferences, parameters, parameterDefinitions]);
 
-    const [chartsWithDateZoomApplied, setChartsWithDateZoomApplied] =
+    const [tilesWithDateZoomApplied, setTilesWithDateZoomApplied] =
         useState<Set<string>>();
 
     // Update dashboard url date zoom change
@@ -1657,8 +1657,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setChartSort,
         dateZoomGranularity,
         setDateZoomGranularity,
-        chartsWithDateZoomApplied,
-        setChartsWithDateZoomApplied,
+        tilesWithDateZoomApplied,
+        setTilesWithDateZoomApplied,
         dateZoomConfig,
         setDateZoomConfig,
         hasDateZoomConfigChanged,

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -106,6 +106,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     children,
 }) => {
     const { search, pathname } = useLocation();
+    // Mirrors `search` without re-triggering effects that should fire on other
+    // deps (e.g. dashboard load) while still reading the live URL.
+    const searchRef = useRef(search);
+    searchRef.current = search;
     const navigate = useNavigate();
     const { showToastWarning, showToastInfo } = useToaster();
     const hasNotifiedLockedOverrideRef = useRef(false);
@@ -401,8 +405,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [dashboard?.config?.defaultDateZoomGranularity]);
 
     // Reset per-control runtime overrides when the dashboard identity changes;
-    // each control's default comes from its persisted granularity.
+    // each control's default comes from its persisted granularity. Skip when the
+    // URL carries `dateZoom.<control>` overrides (deep link / refresh), mirroring
+    // the global default's URL guard so `useMount` hydration isn't clobbered when
+    // the dashboard query resolves after mount.
     useEffect(() => {
+        const hasUrlOverride = [
+            ...new URLSearchParams(searchRef.current).keys(),
+        ].some((key) => key.startsWith('dateZoom.'));
+        if (hasUrlOverride) return;
         setControlGranularities({});
     }, [dashboard?.uuid]);
 
@@ -658,23 +669,35 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             return;
         }
 
-        const currentParams = new URLSearchParams(search);
-        const newParams = new URLSearchParams(search);
+        const params = new URLSearchParams(search);
+        const currentControlParams = [...params.entries()].filter(([key]) =>
+            key.startsWith('dateZoom.'),
+        );
+        const nextControlParams: Array<[string, string]> = Object.entries(
+            controlGranularities,
+        ).map(([uuid, grain]) => [
+            `dateZoom.${uuid}`,
+            grain.toString().toLowerCase(),
+        ]);
 
-        [...newParams.keys()]
-            .filter((key) => key.startsWith('dateZoom.'))
-            .forEach((key) => newParams.delete(key));
-
-        Object.entries(controlGranularities).forEach(([uuid, grain]) => {
-            newParams.set(`dateZoom.${uuid}`, grain.toString().toLowerCase());
-        });
-
-        if (currentParams.toString() !== newParams.toString()) {
-            void navigate(
-                { pathname, search: newParams.toString() },
-                { replace: true },
-            );
+        // Compare content order-independently so a deep link with interleaved
+        // params doesn't trigger a no-op navigation just from re-appending.
+        const serialize = (entries: Array<[string, string]>): string =>
+            entries
+                .map(([key, value]) => `${key}=${value}`)
+                .sort()
+                .join('&');
+        if (serialize(currentControlParams) === serialize(nextControlParams)) {
+            return;
         }
+
+        currentControlParams.forEach(([key]) => params.delete(key));
+        nextControlParams.forEach(([key, value]) => params.set(key, value));
+
+        void navigate(
+            { pathname, search: params.toString() },
+            { replace: true },
+        );
     }, [controlGranularities, search, navigate, pathname, embed.mode]);
 
     const {
@@ -1191,10 +1214,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     });
 
     // Apply default date zoom granularity when dashboard loads (if no URL override).
-    // Uses a ref for `search` so URL changes don't re-trigger this effect —
-    // it should only fire when the configured default changes (initial load + after saves).
-    const searchRef = useRef(search);
-    searchRef.current = search;
+    // Uses `searchRef` so URL changes don't re-trigger this effect — it should
+    // only fire when the configured default changes (initial load + after saves).
     useEffect(() => {
         if (isEditMode) return;
         if (

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -314,6 +314,22 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setHasDateZoomConfigChanged(true);
     }, []);
 
+    // Persisted config, used to seed editable state on load and after save.
+    const persistedDateZoomConfig = useMemo(
+        () => normalizeDateZoomConfig(dashboard?.config),
+        [dashboard?.config],
+    );
+    const [syncedDateZoomConfig, setSyncedDateZoomConfig] =
+        useState<DateZoomConfig | null>(null);
+
+    // Re-seed editable state when persisted content changes (load + post-save),
+    // adjusting during render so a no-op refetch can't clobber in-progress edits.
+    if (!isEqual(persistedDateZoomConfig, syncedDateZoomConfig)) {
+        setSyncedDateZoomConfig(persistedDateZoomConfig);
+        setDateZoomConfigState(persistedDateZoomConfig);
+        setHasDateZoomConfigChanged(false);
+    }
+
     // Per-control runtime grain overrides only; an absent entry means "use the
     // control's persisted default" (the resolver applies `?? control.granularity`).
     const [controlGranularities, setControlGranularities] = useState<
@@ -383,13 +399,6 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             dashboard?.config?.defaultDateZoomGranularity,
         );
     }, [dashboard?.config?.defaultDateZoomGranularity]);
-
-    // Sync date zoom control config from dashboard config (normalizing an
-    // absent config to the empty controls/tileTargets shape).
-    useEffect(() => {
-        setDateZoomConfigState(normalizeDateZoomConfig(dashboard?.config));
-        setHasDateZoomConfigChanged(false);
-    }, [dashboard?.uuid, dashboard?.config]);
 
     // Reset per-control runtime overrides when the dashboard identity changes;
     // each control's default comes from its persisted granularity.

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -6,6 +6,7 @@ import {
     type DashboardFilters,
     type DashboardParameters,
     type DateGranularity,
+    type DateZoomConfig,
     type FilterableDimension,
     type Metric,
     type ParameterDefinitions,
@@ -108,6 +109,10 @@ export type DashboardContextType = {
     setChartsWithDateZoomApplied: Dispatch<
         SetStateAction<Set<string> | undefined>
     >;
+    dateZoomConfig: DateZoomConfig;
+    setDateZoomConfig: (config: DateZoomConfig) => void;
+    hasDateZoomConfigChanged: boolean;
+    setHasDateZoomConfigChanged: Dispatch<SetStateAction<boolean>>;
     dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
     dashboardComments?: ReturnType<typeof useGetComments>['data'];
     hasTileComments: (tileUuid: string) => boolean;

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -113,6 +113,11 @@ export type DashboardContextType = {
     setDateZoomConfig: (config: DateZoomConfig) => void;
     hasDateZoomConfigChanged: boolean;
     setHasDateZoomConfigChanged: Dispatch<SetStateAction<boolean>>;
+    controlGranularities: Record<string, DateGranularity | string>;
+    setControlGranularity: (
+        controlUuid: string,
+        granularity: DateGranularity | string | undefined,
+    ) => void;
     dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
     dashboardComments?: ReturnType<typeof useGetComments>['data'];
     hasTileComments: (tileUuid: string) => boolean;

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -105,8 +105,8 @@ export type DashboardContextType = {
     setDateZoomGranularity: Dispatch<
         SetStateAction<DateGranularity | string | undefined>
     >;
-    chartsWithDateZoomApplied: Set<string> | undefined;
-    setChartsWithDateZoomApplied: Dispatch<
+    tilesWithDateZoomApplied: Set<string> | undefined;
+    setTilesWithDateZoomApplied: Dispatch<
         SetStateAction<Set<string> | undefined>
     >;
     dateZoomConfig: DateZoomConfig;


### PR DESCRIPTION
Part 2/3 of making date zoom configurable like dashboard filters.

Wires the runtime: dashboard-provider edit state, per-control runtime granularity with URL sync, the resolved per-tile `DateZoom` in the ready query, and the tile consumers (visualization, downloads, underlying data). Behind the flag.

Relates to [GLITCH-225](https://linear.app/lightdash/issue/GLITCH-225/make-date-zoom-more-configurable-like-dashboard-filters)