### PR TITLE
feat: add app uuid to query tags for data app queries

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -998,6 +998,7 @@ export class EmbedService extends BaseService {
         queryTags: Omit<
             Required<RunQueryTags>,
             | 'user_uuid'
+            | 'app_uuid'
             | 'chart_uuid'
             | 'dashboard_uuid'
             // Scheduler-attribution tags only apply to scheduler-driven jobs,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14348,13 +14348,13 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                fieldId:
+                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                operator:
+                                                                                                                                fieldId:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -14731,6 +14731,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -14755,14 +14774,14 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'false',
+                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'true',
+                                                                                                        'false',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
@@ -14835,12 +14854,6 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -14851,27 +14864,14 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
                                                                             },
                                                                     },
-                                                                    required: true,
-                                                                },
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -14935,13 +14935,13 @@ const models: TsoaRoute.Models = {
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            fieldId:
+                                                                                                            operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
                                                                                                                     required: true,
                                                                                                                 },
-                                                                                                            operator:
+                                                                                                            fieldId:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
@@ -15141,6 +15141,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
@@ -15152,13 +15159,6 @@ const models: TsoaRoute.Models = {
                                                 },
                                                 uuid: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -15349,6 +15349,13 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
                                                                                             'read',
                                                                                         ],
                                                                                     },
