### PR TITLE
fix: allow compile flows to sync YAML tags

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -240,6 +240,10 @@ const catalogModel = {
     getAllMetricsTreeNodes: jest.fn(async () => []),
 };
 
+const tagsModel = {
+    replaceYamlTags: jest.fn(async () => ({ yamlTagsToCreateOrUpdate: [] })),
+};
+
 const projectCompileLogModel = {
     insert: jest.fn(async () => undefined),
 };
@@ -275,7 +279,7 @@ const getMockedProjectService = (
         downloadFileModel: {} as unknown as DownloadFileModel,
         fileStorageClient: {} as FileStorageClient,
         groupsModel: {} as GroupsModel,
-        tagsModel: {} as TagsModel,
+        tagsModel: tagsModel as unknown as TagsModel,
         catalogModel: catalogModel as unknown as CatalogModel,
         contentModel: {} as ContentModel,
         encryptionUtil: {} as EncryptionUtil,
@@ -298,6 +302,7 @@ const getMockedProjectService = (
         } as unknown as FeatureFlagModel,
         projectParametersModel: {
             find: jest.fn(async () => []),
+            replace: jest.fn(async () => undefined),
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as unknown as OrganizationWarehouseCredentialsModel,
@@ -1599,6 +1604,105 @@ describe('ProjectService', () => {
                 jobStatus: JobStatusType.ERROR,
             });
             expect(projectModel.tryAcquireProjectLock).not.toHaveBeenCalled();
+        });
+
+        test('syncs YAML tags during compilation without manage tag permissions', async () => {
+            const compileJobUuid = 'compile-job-uuid';
+            const previewProjectUuid = 'preview-project-uuid';
+            const previewCompileUser: SessionUser = {
+                ...user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Job', action: ['create'] },
+                    { subject: 'CompileProject', action: ['manage'] },
+                    { subject: 'Project', action: ['update', 'view'] },
+                ]),
+            };
+
+            jest.spyOn(
+                service as unknown as {
+                    refreshTablesAndProjectConfig: () => Promise<unknown>;
+                },
+                'refreshTablesAndProjectConfig',
+            ).mockResolvedValueOnce({
+                explores: [],
+                lightdashProjectConfig: {
+                    spotlight: {
+                        categories: {
+                            finance: { label: 'Finance', color: 'blue' },
+                        },
+                    },
+                    parameters: {},
+                    table_groups: {},
+                },
+                projectContext: undefined,
+            });
+            (projectModel.getSummary as jest.Mock)
+                .mockResolvedValueOnce({
+                    ...projectSummary,
+                    projectUuid: previewProjectUuid,
+                    type: ProjectType.PREVIEW,
+                })
+                .mockResolvedValueOnce({
+                    ...projectSummary,
+                    projectUuid: previewProjectUuid,
+                    type: ProjectType.PREVIEW,
+                })
+                .mockResolvedValueOnce({
+                    ...projectSummary,
+                    projectUuid: previewProjectUuid,
+                    type: ProjectType.PREVIEW,
+                });
+            (projectModel.get as jest.Mock).mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                projectUuid: previewProjectUuid,
+                type: ProjectType.PREVIEW,
+            });
+
+            await service.compileProject(
+                previewCompileUser,
+                previewProjectUuid,
+                RequestMethod.WEB_APP,
+                compileJobUuid,
+            );
+
+            expect(tagsModel.replaceYamlTags).toHaveBeenCalledWith(
+                previewProjectUuid,
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        project_uuid: previewProjectUuid,
+                        yaml_reference: 'finance',
+                    }),
+                ]),
+            );
+            expect(jobModel.update).toHaveBeenCalledWith(compileJobUuid, {
+                jobStatus: JobStatusType.DONE,
+                jobResults: { indexCatalogJobUuid: { jobId: 'catalog-job-1' } },
+            });
+        });
+
+        test('requires manage tag permissions for direct YAML tag sync', async () => {
+            const noTagUser: SessionUser = {
+                ...user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['update', 'view'] },
+                ]),
+            };
+            (projectModel.getSummary as jest.Mock).mockResolvedValueOnce({
+                ...projectSummary,
+                type: ProjectType.DEFAULT,
+            });
+
+            await expect(
+                service.replaceYamlTags(noTagUser, projectUuid, [
+                    {
+                        yamlReference: 'finance',
+                        name: 'Finance',
+                        color: 'blue',
+                    },
+                ]),
+            ).rejects.toThrowError(ForbiddenError);
+
+            expect(tagsModel.replaceYamlTags).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2632,8 +2632,9 @@ export class ProjectService extends BaseService {
                         );
                     }
 
-                    await this.replaceYamlTags(
+                    await this.replaceYamlTagsWithoutPermissionCheck(
                         user,
+                        user.organizationUuid,
                         newProjectUuid,
                         // Create util to generate categories from lightdashProjectConfig - this is used as well in deploy.ts
                         Object.entries(
@@ -3180,8 +3181,9 @@ export class ProjectService extends BaseService {
                             timings.getConfig.end = performance.now();
 
                             timings.yaml.start = performance.now();
-                            await this.replaceYamlTags(
+                            await this.replaceYamlTagsWithoutPermissionCheck(
                                 user,
+                                user.organizationUuid,
                                 projectUuid,
                                 // TODO: Create util to generate categories from lightdashProjectConfig - this is used as well in deploy.ts
                                 Object.entries(
@@ -6355,8 +6357,9 @@ export class ProjectService extends BaseService {
                         );
 
                         timings.yaml.start = performance.now();
-                        await this.replaceYamlTags(
+                        await this.replaceYamlTagsWithoutPermissionCheck(
                             user,
+                            organizationUuid,
                             projectUuid,
                             // TODO: Create util to generate categories from lightdashProjectConfig - this is used as well in deploy.ts
                             Object.entries(
@@ -9040,6 +9043,22 @@ export class ProjectService extends BaseService {
             );
         }
 
+        await this.replaceYamlTagsWithoutPermissionCheck(
+            user,
+            organizationUuid,
+            projectUuid,
+            yamlTags,
+        );
+    }
+
+    private async replaceYamlTagsWithoutPermissionCheck(
+        user: SessionUser,
+        organizationUuid: string,
+        projectUuid: string,
+        yamlTags: (Pick<Tag, 'name' | 'color'> & {
+            yamlReference: NonNullable<Tag['yamlReference']>;
+        })[],
+    ) {
         const yamlTagsIn = yamlTags.map((tag) => ({
             project_uuid: projectUuid,
             name: tag.name,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8501
Closes: #24737

### Description:
Allow project compile/deploy flows to sync YAML-defined tags after compile/deploy permissions have authorized the operation.
Direct YAML tag sync still requires tag-management permission.
Added ProjectService coverage for compile-time tag sync and direct tag permission enforcement.