### PR TITLE
refactor(sandbox): abstract data-app sandboxes behind a SandboxProvider

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -371,6 +371,8 @@ export const lightdashConfigMock: LightdashConfig = {
         e2bTemplateTag: '',
         e2bAiWritebackTemplateName: 'lightdash-ai-writeback',
         e2bAiWritebackTemplateTag: '',
+        sandboxProvider: 'e2b',
+        sandboxDockerImage: 'lightdash-sandbox:local',
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1589,6 +1589,18 @@ export type AppRuntimeConfig = {
      */
     e2bAiWritebackTemplateName: string;
     e2bAiWritebackTemplateTag: string;
+    /**
+     * Which sandbox backend the data-app pipeline launches sandboxes on.
+     * `e2b` keeps today's hosted path; `docker` runs a plain local container
+     * (dev / self-host testbed — see SandboxRuntime/DESIGN.md). Later:
+     * kubernetes | ecs | microsandbox.
+     */
+    sandboxProvider: 'e2b' | 'docker';
+    /**
+     * OCI image the `docker` sandbox provider launches containers from. Built
+     * locally from sandboxes/data-apps (e.g. `lightdash-sandbox:local`).
+     */
+    sandboxDockerImage: string;
 };
 
 export type IntercomConfig = {
@@ -1813,6 +1825,10 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             'lightdash-ai-writeback',
         e2bAiWritebackTemplateTag:
             process.env.E2B_AI_WRITEBACK_TEMPLATE_TAG ?? (VERSION as string),
+        sandboxProvider:
+            process.env.SANDBOX_PROVIDER === 'docker' ? 'docker' : 'e2b',
+        sandboxDockerImage:
+            process.env.SANDBOX_DOCKER_IMAGE || 'lightdash-sandbox:local',
     };
 };
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -46,7 +46,6 @@ import {
     type TogglePinnedItemInfo,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
-import { ALL_TRAFFIC, CommandExitError, Sandbox } from 'e2b';
 import { Knex } from 'knex';
 import { performance } from 'node:perf_hooks';
 import { PassThrough, Readable } from 'node:stream';
@@ -82,6 +81,13 @@ import type { SpacePermissionService } from '../../../services/SpaceService/Spac
 import { type ExternalConnectionModel } from '../../models/ExternalConnectionModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 import { getModel } from '../ai/models';
+import {
+    createSandboxProvider,
+    SandboxCommandError,
+    type SandboxHandle,
+    type SandboxProvider,
+    type SandboxSpec,
+} from '../SandboxRuntime';
 import { assertCanViewApp as assertUserCanViewApp } from './appAuthz';
 import {
     classifyClaudeCliFailure,
@@ -181,6 +187,9 @@ export class AppGenerateService extends BaseService {
     private readonly promoteService: PromoteService;
 
     private readonly externalConnectionModel: ExternalConnectionModel;
+
+    // Lazily built from config on first use; memoized for the service lifetime.
+    private sandboxProvider: SandboxProvider | undefined;
 
     constructor({
         lightdashConfig,
@@ -355,14 +364,48 @@ export class AppGenerateService extends BaseService {
         );
     }
 
-    private getE2bApiKey(): string {
-        const key = this.lightdashConfig.appRuntime.e2bApiKey;
-        if (!key) {
-            throw new MissingConfigError(
-                'E2B API key is not configured (E2B_API_KEY)',
-            );
+    /**
+     * The sandbox provider selected by `SANDBOX_PROVIDER` (e2b | docker).
+     * Memoized — feature code talks only to this provider, never to a concrete
+     * sandbox SDK. See SandboxRuntime/DESIGN.md.
+     */
+    private getSandboxProvider(): SandboxProvider {
+        if (!this.sandboxProvider) {
+            this.sandboxProvider = createSandboxProvider({
+                provider: this.lightdashConfig.appRuntime.sandboxProvider,
+                e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
+                dockerImage: this.lightdashConfig.appRuntime.sandboxDockerImage,
+                logger: this.logger,
+            });
         }
-        return key;
+        return this.sandboxProvider;
+    }
+
+    /**
+     * Resolve the template/image ref the active provider launches from. E2B
+     * composes `name:tag`; Docker uses the local image name.
+     */
+    private getSandboxTemplateRef(): string {
+        const { sandboxProvider, e2bTemplateName, e2bTemplateTag } =
+            this.lightdashConfig.appRuntime;
+        if (sandboxProvider === 'docker') {
+            return this.lightdashConfig.appRuntime.sandboxDockerImage;
+        }
+        // E2B treats `name` and `name:default` interchangeably, so an empty
+        // tag is fine — it just resolves to the implicit `default` build.
+        return e2bTemplateTag
+            ? `${e2bTemplateName}:${e2bTemplateTag}`
+            : e2bTemplateName;
+    }
+
+    private buildSandboxSpec(): SandboxSpec {
+        return {
+            templateRef: this.getSandboxTemplateRef(),
+            timeoutMs: 60 * 60 * 1000,
+            egress: {
+                allow: claudeCodeAllowedHosts(this.lightdashConfig.ai.copilot),
+            },
+        };
     }
 
     private getS3Client(): { client: S3Client; bucket: string } {
@@ -956,39 +999,22 @@ export class AppGenerateService extends BaseService {
 
     private async createSandbox(
         appUuid: string,
-        e2bApiKey: string,
-    ): Promise<{ sandbox: Sandbox; durationMs: number }> {
+    ): Promise<{ sandbox: SandboxHandle; durationMs: number }> {
         const start = performance.now();
-        const { e2bTemplateName, e2bTemplateTag } =
-            this.lightdashConfig.appRuntime;
-        // E2B treats `name` and `name:default` interchangeably, so an empty
-        // tag is fine — it just resolves to the implicit `default` build.
-        const templateRef = e2bTemplateTag
-            ? `${e2bTemplateName}:${e2bTemplateTag}`
-            : e2bTemplateName;
-        const sandbox = await Sandbox.create(templateRef, {
-            timeoutMs: 60 * 60 * 1000,
-            apiKey: e2bApiKey,
-            lifecycle: { onTimeout: 'pause' },
-            network: {
-                allowOut: claudeCodeAllowedHosts(
-                    this.lightdashConfig.ai.copilot,
-                ),
-                denyOut: [ALL_TRAFFIC],
-            },
-        });
+        const spec = this.buildSandboxSpec();
         this.logger.info(
-            `App ${appUuid}: launching sandbox from template ${templateRef}`,
+            `App ${appUuid}: launching sandbox from template ${spec.templateRef} (provider=${this.lightdashConfig.appRuntime.sandboxProvider})`,
         );
+        const sandbox = await this.getSandboxProvider().create(spec);
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
-            `App ${appUuid}: E2B sandbox created (sandboxId=${sandbox.sandboxId}, ${durationMs}ms)`,
+            `App ${appUuid}: sandbox created (sandboxId=${sandbox.sandboxId}, ${durationMs}ms)`,
         );
         return { sandbox, durationMs };
     }
 
     private async pauseSandbox(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
     ): Promise<void> {
         try {
@@ -1008,22 +1034,18 @@ export class AppGenerateService extends BaseService {
     private async resumeSandbox(
         sandboxId: string,
         appUuid: string,
-        e2bApiKey: string,
-    ): Promise<{ sandbox: Sandbox; durationMs: number }> {
+    ): Promise<{ sandbox: SandboxHandle; durationMs: number }> {
         const start = performance.now();
-        const sandbox = await Sandbox.connect(sandboxId, {
-            apiKey: e2bApiKey,
-            timeoutMs: 60 * 60 * 1000,
-        });
+        const sandbox = await this.getSandboxProvider().connect(sandboxId);
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
-            `App ${appUuid}: E2B sandbox resumed (sandboxId=${sandbox.sandboxId}, ${durationMs}ms)`,
+            `App ${appUuid}: sandbox resumed (sandboxId=${sandbox.sandboxId}, ${durationMs}ms)`,
         );
         return { sandbox, durationMs };
     }
 
     private async restoreSourceFromS3(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         s3Client: S3Client,
         bucket: string,
         appUuid: string,
@@ -1042,13 +1064,7 @@ export class AppGenerateService extends BaseService {
         }
         const tarBuffer = Buffer.concat(chunks);
 
-        await sandbox.files.write(
-            '/tmp/source.tar',
-            tarBuffer.buffer.slice(
-                tarBuffer.byteOffset,
-                tarBuffer.byteOffset + tarBuffer.byteLength,
-            ) as ArrayBuffer,
-        );
+        await sandbox.files.write('/tmp/source.tar', tarBuffer);
         const result = await sandbox.commands.run(
             'tar -xf /tmp/source.tar -C /app',
             { timeoutMs: 60_000 },
@@ -1068,17 +1084,16 @@ export class AppGenerateService extends BaseService {
 
     /**
      * Resume an existing sandbox or create a new one with source restored from S3.
-     * Always returns a running Sandbox instance or throws.
+     * Always returns a running sandbox handle or throws.
      */
     private async acquireSandbox(
         app: DbApp,
         appUuid: string,
         newVersion: number,
-        e2bApiKey: string,
         s3Client: S3Client,
         bucket: string,
     ): Promise<{
-        sandbox: Sandbox;
+        sandbox: SandboxHandle;
         wasResumed: boolean;
         durations: Record<string, number>;
     }> {
@@ -1090,7 +1105,6 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
-                    e2bApiKey,
                 );
                 durations.resumeMs = result.durationMs;
                 return {
@@ -1106,7 +1120,7 @@ export class AppGenerateService extends BaseService {
         }
 
         // Fallback: create new sandbox and restore source from latest ready version
-        const createResult = await this.createSandbox(appUuid, e2bApiKey);
+        const createResult = await this.createSandbox(appUuid);
         durations.sandboxMs = createResult.durationMs;
         await this.appModel.updateSandboxId(
             appUuid,
@@ -1133,7 +1147,7 @@ export class AppGenerateService extends BaseService {
      * no references were provided.
      */
     private async writeChartReferences(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         chartReferences: ChartReference[],
     ): Promise<string> {
@@ -1209,7 +1223,7 @@ export class AppGenerateService extends BaseService {
      * connections.
      */
     private async writeExternalConnectionSamples(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         docs: AppExternalConnectionDoc[],
     ): Promise<string> {
@@ -1305,7 +1319,7 @@ export class AppGenerateService extends BaseService {
     }
 
     private async writeCatalogAndPrompt(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         projectUuid: string,
         prompt: string,
@@ -1453,7 +1467,7 @@ export class AppGenerateService extends BaseService {
      * never end up in the bundle — they describe current state, not target.
      */
     private async writeImageToSandbox(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         imageId: string,
         s3Client: S3Client,
@@ -1494,10 +1508,6 @@ export class AppGenerateService extends BaseService {
             throw new Error('Unexpected S3 response body type');
         }
         const buffer = Buffer.concat(chunks);
-        const arrayBuffer = buffer.buffer.slice(
-            buffer.byteOffset,
-            buffer.byteOffset + buffer.byteLength,
-        ) as ArrayBuffer;
 
         // Write to sandbox
         this.logger.info(
@@ -1506,7 +1516,7 @@ export class AppGenerateService extends BaseService {
         await sandbox.commands.run('mkdir -p /tmp/images', {
             timeoutMs: 10_000,
         });
-        await sandbox.files.write(sandboxPath, arrayBuffer);
+        await sandbox.files.write(sandboxPath, buffer);
 
         // Design references go into the Vite-bundled source tree so the agent
         // can `import logo from './uploads/<file>'` and have the URL hashed,
@@ -1516,10 +1526,7 @@ export class AppGenerateService extends BaseService {
             await sandbox.commands.run('mkdir -p /app/src/uploads', {
                 timeoutMs: 10_000,
             });
-            await sandbox.files.write(
-                `/app/src/uploads/${filename}`,
-                arrayBuffer,
-            );
+            await sandbox.files.write(`/app/src/uploads/${filename}`, buffer);
         }
 
         return sandboxPath;
@@ -1608,7 +1615,7 @@ export class AppGenerateService extends BaseService {
      * dilute the customer instructions.
      */
     private async assembleEffectiveSkill(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         designCopy: DesignSandboxCopyResult,
     ): Promise<void> {
         this.logger.debug(
@@ -1652,7 +1659,7 @@ export class AppGenerateService extends BaseService {
     }
 
     private async runClaudeGeneration(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         version: number,
         continueSession: boolean,
@@ -1765,12 +1772,12 @@ export class AppGenerateService extends BaseService {
                     },
                 )
                 .catch((err: unknown) => {
-                    // E2B's `commands.run` throws `CommandExitError` on a non-zero
-                    // exit (no opt-out), so convert it to a result here — mirroring
-                    // the build path. Otherwise a failed claude run propagates as an
+                    // The sandbox `commands.run` throws `SandboxCommandError` on a
+                    // non-zero exit, so convert it to a result here — mirroring the
+                    // build path. Otherwise a failed claude run propagates as an
                     // opaque "exit status 1" with the real error swallowed, and the
                     // stderr-logging + retry below never run.
-                    if (!(err instanceof CommandExitError)) {
+                    if (!(err instanceof SandboxCommandError)) {
                         throw err;
                     }
                     return {
@@ -1891,7 +1898,7 @@ export class AppGenerateService extends BaseService {
      * Returns null if parsing fails — callers should treat this as non-fatal.
      */
     private async generateAppMetadata(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         version: number,
         claudeCodeEnv: Record<string, string>,
@@ -1976,7 +1983,7 @@ export class AppGenerateService extends BaseService {
     }
 
     private async runBuild(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
     ): Promise<{
         durationMs: number;
@@ -1985,10 +1992,10 @@ export class AppGenerateService extends BaseService {
         stderr: string;
     }> {
         const start = performance.now();
-        // E2B's `commands.run` throws `CommandExitError` on a non-zero exit
-        // code (no opt-out), so we have to catch it ourselves and surface the
-        // result — otherwise `runBuildWithAutoFix` would never see a failed
-        // build and could not retry.
+        // The sandbox `commands.run` throws `SandboxCommandError` on a non-zero
+        // exit code, so we have to catch it ourselves and surface the result —
+        // otherwise `runBuildWithAutoFix` would never see a failed build and
+        // could not retry.
         let result: {
             exitCode: number;
             stdout: string;
@@ -2010,7 +2017,7 @@ export class AppGenerateService extends BaseService {
                 },
             });
         } catch (err) {
-            if (!(err instanceof CommandExitError)) {
+            if (!(err instanceof SandboxCommandError)) {
                 throw err;
             }
             result = {
@@ -2042,7 +2049,7 @@ export class AppGenerateService extends BaseService {
      * Retries up to MAX_BUILD_FIX_ATTEMPTS times before giving up and throwing.
      */
     private async runBuildWithAutoFix(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         version: number,
         claudeCodeEnv: Record<string, string>,
@@ -2209,7 +2216,7 @@ export class AppGenerateService extends BaseService {
      * build, so any error resolves to null (treat as authored).
      */
     private async detectBlankApp(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
     ): Promise<string | null> {
         try {
@@ -2237,7 +2244,7 @@ export class AppGenerateService extends BaseService {
     }
 
     private async packageArtifacts(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
     ): Promise<{ distTar: Buffer; sourceTar: Buffer; durationMs: number }> {
         const start = performance.now();
@@ -2252,8 +2259,8 @@ export class AppGenerateService extends BaseService {
         ]);
 
         const [distBytes, sourceBytes] = await Promise.all([
-            sandbox.files.read('/tmp/dist.tar', { format: 'bytes' }),
-            sandbox.files.read('/tmp/source.tar', { format: 'bytes' }),
+            sandbox.files.readBytes('/tmp/dist.tar'),
+            sandbox.files.readBytes('/tmp/source.tar'),
         ]);
         const distTar = Buffer.from(distBytes);
         const sourceTar = Buffer.from(sourceBytes);
@@ -2372,12 +2379,10 @@ export class AppGenerateService extends BaseService {
         }
 
         let claudeCodeEnv: Record<string, string>;
-        let e2bApiKey: string;
         let s3Client: S3Client;
         let bucket: string;
         try {
             claudeCodeEnv = this.getClaudeCodeEnv();
-            e2bApiKey = this.getE2bApiKey();
             ({ client: s3Client, bucket } = this.getS3Client());
         } catch (error) {
             // Config errors (missing/incomplete provider, E2B, or S3 setup) carry
@@ -2410,7 +2415,7 @@ export class AppGenerateService extends BaseService {
         );
 
         // --- Stage: sandbox ---
-        let sandbox: Sandbox;
+        let sandbox: SandboxHandle;
         let wasResumed = false;
         if (AppGenerateService.shouldRunStage(currentStatus, 'sandbox')) {
             const advanced = await this.advanceStage(
@@ -2432,7 +2437,6 @@ export class AppGenerateService extends BaseService {
                         app,
                         appUuid,
                         version,
-                        e2bApiKey,
                         s3Client,
                         bucket,
                     );
@@ -2440,7 +2444,7 @@ export class AppGenerateService extends BaseService {
                     wasResumed = acquired.wasResumed;
                     Object.assign(durations, acquired.durations);
                 } else {
-                    const result = await this.createSandbox(appUuid, e2bApiKey);
+                    const result = await this.createSandbox(appUuid);
                     sandbox = result.sandbox;
                     durations.sandboxMs = result.durationMs;
                     await this.appModel.updateSandboxId(
@@ -2496,7 +2500,6 @@ export class AppGenerateService extends BaseService {
                 const result = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
-                    e2bApiKey,
                 );
                 sandbox = result.sandbox;
                 wasResumed = true;
@@ -2557,7 +2560,7 @@ export class AppGenerateService extends BaseService {
     }
 
     private async runPipelineStages(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         payload: AppGeneratePipelineJobPayload,
         s3Client: S3Client,
         bucket: string,
@@ -3940,12 +3943,11 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // standard cold-start path will extract source.tar from S3 on its
         // own.
         if (app.sandbox_id) {
-            let sandbox: Sandbox | null = null;
+            let sandbox: SandboxHandle | null = null;
             try {
                 const resumed = await this.resumeSandbox(
                     app.sandbox_id,
                     appUuid,
-                    this.getE2bApiKey(),
                 );
                 sandbox = resumed.sandbox;
                 await this.resyncSandboxFromS3(
@@ -4081,7 +4083,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
      * iteration starts.
      */
     private async resyncSandboxFromS3(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         s3Client: S3Client,
         bucket: string,
         appUuid: string,
@@ -4123,13 +4125,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
                 `Failed to clear staged tarball path ${stagedPath} (exit ${cleanup.exitCode}): ${cleanup.stderr}`,
             );
         }
-        await sandbox.files.write(
-            stagedPath,
-            tarBuffer.buffer.slice(
-                tarBuffer.byteOffset,
-                tarBuffer.byteOffset + tarBuffer.byteLength,
-            ) as ArrayBuffer,
-        );
+        await sandbox.files.write(stagedPath, tarBuffer);
         const extractResult = await sandbox.commands.run(
             `tar -xf ${stagedPath} -C /app && rm -f ${stagedPath}`,
             { timeoutMs: 60_000 },
@@ -4156,7 +4152,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
      * the user's next prompt will simply not benefit from the heads-up.
      */
     private async notifyClaudeOfRestore(
-        sandbox: Sandbox,
+        sandbox: SandboxHandle,
         appUuid: string,
         sourceVersion: number,
     ): Promise<void> {
@@ -5028,9 +5024,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         // so no spurious failed analytics event fires on top of the cancel.
         if (app.sandbox_id) {
             try {
-                await Sandbox.pause(app.sandbox_id, {
-                    apiKey: this.getE2bApiKey(),
-                });
+                await this.getSandboxProvider().pause(app.sandbox_id);
                 this.logger.info(
                     `App ${appUuid}: sandbox paused after cancel (sandboxId=${app.sandbox_id})`,
                 );
@@ -5503,9 +5497,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     ): Promise<void> {
         if (!sandboxId) return;
         try {
-            await Sandbox.pause(sandboxId, {
-                apiKey: this.getE2bApiKey(),
-            });
+            await this.getSandboxProvider().pause(sandboxId);
             this.logger.info(
                 `App ${appUuid}: sandbox paused during delete (sandboxId=${sandboxId})`,
             );
@@ -5522,9 +5514,7 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
     ): Promise<void> {
         if (!sandboxId) return;
         try {
-            await Sandbox.kill(sandboxId, {
-                apiKey: this.getE2bApiKey(),
-            });
+            await this.getSandboxProvider().destroy(sandboxId);
             this.logger.info(
                 `App ${appUuid}: sandbox killed during hard delete (sandboxId=${sandboxId})`,
             );

--- a/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/designSandboxCopy.ts
@@ -3,10 +3,10 @@ import {
     type AppVersionDesignSnapshot,
     type OrganizationDesignFileKind,
 } from '@lightdash/common';
-import { Sandbox } from 'e2b';
 import type { Logger } from 'winston';
 import type { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { designS3Key } from '../../../services/OrganizationDesignService/OrganizationDesignService';
+import { type SandboxHandle } from '../SandboxRuntime';
 
 /**
  * Sandbox layout the agent sees when a theme is applied. Subdirectories are
@@ -73,7 +73,7 @@ const readS3ObjectAsBuffer = async (
  * previous version sitting on a warm sandbox.
  */
 export async function copyDesignIntoSandbox(args: {
-    sandbox: Sandbox;
+    sandbox: SandboxHandle;
     s3Client: S3Client;
     bucket: string;
     organizationDesignModel: OrganizationDesignModel;
@@ -151,13 +151,7 @@ export async function copyDesignIntoSandbox(args: {
                 );
             } else {
                 const sandboxPath = `${dir}/${file.filename}`;
-                await sandbox.files.write(
-                    sandboxPath,
-                    buffer.buffer.slice(
-                        buffer.byteOffset,
-                        buffer.byteOffset + buffer.byteLength,
-                    ) as ArrayBuffer,
-                );
+                await sandbox.files.write(sandboxPath, buffer);
 
                 if (file.kind === 'css') cssEntrypoints.push(sandboxPath);
                 else if (file.kind === 'image') imagePaths.push(sandboxPath);

--- a/packages/backend/src/ee/services/SandboxRuntime/DESIGN.md
+++ b/packages/backend/src/ee/services/SandboxRuntime/DESIGN.md
@@ -1,0 +1,406 @@
+# Sandbox Runtime — Design
+
+> Status: **Design / RFC** · Branch: `claude/e2b-abstraction-research-2yqno9`
+> Scope: backend EE (`AppGenerateService`, `AiWritebackService`)
+
+## 1. What we're trying to do
+
+Today, two EE features run AI agents (Claude Code) inside an **E2B** sandbox: data-app
+generation (`AppGenerateService`) and AI writeback to dbt repos (`AiWritebackService`).
+Both import the `e2b` SDK directly and pass the concrete `Sandbox` type through their
+internal layers (e.g. the git-provider strategy takes `sandbox: Sandbox`). E2B is a great
+hosted product, but it is an **external dependency**: it requires an API key, sends code
+and repository contents to a third party, and can't be self-hosted.
+
+**Goal:** introduce a thin abstraction so the application code depends on a
+provider-neutral interface instead of the `e2b` package, and so the _same_ feature code
+runs on top of whichever sandbox backend an operator has available:
+
+| Environment                             | Realistic backend                                    | Isolation                     |
+| --------------------------------------- | ---------------------------------------------------- | ----------------------------- |
+| **Local dev (laptop / Docker Compose)** | **plain Docker container** (this doc's first target) | container (`runc`) — dev only |
+| Self-hosted VM                          | microsandbox (`msbserver`) if KVM, else Docker       | microVM → container           |
+| GCP **GKE**                             | GKE Agent Sandbox (gVisor + warm pool)               | gVisor                        |
+| AWS **ECS**                             | Fargate task per sandbox (Firecracker)               | microVM                       |
+| Managed default                         | **E2B** (unchanged)                                  | microVM                       |
+
+This is explicitly a **multi-architecture** abstraction. But we are **not** building all
+providers at once. The first deliverable is the interface plus a **local Docker provider**,
+because it lets us exercise the whole abstraction on a MacBook with zero external services,
+and it forces the interface to be honest about a backend that has _none_ of E2B's
+conveniences (no native pause, no built-in agent, no egress allowlist).
+
+### Non-goals (for now)
+
+- Production-grade isolation in the local provider (it's a testbed; `runc` + Docker socket
+  is root-equivalent on the host — gated to non-production only).
+- Building the GKE / ECS / microsandbox providers (designed for here, implemented later).
+- Replacing E2B's in-memory pause with a true memory snapshot. We replace it with
+  **filesystem persistence + agent resume** (see §6), which is sufficient for multi-turn.
+
+## 2. How E2B is used today (the surface we must cover)
+
+Reverse-engineered from `AppGenerateService` and `AiWritebackService`:
+
+- **Lifecycle (static):** `Sandbox.create(templateRef, opts)`, `Sandbox.connect(id, opts)`,
+  `Sandbox.kill(id, opts)`; instance `sandbox.pause()`, `sandbox.sandboxId`.
+  `create` opts used: `timeoutMs`, `apiKey`, `lifecycle: { onTimeout: 'pause' }`,
+  `network: { allowOut, denyOut: [ALL_TRAFFIC] }`.
+- **Commands:** `sandbox.commands.run(cmd, { cwd?, envs?, timeoutMs?, onStdout?, onStderr? })`
+  → `{ stdout, stderr, exitCode }`. Throws `CommandExitError` (`.exitCode`, `.stderr`) on
+  non-zero exit, `TimeoutError` on timeout.
+- **Files:** `sandbox.files.write(path, contents)`, `.read(path)`, `.remove(path)`.
+- **Git helper:** `sandbox.git.clone/status/createBranch/add/commit/push`.
+- **Constants/errors imported:** `ALL_TRAFFIC`, `CommandExitError`, `TimeoutError`.
+
+The interface in §5 is derived from exactly this list, so the **E2B provider is nearly a
+1:1 passthrough** and the migration is no-behavior-change.
+
+## 3. Architecture: three layers, two planes
+
+The design separates two concerns that generalize very differently:
+
+- **Control plane** — _spawn / stop / persist / resume a sandbox._ Irreducibly
+  environment-specific (Docker API, k8s API, ECS RunTask, E2B API).
+- **Data plane** — _run a command, read/write files, git inside a sandbox._ Can be made
+  **uniform** across environments.
+
+These map onto three layers:
+
+```
+        ┌──────────────────────────────────────────────────────────┐
+        │ AppGenerateService / AiWritebackService                   │
+        │   (feature code — sees ONLY the Manager + SandboxHandle)  │
+        └───────────────────────────┬──────────────────────────────┘
+                                     │
+        ┌────────────────────────────▼─────────────────────────────┐
+LAYER 1 │ Sandbox Manager                                          │
+        │  registry (Postgres) · pool/warm · reaper (Graphile) ·   │
+        │  capacity caps · leases (JetStream KV) · live logs (NATS)│
+        │  picks a Provider by config; owns persist/resume policy   │
+        └───────┬──────────────────────────────────┬───────────────┘
+                │ control plane                     │ delegates persistence
+        ┌───────▼───────────┐              ┌────────▼─────────────────┐
+LAYER 2 │ SandboxProvider   │   returns →  │ LAYER 3  Volume / Storage│
+        │  create/connect/  │  SandboxHandle│  persist(): snapshot    │
+        │  destroy/persist/ │   ┌─────────┐ │  resume():  restore     │
+        │  resume           │   │Execution│ │  tiers: memory|volume|  │
+        │  (Docker/E2B/k8s/ │   │  (data  │ │         objectstore     │
+        │   ECS impls)      │   │  plane) │ │  default: tar→S3/MinIO  │
+        └───────────────────┘   └─────────┘ └──────────────────────────┘
+```
+
+- **Layer 1 — Sandbox Manager:** the only thing feature code talks to. Env-agnostic.
+  Owns the _operational_ concerns (which sandbox belongs to which thread, idle reaping,
+  capacity, crash recovery, live log fan-out). Selects a provider via `SANDBOX_PROVIDER`.
+- **Layer 2 — Execution layer (the `SandboxHandle` data plane):** `commands` / `files` /
+  `git`. For E2B/GKE this is the provider's native client; for local Docker it's
+  `docker exec` through the socket; for ECS/raw-Docker-in-prod it's a small **in-sandbox
+  agent** (see §5.4). Same interface regardless.
+- **Layer 3 — Volume / storage layer:** how on-disk state survives between turns. Has a
+  **universal default** (tar the working set to S3/MinIO) and **per-provider overrides**
+  (E2B memory pause; ECS EFS; k8s PVC).
+
+## 4. Features the abstraction must provide
+
+1. **Lifecycle:** create, connect (re-attach by id), destroy.
+2. **Command execution:** run a shell command with `cwd`, `envs`, `timeoutMs`, and
+   **streaming** `onStdout`/`onStderr`; return `{ stdout, stderr, exitCode }`.
+3. **File operations:** read, write, remove.
+4. **Git operations:** clone, status, createBranch, add, commit, push (provider-native on
+   E2B; otherwise implemented over command execution).
+5. **Normalized errors:** `SandboxCommandError` (non-zero exit) and `SandboxTimeoutError`,
+   so callers never `instanceof CommandExitError` against a vendor type.
+6. **Egress control:** an allowlist of outbound hosts (`api.anthropic.com`, `github.com`,
+   …) enforced by whatever mechanism the environment offers.
+7. **Persistence / multi-turn:** snapshot a declared working set at end of turn and restore
+   it next turn, so agent chat history (on disk) survives. Pause/resume where native.
+8. **Operational robustness (Manager):** idle reaping, capacity limits, crash recovery via
+   leases, warm pools where supported, live log streaming.
+9. **Capability discovery:** providers advertise what they can do (pause/resume, isolation
+   level, egress enforcement, warm pool) so the Manager can degrade gracefully.
+
+## 5. The interfaces
+
+Location (proposed): `packages/backend/src/ee/services/SandboxRuntime/`.
+
+### 5.1 Provider (control plane)
+
+```ts
+interface SandboxProvider {
+    create(spec: SandboxSpec): Promise<SandboxHandle>;
+    connect(sandboxId: string): Promise<SandboxHandle>;
+    destroy(sandboxId: string): Promise<void>;
+
+    // Persistence — see §6. Default impls live in the Manager (tar→S3);
+    // providers override when they have something better.
+    persist(sandboxId: string): Promise<SnapshotRef>;
+    resume(ref: SnapshotRef): Promise<SandboxHandle>;
+
+    readonly capabilities: SandboxCapabilities;
+}
+
+interface SandboxSpec {
+    templateRef: string; // OCI image / E2B template / k8s SandboxTemplate
+    timeoutMs: number;
+    egress: { allow: string[] }; // denyOut: ALL_TRAFFIC is implicit
+    envs?: Record<string, string>;
+    workspace: PersistentWorkspace; // declares what persist() captures (§6)
+}
+
+interface SandboxCapabilities {
+    isolation: 'microvm' | 'gvisor' | 'container';
+    pauseResume: boolean; // true only where memory snapshot exists (E2B)
+    egressAllowlist: boolean; // can it actually enforce SandboxSpec.egress?
+    warmPool: boolean;
+    persistence: 'memory' | 'volume' | 'objectstore';
+}
+```
+
+### 5.2 Handle (execution / data plane)
+
+```ts
+interface SandboxHandle {
+    readonly sandboxId: string;
+    pause(): Promise<void>; // capability-gated; no-op→throws if unsupported
+
+    commands: {
+        run(cmd: string, opts?: RunOptions): Promise<CommandResult>;
+    };
+    files: {
+        read(path: string): Promise<string>;
+        write(path: string, contents: string | Buffer): Promise<void>;
+        remove(path: string): Promise<void>;
+    };
+    git: SandboxGit;
+}
+
+interface RunOptions {
+    cwd?: string;
+    envs?: Record<string, string>;
+    timeoutMs?: number;
+    onStdout?: (chunk: string) => void;
+    onStderr?: (chunk: string) => void;
+}
+
+interface CommandResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+}
+
+interface SandboxGit {
+    clone(url: string, opts: GitCloneOptions): Promise<void>;
+    status(
+        cwd: string,
+    ): Promise<{ currentBranch: string | null; hasChanges: boolean }>;
+    createBranch(cwd: string, branch: string): Promise<void>;
+    add(cwd: string, opts: { files: string[] } | { all: true }): Promise<void>;
+    commit(
+        cwd: string,
+        message: string,
+        author: { name: string; email: string },
+    ): Promise<void>;
+    push(cwd: string, opts: GitPushOptions): Promise<void>;
+}
+```
+
+### 5.3 Errors (normalized, vendor-neutral)
+
+```ts
+class SandboxCommandError extends Error {
+    // maps E2B CommandExitError
+    constructor(
+        readonly exitCode: number,
+        readonly stderr: string,
+    ) {
+        super();
+    }
+}
+class SandboxTimeoutError extends Error {} // maps E2B TimeoutError
+```
+
+The only real translation work in any provider is catching the vendor error and rethrowing
+one of these. Feature code branches on `instanceof SandboxCommandError` only.
+
+### 5.4 The execution layer's two shapes
+
+`SandboxHandle` is satisfied one of three ways, all behind the same interface:
+
+| Backend                             | How `commands/files/git` are implemented                                                                                                                    | Build an agent?                    |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **E2B**                             | thin shim over the `e2b` SDK (`sandbox.commands/files/git`)                                                                                                 | no — E2B's `envd`                  |
+| **GKE Agent Sandbox**               | shim over the Sandbox Router / `sandbox.run()`                                                                                                              | no — provided                      |
+| **Local Docker (first target)**     | `docker exec` via the Docker socket; files via `putArchive`/`getArchive` or base64-over-exec; git over exec                                                 | **no** — the socket is the channel |
+| **ECS Fargate / raw Docker (prod)** | HTTP to a small **in-sandbox agent** baked into the image, started by the entrypoint; per-sandbox bearer token over TLS; reached on the task/pod private IP | **yes**                            |
+
+Key point: the local provider needs **no agent and no networking** — `docker exec` streams
+stdout/stderr/exit back through the daemon, which is why it's the simplest possible testbed
+(and dodges macOS container-IP routing entirely).
+
+### 5.5 What is E2B-compatible — and what isn't
+
+**Maps natively / near-1:1 (E2B provider is a passthrough):**
+
+- `create/connect/destroy/pause` → `Sandbox.create/connect/kill` + `sandbox.pause`.
+- `commands.run` incl. `cwd/envs/timeoutMs/onStdout/onStderr` → `sandbox.commands.run`.
+- `files.read/write/remove` → `sandbox.files.*`.
+- `git.*` → `sandbox.git.*` (E2B even ships the git helper).
+- `egress.allow` → `network.allowOut` with implicit `denyOut: [ALL_TRAFFIC]`.
+- Errors → catch `CommandExitError`/`TimeoutError`, rethrow neutral.
+
+**Does NOT carry over to other providers (must be emulated by the Manager / providers):**
+
+| E2B feature                                           | Why it won't port                                         | Replacement                                                                                                 |
+| ----------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **In-memory `pause()`/resume** (RAM + live processes) | needs microVM memory snapshot; Docker/k8s/ECS can't       | **filesystem persistence + agent `--resume`** (§6); `capabilities.pauseResume=false`                        |
+| **Native egress allowlist**                           | Docker/k8s/ECS enforce egress differently                 | provider-specific: NetworkPolicy / security group / host firewall; local Docker = best-effort or none (dev) |
+| **Managed transport + auth** (API key, no IPs, TLS)   | self-hosted has no managed plane                          | in-sandbox agent + per-sandbox token + NetworkPolicy/SG (prod); Docker socket (local)                       |
+| **Built-in `git` helper**                             | only E2B ships it                                         | implement `SandboxGit` over `commands.run` (git binary in image)                                            |
+| **Elastic capacity**                                  | one host/cluster is finite                                | Manager capacity caps + warm pools                                                                          |
+| **Streaming fidelity**                                | some data planes merge stdout/stderr (k8s exec, ECS Exec) | accept merged streams there, or rely on the agent which keeps them separate                                 |
+
+So the abstraction is "**E2B-shaped**": E2B is the reference and the easy case; the design
+work is making poorer backends present the same `SandboxHandle`.
+
+## 6. Volume / storage layer (persistence & multi-turn)
+
+Multi-turn agents persist **chat history to disk** inside the sandbox. We don't need E2B's
+memory snapshot to keep that — we need the _filesystem_ to survive between turns, plus a
+relaunch of the agent in resume mode. Three fidelity tiers:
+
+| Tier          | Survives                        | Mechanism                                  | Notes                                   |
+| ------------- | ------------------------------- | ------------------------------------------ | --------------------------------------- |
+| 1 memory      | RAM + disk + **live processes** | E2B `pause()`                              | transparent resume; E2B only            |
+| 2 volume      | disk                            | EFS / PVC / named Docker volume reattached | fast (no copy); pins location           |
+| 3 objectstore | disk subset                     | **tar working set → S3/MinIO**             | portable; copy cost ∝ size; **default** |
+
+### Declared working set — persist a slice, not the disk
+
+`PersistentWorkspace` declares the small set of paths worth keeping; everything else is
+re-derived (`git clone`, `pnpm install`) on resume. This keeps snapshots tiny and avoids
+persisting secrets.
+
+```ts
+interface PersistentWorkspace {
+    include: string[]; // e.g. agent session dir (~/.claude), mutable working tree
+    exclude: string[]; // node_modules, .git objects, build output, injected secrets
+}
+type SnapshotRef =
+    | { kind: 'e2b-paused'; sandboxId: string }
+    | { kind: 'volume'; volumeId: string }
+    | { kind: 's3-tar'; key: string };
+```
+
+### Default implementation lives in the Manager
+
+`persist`/`resume` have a **single default implementation in the Manager** — tar the
+working set and stream it to S3 via the existing `FileStorageClient` (locally: MinIO, zero
+new infra). Every provider inherits working multi-turn for free. Providers **override**
+only when they have something faster: E2B → `pause()` (tier 1), ECS → EFS (tier 2).
+
+### Resume flow (tier 2/3)
+
+```
+turn ends   → Manager.persist(): quiesce agent → tar {workspace.include} → S3 key
+              → store {snapshotRef, agentSessionId} in registry → destroy/stop sandbox
+turn starts → Manager.resume(ref):
+                provider.create() (warm pool if available)
+                re-derive code:   git clone + install
+                restore state:    download tar → extract over the top
+                relaunch agent:   `claude --resume <agentSessionId>`
+```
+
+The agent reading its restored transcript is what continues the conversation — RAM was
+never the source of truth.
+
+### Two retention policies (don't conflate)
+
+- **Idle reap** (minutes): a _live_ sandbox with no activity → stop/destroy to free the
+  host. Keyed on `lastActivityAt`.
+- **Snapshot retention** (days): how long a _thread_ can be resumed → GC the S3 tar / volume.
+
+## 7. Sandbox Manager layer (operational concerns)
+
+The Manager is the only dependency of `AppGenerateService` / `AiWritebackService`. It wraps
+a `SandboxProvider` and adds everything E2B's hosted plane gave us for free. It reuses
+**infra we already run**:
+
+| Concern                                                                                                      | Implementation                                                                    | Infra                                           |
+| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Registry** (sandbox ↔ thread, provider, address, state, `lastActivityAt`, `snapshotRef`, `agentSessionId`) | new table; extends today's persisted `sandboxId`                                  | **Postgres**                                    |
+| **Capacity / claim**                                                                                         | `SELECT … FOR UPDATE SKIP LOCKED` to cap concurrent sandboxes and claim warm ones | **Postgres**                                    |
+| **Reaper** (idle + snapshot GC)                                                                              | recurring job; generalizes today's stale-job release                              | **Graphile cron**                               |
+| **Durable retry / state machine**                                                                            | enqueue next turn + registry update in one txn                                    | **Graphile + Postgres**                         |
+| **Lease / liveness / orphan detect**                                                                         | worker heartbeats a TTL key; expiry ⇒ orphan ⇒ re-adopt or reap                   | **JetStream KV** (TTL) or Postgres lease column |
+| **Live + replayable stdout, cancel**                                                                         | fan out `onStdout` to the API pod holding the user's stream                       | **NATS / JetStream**                            |
+| **Warm pool**                                                                                                | pre-created idle sandboxes (provider-native on GKE/ECS)                           | provider + registry                             |
+
+**Crash recovery is the headline robustness property:** because the sandbox lives _outside_
+the worker, a worker death doesn't kill the run. The lease expires, a fresh worker
+`connect()`s by `sandboxId` and resumes streaming. The Manager owns this; providers just
+implement `connect`.
+
+### Manager ↔ Provider ↔ Volume interaction (per turn)
+
+```
+feature code → Manager.runTurn(threadId, prompt)
+  Manager: look up registry row for threadId
+    if none / expired snapshot  → provider.create(spec)             [+ Volume restore if snapshotRef]
+    else                        → provider.connect(id) | resume(ref)
+  Manager: acquire lease (JetStream KV TTL), start heartbeat
+  feature code uses SandboxHandle.commands/files/git  (Execution/data plane)
+    Manager streams onStdout → NATS → user
+  turn ends:
+    Manager.persist(id) → Volume layer: tar include-set → MinIO/S3 → snapshotRef
+    Manager: update registry (snapshotRef, lastActivityAt), release lease
+    Manager: provider.destroy(id)  (or pause on E2B)
+  later: reaper GCs idle sandboxes (minutes) and stale snapshots (days)
+```
+
+## 8. Local-dev testbed (first target, concrete)
+
+`DockerSandboxProvider` — the simplest thing that exercises every layer on a MacBook:
+
+- **Image:** reuse `sandboxes/ai-writeback/e2b.Dockerfile` built as a plain image
+  (`lightdash-sandbox:local`) — already has node, git, claude, dbt.
+- **Control plane:** `dockerode` over the Docker socket mounted into `lightdash-dev`
+  (`- /var/run/docker.sock:/var/run/docker.sock`). `create` runs the image with entrypoint
+  `sleep infinity` on the `lightdash-app_default` network; `destroy` force-removes it.
+- **Execution layer:** `container.exec` (no agent, no network, no token). Files via
+  `putArchive`/`getArchive` or base64-over-exec; git over exec.
+- **Volume layer:** Manager default — tar working set → **MinIO** (already wired into
+  `FileStorageClient`). Validates tier-3 persistence end-to-end locally.
+- **Capabilities:** `{ isolation: 'container', pauseResume: false, egressAllowlist: false,
+warmPool: false, persistence: 'objectstore' }`.
+- **Safety gate:** refuses to initialize when `NODE_ENV === 'production'`.
+
+Selected by `SANDBOX_PROVIDER=docker`; `SANDBOX_PROVIDER=e2b` keeps today's path.
+
+## 9. Configuration
+
+```
+SANDBOX_PROVIDER = e2b | docker        # (later: kubernetes | ecs | microsandbox)
+```
+
+Lives in `lightdashConfig.appRuntime`. E2B keeps its existing `E2B_*` settings. The Docker
+provider needs only the image name and the socket mount. Egress allowlists move from
+hard-coded arrays into `SandboxSpec.egress.allow` built by each feature service.
+
+## 10. Phasing
+
+- **Phase 0 — interface + local provider (this design):** `SandboxProvider`/`SandboxHandle`
+    - errors + capabilities; `DockerSandboxProvider`; `SANDBOX_PROVIDER` flag; migrate
+      `AppGenerateService`/`AiWritebackService` and the git-provider strategy off the concrete
+      `e2b` type (E2B shim = no behavior change). Compose socket mount. _No persistence yet._
+- **Phase 1 — persistence / multi-turn:** `PersistentWorkspace` + Manager default
+  `persist`/`resume` (tar→MinIO) + agent `--resume`. Validate a 2-turn conversation
+  surviving container destruction.
+- **Phase 2 — Manager hardening:** registry table, reaper (Graphile cron), capacity caps,
+  leases (JetStream KV), live logs (NATS), crash-recovery re-adopt.
+- **Phase 3 — real providers:** GKE Agent Sandbox, ECS Fargate (+ in-sandbox agent),
+  microsandbox — each conforming to the Phase-0 interface.
+
+```
+
+```

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
@@ -1,0 +1,141 @@
+import { ALL_TRAFFIC, CommandExitError, Sandbox, TimeoutError } from 'e2b';
+import { SandboxCommandError, SandboxTimeoutError } from './errors';
+import {
+    type CommandResult,
+    type RunOptions,
+    type SandboxCapabilities,
+    type SandboxHandle,
+    type SandboxProvider,
+    type SandboxSpec,
+} from './types';
+
+// Sandboxes re-attached via connect() get the same long-lived ceiling as the
+// pipeline grants on create — long enough to cover a full multi-stage run.
+const CONNECT_TIMEOUT_MS = 60 * 60 * 1000;
+
+const toArrayBuffer = (bytes: Uint8Array): ArrayBuffer =>
+    bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
+
+/** Rethrow E2B's command/timeout errors as vendor-neutral ones. */
+const normalizeError = (error: unknown): never => {
+    if (error instanceof CommandExitError) {
+        throw new SandboxCommandError(
+            error.exitCode,
+            error.stderr,
+            error.stdout,
+        );
+    }
+    if (error instanceof TimeoutError) {
+        throw new SandboxTimeoutError(error.message);
+    }
+    throw error;
+};
+
+class E2bSandboxHandle implements SandboxHandle {
+    constructor(private readonly sandbox: Sandbox) {}
+
+    get sandboxId(): string {
+        return this.sandbox.sandboxId;
+    }
+
+    async pause(): Promise<void> {
+        await this.sandbox.pause();
+    }
+
+    readonly commands = {
+        run: async (
+            command: string,
+            options?: RunOptions,
+        ): Promise<CommandResult> => {
+            try {
+                const result = await this.sandbox.commands.run(command, {
+                    cwd: options?.cwd,
+                    envs: options?.envs,
+                    timeoutMs: options?.timeoutMs,
+                    onStdout: options?.onStdout,
+                    onStderr: options?.onStderr,
+                });
+                return {
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                    exitCode: result.exitCode,
+                };
+            } catch (error) {
+                return normalizeError(error);
+            }
+        },
+    };
+
+    readonly files = {
+        read: (path: string): Promise<string> => this.sandbox.files.read(path),
+        readBytes: async (path: string): Promise<Buffer> => {
+            const bytes = await this.sandbox.files.read(path, {
+                format: 'bytes',
+            });
+            return Buffer.from(bytes);
+        },
+        write: async (
+            path: string,
+            contents: string | Uint8Array,
+        ): Promise<void> => {
+            await this.sandbox.files.write(
+                path,
+                typeof contents === 'string'
+                    ? contents
+                    : toArrayBuffer(contents),
+            );
+        },
+        remove: async (path: string): Promise<void> => {
+            await this.sandbox.files.remove(path);
+        },
+    };
+}
+
+/**
+ * E2B-backed provider — a near 1:1 passthrough to the `e2b` SDK. This is the
+ * reference implementation and the managed default.
+ */
+export class E2bSandboxProvider implements SandboxProvider {
+    readonly capabilities: SandboxCapabilities = {
+        isolation: 'microvm',
+        pauseResume: true,
+        egressAllowlist: true,
+        warmPool: false,
+        persistence: 'memory',
+    };
+
+    constructor(private readonly apiKey: string) {}
+
+    async create(spec: SandboxSpec): Promise<SandboxHandle> {
+        const sandbox = await Sandbox.create(spec.templateRef, {
+            timeoutMs: spec.timeoutMs,
+            apiKey: this.apiKey,
+            lifecycle: { onTimeout: 'pause' },
+            network: {
+                allowOut: spec.egress.allow,
+                denyOut: [ALL_TRAFFIC],
+            },
+            ...(spec.envs ? { envs: spec.envs } : {}),
+        });
+        return new E2bSandboxHandle(sandbox);
+    }
+
+    async connect(sandboxId: string): Promise<SandboxHandle> {
+        const sandbox = await Sandbox.connect(sandboxId, {
+            apiKey: this.apiKey,
+            timeoutMs: CONNECT_TIMEOUT_MS,
+        });
+        return new E2bSandboxHandle(sandbox);
+    }
+
+    async destroy(sandboxId: string): Promise<void> {
+        await Sandbox.kill(sandboxId, { apiKey: this.apiKey });
+    }
+
+    async pause(sandboxId: string): Promise<void> {
+        await Sandbox.pause(sandboxId, { apiKey: this.apiKey });
+    }
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/errors.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Vendor-neutral sandbox errors. Providers catch their backend's error types and
+ * rethrow one of these, so feature code never branches on a vendor type (e.g.
+ * E2B's `CommandExitError`).
+ */
+
+/** Thrown when a sandbox command exits with a non-zero status. */
+export class SandboxCommandError extends Error {
+    constructor(
+        readonly exitCode: number,
+        readonly stderr: string,
+        readonly stdout: string,
+    ) {
+        super(`Sandbox command failed with exit code ${exitCode}`);
+        this.name = 'SandboxCommandError';
+    }
+}
+
+/** Thrown when a sandbox command exceeds its timeout. */
+export class SandboxTimeoutError extends Error {
+    constructor(message = 'Sandbox command timed out') {
+        super(message);
+        this.name = 'SandboxTimeoutError';
+    }
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/index.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/index.ts
@@ -1,0 +1,39 @@
+import { MissingConfigError } from '@lightdash/common';
+import { E2bSandboxProvider } from './E2bSandboxProvider';
+import { type SandboxLogger, type SandboxProvider } from './types';
+
+export * from './errors';
+export * from './types';
+
+export type SandboxProviderKind = 'e2b' | 'docker';
+
+export interface CreateSandboxProviderOptions {
+    provider: SandboxProviderKind;
+    e2bApiKey: string | null;
+    dockerImage: string;
+    logger: SandboxLogger;
+}
+
+/**
+ * Build the sandbox provider selected by `SANDBOX_PROVIDER`. Throws a clear
+ * config error when the chosen provider is missing required configuration.
+ */
+export const createSandboxProvider = (
+    options: CreateSandboxProviderOptions,
+): SandboxProvider => {
+    switch (options.provider) {
+        case 'e2b':
+            if (!options.e2bApiKey) {
+                throw new MissingConfigError(
+                    'E2B API key is not configured (E2B_API_KEY)',
+                );
+            }
+            return new E2bSandboxProvider(options.e2bApiKey);
+        default:
+            // The `docker` provider lands in the next PR of this stack; until
+            // then E2B is the only backend and anything else is unsupported.
+            throw new MissingConfigError(
+                `Unsupported SANDBOX_PROVIDER: ${options.provider as string}`,
+            );
+    }
+};

--- a/packages/backend/src/ee/services/SandboxRuntime/types.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Provider-neutral sandbox runtime interfaces. Application code (AppGenerateService,
+ * AiWritebackService) depends on these instead of the concrete `e2b` SDK, so the
+ * same feature code runs on any backend (E2B, local Docker, …). See DESIGN.md.
+ */
+
+/** A minimal logger surface (structurally compatible with winston's Logger). */
+export interface SandboxLogger {
+    info(message: string): void;
+    warn(message: string): void;
+    debug(message: string): void;
+    error(message: string): void;
+}
+
+export interface CommandResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+}
+
+export interface RunOptions {
+    cwd?: string;
+    envs?: Record<string, string>;
+    timeoutMs?: number;
+    onStdout?: (chunk: string) => void;
+    onStderr?: (chunk: string) => void;
+}
+
+/** Data plane: run a command inside the sandbox. */
+export interface SandboxCommands {
+    /**
+     * Run a shell command. Resolves with the command result on a zero exit and
+     * throws {@link SandboxCommandError} on any non-zero exit (matching E2B's
+     * no-opt-out behavior), or {@link SandboxTimeoutError} on timeout.
+     */
+    run(command: string, options?: RunOptions): Promise<CommandResult>;
+}
+
+/** Data plane: read/write files inside the sandbox. */
+export interface SandboxFiles {
+    /** Read a UTF-8 text file. */
+    read(path: string): Promise<string>;
+    /** Read a binary file as raw bytes. */
+    readBytes(path: string): Promise<Buffer>;
+    /** Write a text or binary file, creating parent directories as needed. */
+    write(path: string, contents: string | Uint8Array): Promise<void>;
+    /** Remove a file (no error if it does not exist). */
+    remove(path: string): Promise<void>;
+}
+
+/**
+ * Execution / data plane handle for a single running sandbox. Satisfied by the
+ * provider's native client (E2B) or by `docker exec` (local Docker).
+ */
+export interface SandboxHandle {
+    readonly sandboxId: string;
+    /**
+     * Persist + suspend the sandbox so it can be resumed later. Capability-gated:
+     * providers without a native pause (Docker) treat this as a no-op.
+     */
+    pause(): Promise<void>;
+    readonly commands: SandboxCommands;
+    readonly files: SandboxFiles;
+}
+
+export type SandboxIsolation = 'microvm' | 'gvisor' | 'container';
+export type SandboxPersistence = 'memory' | 'volume' | 'objectstore';
+
+export interface SandboxCapabilities {
+    isolation: SandboxIsolation;
+    /** true only where a native memory snapshot exists (E2B). */
+    pauseResume: boolean;
+    /** can it actually enforce SandboxSpec.egress? */
+    egressAllowlist: boolean;
+    warmPool: boolean;
+    persistence: SandboxPersistence;
+}
+
+export interface SandboxSpec {
+    /** OCI image / E2B template ref — interpreted by the chosen provider. */
+    templateRef: string;
+    timeoutMs: number;
+    /** Outbound host allowlist. `denyOut: ALL_TRAFFIC` is implicit. */
+    egress: { allow: string[] };
+    envs?: Record<string, string>;
+}
+
+/**
+ * Control plane: spawn / re-attach / destroy / pause a sandbox. Irreducibly
+ * environment-specific (Docker API, E2B API, k8s, …).
+ */
+export interface SandboxProvider {
+    readonly capabilities: SandboxCapabilities;
+    create(spec: SandboxSpec): Promise<SandboxHandle>;
+    /** Re-attach to an existing sandbox by id. */
+    connect(sandboxId: string): Promise<SandboxHandle>;
+    /** Permanently destroy a sandbox. No error if it is already gone. */
+    destroy(sandboxId: string): Promise<void>;
+    /** Pause a sandbox by id (capability-gated; no-op where unsupported). */
+    pause(sandboxId: string): Promise<void>;
+}


### PR DESCRIPTION
### Description

Phase 0 (part 1) of the open-source/self-hostable alternative to E2B for data apps — the no-behaviour-change refactor.

Introduce a provider-neutral sandbox runtime interface so the data-app generation pipeline depends on `SandboxProvider` / `SandboxHandle` instead of the concrete `e2b` SDK. E2B stays the only backend and the default, routed through a 1:1 passthrough shim — nothing changes in prod.

**Changes**

- `SandboxProvider` / `SandboxHandle` interfaces; normalized errors (`SandboxCommandError` / `SandboxTimeoutError`); capability discovery.
- `E2bSandboxProvider` — near 1:1 passthrough of today's E2B usage.
- `SANDBOX_PROVIDER` config flag (defaults to `e2b`).
- `AppGenerateService` migrated off the concrete `e2b.Sandbox` type.

Design: `packages/backend/src/ee/services/SandboxRuntime/DESIGN.md`. The local Docker provider lands in the next PR of the stack (#24743). AiWritebackService + git migration is still future work.

**Verification**

Ran end-to-end on the E2B provider (`SANDBOX_PROVIDER=e2b`): fresh generation and iteration both succeed — sandbox create → claude code → vite build → S3 upload → ready, and iteration correctly resumes the paused microvm via `Sandbox.connect`.

Closes: PROD-8502
Relates: #24605
