### PR TITLE
fix: bypass playwright for app viewport height

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1102,6 +1102,33 @@ export class UnfurlService extends BaseService {
                                 .internalLightdashHostIgnoreHttpsErrors,
                     });
 
+                    if (lightdashPage === LightdashPage.APP) {
+                        // Browserless drops Playwright's viewport over CDP (see [APP-DIAG]
+                        // logs stuck at 800×600); push the override straight to Chrome.
+                        try {
+                            const cdp = await page
+                                .context()
+                                .newCDPSession(page);
+                            await cdp.send(
+                                'Emulation.setDeviceMetricsOverride',
+                                {
+                                    width: initialViewport.width,
+                                    height: initialViewport.height,
+                                    deviceScaleFactor: 1,
+                                    mobile: false,
+                                },
+                            );
+                        } catch (cdpErr) {
+                            this.logger.warn(
+                                `[APP] CDP viewport override failed; falling through - unfurlId: ${imageId}, err: ${
+                                    cdpErr instanceof Error
+                                        ? cdpErr.message
+                                        : String(cdpErr)
+                                }`,
+                            );
+                        }
+                    }
+
                     // Scope custom headers to internal requests only — setting them
                     // on every request (e.g. Google Fonts) triggers CORS preflight failures.
                     const internalHost =


### PR DESCRIPTION
## Problem

Data app scheduled deliveries arrive cropped — only the top-left ~800×600 of a
much taller intended render shows in the delivered image.

Diagnostic logging on an APP delivery confirmed the root cause: Playwright
reports the configured viewport (1400×4000), but Chrome's real surface stays at
800×600 (`window.innerWidth/innerHeight = 800/600`), so content lays out at 800
wide and gets clipped.

The reason is `connectOverCDP`: Playwright connects with
`noDefaultViewport: true`, so for pages in the (Browserless-default) context it
deliberately **never sends** `Emulation.setDeviceMetricsOverride`. Every prior
attempt routed through this same gated path — `setViewportSize` (#24284,
#24436, #24459) and the `--window-size` launch arg (#24522) — which is why none
of them took effect.

## Fix

For `LightdashPage.APP` only, after `newPage()` and before navigation, send
`Emulation.setDeviceMetricsOverride` directly on a raw `CDPSession`. This
bypasses Playwright's viewport plumbing and reaches Chrome's renderer directly,
applying the override Playwright skips.

- **APP-scoped**: entire block guarded by `lightdashPage === LightdashPage.APP`;
  non-APP delivery paths are unchanged.
- **Fully isolated**: wrapped in try/catch that only logs a warning and never
  rethrows — on failure we fall through to existing behavior, no worse than
  today.
- The prior `--window-size` arg and the `[APP-DIAG]` logging are left in place
  so we can verify the fix in production (`parent.innerW` should now read 1400).

