### PR TITLE
fix: data app schedule delivery stale toggle

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1102,6 +1102,33 @@ export class UnfurlService extends BaseService {
                                 .internalLightdashHostIgnoreHttpsErrors,
                     });
 
+                    if (lightdashPage === LightdashPage.APP) {
+                        // Browserless drops Playwright's viewport over CDP (see [APP-DIAG]
+                        // logs stuck at 800×600); push the override straight to Chrome.
+                        try {
+                            const cdp = await page
+                                .context()
+                                .newCDPSession(page);
+                            await cdp.send(
+                                'Emulation.setDeviceMetricsOverride',
+                                {
+                                    width: initialViewport.width,
+                                    height: initialViewport.height,
+                                    deviceScaleFactor: 1,
+                                    mobile: false,
+                                },
+                            );
+                        } catch (cdpErr) {
+                            this.logger.warn(
+                                `[APP] CDP viewport override failed; falling through - unfurlId: ${imageId}, err: ${
+                                    cdpErr instanceof Error
+                                        ? cdpErr.message
+                                        : String(cdpErr)
+                                }`,
+                            );
+                        }
+                    }
+
                     // Scope custom headers to internal requests only — setting them
                     // on every request (e.g. Google Fonts) triggers CORS preflight failures.
                     const internalHost =

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulerReassignOwnerMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulerReassignOwnerMutation.ts
@@ -31,6 +31,7 @@ export const useSchedulerReassignOwnerMutation = (projectUuid: string) => {
             await queryClient.invalidateQueries(['paginatedSchedulers']);
             await queryClient.invalidateQueries(['chart_schedulers']);
             await queryClient.invalidateQueries(['dashboard_schedulers']);
+            await queryClient.invalidateQueries(['app_schedulers']);
 
             const count = variables.schedulerUuids.length;
             showToastSuccess({

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulersDeleteMutation.ts
@@ -19,6 +19,7 @@ export const useSchedulersDeleteMutation = () => {
             await queryClient.invalidateQueries(['chart_schedulers']);
             await queryClient.invalidateQueries(['dashboard_schedulers']);
             await queryClient.invalidateQueries(['sql_chart_schedulers']);
+            await queryClient.invalidateQueries(['app_schedulers']);
             await queryClient.invalidateQueries(['paginatedSchedulers']);
             showToastSuccess({
                 title: `Success! Scheduled delivery was deleted`,

--- a/packages/frontend/src/features/scheduler/hooks/useSchedulersUpdateMutation.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useSchedulersUpdateMutation.ts
@@ -30,6 +30,7 @@ export const useSchedulersUpdateMutation = (schedulerUuid: string) => {
             await queryClient.invalidateQueries(['chart_schedulers']);
             await queryClient.invalidateQueries(['dashboard_schedulers']);
             await queryClient.invalidateQueries(['sql_chart_schedulers']);
+            await queryClient.invalidateQueries(['app_schedulers']);
             await queryClient.invalidateQueries(['scheduler', schedulerUuid]);
             showToastSuccess({
                 title: `Success! Scheduled delivery was updated.`,
@@ -62,6 +63,7 @@ export const useSchedulersEnabledUpdateMutation = (schedulerUuid: string) => {
                 await queryClient.invalidateQueries(['chart_schedulers']);
                 await queryClient.invalidateQueries(['dashboard_schedulers']);
                 await queryClient.invalidateQueries(['sql_chart_schedulers']);
+                await queryClient.invalidateQueries(['app_schedulers']);
             },
             onError: ({ error }) => {
                 showToastApiError({


### PR DESCRIPTION
### Description:

Data app scheduled delivery mutations were getting stale, this fixes them by invalidating the queries, just like for other chart types. 