### PR TITLE
feat(date-zoom): control modal, tile attachment, and view pills

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3269,6 +3269,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                hidden: { dataType: 'boolean' },
                 granularity: {
                     dataType: 'union',
                     subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3359,6 +3359,9 @@
             },
             "DateZoomControl": {
                 "properties": {
+                    "hidden": {
+                        "type": "boolean"
+                    },
                     "granularity": {
                         "anyOf": [
                             {

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -664,6 +664,9 @@
                         }
                     ]
                 },
+                "hidden": {
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -216,6 +216,8 @@ export type DateZoomControl = {
     uuid: string;
     name: string;
     granularity: DateGranularity | string;
+    // Hidden from viewers; grain still applies to its tiles.
+    hidden?: boolean;
 };
 
 export type DateZoomConfig = {

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -9,6 +9,7 @@ import { DateGranularity } from '../types/timeFrames';
 import {
     copyDateZoomTileTargets,
     EMPTY_DATE_ZOOM_CONFIG,
+    getChartZoomableFields,
     getControlActiveGranularity,
     getDateZoomCapabilities,
     getDateZoomXAxisFieldId,
@@ -1084,5 +1085,96 @@ describe('getDateZoomXAxisFieldId', () => {
                 undefined,
             ),
         ).toBeUndefined();
+    });
+});
+
+describe('getChartZoomableFields', () => {
+    it('returns only the chart-queried date/timestamp dimensions', () => {
+        const dateDim = makeDimension({
+            name: 'order_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            label: 'Order date',
+        });
+        const createdAt = makeDimension({
+            name: 'created_at',
+            table: 'orders',
+            type: DimensionType.TIMESTAMP,
+            label: 'Created at',
+        });
+        const unusedDate = makeDimension({
+            name: 'shipped_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            label: 'Shipped date',
+        });
+        const stringDim = makeDimension({
+            name: 'status',
+            table: 'orders',
+            type: DimensionType.STRING,
+        });
+        const explore = makeExplore([
+            dateDim,
+            createdAt,
+            unusedDate,
+            stringDim,
+        ]);
+        const metricQuery = makeMetricQuery([
+            'orders_order_date',
+            'orders_created_at',
+            'orders_status',
+        ]);
+
+        expect(getChartZoomableFields(explore, metricQuery)).toEqual([
+            {
+                fieldId: 'orders_order_date',
+                label: 'Order date',
+                tableName: 'orders',
+            },
+            {
+                fieldId: 'orders_created_at',
+                label: 'Created at',
+                tableName: 'orders',
+            },
+        ]);
+    });
+
+    it('includes a queried time-interval dimension (resolves to a base time dim)', () => {
+        const baseDim = makeDimension({
+            name: 'order_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            isIntervalBase: true,
+        });
+        const monthDim = makeDimension({
+            name: 'order_date_month',
+            table: 'orders',
+            type: DimensionType.DATE,
+            timeInterval: 'MONTH' as CompiledDimension['timeInterval'],
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Order date month',
+        });
+        const explore = makeExplore([baseDim, monthDim]);
+        const metricQuery = makeMetricQuery(['orders_order_date_month']);
+
+        expect(getChartZoomableFields(explore, metricQuery)).toEqual([
+            {
+                fieldId: 'orders_order_date_month',
+                label: 'Order date month',
+                tableName: 'orders',
+            },
+        ]);
+    });
+
+    it('returns an empty list when the chart queries no date dimensions', () => {
+        const stringDim = makeDimension({
+            name: 'status',
+            table: 'orders',
+            type: DimensionType.STRING,
+        });
+        const explore = makeExplore([stringDim]);
+        const metricQuery = makeMetricQuery(['orders_status']);
+
+        expect(getChartZoomableFields(explore, metricQuery)).toEqual([]);
     });
 });

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -191,6 +191,49 @@ export const getDateZoomXAxisFieldId = (
     return baseTimeDimension ? xFieldId : undefined;
 };
 
+export type ChartZoomableField = {
+    fieldId: string;
+    label: string;
+    tableName: string;
+};
+
+/**
+ * The date fields a chart can actually be zoomed on: the dimensions in the
+ * chart's own `metricQuery` that resolve to a base DATE/TIMESTAMP dimension.
+ * This is the set a date-zoom control should offer for a tile, narrower than
+ * the dashboard-filter field set, which exposes every filterable dimension in
+ * the explore regardless of whether the chart plots it.
+ *
+ * The returned `fieldId` is the queried dimension id (e.g. `orders_order_date_month`),
+ * matching the `xAxisFieldId` the backend re-grains in `_getDateZoomExplore`.
+ */
+export const getChartZoomableFields = (
+    explore: Explore,
+    metricQuery: MetricQuery,
+): ChartZoomableField[] => {
+    const allDimensionsMap = getAllDimensionsMap(explore);
+    const timeDimensionsMap = getTimeDimensionsMap(explore);
+    const fields: ChartZoomableField[] = [];
+    const seen = new Set<string>();
+    [...new Set(metricQuery.dimensions)].forEach((dimId) => {
+        const dim = allDimensionsMap[dimId];
+        if (!dim || seen.has(dimId)) return;
+        const baseTimeDimension = resolveToBaseTimeDimension(
+            dimId,
+            allDimensionsMap,
+            timeDimensionsMap,
+        );
+        if (!baseTimeDimension) return;
+        seen.add(dimId);
+        fields.push({
+            fieldId: dimId,
+            label: dim.label ?? dimId,
+            tableName: dim.table,
+        });
+    });
+    return fields;
+};
+
 export const EMPTY_DATE_ZOOM_CONFIG: DateZoomConfig = {
     controls: [],
     tileTargets: {},

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,4 +1,8 @@
-import { DateGranularity, isStandardDateGranularity } from '@lightdash/common';
+import {
+    DateGranularity,
+    FeatureFlags,
+    isStandardDateGranularity,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -20,12 +24,14 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { getGranularityLabel } from '../utils';
 import styles from './DateZoom.module.css';
+import { DateZoomControlPills } from './DateZoomControlPills';
 
 type EditModeGranularityItemProps = {
     granularity: string;
@@ -146,6 +152,11 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
         (c) => c.availableCustomGranularities,
     );
     const { track } = useTracking();
+    const { data: dateZoomConfigFlag } = useServerFeatureFlag(
+        FeatureFlags.DateZoomConfiguration,
+    );
+    const isDateZoomConfigEnabled =
+        dateZoomConfigFlag?.enabled ?? import.meta.env.DEV;
 
     useEffect(() => {
         if (isEditMode) setDateZoomGranularity(undefined);
@@ -250,234 +261,254 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
     }
 
     return (
-        <Group gap={0} wrap="nowrap">
-            <Menu
-                withinPortal
-                withArrow
-                closeOnItemClick={!isEditMode}
-                closeOnClickOutside
-                offset={-1}
-                position="bottom-end"
-                classNames={{ dropdown: dropdownClassName }}
-                onOpen={() => setShowOpenIcon(true)}
-                onClose={() => setShowOpenIcon(false)}
-            >
-                <Menu.Target>
-                    <Button
-                        size="xs"
-                        variant="default"
-                        classNames={
-                            !isEditMode && dateZoomGranularity
-                                ? { root: styles.activeDateZoomButton }
-                                : undefined
-                        }
-                        styles={
-                            isEditMode
-                                ? {
-                                      root: {
-                                          borderRightWidth: '0px',
-                                          borderTopRightRadius: '0px',
-                                          borderBottomRightRadius: '0px',
-                                      },
-                                  }
-                                : undefined
-                        }
-                        rightSection={
-                            <MantineIcon
-                                icon={
-                                    showOpenIcon
-                                        ? IconChevronUp
-                                        : IconChevronDown
-                                }
-                            />
-                        }
-                    >
-                        <Text fz="inherit" fw={600}>
-                            Date Zoom
-                        </Text>
-                        {!isEditMode && dateZoomGranularity ? (
-                            <>
-                                :{' '}
-                                <Text fz="inherit" fw={500} ml="xxs">
-                                    {getGranularityLabel(
-                                        dateZoomGranularity,
-                                        availableCustomGranularities,
-                                    )}
-                                </Text>
-                            </>
-                        ) : null}
-                    </Button>
-                </Menu.Target>
-                <Menu.Dropdown>
-                    {isEditMode ? (
-                        <>
-                            <Menu.Label>Granularities</Menu.Label>
-                            {standardGranularities.map((granularity) => (
-                                <EditModeGranularityItem
-                                    key={granularity}
-                                    granularity={granularity}
-                                    label={granularity}
-                                    isEnabled={dateZoomGranularities.includes(
-                                        granularity,
-                                    )}
-                                    isDefault={
-                                        defaultDateZoomGranularity ===
-                                        granularity
+        <Group gap="xs" wrap="nowrap">
+            {isDateZoomConfigEnabled && (
+                <DateZoomControlPills isEditMode={isEditMode} />
+            )}
+            <Group gap={0} wrap="nowrap">
+                <Menu
+                    withinPortal
+                    withArrow
+                    closeOnItemClick={!isEditMode}
+                    closeOnClickOutside
+                    offset={-1}
+                    position="bottom-end"
+                    classNames={{ dropdown: dropdownClassName }}
+                    onOpen={() => setShowOpenIcon(true)}
+                    onClose={() => setShowOpenIcon(false)}
+                >
+                    <Menu.Target>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            classNames={
+                                !isEditMode && dateZoomGranularity
+                                    ? { root: styles.activeDateZoomButton }
+                                    : undefined
+                            }
+                            styles={
+                                isEditMode
+                                    ? {
+                                          root: {
+                                              borderRightWidth: '0px',
+                                              borderTopRightRadius: '0px',
+                                              borderBottomRightRadius: '0px',
+                                          },
+                                      }
+                                    : undefined
+                            }
+                            rightSection={
+                                <MantineIcon
+                                    icon={
+                                        showOpenIcon
+                                            ? IconChevronUp
+                                            : IconChevronDown
                                     }
-                                    isLastEnabled={
-                                        dateZoomGranularities.includes(
-                                            granularity,
-                                        ) && dateZoomGranularities.length <= 1
-                                    }
-                                    onToggle={handleToggleGranularity}
-                                    onSetDefault={handleSetDefault}
                                 />
-                            ))}
-                            {customGranularities.length > 0 && (
+                            }
+                        >
+                            <Text fz="inherit" fw={600}>
+                                Date Zoom
+                            </Text>
+                            {!isEditMode && dateZoomGranularity ? (
                                 <>
-                                    <Menu.Divider />
-                                    <Menu.Label>Custom</Menu.Label>
-                                    {customGranularities.map((granularity) => (
-                                        <EditModeGranularityItem
-                                            key={granularity}
-                                            granularity={granularity}
-                                            label={getGranularityLabel(
-                                                granularity,
-                                                availableCustomGranularities,
-                                            )}
-                                            isEnabled={dateZoomGranularities.includes(
-                                                granularity,
-                                            )}
-                                            isDefault={
-                                                defaultDateZoomGranularity ===
-                                                granularity
-                                            }
-                                            isLastEnabled={
-                                                dateZoomGranularities.includes(
-                                                    granularity,
-                                                ) &&
-                                                dateZoomGranularities.length <=
-                                                    1
-                                            }
-                                            onToggle={handleToggleGranularity}
-                                            onSetDefault={handleSetDefault}
-                                        />
-                                    ))}
+                                    :{' '}
+                                    <Text fz="inherit" fw={500} ml="xxs">
+                                        {getGranularityLabel(
+                                            dateZoomGranularity,
+                                            availableCustomGranularities,
+                                        )}
+                                    </Text>
                                 </>
-                            )}
-                        </>
-                    ) : (
-                        <>
-                            <Tooltip
-                                label="Charts will display dates using their original granularity settings."
-                                position="left"
-                                multiline
-                                maw={200}
-                            >
-                                <Menu.Item
-                                    fz="xs"
-                                    onClick={() => {
-                                        track({
-                                            name: EventName.DATE_ZOOM_CLICKED,
-                                            properties: {
-                                                granularity: 'default',
-                                            },
-                                        });
-
-                                        setDateZoomGranularity(undefined);
-                                    }}
-                                    disabled={dateZoomGranularity === undefined}
-                                    rightSection={
-                                        dateZoomGranularity === undefined ? (
-                                            <MantineIcon
-                                                icon={IconCheck}
-                                                size={14}
-                                            />
-                                        ) : null
-                                    }
-                                >
-                                    None
-                                </Menu.Item>
-                            </Tooltip>
-
-                            {dateZoomGranularities
-                                .filter((g) => isStandardDateGranularity(g))
-                                .map((granularity) => (
-                                    <ViewModeGranularityItem
+                            ) : null}
+                        </Button>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        {isEditMode ? (
+                            <>
+                                <Menu.Label>Granularities</Menu.Label>
+                                {standardGranularities.map((granularity) => (
+                                    <EditModeGranularityItem
                                         key={granularity}
                                         granularity={granularity}
                                         label={granularity}
-                                        isActive={
-                                            dateZoomGranularity === granularity
+                                        isEnabled={dateZoomGranularities.includes(
+                                            granularity,
+                                        )}
+                                        isDefault={
+                                            defaultDateZoomGranularity ===
+                                            granularity
                                         }
-                                        onSelect={handleSelectGranularity}
+                                        isLastEnabled={
+                                            dateZoomGranularities.includes(
+                                                granularity,
+                                            ) &&
+                                            dateZoomGranularities.length <= 1
+                                        }
+                                        onToggle={handleToggleGranularity}
+                                        onSetDefault={handleSetDefault}
                                     />
                                 ))}
+                                {customGranularities.length > 0 && (
+                                    <>
+                                        <Menu.Divider />
+                                        <Menu.Label>Custom</Menu.Label>
+                                        {customGranularities.map(
+                                            (granularity) => (
+                                                <EditModeGranularityItem
+                                                    key={granularity}
+                                                    granularity={granularity}
+                                                    label={getGranularityLabel(
+                                                        granularity,
+                                                        availableCustomGranularities,
+                                                    )}
+                                                    isEnabled={dateZoomGranularities.includes(
+                                                        granularity,
+                                                    )}
+                                                    isDefault={
+                                                        defaultDateZoomGranularity ===
+                                                        granularity
+                                                    }
+                                                    isLastEnabled={
+                                                        dateZoomGranularities.includes(
+                                                            granularity,
+                                                        ) &&
+                                                        dateZoomGranularities.length <=
+                                                            1
+                                                    }
+                                                    onToggle={
+                                                        handleToggleGranularity
+                                                    }
+                                                    onSetDefault={
+                                                        handleSetDefault
+                                                    }
+                                                />
+                                            ),
+                                        )}
+                                    </>
+                                )}
+                            </>
+                        ) : (
+                            <>
+                                <Tooltip
+                                    label="Charts will display dates using their original granularity settings."
+                                    position="left"
+                                    multiline
+                                    maw={200}
+                                >
+                                    <Menu.Item
+                                        fz="xs"
+                                        onClick={() => {
+                                            track({
+                                                name: EventName.DATE_ZOOM_CLICKED,
+                                                properties: {
+                                                    granularity: 'default',
+                                                },
+                                            });
 
-                            {enabledCustomGranularities.length > 0 && (
-                                <>
-                                    <Menu.Divider />
-                                    {enabledCustomGranularities.map(
-                                        (granularity) => (
-                                            <ViewModeGranularityItem
-                                                key={granularity}
-                                                granularity={granularity}
-                                                label={getGranularityLabel(
-                                                    granularity,
-                                                    availableCustomGranularities,
-                                                )}
-                                                isActive={
-                                                    dateZoomGranularity ===
-                                                    granularity
-                                                }
-                                                onSelect={
-                                                    handleSelectGranularity
-                                                }
-                                            />
-                                        ),
-                                    )}
-                                </>
-                            )}
-                        </>
-                    )}
-                </Menu.Dropdown>
-            </Menu>
+                                            setDateZoomGranularity(undefined);
+                                        }}
+                                        disabled={
+                                            dateZoomGranularity === undefined
+                                        }
+                                        rightSection={
+                                            dateZoomGranularity ===
+                                            undefined ? (
+                                                <MantineIcon
+                                                    icon={IconCheck}
+                                                    size={14}
+                                                />
+                                            ) : null
+                                        }
+                                    >
+                                        None
+                                    </Menu.Item>
+                                </Tooltip>
 
-            {isEditMode && (
-                <>
-                    <Divider orientation="vertical" />
+                                {dateZoomGranularities
+                                    .filter((g) => isStandardDateGranularity(g))
+                                    .map((granularity) => (
+                                        <ViewModeGranularityItem
+                                            key={granularity}
+                                            granularity={granularity}
+                                            label={granularity}
+                                            isActive={
+                                                dateZoomGranularity ===
+                                                granularity
+                                            }
+                                            onSelect={handleSelectGranularity}
+                                        />
+                                    ))}
 
-                    <Tooltip
-                        label={
-                            isDateZoomDisabled
-                                ? 'Hidden from viewers. Click to show.'
-                                : 'Visible to viewers. Click to hide.'
-                        }
-                        withinPortal
-                    >
-                        <Button
-                            aria-label="Toggle date zoom visibility for viewers"
-                            size="xs"
-                            variant="default"
-                            color="gray"
-                            onClick={() =>
-                                setIsDateZoomDisabled(!isDateZoomDisabled)
+                                {enabledCustomGranularities.length > 0 && (
+                                    <>
+                                        <Menu.Divider />
+                                        {enabledCustomGranularities.map(
+                                            (granularity) => (
+                                                <ViewModeGranularityItem
+                                                    key={granularity}
+                                                    granularity={granularity}
+                                                    label={getGranularityLabel(
+                                                        granularity,
+                                                        availableCustomGranularities,
+                                                    )}
+                                                    isActive={
+                                                        dateZoomGranularity ===
+                                                        granularity
+                                                    }
+                                                    onSelect={
+                                                        handleSelectGranularity
+                                                    }
+                                                />
+                                            ),
+                                        )}
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </Menu.Dropdown>
+                </Menu>
+
+                {isEditMode && (
+                    <>
+                        <Divider orientation="vertical" />
+
+                        <Tooltip
+                            label={
+                                isDateZoomDisabled
+                                    ? 'Hidden from viewers. Click to show.'
+                                    : 'Visible to viewers. Click to hide.'
                             }
-                            styles={{
-                                root: {
-                                    borderLeftWidth: '0px',
-                                    borderStartStartRadius: '0px',
-                                    borderEndStartRadius: '0px',
-                                },
-                            }}
+                            withinPortal
                         >
-                            <MantineIcon
-                                icon={isDateZoomDisabled ? IconEyeOff : IconEye}
-                            />
-                        </Button>
-                    </Tooltip>
-                </>
-            )}
+                            <Button
+                                aria-label="Toggle date zoom visibility for viewers"
+                                size="xs"
+                                variant="default"
+                                color="gray"
+                                onClick={() =>
+                                    setIsDateZoomDisabled(!isDateZoomDisabled)
+                                }
+                                styles={{
+                                    root: {
+                                        borderLeftWidth: '0px',
+                                        borderStartStartRadius: '0px',
+                                        borderEndStartRadius: '0px',
+                                    },
+                                }}
+                            >
+                                <MantineIcon
+                                    icon={
+                                        isDateZoomDisabled
+                                            ? IconEyeOff
+                                            : IconEye
+                                    }
+                                />
+                            </Button>
+                        </Tooltip>
+                    </>
+                )}
+            </Group>
         </Group>
     );
 };

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,6 +1,7 @@
 import {
     DateGranularity,
     FeatureFlags,
+    getTileControl,
     isStandardDateGranularity,
 } from '@lightdash/common';
 import {
@@ -157,6 +158,34 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
     );
     const isDateZoomConfigEnabled =
         dateZoomConfigFlag?.enabled ?? import.meta.env.DEV;
+    const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
+    const chartZoomableFieldsByTileUuid = useDashboardContext(
+        (c) => c.chartZoomableFieldsByTileUuid,
+    );
+
+    // Charts the Default governs: date-zoomable tiles not claimed by a control.
+    const defaultTileCount = useMemo(() => {
+        if (!isDateZoomConfigEnabled) return undefined;
+        return Object.entries(chartZoomableFieldsByTileUuid)
+            .filter(([, fields]) => fields.length > 0)
+            .filter(([uuid]) => !getTileControl(dateZoomConfig, uuid)).length;
+    }, [
+        isDateZoomConfigEnabled,
+        chartZoomableFieldsByTileUuid,
+        dateZoomConfig,
+    ]);
+
+    const isDefaultInert = defaultTileCount === 0;
+    // Hide the inert Default from viewers; nothing falls through to it.
+    const hideDefaultInView = !isEditMode && isDefaultInert;
+    const defaultTooltip =
+        defaultTileCount === undefined
+            ? undefined
+            : defaultTileCount === 0
+              ? 'No charts use the default (every chart is in a zoom control)'
+              : `Applies to ${defaultTileCount} chart${
+                    defaultTileCount === 1 ? '' : 's'
+                } not in a zoom control`;
 
     useEffect(() => {
         if (isEditMode) setDateZoomGranularity(undefined);
@@ -262,253 +291,305 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
 
     return (
         <Group gap="xs" wrap="nowrap">
+            {!hideDefaultInView && (
+                <Group gap={0} wrap="nowrap">
+                    <Menu
+                        withinPortal
+                        withArrow
+                        closeOnItemClick={!isEditMode}
+                        closeOnClickOutside
+                        offset={-1}
+                        position="bottom-end"
+                        classNames={{ dropdown: dropdownClassName }}
+                        onOpen={() => setShowOpenIcon(true)}
+                        onClose={() => setShowOpenIcon(false)}
+                    >
+                        <Menu.Target>
+                            <Tooltip
+                                label={defaultTooltip}
+                                disabled={!defaultTooltip}
+                                withinPortal
+                                position="bottom"
+                            >
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    classNames={
+                                        !isEditMode && dateZoomGranularity
+                                            ? {
+                                                  root: styles.activeDateZoomButton,
+                                              }
+                                            : undefined
+                                    }
+                                    styles={
+                                        isEditMode
+                                            ? {
+                                                  root: {
+                                                      borderRightWidth: '0px',
+                                                      borderTopRightRadius:
+                                                          '0px',
+                                                      borderBottomRightRadius:
+                                                          '0px',
+                                                  },
+                                              }
+                                            : undefined
+                                    }
+                                    rightSection={
+                                        <MantineIcon
+                                            icon={
+                                                showOpenIcon
+                                                    ? IconChevronUp
+                                                    : IconChevronDown
+                                            }
+                                        />
+                                    }
+                                >
+                                    <Text
+                                        fz="inherit"
+                                        fw={600}
+                                        c={
+                                            isDefaultInert
+                                                ? 'dimmed'
+                                                : undefined
+                                        }
+                                    >
+                                        {isDateZoomConfigEnabled
+                                            ? 'Default zoom'
+                                            : 'Date Zoom'}
+                                    </Text>
+                                    {!isEditMode && dateZoomGranularity ? (
+                                        <>
+                                            {isDateZoomConfigEnabled
+                                                ? ' · '
+                                                : ': '}
+                                            <Text
+                                                fz="inherit"
+                                                fw={500}
+                                                ml="xxs"
+                                                c={
+                                                    isDefaultInert
+                                                        ? 'dimmed'
+                                                        : undefined
+                                                }
+                                            >
+                                                {getGranularityLabel(
+                                                    dateZoomGranularity,
+                                                    availableCustomGranularities,
+                                                )}
+                                            </Text>
+                                        </>
+                                    ) : null}
+                                </Button>
+                            </Tooltip>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            {isEditMode ? (
+                                <>
+                                    <Menu.Label>Granularities</Menu.Label>
+                                    {standardGranularities.map(
+                                        (granularity) => (
+                                            <EditModeGranularityItem
+                                                key={granularity}
+                                                granularity={granularity}
+                                                label={granularity}
+                                                isEnabled={dateZoomGranularities.includes(
+                                                    granularity,
+                                                )}
+                                                isDefault={
+                                                    defaultDateZoomGranularity ===
+                                                    granularity
+                                                }
+                                                isLastEnabled={
+                                                    dateZoomGranularities.includes(
+                                                        granularity,
+                                                    ) &&
+                                                    dateZoomGranularities.length <=
+                                                        1
+                                                }
+                                                onToggle={
+                                                    handleToggleGranularity
+                                                }
+                                                onSetDefault={handleSetDefault}
+                                            />
+                                        ),
+                                    )}
+                                    {customGranularities.length > 0 && (
+                                        <>
+                                            <Menu.Divider />
+                                            <Menu.Label>Custom</Menu.Label>
+                                            {customGranularities.map(
+                                                (granularity) => (
+                                                    <EditModeGranularityItem
+                                                        key={granularity}
+                                                        granularity={
+                                                            granularity
+                                                        }
+                                                        label={getGranularityLabel(
+                                                            granularity,
+                                                            availableCustomGranularities,
+                                                        )}
+                                                        isEnabled={dateZoomGranularities.includes(
+                                                            granularity,
+                                                        )}
+                                                        isDefault={
+                                                            defaultDateZoomGranularity ===
+                                                            granularity
+                                                        }
+                                                        isLastEnabled={
+                                                            dateZoomGranularities.includes(
+                                                                granularity,
+                                                            ) &&
+                                                            dateZoomGranularities.length <=
+                                                                1
+                                                        }
+                                                        onToggle={
+                                                            handleToggleGranularity
+                                                        }
+                                                        onSetDefault={
+                                                            handleSetDefault
+                                                        }
+                                                    />
+                                                ),
+                                            )}
+                                        </>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    <Tooltip
+                                        label="Charts will display dates using their original granularity settings."
+                                        position="left"
+                                        multiline
+                                        maw={200}
+                                    >
+                                        <Menu.Item
+                                            fz="xs"
+                                            onClick={() => {
+                                                track({
+                                                    name: EventName.DATE_ZOOM_CLICKED,
+                                                    properties: {
+                                                        granularity: 'default',
+                                                    },
+                                                });
+
+                                                setDateZoomGranularity(
+                                                    undefined,
+                                                );
+                                            }}
+                                            disabled={
+                                                dateZoomGranularity ===
+                                                undefined
+                                            }
+                                            rightSection={
+                                                dateZoomGranularity ===
+                                                undefined ? (
+                                                    <MantineIcon
+                                                        icon={IconCheck}
+                                                        size={14}
+                                                    />
+                                                ) : null
+                                            }
+                                        >
+                                            None
+                                        </Menu.Item>
+                                    </Tooltip>
+
+                                    {dateZoomGranularities
+                                        .filter((g) =>
+                                            isStandardDateGranularity(g),
+                                        )
+                                        .map((granularity) => (
+                                            <ViewModeGranularityItem
+                                                key={granularity}
+                                                granularity={granularity}
+                                                label={granularity}
+                                                isActive={
+                                                    dateZoomGranularity ===
+                                                    granularity
+                                                }
+                                                onSelect={
+                                                    handleSelectGranularity
+                                                }
+                                            />
+                                        ))}
+
+                                    {enabledCustomGranularities.length > 0 && (
+                                        <>
+                                            <Menu.Divider />
+                                            {enabledCustomGranularities.map(
+                                                (granularity) => (
+                                                    <ViewModeGranularityItem
+                                                        key={granularity}
+                                                        granularity={
+                                                            granularity
+                                                        }
+                                                        label={getGranularityLabel(
+                                                            granularity,
+                                                            availableCustomGranularities,
+                                                        )}
+                                                        isActive={
+                                                            dateZoomGranularity ===
+                                                            granularity
+                                                        }
+                                                        onSelect={
+                                                            handleSelectGranularity
+                                                        }
+                                                    />
+                                                ),
+                                            )}
+                                        </>
+                                    )}
+                                </>
+                            )}
+                        </Menu.Dropdown>
+                    </Menu>
+
+                    {isEditMode && (
+                        <>
+                            <Divider orientation="vertical" />
+
+                            <Tooltip
+                                label={
+                                    isDateZoomDisabled
+                                        ? 'Hidden from viewers. Click to show.'
+                                        : 'Visible to viewers. Click to hide.'
+                                }
+                                withinPortal
+                            >
+                                <Button
+                                    aria-label="Toggle date zoom visibility for viewers"
+                                    size="xs"
+                                    variant="default"
+                                    color="gray"
+                                    onClick={() =>
+                                        setIsDateZoomDisabled(
+                                            !isDateZoomDisabled,
+                                        )
+                                    }
+                                    styles={{
+                                        root: {
+                                            borderLeftWidth: '0px',
+                                            borderStartStartRadius: '0px',
+                                            borderEndStartRadius: '0px',
+                                        },
+                                    }}
+                                >
+                                    <MantineIcon
+                                        icon={
+                                            isDateZoomDisabled
+                                                ? IconEyeOff
+                                                : IconEye
+                                        }
+                                    />
+                                </Button>
+                            </Tooltip>
+                        </>
+                    )}
+                </Group>
+            )}
             {isDateZoomConfigEnabled && (
                 <DateZoomControlPills isEditMode={isEditMode} />
             )}
-            <Group gap={0} wrap="nowrap">
-                <Menu
-                    withinPortal
-                    withArrow
-                    closeOnItemClick={!isEditMode}
-                    closeOnClickOutside
-                    offset={-1}
-                    position="bottom-end"
-                    classNames={{ dropdown: dropdownClassName }}
-                    onOpen={() => setShowOpenIcon(true)}
-                    onClose={() => setShowOpenIcon(false)}
-                >
-                    <Menu.Target>
-                        <Button
-                            size="xs"
-                            variant="default"
-                            classNames={
-                                !isEditMode && dateZoomGranularity
-                                    ? { root: styles.activeDateZoomButton }
-                                    : undefined
-                            }
-                            styles={
-                                isEditMode
-                                    ? {
-                                          root: {
-                                              borderRightWidth: '0px',
-                                              borderTopRightRadius: '0px',
-                                              borderBottomRightRadius: '0px',
-                                          },
-                                      }
-                                    : undefined
-                            }
-                            rightSection={
-                                <MantineIcon
-                                    icon={
-                                        showOpenIcon
-                                            ? IconChevronUp
-                                            : IconChevronDown
-                                    }
-                                />
-                            }
-                        >
-                            <Text fz="inherit" fw={600}>
-                                Date Zoom
-                            </Text>
-                            {!isEditMode && dateZoomGranularity ? (
-                                <>
-                                    :{' '}
-                                    <Text fz="inherit" fw={500} ml="xxs">
-                                        {getGranularityLabel(
-                                            dateZoomGranularity,
-                                            availableCustomGranularities,
-                                        )}
-                                    </Text>
-                                </>
-                            ) : null}
-                        </Button>
-                    </Menu.Target>
-                    <Menu.Dropdown>
-                        {isEditMode ? (
-                            <>
-                                <Menu.Label>Granularities</Menu.Label>
-                                {standardGranularities.map((granularity) => (
-                                    <EditModeGranularityItem
-                                        key={granularity}
-                                        granularity={granularity}
-                                        label={granularity}
-                                        isEnabled={dateZoomGranularities.includes(
-                                            granularity,
-                                        )}
-                                        isDefault={
-                                            defaultDateZoomGranularity ===
-                                            granularity
-                                        }
-                                        isLastEnabled={
-                                            dateZoomGranularities.includes(
-                                                granularity,
-                                            ) &&
-                                            dateZoomGranularities.length <= 1
-                                        }
-                                        onToggle={handleToggleGranularity}
-                                        onSetDefault={handleSetDefault}
-                                    />
-                                ))}
-                                {customGranularities.length > 0 && (
-                                    <>
-                                        <Menu.Divider />
-                                        <Menu.Label>Custom</Menu.Label>
-                                        {customGranularities.map(
-                                            (granularity) => (
-                                                <EditModeGranularityItem
-                                                    key={granularity}
-                                                    granularity={granularity}
-                                                    label={getGranularityLabel(
-                                                        granularity,
-                                                        availableCustomGranularities,
-                                                    )}
-                                                    isEnabled={dateZoomGranularities.includes(
-                                                        granularity,
-                                                    )}
-                                                    isDefault={
-                                                        defaultDateZoomGranularity ===
-                                                        granularity
-                                                    }
-                                                    isLastEnabled={
-                                                        dateZoomGranularities.includes(
-                                                            granularity,
-                                                        ) &&
-                                                        dateZoomGranularities.length <=
-                                                            1
-                                                    }
-                                                    onToggle={
-                                                        handleToggleGranularity
-                                                    }
-                                                    onSetDefault={
-                                                        handleSetDefault
-                                                    }
-                                                />
-                                            ),
-                                        )}
-                                    </>
-                                )}
-                            </>
-                        ) : (
-                            <>
-                                <Tooltip
-                                    label="Charts will display dates using their original granularity settings."
-                                    position="left"
-                                    multiline
-                                    maw={200}
-                                >
-                                    <Menu.Item
-                                        fz="xs"
-                                        onClick={() => {
-                                            track({
-                                                name: EventName.DATE_ZOOM_CLICKED,
-                                                properties: {
-                                                    granularity: 'default',
-                                                },
-                                            });
-
-                                            setDateZoomGranularity(undefined);
-                                        }}
-                                        disabled={
-                                            dateZoomGranularity === undefined
-                                        }
-                                        rightSection={
-                                            dateZoomGranularity ===
-                                            undefined ? (
-                                                <MantineIcon
-                                                    icon={IconCheck}
-                                                    size={14}
-                                                />
-                                            ) : null
-                                        }
-                                    >
-                                        None
-                                    </Menu.Item>
-                                </Tooltip>
-
-                                {dateZoomGranularities
-                                    .filter((g) => isStandardDateGranularity(g))
-                                    .map((granularity) => (
-                                        <ViewModeGranularityItem
-                                            key={granularity}
-                                            granularity={granularity}
-                                            label={granularity}
-                                            isActive={
-                                                dateZoomGranularity ===
-                                                granularity
-                                            }
-                                            onSelect={handleSelectGranularity}
-                                        />
-                                    ))}
-
-                                {enabledCustomGranularities.length > 0 && (
-                                    <>
-                                        <Menu.Divider />
-                                        {enabledCustomGranularities.map(
-                                            (granularity) => (
-                                                <ViewModeGranularityItem
-                                                    key={granularity}
-                                                    granularity={granularity}
-                                                    label={getGranularityLabel(
-                                                        granularity,
-                                                        availableCustomGranularities,
-                                                    )}
-                                                    isActive={
-                                                        dateZoomGranularity ===
-                                                        granularity
-                                                    }
-                                                    onSelect={
-                                                        handleSelectGranularity
-                                                    }
-                                                />
-                                            ),
-                                        )}
-                                    </>
-                                )}
-                            </>
-                        )}
-                    </Menu.Dropdown>
-                </Menu>
-
-                {isEditMode && (
-                    <>
-                        <Divider orientation="vertical" />
-
-                        <Tooltip
-                            label={
-                                isDateZoomDisabled
-                                    ? 'Hidden from viewers. Click to show.'
-                                    : 'Visible to viewers. Click to hide.'
-                            }
-                            withinPortal
-                        >
-                            <Button
-                                aria-label="Toggle date zoom visibility for viewers"
-                                size="xs"
-                                variant="default"
-                                color="gray"
-                                onClick={() =>
-                                    setIsDateZoomDisabled(!isDateZoomDisabled)
-                                }
-                                styles={{
-                                    root: {
-                                        borderLeftWidth: '0px',
-                                        borderStartStartRadius: '0px',
-                                        borderEndStartRadius: '0px',
-                                    },
-                                }}
-                            >
-                                <MantineIcon
-                                    icon={
-                                        isDateZoomDisabled
-                                            ? IconEyeOff
-                                            : IconEye
-                                    }
-                                />
-                            </Button>
-                        </Tooltip>
-                    </>
-                )}
-            </Group>
         </Group>
     );
 };

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
@@ -1,0 +1,379 @@
+import {
+    DimensionType,
+    DateGranularity,
+    getItemId,
+    getTileControl,
+    isDashboardChartTileType,
+    isDimension,
+    type DateZoomConfig,
+    type DateZoomControl,
+    type DateZoomTileTarget,
+    type FilterableDimension,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Tabs,
+    Text,
+    TextInput,
+} from '@mantine-8/core';
+import { useMemo, useState, type FC } from 'react';
+import MantineModal from '../../../components/common/MantineModal';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+
+// The control modal owns a draft of one control plus that control's slice of
+// `tileTargets`, and returns the full updated config so the caller just stores it.
+export type DateZoomControlModalProps = {
+    control: DateZoomControl;
+    config: DateZoomConfig;
+    opened: boolean;
+    onSave: (nextConfig: DateZoomConfig) => void;
+    onDelete: (controlUuid: string) => void;
+    onClose: () => void;
+};
+
+// v1 offers the five day+ granularities; sub-day grains are intentionally omitted.
+const CONTROL_GRANULARITIES: DateGranularity[] = [
+    DateGranularity.DAY,
+    DateGranularity.WEEK,
+    DateGranularity.MONTH,
+    DateGranularity.QUARTER,
+    DateGranularity.YEAR,
+];
+
+enum ControlModalTab {
+    SETTINGS = 'settings',
+    TILES = 'tiles',
+}
+
+type DraftTarget = { fieldId: string; tableName: string };
+
+const isDateField = (field: FilterableDimension): boolean =>
+    field.type === DimensionType.DATE || field.type === DimensionType.TIMESTAMP;
+
+export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
+    control,
+    config,
+    opened,
+    onSave,
+    onDelete,
+    onClose,
+}) => {
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const filterableFieldsByTileUuid = useDashboardContext(
+        (c) => c.filterableFieldsByTileUuid,
+    );
+
+    const [selectedTab, setSelectedTab] = useState<ControlModalTab>(
+        ControlModalTab.SETTINGS,
+    );
+
+    // Seeded once on mount; the parent remounts with `key={control.uuid}` when
+    // switching controls, so we never sync props into state via useEffect.
+    const [draft, setDraft] = useState<DateZoomControl>(() => control);
+    const [draftTargets, setDraftTargets] = useState<
+        Record<string, DraftTarget>
+    >(() =>
+        Object.fromEntries(
+            Object.entries(config.tileTargets)
+                .filter(([, target]) => target.controlUuid === control.uuid)
+                .map(([tileUuid, target]) => [
+                    tileUuid,
+                    { fieldId: target.fieldId, tableName: target.tableName },
+                ]),
+        ),
+    );
+
+    const targetCount = useMemo(
+        () => Object.keys(draftTargets).length,
+        [draftTargets],
+    );
+
+    // Saved-chart tiles that expose at least one DATE/TIMESTAMP field, with the
+    // control they are currently attached to (for conflict display).
+    const eligibleTiles = useMemo(() => {
+        return (dashboardTiles ?? [])
+            .filter(isDashboardChartTileType)
+            .map((tile) => {
+                const dateFields = (
+                    filterableFieldsByTileUuid?.[tile.uuid] ?? []
+                ).filter(
+                    (field): field is FilterableDimension =>
+                        isDimension(field) && isDateField(field),
+                );
+                const otherControl = getTileControl(config, tile.uuid);
+                const conflictControl =
+                    otherControl && otherControl.uuid !== draft.uuid
+                        ? otherControl
+                        : undefined;
+                const label =
+                    (tile.properties.title?.length
+                        ? tile.properties.title
+                        : tile.properties.chartName) || 'Untitled chart';
+                return { tile, dateFields, conflictControl, label };
+            })
+            .filter(({ dateFields }) => dateFields.length > 0);
+    }, [dashboardTiles, filterableFieldsByTileUuid, config, draft.uuid]);
+
+    const toggleTile = (
+        tileUuid: string,
+        dateFields: FilterableDimension[],
+        checked: boolean,
+    ) => {
+        setDraftTargets((prev) => {
+            if (!checked) {
+                const { [tileUuid]: _removed, ...rest } = prev;
+                return rest;
+            }
+            const firstField = dateFields[0];
+            return {
+                ...prev,
+                [tileUuid]: {
+                    fieldId: getItemId(firstField),
+                    tableName: firstField.table,
+                },
+            };
+        });
+    };
+
+    const setTileField = (
+        tileUuid: string,
+        dateFields: FilterableDimension[],
+        fieldId: string,
+    ) => {
+        const field = dateFields.find((f) => getItemId(f) === fieldId);
+        if (!field) return;
+        setDraftTargets((prev) => ({
+            ...prev,
+            [tileUuid]: { fieldId, tableName: field.table },
+        }));
+    };
+
+    const handleSelectAll = () => {
+        setDraftTargets((prev) => {
+            const next = { ...prev };
+            eligibleTiles.forEach(({ tile, dateFields, conflictControl }) => {
+                if (conflictControl || next[tile.uuid]) return;
+                const firstField = dateFields[0];
+                next[tile.uuid] = {
+                    fieldId: getItemId(firstField),
+                    tableName: firstField.table,
+                };
+            });
+            return next;
+        });
+    };
+
+    const handleSave = () => {
+        // Upsert this control.
+        const controls = config.controls.some((c) => c.uuid === draft.uuid)
+            ? config.controls.map((c) => (c.uuid === draft.uuid ? draft : c))
+            : [...config.controls, draft];
+
+        // Rewrite only THIS control's targets; leave other controls untouched.
+        const tileTargets: Record<string, DateZoomTileTarget> =
+            Object.fromEntries(
+                Object.entries(config.tileTargets).filter(
+                    ([, target]) => target.controlUuid !== draft.uuid,
+                ),
+            );
+        Object.entries(draftTargets).forEach(
+            ([tileUuid, { fieldId, tableName }]) => {
+                tileTargets[tileUuid] = {
+                    controlUuid: draft.uuid,
+                    fieldId,
+                    tableName,
+                };
+            },
+        );
+
+        onSave({ controls, tileTargets });
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Date zoom control"
+            size="lg"
+            onConfirm={handleSave}
+            confirmLabel="Save changes"
+            confirmDisabled={draft.name.trim().length === 0}
+            leftActions={
+                <Button
+                    variant="subtle"
+                    color="red"
+                    onClick={() => onDelete(draft.uuid)}
+                >
+                    Delete
+                </Button>
+            }
+        >
+            <Tabs
+                value={selectedTab}
+                onChange={(value) =>
+                    setSelectedTab(
+                        (value as ControlModalTab) ?? ControlModalTab.SETTINGS,
+                    )
+                }
+            >
+                <Tabs.List mb="md">
+                    <Tabs.Tab value={ControlModalTab.SETTINGS}>
+                        Zoom settings
+                    </Tabs.Tab>
+                    <Tabs.Tab value={ControlModalTab.TILES}>
+                        Chart tiles
+                    </Tabs.Tab>
+                </Tabs.List>
+
+                <Tabs.Panel value={ControlModalTab.SETTINGS}>
+                    <Stack gap="md">
+                        <TextInput
+                            label="Control name"
+                            placeholder="e.g. Revenue zoom"
+                            value={draft.name}
+                            onChange={(e) =>
+                                setDraft((prev) => ({
+                                    ...prev,
+                                    name: e.currentTarget.value,
+                                }))
+                            }
+                        />
+
+                        <Stack gap="xxs">
+                            <Text fz="sm" fw={500}>
+                                Default granularity
+                            </Text>
+                            <SegmentedControl
+                                data={CONTROL_GRANULARITIES.map(
+                                    (granularity) => ({
+                                        label: granularity,
+                                        value: granularity,
+                                    }),
+                                )}
+                                value={String(draft.granularity)}
+                                onChange={(value) =>
+                                    setDraft((prev) => ({
+                                        ...prev,
+                                        granularity: value,
+                                    }))
+                                }
+                            />
+                        </Stack>
+
+                        <Group justify="space-between">
+                            <Text fz="sm" c="dimmed">
+                                Targeting {targetCount}{' '}
+                                {targetCount === 1 ? 'tile' : 'tiles'}
+                            </Text>
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                onClick={() =>
+                                    setSelectedTab(ControlModalTab.TILES)
+                                }
+                            >
+                                Edit tiles
+                            </Button>
+                        </Group>
+                    </Stack>
+                </Tabs.Panel>
+
+                <Tabs.Panel value={ControlModalTab.TILES}>
+                    <Stack gap="xs">
+                        {eligibleTiles.length === 0 ? (
+                            <Text fz="sm" c="dimmed">
+                                No chart tiles with a date dimension to zoom.
+                            </Text>
+                        ) : (
+                            <>
+                                <Group justify="flex-end">
+                                    <Button
+                                        variant="subtle"
+                                        size="xs"
+                                        onClick={handleSelectAll}
+                                    >
+                                        Select all
+                                    </Button>
+                                </Group>
+                                {eligibleTiles.map(
+                                    ({
+                                        tile,
+                                        dateFields,
+                                        conflictControl,
+                                        label,
+                                    }) => {
+                                        const target = draftTargets[tile.uuid];
+                                        const isChecked = !!target;
+                                        return (
+                                            <Group
+                                                key={tile.uuid}
+                                                justify="space-between"
+                                                wrap="nowrap"
+                                            >
+                                                <Checkbox
+                                                    label={label}
+                                                    checked={isChecked}
+                                                    disabled={!!conflictControl}
+                                                    onChange={(e) =>
+                                                        toggleTile(
+                                                            tile.uuid,
+                                                            dateFields,
+                                                            e.currentTarget
+                                                                .checked,
+                                                        )
+                                                    }
+                                                />
+                                                {conflictControl ? (
+                                                    <Badge
+                                                        color="gray"
+                                                        variant="light"
+                                                    >
+                                                        in:{' '}
+                                                        {conflictControl.name}
+                                                    </Badge>
+                                                ) : (
+                                                    <Select
+                                                        size="xs"
+                                                        w={200}
+                                                        disabled={!isChecked}
+                                                        placeholder="Date field"
+                                                        data={dateFields.map(
+                                                            (field) => ({
+                                                                value: getItemId(
+                                                                    field,
+                                                                ),
+                                                                label: field.label,
+                                                            }),
+                                                        )}
+                                                        value={
+                                                            target?.fieldId ??
+                                                            null
+                                                        }
+                                                        onChange={(value) =>
+                                                            value &&
+                                                            setTileField(
+                                                                tile.uuid,
+                                                                dateFields,
+                                                                value,
+                                                            )
+                                                        }
+                                                    />
+                                                )}
+                                            </Group>
+                                        );
+                                    },
+                                )}
+                            </>
+                        )}
+                    </Stack>
+                </Tabs.Panel>
+            </Tabs>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
@@ -1,21 +1,17 @@
 import {
-    DimensionType,
-    DateGranularity,
-    getItemId,
     getTileControl,
     isDashboardChartTileType,
-    isDimension,
+    isStandardDateGranularity,
+    type ChartZoomableField,
     type DateZoomConfig,
     type DateZoomControl,
     type DateZoomTileTarget,
-    type FilterableDimension,
 } from '@lightdash/common';
 import {
     Badge,
     Button,
     Checkbox,
     Group,
-    SegmentedControl,
     Select,
     Stack,
     Tabs,
@@ -25,6 +21,8 @@ import {
 import { useMemo, useState, type FC } from 'react';
 import MantineModal from '../../../components/common/MantineModal';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
+import { getGranularityLabel } from '../utils';
 
 // The control modal owns a draft of one control plus that control's slice of
 // `tileTargets`, and returns the full updated config so the caller just stores it.
@@ -37,24 +35,12 @@ export type DateZoomControlModalProps = {
     onClose: () => void;
 };
 
-// v1 offers the five day+ granularities; sub-day grains are intentionally omitted.
-const CONTROL_GRANULARITIES: DateGranularity[] = [
-    DateGranularity.DAY,
-    DateGranularity.WEEK,
-    DateGranularity.MONTH,
-    DateGranularity.QUARTER,
-    DateGranularity.YEAR,
-];
-
 enum ControlModalTab {
     SETTINGS = 'settings',
     TILES = 'tiles',
 }
 
 type DraftTarget = { fieldId: string; tableName: string };
-
-const isDateField = (field: FilterableDimension): boolean =>
-    field.type === DimensionType.DATE || field.type === DimensionType.TIMESTAMP;
 
 export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
     control,
@@ -65,8 +51,18 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
     onClose,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
-    const filterableFieldsByTileUuid = useDashboardContext(
-        (c) => c.filterableFieldsByTileUuid,
+    const chartZoomableFieldsByTileUuid = useDashboardContext(
+        (c) => c.chartZoomableFieldsByTileUuid,
+    );
+    // Custom granularities discovered across the dashboard's tiles (same source
+    // as the global picker). A control can zoom to these when available.
+    const availableCustomGranularities = useDashboardTileStatusContext(
+        (c) => c.availableCustomGranularities,
+    );
+    // The dashboard's enabled granularities (set in the default picker); every
+    // control offers only these.
+    const dateZoomGranularities = useDashboardContext(
+        (c) => c.dateZoomGranularities,
     );
 
     const [selectedTab, setSelectedTab] = useState<ControlModalTab>(
@@ -94,18 +90,45 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
         [draftTargets],
     );
 
-    // Saved-chart tiles that expose at least one DATE/TIMESTAMP field, with the
-    // control they are currently attached to (for conflict display).
+    // Only the dashboard's enabled granularities, grouped standard vs custom.
+    const granularityData = useMemo(() => {
+        const standardItems = dateZoomGranularities
+            .filter(isStandardDateGranularity)
+            .map((granularity) => ({
+                value: String(granularity),
+                label: String(granularity),
+            }));
+        const customItems = dateZoomGranularities
+            .filter((g) => !isStandardDateGranularity(g))
+            .sort((a, b) =>
+                getGranularityLabel(
+                    a,
+                    availableCustomGranularities,
+                ).localeCompare(
+                    getGranularityLabel(b, availableCustomGranularities),
+                ),
+            )
+            .map((key) => ({
+                value: key,
+                label: getGranularityLabel(key, availableCustomGranularities),
+            }));
+        if (customItems.length === 0) return standardItems;
+        if (standardItems.length === 0) return customItems;
+        return [
+            { group: 'Standard', items: standardItems },
+            { group: 'Custom', items: customItems },
+        ];
+    }, [dateZoomGranularities, availableCustomGranularities]);
+
+    // Chart tiles that expose at least one zoomable date field (a date/timestamp
+    // dimension the chart actually queries), with the control they are currently
+    // attached to (for conflict display).
     const eligibleTiles = useMemo(() => {
         return (dashboardTiles ?? [])
             .filter(isDashboardChartTileType)
             .map((tile) => {
-                const dateFields = (
-                    filterableFieldsByTileUuid?.[tile.uuid] ?? []
-                ).filter(
-                    (field): field is FilterableDimension =>
-                        isDimension(field) && isDateField(field),
-                );
+                const zoomableFields =
+                    chartZoomableFieldsByTileUuid[tile.uuid] ?? [];
                 const otherControl = getTileControl(config, tile.uuid);
                 const conflictControl =
                     otherControl && otherControl.uuid !== draft.uuid
@@ -115,14 +138,14 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                     (tile.properties.title?.length
                         ? tile.properties.title
                         : tile.properties.chartName) || 'Untitled chart';
-                return { tile, dateFields, conflictControl, label };
+                return { tile, zoomableFields, conflictControl, label };
             })
-            .filter(({ dateFields }) => dateFields.length > 0);
-    }, [dashboardTiles, filterableFieldsByTileUuid, config, draft.uuid]);
+            .filter(({ zoomableFields }) => zoomableFields.length > 0);
+    }, [dashboardTiles, chartZoomableFieldsByTileUuid, config, draft.uuid]);
 
     const toggleTile = (
         tileUuid: string,
-        dateFields: FilterableDimension[],
+        zoomableFields: ChartZoomableField[],
         checked: boolean,
     ) => {
         setDraftTargets((prev) => {
@@ -130,12 +153,12 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                 const { [tileUuid]: _removed, ...rest } = prev;
                 return rest;
             }
-            const firstField = dateFields[0];
+            const firstField = zoomableFields[0];
             return {
                 ...prev,
                 [tileUuid]: {
-                    fieldId: getItemId(firstField),
-                    tableName: firstField.table,
+                    fieldId: firstField.fieldId,
+                    tableName: firstField.tableName,
                 },
             };
         });
@@ -143,28 +166,30 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
 
     const setTileField = (
         tileUuid: string,
-        dateFields: FilterableDimension[],
+        zoomableFields: ChartZoomableField[],
         fieldId: string,
     ) => {
-        const field = dateFields.find((f) => getItemId(f) === fieldId);
+        const field = zoomableFields.find((f) => f.fieldId === fieldId);
         if (!field) return;
         setDraftTargets((prev) => ({
             ...prev,
-            [tileUuid]: { fieldId, tableName: field.table },
+            [tileUuid]: { fieldId, tableName: field.tableName },
         }));
     };
 
     const handleSelectAll = () => {
         setDraftTargets((prev) => {
             const next = { ...prev };
-            eligibleTiles.forEach(({ tile, dateFields, conflictControl }) => {
-                if (conflictControl || next[tile.uuid]) return;
-                const firstField = dateFields[0];
-                next[tile.uuid] = {
-                    fieldId: getItemId(firstField),
-                    tableName: firstField.table,
-                };
-            });
+            eligibleTiles.forEach(
+                ({ tile, zoomableFields, conflictControl }) => {
+                    if (conflictControl || next[tile.uuid]) return;
+                    const firstField = zoomableFields[0];
+                    next[tile.uuid] = {
+                        fieldId: firstField.fieldId,
+                        tableName: firstField.tableName,
+                    };
+                },
+            );
             return next;
         });
     };
@@ -203,7 +228,9 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
             size="lg"
             onConfirm={handleSave}
             confirmLabel="Save changes"
-            confirmDisabled={draft.name.trim().length === 0}
+            confirmDisabled={
+                draft.name.trim().length === 0 || targetCount === 0
+            }
             leftActions={
                 <Button
                     variant="subtle"
@@ -243,31 +270,30 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                             }}
                         />
 
-                        <Stack gap="xxs">
-                            <Text fz="sm" fw={500}>
-                                Default granularity
-                            </Text>
-                            <SegmentedControl
-                                data={CONTROL_GRANULARITIES.map(
-                                    (granularity) => ({
-                                        label: granularity,
-                                        value: granularity,
-                                    }),
-                                )}
-                                value={String(draft.granularity)}
-                                onChange={(value) =>
-                                    setDraft((prev) => ({
-                                        ...prev,
-                                        granularity: value,
-                                    }))
-                                }
-                            />
-                        </Stack>
+                        <Select
+                            label="Default granularity"
+                            data={granularityData}
+                            value={String(draft.granularity)}
+                            allowDeselect={false}
+                            onChange={(value) =>
+                                value &&
+                                setDraft((prev) => ({
+                                    ...prev,
+                                    granularity: value,
+                                }))
+                            }
+                        />
 
                         <Group justify="space-between">
-                            <Text fz="sm" c="dimmed">
-                                Targeting {targetCount}{' '}
-                                {targetCount === 1 ? 'tile' : 'tiles'}
+                            <Text
+                                fz="sm"
+                                c={targetCount === 0 ? 'red' : 'dimmed'}
+                            >
+                                {targetCount === 0
+                                    ? 'Select at least one chart'
+                                    : `Targeting ${targetCount} ${
+                                          targetCount === 1 ? 'chart' : 'charts'
+                                      }`}
                             </Text>
                             <Button
                                 variant="subtle"
@@ -276,7 +302,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                     setSelectedTab(ControlModalTab.TILES)
                                 }
                             >
-                                Edit tiles
+                                Edit charts
                             </Button>
                         </Group>
                     </Stack>
@@ -302,7 +328,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                 {eligibleTiles.map(
                                     ({
                                         tile,
-                                        dateFields,
+                                        zoomableFields,
                                         conflictControl,
                                         label,
                                     }) => {
@@ -321,7 +347,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                                     onChange={(e) =>
                                                         toggleTile(
                                                             tile.uuid,
-                                                            dateFields,
+                                                            zoomableFields,
                                                             e.currentTarget
                                                                 .checked,
                                                         )
@@ -341,11 +367,9 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                                         w={200}
                                                         disabled={!isChecked}
                                                         placeholder="Date field"
-                                                        data={dateFields.map(
+                                                        data={zoomableFields.map(
                                                             (field) => ({
-                                                                value: getItemId(
-                                                                    field,
-                                                                ),
+                                                                value: field.fieldId,
                                                                 label: field.label,
                                                             }),
                                                         )}
@@ -357,7 +381,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                                             value &&
                                                             setTileField(
                                                                 tile.uuid,
-                                                                dateFields,
+                                                                zoomableFields,
                                                                 value,
                                                             )
                                                         }

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
@@ -237,12 +237,10 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                             label="Control name"
                             placeholder="e.g. Revenue zoom"
                             value={draft.name}
-                            onChange={(e) =>
-                                setDraft((prev) => ({
-                                    ...prev,
-                                    name: e.currentTarget.value,
-                                }))
-                            }
+                            onChange={(e) => {
+                                const name = e.currentTarget.value;
+                                setDraft((prev) => ({ ...prev, name }));
+                            }}
                         />
 
                         <Stack gap="xxs">

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
@@ -1,25 +1,27 @@
 import {
     DateGranularity,
     getControlActiveGranularity,
+    isStandardDateGranularity,
     pruneDateZoomConfig,
     type DateZoomConfig,
     type DateZoomControl,
 } from '@lightdash/common';
 import { Button, Group, Menu } from '@mantine-8/core';
-import { IconChevronDown, IconPlus, IconSettings } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import {
+    IconChevronDown,
+    IconEye,
+    IconEyeOff,
+    IconPlus,
+    IconSettings,
+    IconTrash,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FC } from 'react';
 import { v4 as uuid4 } from 'uuid';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
+import { getGranularityLabel } from '../utils';
 import { DateZoomControlModal } from './DateZoomControlModal';
-
-const CONTROL_GRANULARITIES: DateGranularity[] = [
-    DateGranularity.DAY,
-    DateGranularity.WEEK,
-    DateGranularity.MONTH,
-    DateGranularity.QUARTER,
-    DateGranularity.YEAR,
-];
 
 type Props = {
     isEditMode: boolean;
@@ -33,6 +35,36 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
     );
     const setControlGranularity = useDashboardContext(
         (c) => c.setControlGranularity,
+    );
+    const availableCustomGranularities = useDashboardTileStatusContext(
+        (c) => c.availableCustomGranularities,
+    );
+    const dateZoomGranularities = useDashboardContext(
+        (c) => c.dateZoomGranularities,
+    );
+    const defaultDateZoomGranularity = useDashboardContext(
+        (c) => c.defaultDateZoomGranularity,
+    );
+
+    // A control offers only the dashboard's enabled granularities, split into
+    // standard and custom (customs sorted by label).
+    const standardGranularities = useMemo(
+        () => dateZoomGranularities.filter(isStandardDateGranularity),
+        [dateZoomGranularities],
+    );
+    const customGranularities = useMemo(
+        () =>
+            dateZoomGranularities
+                .filter((g) => !isStandardDateGranularity(g))
+                .sort((a, b) =>
+                    getGranularityLabel(
+                        a,
+                        availableCustomGranularities,
+                    ).localeCompare(
+                        getGranularityLabel(b, availableCustomGranularities),
+                    ),
+                ),
+        [dateZoomGranularities, availableCustomGranularities],
     );
 
     const [editingControl, setEditingControl] = useState<DateZoomControl>();
@@ -54,9 +86,22 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
         setEditingControl(undefined);
     };
 
+    const handleToggleHidden = (control: DateZoomControl) => {
+        setDateZoomConfig({
+            ...dateZoomConfig,
+            controls: dateZoomConfig.controls.map((c) =>
+                c.uuid === control.uuid ? { ...c, hidden: !c.hidden } : c,
+            ),
+        });
+    };
+
+    const visibleControls = dateZoomConfig.controls.filter(
+        (control) => isEditMode || !control.hidden,
+    );
+
     return (
         <Group gap="xs" wrap="nowrap">
-            {dateZoomConfig.controls.map((control) => {
+            {visibleControls.map((control) => {
                 const activeGranularity = getControlActiveGranularity(
                     control,
                     controlGranularities,
@@ -72,16 +117,26 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                             <Button
                                 size="xs"
                                 variant="default"
+                                c={control.hidden ? 'dimmed' : undefined}
+                                leftSection={
+                                    control.hidden ? (
+                                        <MantineIcon icon={IconEyeOff} />
+                                    ) : undefined
+                                }
                                 rightSection={
                                     <MantineIcon icon={IconChevronDown} />
                                 }
                             >
-                                {control.name} · {activeGranularity}
+                                {control.name} ·{' '}
+                                {getGranularityLabel(
+                                    activeGranularity,
+                                    availableCustomGranularities,
+                                )}
                             </Button>
                         </Menu.Target>
                         <Menu.Dropdown>
                             <Menu.Label>Granularity</Menu.Label>
-                            {CONTROL_GRANULARITIES.map((granularity) => (
+                            {standardGranularities.map((granularity) => (
                                 <Menu.Item
                                     key={granularity}
                                     fz="xs"
@@ -96,6 +151,33 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                                     {granularity}
                                 </Menu.Item>
                             ))}
+                            {customGranularities.length > 0 && (
+                                <>
+                                    <Menu.Divider />
+                                    <Menu.Label>Custom</Menu.Label>
+                                    {customGranularities.map((granularity) => (
+                                        <Menu.Item
+                                            key={granularity}
+                                            fz="xs"
+                                            disabled={
+                                                activeGranularity ===
+                                                granularity
+                                            }
+                                            onClick={() =>
+                                                setControlGranularity(
+                                                    control.uuid,
+                                                    granularity,
+                                                )
+                                            }
+                                        >
+                                            {getGranularityLabel(
+                                                granularity,
+                                                availableCustomGranularities,
+                                            )}
+                                        </Menu.Item>
+                                    ))}
+                                </>
+                            )}
                             <Menu.Divider />
                             <Menu.Item
                                 fz="xs"
@@ -109,15 +191,50 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                                 Reset to default
                             </Menu.Item>
                             {isEditMode && (
-                                <Menu.Item
-                                    fz="xs"
-                                    leftSection={
-                                        <MantineIcon icon={IconSettings} />
-                                    }
-                                    onClick={() => setEditingControl(control)}
-                                >
-                                    Configure
-                                </Menu.Item>
+                                <>
+                                    <Menu.Item
+                                        fz="xs"
+                                        leftSection={
+                                            <MantineIcon icon={IconSettings} />
+                                        }
+                                        onClick={() =>
+                                            setEditingControl(control)
+                                        }
+                                    >
+                                        Configure
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        fz="xs"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={
+                                                    control.hidden
+                                                        ? IconEye
+                                                        : IconEyeOff
+                                                }
+                                            />
+                                        }
+                                        onClick={() =>
+                                            handleToggleHidden(control)
+                                        }
+                                    >
+                                        {control.hidden
+                                            ? 'Show to viewers'
+                                            : 'Hide from viewers'}
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        fz="xs"
+                                        color="red"
+                                        leftSection={
+                                            <MantineIcon icon={IconTrash} />
+                                        }
+                                        onClick={() =>
+                                            handleDelete(control.uuid)
+                                        }
+                                    >
+                                        Remove
+                                    </Menu.Item>
+                                </>
                             )}
                         </Menu.Dropdown>
                     </Menu>
@@ -133,7 +250,10 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                         setEditingControl({
                             uuid: uuid4(),
                             name: 'Date zoom',
-                            granularity: DateGranularity.MONTH,
+                            granularity:
+                                defaultDateZoomGranularity ??
+                                dateZoomGranularities[0] ??
+                                DateGranularity.MONTH,
                         })
                     }
                 >

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
@@ -1,0 +1,157 @@
+import {
+    DateGranularity,
+    getControlActiveGranularity,
+    pruneDateZoomConfig,
+    type DateZoomConfig,
+    type DateZoomControl,
+} from '@lightdash/common';
+import { Button, Group, Menu } from '@mantine-8/core';
+import { IconChevronDown, IconPlus, IconSettings } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { v4 as uuid4 } from 'uuid';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import { DateZoomControlModal } from './DateZoomControlModal';
+
+const CONTROL_GRANULARITIES: DateGranularity[] = [
+    DateGranularity.DAY,
+    DateGranularity.WEEK,
+    DateGranularity.MONTH,
+    DateGranularity.QUARTER,
+    DateGranularity.YEAR,
+];
+
+type Props = {
+    isEditMode: boolean;
+};
+
+export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
+    const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
+    const setDateZoomConfig = useDashboardContext((c) => c.setDateZoomConfig);
+    const controlGranularities = useDashboardContext(
+        (c) => c.controlGranularities,
+    );
+    const setControlGranularity = useDashboardContext(
+        (c) => c.setControlGranularity,
+    );
+
+    const [editingControl, setEditingControl] = useState<DateZoomControl>();
+
+    const handleSave = (nextConfig: DateZoomConfig) => {
+        setDateZoomConfig(nextConfig);
+        setEditingControl(undefined);
+    };
+
+    const handleDelete = (controlUuid: string) => {
+        setDateZoomConfig(
+            pruneDateZoomConfig({
+                ...dateZoomConfig,
+                controls: dateZoomConfig.controls.filter(
+                    (c) => c.uuid !== controlUuid,
+                ),
+            }),
+        );
+        setEditingControl(undefined);
+    };
+
+    return (
+        <Group gap="xs" wrap="nowrap">
+            {dateZoomConfig.controls.map((control) => {
+                const activeGranularity = getControlActiveGranularity(
+                    control,
+                    controlGranularities,
+                );
+                return (
+                    <Menu
+                        key={control.uuid}
+                        withinPortal
+                        position="bottom-start"
+                        closeOnItemClick
+                    >
+                        <Menu.Target>
+                            <Button
+                                size="xs"
+                                variant="default"
+                                rightSection={
+                                    <MantineIcon icon={IconChevronDown} />
+                                }
+                            >
+                                {control.name} · {activeGranularity}
+                            </Button>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Label>Granularity</Menu.Label>
+                            {CONTROL_GRANULARITIES.map((granularity) => (
+                                <Menu.Item
+                                    key={granularity}
+                                    fz="xs"
+                                    disabled={activeGranularity === granularity}
+                                    onClick={() =>
+                                        setControlGranularity(
+                                            control.uuid,
+                                            granularity,
+                                        )
+                                    }
+                                >
+                                    {granularity}
+                                </Menu.Item>
+                            ))}
+                            <Menu.Divider />
+                            <Menu.Item
+                                fz="xs"
+                                onClick={() =>
+                                    setControlGranularity(
+                                        control.uuid,
+                                        undefined,
+                                    )
+                                }
+                            >
+                                Reset to default
+                            </Menu.Item>
+                            {isEditMode && (
+                                <Menu.Item
+                                    fz="xs"
+                                    leftSection={
+                                        <MantineIcon icon={IconSettings} />
+                                    }
+                                    onClick={() => setEditingControl(control)}
+                                >
+                                    Configure
+                                </Menu.Item>
+                            )}
+                        </Menu.Dropdown>
+                    </Menu>
+                );
+            })}
+
+            {isEditMode && (
+                <Button
+                    size="xs"
+                    variant="subtle"
+                    leftSection={<MantineIcon icon={IconPlus} />}
+                    onClick={() =>
+                        setEditingControl({
+                            uuid: uuid4(),
+                            name: 'Date zoom',
+                            granularity: DateGranularity.MONTH,
+                        })
+                    }
+                >
+                    Add zoom
+                </Button>
+            )}
+
+            {editingControl && (
+                <DateZoomControlModal
+                    key={editingControl.uuid}
+                    control={editingControl}
+                    config={dateZoomConfig}
+                    opened
+                    onSave={handleSave}
+                    onDelete={handleDelete}
+                    onClose={() => setEditingControl(undefined)}
+                />
+            )}
+        </Group>
+    );
+};

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -2,6 +2,7 @@ import {
     EMPTY_DATE_ZOOM_CONFIG,
     FeatureFlags,
     getAvailableParametersFromTables,
+    getChartZoomableFields,
     getDateZoomCapabilities,
     getDateZoomXAxisFieldId,
     hasReservedParameterReference,
@@ -123,6 +124,9 @@ export const useDashboardChartReadyQuery = (
     const addParameterDefinitions = useDashboardContext(
         (c) => c.addParameterDefinitions,
     );
+    const setChartZoomableFields = useDashboardContext(
+        (c) => c.setChartZoomableFields,
+    );
 
     const sortKey =
         dashboardSorts
@@ -156,6 +160,19 @@ export const useDashboardChartReadyQuery = (
         if (!chartQuery.data || !explore) return undefined;
         return getDateZoomCapabilities(explore, chartQuery.data.metricQuery);
     }, [chartQuery.data, explore]);
+
+    // Report this tile's zoomable date fields up so the date-zoom control modal
+    // can offer exactly the fields the chart plots, not every explore dimension.
+    const chartZoomableFields = useMemo(() => {
+        if (!chartQuery.data || !explore) return undefined;
+        return getChartZoomableFields(explore, chartQuery.data.metricQuery);
+    }, [chartQuery.data, explore]);
+
+    useEffect(() => {
+        if (chartZoomableFields) {
+            setChartZoomableFields(tileUuid, chartZoomableFields);
+        }
+    }, [chartZoomableFields, setChartZoomableFields, tileUuid]);
 
     // Target the chart's own x-axis date field so the backend re-grains the
     // field the chart actually plots, rather than auto-picking the first date

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -2,6 +2,9 @@ import { subject } from '@casl/ability';
 import {
     copyDateZoomTileTargets,
     getShadowedReservedNames,
+    isEmptyDateZoomConfig,
+    normalizeDateZoomConfig,
+    pruneDateZoomConfig,
     ContentType,
     DateGranularity,
     type UpdateDashboard,
@@ -178,6 +181,12 @@ const Dashboard: FC = () => {
     const setHasDefaultDateZoomGranularityChanged = useDashboardContext(
         (c) => c.setHasDefaultDateZoomGranularityChanged,
     );
+    const hasDateZoomConfigChanged = useDashboardContext(
+        (c) => c.hasDateZoomConfigChanged,
+    );
+    const setHasDateZoomConfigChanged = useDashboardContext(
+        (c) => c.setHasDateZoomConfigChanged,
+    );
 
     const parameterDefinitions = useDashboardContext(
         (c) => c.parameterDefinitions,
@@ -346,6 +355,7 @@ const Dashboard: FC = () => {
             setHavePinnedParametersChanged(false);
             setHaveDateZoomGranularitiesChanged(false);
             setHasDefaultDateZoomGranularityChanged(false);
+            setHasDateZoomConfigChanged(false);
             setDashboardTemporaryFilters({
                 dimensions: [],
                 metrics: [],
@@ -376,6 +386,7 @@ const Dashboard: FC = () => {
         setHavePinnedParametersChanged,
         setHaveDateZoomGranularitiesChanged,
         setHasDefaultDateZoomGranularityChanged,
+        setHasDateZoomConfigChanged,
         dashboardTabs,
         activeTab,
     ]);
@@ -589,6 +600,8 @@ const Dashboard: FC = () => {
             dashboard.config?.defaultDateZoomGranularity,
         );
         setHasDefaultDateZoomGranularityChanged(false);
+        setDateZoomConfig(normalizeDateZoomConfig(dashboard.config));
+        setHasDateZoomConfigChanged(false);
 
         if (dashboardTabs.length > 0) {
             void navigate(
@@ -621,6 +634,8 @@ const Dashboard: FC = () => {
         setHaveDateZoomGranularitiesChanged,
         setDefaultDateZoomGranularity,
         setHasDefaultDateZoomGranularityChanged,
+        setDateZoomConfig,
+        setHasDateZoomConfigChanged,
         setHasParameterOrderChanged,
     ]);
 
@@ -753,6 +768,15 @@ const Dashboard: FC = () => {
             return filter;
         });
 
+        // Prune empty controls + dangling targets on save; omit the field
+        // entirely when no controls remain so untouched dashboards don't churn.
+        const prunedDateZoomConfig = pruneDateZoomConfig(dateZoomConfig);
+        const savedDateZoomConfig = hasDateZoomConfigChanged
+            ? isEmptyDateZoomConfig(prunedDateZoomConfig)
+                ? undefined
+                : prunedDateZoomConfig
+            : dashboard.config?.dateZoomConfig;
+
         const dashboardUpdate: UpdateDashboard = {
             tiles: dashboardTiles,
             filters: {
@@ -781,6 +805,7 @@ const Dashboard: FC = () => {
                 defaultDateZoomGranularity: hasDefaultDateZoomGranularityChanged
                     ? defaultDateZoomGranularity
                     : dashboard.config?.defaultDateZoomGranularity,
+                dateZoomConfig: savedDateZoomConfig,
             },
             parameters: dashboardParameters,
             ...(preserveVerification !== undefined
@@ -816,7 +841,8 @@ const Dashboard: FC = () => {
             havePinnedParametersChanged ||
             hasParameterOrderChanged ||
             haveDateZoomGranularitiesChanged ||
-            hasDefaultDateZoomGranularityChanged,
+            hasDefaultDateZoomGranularityChanged ||
+            hasDateZoomConfigChanged,
         onAddTiles: handleAddTiles,
         onSaveDashboard: () => {
             if (shouldShowVerificationSaveOptions) {

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -16,6 +16,7 @@ import {
     normalizeDateZoomConfig,
     normalizeGranularityParam,
     stripOverridesForLockedFiltersOnTab,
+    type ChartZoomableField,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -557,6 +558,39 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         if (dashboardTiles) {
             setTileParameterReferences((old) => {
                 if (!dashboardTiles) return {};
+                const tileIds = new Set(
+                    dashboardTiles.map((tile) => tile.uuid),
+                );
+                return Object.fromEntries(
+                    Object.entries(old).filter(([tileId]) =>
+                        tileIds.has(tileId),
+                    ),
+                );
+            });
+        }
+    }, [dashboardTiles]);
+
+    // The date fields each chart tile can actually be zoomed on, reported up
+    // from each tile (it has the explore + metricQuery). The date-zoom control
+    // modal offers exactly these per tile, instead of every filterable date
+    // dimension in the explore.
+    const [chartZoomableFieldsByTileUuid, setChartZoomableFieldsByTileUuid] =
+        useState<Record<string, ChartZoomableField[]>>({});
+
+    const setChartZoomableFields = useCallback(
+        (tileUuid: string, fields: ChartZoomableField[]) => {
+            setChartZoomableFieldsByTileUuid((prev) => {
+                if (isEqual(prev[tileUuid], fields)) return prev;
+                return { ...prev, [tileUuid]: fields };
+            });
+        },
+        [],
+    );
+
+    // Drop zoomable fields for tiles no longer on the dashboard
+    useEffect(() => {
+        if (dashboardTiles) {
+            setChartZoomableFieldsByTileUuid((old) => {
                 const tileIds = new Set(
                     dashboardTiles.map((tile) => tile.uuid),
                 );
@@ -1681,6 +1715,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         isLoadingDashboardFilters,
         isFetchingDashboardFilters,
         filterableFieldsByTileUuid,
+        chartZoomableFieldsByTileUuid,
+        setChartZoomableFields,
         allFilters,
         hasTilesThatSupportFilters,
         chartSort,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -1,5 +1,6 @@
 import {
     type ApiError,
+    type ChartZoomableField,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -98,6 +99,11 @@ export type DashboardContextType = {
     filterableFieldsByTileUuid:
         | Record<string, DashboardFilterableField[]>
         | undefined;
+    chartZoomableFieldsByTileUuid: Record<string, ChartZoomableField[]>;
+    setChartZoomableFields: (
+        tileUuid: string,
+        fields: ChartZoomableField[],
+    ) => void;
     hasTilesThatSupportFilters: boolean;
     chartSort: Record<string, SortField[]>;
     setChartSort: (sort: Record<string, SortField[]>) => void;


### PR DESCRIPTION
Part 3/3 of making date zoom configurable like dashboard filters.

Adds the authoring UI: the control modal and view-mode pills, with controls scoped to each chart's queried date fields and the dashboard's enabled granularities. The default and named controls share one row; the default is labelled and muted or hidden when it governs no charts; controls support inline hide/remove; saving a control requires at least one chart.


<img width="1488" height="913" alt="02-default-zoom-picker-custom-grains" src="https://github.com/user-attachments/assets/8b489d59-b6f7-44e4-bc84-d72f6d687267" />


<img width="1488" height="913" alt="03-control-modal-zoom-settings" src="https://github.com/user-attachments/assets/583a8999-0e8b-48e0-9e37-bccbcebbf513" />

<img width="1488" height="913" alt="04-control-granularity-dropdown" src="https://github.com/user-attachments/assets/67b84d5c-903e-427c-be51-9c142c6290ed" />

<img width="1488" height="1100" alt="05-control-chart-tiles-tab" src="https://github.com/user-attachments/assets/0d06d6c3-b7e4-43fa-8f80-5859bf2cb949" />

<img width="1488" height="1100" alt="09-tab-overview-created" src="https://github.com/user-attachments/assets/54847cec-de3f-4e02-9b1f-c0ab9efe12b5" />

Relates to [GLITCH-225](https://linear.app/lightdash/issue/GLITCH-225/make-date-zoom-more-configurable-like-dashboard-filters)