@@ -15357,13 +15364,6 @@ const models: TsoaRoute.Models = {
                                                                                             'enum',
                                                                                         enums: [
                                                                                             'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
                                                                                         ],
                                                                                     },
                                                                                     {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15749,10 +15749,10 @@
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldId": {
+                                                                                    "operator": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "operator": {
+                                                                                    "fieldId": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
@@ -15760,8 +15760,8 @@
                                                                                     "required",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "fieldId",
-                                                                                    "operator"
+                                                                                    "operator",
+                                                                                    "fieldId"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -15961,6 +15961,10 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
@@ -15970,8 +15974,8 @@
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "false",
                                                                                         "true",
+                                                                                        "false",
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
@@ -15995,13 +15999,13 @@
                                                                                 "label": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "name": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -16013,17 +16017,13 @@
                                                                                 "fieldType",
                                                                                 "description",
                                                                                 "label",
-                                                                                "fieldId",
                                                                                 "name",
-                                                                                "table"
+                                                                                "table",
+                                                                                "fieldId"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
@@ -16044,10 +16044,10 @@
                                                                                         "fieldRef": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "fieldId": {
+                                                                                        "operator": {
                                                                                             "type": "string"
                                                                                         },
-                                                                                        "operator": {
+                                                                                        "fieldId": {
                                                                                             "type": "string"
                                                                                         }
                                                                                     },
@@ -16055,8 +16055,8 @@
                                                                                         "required",
                                                                                         "tableName",
                                                                                         "fieldRef",
-                                                                                        "fieldId",
-                                                                                        "operator"
+                                                                                        "operator",
+                                                                                        "fieldId"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -16095,8 +16095,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "fields",
                                                                     "rationale",
+                                                                    "fields",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -16199,6 +16199,12 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
@@ -16210,12 +16216,6 @@
                                                     "uuid": {
                                                         "type": "string"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "name": {
                                                         "type": "string"
                                                     }
@@ -16223,10 +16223,10 @@
                                                 "required": [
                                                     "versionUuids",
                                                     "href",
+                                                    "warnings",
                                                     "status",
                                                     "slug",
                                                     "uuid",
-                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -16267,9 +16267,9 @@
                                                                     "type": "string",
                                                                     "enum": [
                                                                         "search",
+                                                                        "compile",
                                                                         "read",
                                                                         "edit",
-                                                                        "compile",
                                                                         "stage"
                                                                     ]
                                                                 },
@@ -41459,7 +41459,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3249.0",
+        "version": "0.3252.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -1,4 +1,5 @@
 import {
+    LightdashAppUuidHeader,
     LightdashMode,
     LightdashRequestMethodHeader,
     LightdashSdkVersionHeader,
@@ -64,6 +65,7 @@ export type ExecutionContextInfo = {
     };
     organization_uuid?: string;
     organization_name?: string;
+    app_uuid?: string;
     scheduler?: {
         scheduler_uuid?: string;
         scheduler_name?: string;
@@ -99,6 +101,15 @@ export const getOrganizationContext = (): Pick<
         organization_uuid: ctx.organization_uuid,
         organization_name: ctx.organization_name,
     };
+};
+
+// Reads the originating data app from the request-scoped ExecutionContext
+// (populated by requestExecutionContextMiddleware from the app attribution
+// header) so warehouse queries can be tagged back to the app. Returns an empty
+// object outside an app-originated request.
+export const getAppContext = (): Pick<ExecutionContextInfo, 'app_uuid'> => {
+    if (!ExecutionContext.exists()) return {};
+    return { app_uuid: ExecutionContext.get<ExecutionContextInfo>().app_uuid };
 };
 
 const ALIAS_RESPONSE_TIME_AS_DURATION = winston.format((info) => {
@@ -323,10 +334,13 @@ export const expressWinstonPreResponseMiddleware: express.RequestHandler = (
 };
 
 // Stamps every log emitted while processing this request with the requesting
-// user's organization context, by attaching it to the AsyncLocalStorage-backed
-// ExecutionContext that `addExecutionContent` already merges into log payloads.
-// Place this AFTER session/auth middlewares so req.user and req.account are
-// populated. req.user is set for session-authenticated requests; embed/JWT
+// user's organization context and, for data-app traffic, the originating app —
+// by attaching them to the AsyncLocalStorage-backed ExecutionContext that
+// `addExecutionContent` already merges into log payloads. The app id rides in
+// on a self-reported header and is also read here so warehouse query tagging
+// can attribute queries back to the app without threading it through service
+// args. Place this AFTER session/auth middlewares so req.user and req.account
+// are populated. req.user is set for session-authenticated requests; embed/JWT
 // requests populate req.account only, so we fall back to it.
 export const requestExecutionContextMiddleware: express.RequestHandler = (
     req,
@@ -338,13 +352,17 @@ export const requestExecutionContextMiddleware: express.RequestHandler = (
         req.account?.organization?.organizationUuid;
     const organizationName =
         req.user?.organizationName ?? req.account?.organization?.name;
-    if (!organizationUuid && !organizationName) {
+    const appUuidHeader = req.headers[LightdashAppUuidHeader.toLowerCase()];
+    const appUuid =
+        typeof appUuidHeader === 'string' ? appUuidHeader : undefined;
+    if (!organizationUuid && !organizationName && !appUuid) {
         next();
         return;
     }
     const context: ExecutionContextInfo = {
         organization_uuid: organizationUuid,
         organization_name: organizationName,
+        ...(appUuid ? { app_uuid: appUuid } : {}),
     };
     if (ExecutionContext.exists()) {
         ExecutionContext.update(context as unknown as Record<string, unknown>);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -22,6 +22,7 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 import type { SshTunnel } from '@lightdash/warehouses';
+import ExecutionContext from 'node-execution-context';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
@@ -1435,6 +1436,72 @@ describe('AsyncQueryService', () => {
     });
 
     describe('executeAsyncMetricQuery', () => {
+        test('tags warehouse queries with the originating data app from the request context', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            service.getExploreWithUserAccessControls = jest
+                .fn()
+                .mockResolvedValue({
+                    explore: validExplore,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                });
+            (service as AnyType).getWarehouseCredentials = jest
+                .fn()
+                .mockResolvedValue(warehouseClientMock.credentials);
+            service.combineParameters = jest.fn().mockResolvedValue(undefined);
+            (service as AnyType).prepareMetricQueryAsyncQueryArgs = jest
+                .fn()
+                .mockResolvedValue({
+                    sql: 'SELECT * FROM test',
+                    fields: {},
+                    warnings: [],
+                    parameterReferences: [],
+                    missingParameterReferences: [],
+                    usedParameters: {},
+                    responseMetricQuery: metricQueryMock,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                });
+            service['executeAsyncQuery'] = jest.fn().mockResolvedValue({
+                queryUuid: 'queryUuid',
+                cacheMetadata: {
+                    cacheHit: false,
+                },
+            });
+
+            // app_uuid rides in on the request-scoped ExecutionContext (stamped
+            // by requestExecutionContextMiddleware from the app header), not a
+            // query arg — so exercise the real context the same way.
+            await ExecutionContext.run(
+                () =>
+                    service.executeAsyncMetricQuery({
+                        account: sessionAccount,
+                        projectUuid,
+                        metricQuery: metricQueryMock,
+                        context: QueryExecutionContext.EXPLORE,
+                        invalidateCache: false,
+                        dateZoom: undefined,
+                        parameters: undefined,
+                        pivotConfiguration: undefined,
+                    }),
+                { app_uuid: 'app-uuid' },
+            );
+
+            expect(service['executeAsyncQuery']).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    queryTags: expect.objectContaining({
+                        app_uuid: 'app-uuid',
+                    }),
+                }),
+                expect.any(Object),
+            );
+        });
+
         test('attaches required pre-aggregate routing metadata for direct pre-aggregate explores', async () => {
             const mockStrategy: PreAggregateStrategy = {
                 ...makeMockStrategy({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -135,7 +135,7 @@ import type { DbProjectParameter } from '../../database/entities/projectParamete
 import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
-import { getSchedulerContext } from '../../logging/winston';
+import { getAppContext, getSchedulerContext } from '../../logging/winston';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type { SavedSqlModel } from '../../models/SavedSqlModel';
@@ -3169,6 +3169,19 @@ export class AsyncQueryService extends ProjectService {
         return tags;
     }
 
+    /**
+     * Reads the originating data app from the request-scoped ExecutionContext
+     * (populated by requestExecutionContextMiddleware from the app attribution
+     * header) so warehouse queries can be tagged back to the app. Mirrors
+     * getSchedulerQueryTags — provenance is carried ambiently, not via query
+     * args. Returns an empty object outside an app-originated request. The id
+     * is self-reported and not authoritative; tracking only.
+     */
+    private static getAppQueryTags(): Partial<RunQueryTags> {
+        const { app_uuid: appUuid } = getAppContext();
+        return appUuid ? { app_uuid: appUuid } : {};
+    }
+
     private static buildQueryTags(query: QueryHistory): RunQueryTags {
         let actorTags: Record<string, string>;
         if (query.createdByActorType === 'jwt') {
@@ -4139,6 +4152,7 @@ export class AsyncQueryService extends ProjectService {
         const queryTags: RunQueryTags = {
             ...this.getUserQueryTags(account),
             ...AsyncQueryService.getSchedulerQueryTags(),
+            ...AsyncQueryService.getAppQueryTags(),
             organization_uuid: organizationUuid,
             project_uuid: projectUuid,
             explore_name: inputMetricQuery.exploreName,

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -10,6 +10,7 @@ export type RunQueryTags = {
     project_uuid?: string;
     user_uuid?: string;
     organization_uuid?: string;
+    app_uuid?: string;
     chart_uuid?: string;
     dashboard_uuid?: string;
     saved_sql_uuid?: string;

--- a/packages/common/src/utils/api.ts
+++ b/packages/common/src/utils/api.ts
@@ -4,6 +4,10 @@ export const LightdashRequestMethodHeader = 'Lightdash-Request-Method';
 export const LightdashVersionHeader = 'Lightdash-Version';
 export const LightdashSdkVersionHeader = 'Lightdash-SDK-Version';
 export const LightdashCliVersionHeader = 'Lightdash-CLI-Version';
+// Attaches the originating data app to a request so warehouse queries can be
+// tagged with `app_uuid`. Self-reported provenance for tracking only — not
+// authenticated, so it must not gate access or feed anything authoritative.
+export const LightdashAppUuidHeader = 'Lightdash-App-Uuid';
 
 export const getRequestMethod = (
     headerValue: string | undefined,

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.test.ts
@@ -1,3 +1,4 @@
+import { LightdashAppUuidHeader } from '@lightdash/common';
 import { renderHook } from '@testing-library/react';
 import { type RefObject } from 'react';
 import {
@@ -170,6 +171,30 @@ describe('useAppSdkBridge', () => {
             queryUuid: QUERY_UUID,
             rowCount: 42,
         });
+    });
+
+    it('attaches the app UUID header to metric-query requests for warehouse attribution', async () => {
+        renderBridge(() => undefined);
+
+        mockFetchOk({
+            status: 'ok',
+            results: { queryUuid: QUERY_UUID, metricQuery: METRIC_QUERY },
+        });
+        postMetricQuery();
+
+        await vi.waitFor(() =>
+            expect(fetch).toHaveBeenCalledWith(
+                POST_PATH,
+                expect.objectContaining({ method: 'POST' }),
+            ),
+        );
+
+        const [, init] = (fetch as Mock).mock.calls[0];
+        expect(init.headers).toMatchObject({
+            [LightdashAppUuidHeader]: APP_UUID,
+        });
+        // App attribution rides on the header, not the request body.
+        expect(JSON.parse(init.body)).toEqual({ query: METRIC_QUERY });
     });
 
     it('re-keys terminal error events to the POST request id', async () => {

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,4 +1,8 @@
-import { JWT_HEADER_NAME, type DashboardFilters } from '@lightdash/common';
+import {
+    JWT_HEADER_NAME,
+    LightdashAppUuidHeader,
+    type DashboardFilters,
+} from '@lightdash/common';
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { lightdashApi } from '../../../api';
 import useEmbed from '../../../ee/providers/Embed/useEmbed';
@@ -408,7 +412,8 @@ export function useAppSdkBridge(
             // fields aren't in the query's explore, so it's safe to send the
             // full set on every call. `invalidateCache` mirrors what charts
             // send on a dashboard refresh so the app's queries bypass the
-            // warehouse results cache too.
+            // warehouse results cache too. App attribution rides on the
+            // LightdashAppUuidHeader instead (see the fetch below).
             const effectiveBody =
                 isMetricQueryPost(method, path) &&
                 (dashboardFilters || invalidateCache)
@@ -504,6 +509,11 @@ export function useAppSdkBridge(
                         'Content-Type': 'application/json',
                         ...(embedToken
                             ? { [JWT_HEADER_NAME]: embedToken }
+                            : {}),
+                        // Self-reported app attribution; the backend tags
+                        // warehouse queries with it. Tracking only.
+                        ...(appUuid
+                            ? { [LightdashAppUuidHeader]: appUuid }
                             : {}),
                     },
                     ...(effectiveBody


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #24693 

### Description:

Data-app queries are tagged in the warehouse with their originating
`app_uuid`. This moves that attribution off the `executeAsyncMetricQuery`
service args and onto an ambient request header (`Lightdash-App-Uuid`),
mirroring how scheduler tags already flow through the request-scoped
ExecutionContext.

- Frontend SDK bridge sends the header instead of a `source` body field
- Middleware stamps it into ExecutionContext; query tagging reads it there
- Reverts the `source` plumbing through QueryController + the args type

The id is self-reported and unvalidated — tracking metadata only, not a
security boundary. As a bonus it now also stamps app traffic log lines.
