### PR TITLE
fix(data-apps): align agent status bubble helper line

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -224,6 +224,12 @@
     color: var(--mantine-color-dimmed) !important;
 }
 
+/* Align the "continue building" hint with the status text above it, which is
+ * rendered via AiMarkdown and carries the shared 7px markdown padding-left. */
+.buildingHint {
+    padding-left: 7px;
+}
+
 .chatInputArea {
     flex: 0 1 auto;
     min-height: 0;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2281,6 +2281,9 @@ const AppGenerate: FC = () => {
                                                             latestBuildingVersion?.status ===
                                                                 'generating' && (
                                                                 <Text
+                                                                    className={
+                                                                        classes.buildingHint
+                                                                    }
                                                                     fz={11}
                                                                     c="dimmed"
                                                                     mt={6}


### PR DESCRIPTION
### Description:
The status line renders via AiMarkdown (7px markdown padding-left) while the "continue building" helper line was a plain Text with no left padding, so it sat 7px to the left. Add matching left padding to align the two lines.

Before:
<img width="524" height="89" alt="before" src="https://github.com/user-attachments/assets/b56f50c2-6707-494f-ba50-f300bf752c72" />


After:
<img width="524" height="89" alt="after" src="https://github.com/user-attachments/assets/12940e02-e473-4023-9e56-40d5881a1af3" />
