### PR TITLE
fix(data-apps): source synthetic schema.yml from explore cache

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -182,6 +182,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         models.getOrganizationDesignModel(),
                     pinnedListModel: models.getPinnedListModel(),
                     projectModel: models.getProjectModel(),
+                    projectParametersModel: models.getProjectParametersModel(),
                     spaceModel: models.getSpaceModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -240,10 +240,10 @@ describe('AppGenerateService pipeline external connection samples', () => {
                 chartReferences: undefined,
                 template: undefined,
             ) => Promise<unknown>;
-            catalogModel: { getCatalogItemsSummary: jest.Mock };
+            projectModel: { getAllExploresFromCache: jest.Mock };
         };
-        privateService.catalogModel = {
-            getCatalogItemsSummary: jest.fn().mockResolvedValue([]),
+        privateService.projectModel = {
+            getAllExploresFromCache: jest.fn().mockResolvedValue({}),
         };
 
         await privateService.writeCatalogAndPrompt(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.externalSamples.test.ts
@@ -65,6 +65,7 @@ function buildService() {
             organizationDesignModel: {} as never,
             pinnedListModel: {} as never,
             projectModel: {} as never,
+            projectParametersModel: {} as never,
             spaceModel: {} as never,
             schedulerClient: {} as never,
             savedChartService: {} as never,
@@ -241,9 +242,13 @@ describe('AppGenerateService pipeline external connection samples', () => {
                 template: undefined,
             ) => Promise<unknown>;
             projectModel: { getAllExploresFromCache: jest.Mock };
+            projectParametersModel: { find: jest.Mock };
         };
         privateService.projectModel = {
             getAllExploresFromCache: jest.fn().mockResolvedValue({}),
+        };
+        privateService.projectParametersModel = {
+            find: jest.fn().mockResolvedValue([]),
         };
 
         await privateService.writeCatalogAndPrompt(

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -75,6 +75,7 @@ import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagMo
 import { OrganizationDesignModel } from '../../../models/OrganizationDesignModel';
 import { PinnedListModel } from '../../../models/PinnedListModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
+import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { SpaceModel } from '../../../models/SpaceModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
@@ -126,6 +127,7 @@ type AppGenerateServiceDeps = {
     organizationDesignModel: OrganizationDesignModel;
     pinnedListModel: PinnedListModel;
     projectModel: ProjectModel;
+    projectParametersModel: ProjectParametersModel;
     spaceModel: SpaceModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
@@ -170,6 +172,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
+    private readonly projectParametersModel: ProjectParametersModel;
+
     private readonly spaceModel: SpaceModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
@@ -196,6 +200,7 @@ export class AppGenerateService extends BaseService {
         organizationDesignModel,
         pinnedListModel,
         projectModel,
+        projectParametersModel,
         spaceModel,
         schedulerClient,
         savedChartService,
@@ -215,6 +220,7 @@ export class AppGenerateService extends BaseService {
         this.organizationDesignModel = organizationDesignModel;
         this.pinnedListModel = pinnedListModel;
         this.projectModel = projectModel;
+        this.projectParametersModel = projectParametersModel;
         this.spaceModel = spaceModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
@@ -1342,15 +1348,29 @@ export class AppGenerateService extends BaseService {
             metricCount,
         } = AppGenerateService.exploresToYaml(explores);
 
+        // Project-level parameters are global (not attached to any one explore)
+        // and live in lightdash.config.yml — the location skill.md already tells
+        // the agent to look. Write them there so `.parameters()` is usable.
+        const globalParameters =
+            await this.projectParametersModel.find(projectUuid);
+        const configYaml =
+            AppGenerateService.projectParametersToConfigYaml(globalParameters);
+
         // Remove files that may have been created by a previous run with
         // different ownership (e.g. root-owned after Claude CLI execution),
         // which would cause a permission error on write.
         await sandbox.commands.run(
-            'rm -f /tmp/dbt-repo/models/schema.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/metric-queries /tmp/external-data 2>/dev/null; true',
+            'rm -f /tmp/dbt-repo/models/schema.yml /tmp/dbt-repo/lightdash.config.yml /tmp/prompt.txt 2>/dev/null; rm -rf /tmp/images /tmp/metric-queries /tmp/external-data 2>/dev/null; true',
             { timeoutMs: 10_000 },
         );
 
         await sandbox.files.write('/tmp/dbt-repo/models/schema.yml', modelYaml);
+        if (configYaml) {
+            await sandbox.files.write(
+                '/tmp/dbt-repo/lightdash.config.yml',
+                configYaml,
+            );
+        }
 
         // Write chart reference files and prepend summary to prompt
         let finalPrompt = prompt;
@@ -6109,6 +6129,26 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
             dimensionCount,
             metricCount,
         };
+    }
+
+    /**
+     * Render project-level (global) parameters as a `lightdash.config.yml`
+     * fragment — the location skill.md tells the agent project-wide parameters
+     * live in. Returns null when the project defines none.
+     */
+    private static projectParametersToConfigYaml(
+        parameters: { name: string; config: LightdashProjectParameter }[],
+    ): string | null {
+        if (parameters.length === 0) {
+            return null;
+        }
+        const lines: string[] = ['parameters:'];
+        for (const { name, config } of parameters) {
+            lines.push(
+                ...AppGenerateService.renderParameterYaml(name, config, '  '),
+            );
+        }
+        return `${lines.join('\n')}\n`;
     }
 
     private static getContentType(filePath: string): string {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -19,6 +19,7 @@ import {
     formatPromptWithClarifications,
     getErrorMessage,
     isDashboardChartTileType,
+    isExploreError,
     MissingConfigError,
     NotFoundError,
     ParameterError,
@@ -32,14 +33,17 @@ import {
     type AppVersionChartResource,
     type AppVersionExternalConnectionResource,
     type AppVersionResources,
-    type CatalogItemSummary,
     type ChartReference,
     type ChartSampleData,
+    type CompiledExploreJoin,
+    type CompiledTable,
     type DataAppClaudeModel,
     type DataAppTemplate,
     type EmbedProjectApp,
+    type Explore,
     type ExternalConnectionMethod,
     type ExternalConnectionSample,
+    type LightdashProjectParameter,
     type PromoteAppAction,
     type PromoteAppDiff,
     type SessionUser,
@@ -1323,9 +1327,20 @@ export class AppGenerateService extends BaseService {
     }> {
         const start = performance.now();
 
-        const catalogItems =
-            await this.catalogModel.getCatalogItemsSummary(projectUuid);
-        const modelYaml = AppGenerateService.catalogToYaml(catalogItems);
+        // Source the synthetic schema from the compiled explore cache (not the
+        // flattened catalog summary) so it carries joins, real dimension/metric
+        // types, and parameters. See exploresToYaml.
+        const exploresByUuid =
+            await this.projectModel.getAllExploresFromCache(projectUuid);
+        const explores = Object.values(exploresByUuid).filter(
+            (explore): explore is Explore => !isExploreError(explore),
+        );
+        const {
+            yaml: modelYaml,
+            tableCount,
+            dimensionCount,
+            metricCount,
+        } = AppGenerateService.exploresToYaml(explores);
 
         // Remove files that may have been created by a previous run with
         // different ownership (e.g. root-owned after Claude CLI execution),
@@ -1412,30 +1427,15 @@ export class AppGenerateService extends BaseService {
         // responses overly verbose.
         await sandbox.files.write('/tmp/prompt.txt', `${finalPrompt}\n`);
 
-        let tableCount = 0;
-        let totalDimensions = 0;
-        let totalMetrics = 0;
-        for (const item of catalogItems) {
-            if (item.type === 'field') {
-                if (item.fieldType === 'metric') {
-                    totalMetrics += 1;
-                } else {
-                    totalDimensions += 1;
-                }
-            } else {
-                tableCount += 1;
-            }
-        }
-
         const durationMs = AppGenerateService.elapsed(start);
         this.logger.info(
-            `App ${appUuid}: model context written (tables=${tableCount}, dimensions=${totalDimensions}, metrics=${totalMetrics}, yamlBytes=${modelYaml.length}, ${durationMs}ms)`,
+            `App ${appUuid}: model context written (tables=${tableCount}, dimensions=${dimensionCount}, metrics=${metricCount}, yamlBytes=${modelYaml.length}, ${durationMs}ms)`,
         );
         return {
             durationMs,
             tableCount,
-            dimensionCount: totalDimensions,
-            metricCount: totalMetrics,
+            dimensionCount,
+            metricCount,
             yamlBytes: modelYaml.length,
         };
     }
@@ -5873,104 +5873,242 @@ Each question, when asked, must be a single sentence, 5–15 words.`,
         return { token, version: latestReady.version };
     }
 
+    /** Escape a string into a safe, single-line double-quoted YAML scalar. */
+    private static yamlQuote(s: string): string {
+        const cleaned = s
+            .replace(/[\r\n\t]+/g, ' ')
+            .replace(/\\/g, '\\\\')
+            .replace(/"/g, '\\"');
+        return `"${cleaned}"`;
+    }
+
+    /** Render a single Lightdash parameter as indented YAML lines. */
+    private static renderParameterYaml(
+        key: string,
+        param: LightdashProjectParameter,
+        indent: string,
+    ): string[] {
+        const inner = `${indent}  `;
+        const scalar = (v: string | number): string =>
+            typeof v === 'number' ? String(v) : AppGenerateService.yamlQuote(v);
+
+        const lines: string[] = [`${indent}${key}:`];
+        lines.push(
+            `${inner}label: ${AppGenerateService.yamlQuote(param.label)}`,
+        );
+        if (param.description) {
+            lines.push(
+                `${inner}description: ${AppGenerateService.yamlQuote(param.description)}`,
+            );
+        }
+        if (param.type) {
+            lines.push(`${inner}type: ${param.type}`);
+        }
+        if (param.multiple) {
+            lines.push(`${inner}multiple: true`);
+        }
+        if (param.allow_custom_values) {
+            lines.push(`${inner}allow_custom_values: true`);
+        }
+        if (param.options && param.options.length > 0) {
+            const rendered = (param.options as Array<string | number>)
+                .map(scalar)
+                .join(', ');
+            lines.push(`${inner}options: [${rendered}]`);
+        }
+        if (param.options_from_dimension) {
+            lines.push(`${inner}options_from_dimension:`);
+            lines.push(
+                `${inner}  model: ${param.options_from_dimension.model}`,
+            );
+            lines.push(
+                `${inner}  dimension: ${param.options_from_dimension.dimension}`,
+            );
+        }
+        if (param.default !== undefined) {
+            const rendered = Array.isArray(param.default)
+                ? `[${(param.default as Array<string | number>).map(scalar).join(', ')}]`
+                : scalar(param.default);
+            lines.push(`${inner}default: ${rendered}`);
+        }
+        return lines;
+    }
+
     /**
-     * Convert catalog items into a dbt-style YAML that skill.md expects.
-     * Groups fields by table and separates dimensions from metrics.
-     * Includes labels and descriptions (truncated) so the sandbox agent has
-     * semantic context for each model, metric, and dimension.
+     * Convert compiled explores into the dbt-style YAML that skill.md expects.
+     * One model per explore, keyed by the explore name (the value passed to
+     * `query()`), carrying real metric/dimension types, join relationships
+     * (`meta.joins`), and model-level parameters. Joined tables that aren't
+     * themselves a top-level explore (seeds, aliased joins) are inlined so
+     * their dot-notation fields stay discoverable. Hidden fields are skipped;
+     * descriptions are truncated to keep the prompt bounded.
      */
-    private static catalogToYaml(items: CatalogItemSummary[]): string {
+    private static exploresToYaml(explores: Explore[]): {
+        yaml: string;
+        tableCount: number;
+        dimensionCount: number;
+        metricCount: number;
+    } {
         const DESCRIPTION_MAX_LEN = 200;
-
-        const yamlStr = (s: string): string => {
-            const cleaned = s
-                .replace(/[\r\n\t]+/g, ' ')
-                .replace(/\\/g, '\\\\')
-                .replace(/"/g, '\\"');
-            return `"${cleaned}"`;
-        };
-
         const truncate = (s: string): string =>
             s.length > DESCRIPTION_MAX_LEN
                 ? `${s.slice(0, DESCRIPTION_MAX_LEN - 1)}…`
                 : s;
 
-        type FieldInfo = {
-            name: string;
-            label: string | null;
-            description: string | null;
-        };
-
-        const tableDescriptions = new Map<string, string | null>();
-        const tables = new Map<
-            string,
-            { dimensions: FieldInfo[]; metrics: FieldInfo[] }
-        >();
-
-        for (const item of items) {
-            if (item.type === 'table') {
-                tableDescriptions.set(item.name, item.description);
-                if (!tables.has(item.name)) {
-                    tables.set(item.name, { dimensions: [], metrics: [] });
-                }
-            } else if (item.type === 'field') {
-                if (!tables.has(item.tableName)) {
-                    tables.set(item.tableName, { dimensions: [], metrics: [] });
-                }
-                const table = tables.get(item.tableName)!;
-                const field: FieldInfo = {
-                    name: item.name,
-                    label: item.label,
-                    description: item.description,
-                };
-                if (item.fieldType === 'metric') {
-                    table.metrics.push(field);
-                } else {
-                    table.dimensions.push(field);
-                }
-            }
-        }
-
         const lines: string[] = ['models:'];
-        for (const [tableName, fields] of tables) {
-            lines.push(`  - name: ${tableName}`);
-            const tableDesc = tableDescriptions.get(tableName);
-            if (tableDesc) {
-                lines.push(`    description: ${yamlStr(truncate(tableDesc))}`);
+        let tableCount = 0;
+        let dimensionCount = 0;
+        let metricCount = 0;
+
+        // Names already emitted as a standalone model, so the join-target
+        // fallback (pass 2) only inlines tables that aren't otherwise visible.
+        const emittedModelNames = new Set<string>(
+            explores.map((explore) => explore.name),
+        );
+
+        // Emit one model from a compiled table. Joins and parameters live on
+        // the explore (not the table), so they're passed in explicitly.
+        const emitTableModel = (
+            modelName: string,
+            table: CompiledTable,
+            joins: CompiledExploreJoin[],
+            parameters: Record<string, LightdashProjectParameter> | undefined,
+        ): void => {
+            tableCount += 1;
+            lines.push(`  - name: ${modelName}`);
+            if (table.description) {
+                lines.push(
+                    `    description: ${AppGenerateService.yamlQuote(truncate(table.description))}`,
+                );
             }
-            if (fields.metrics.length > 0) {
+
+            const metrics = Object.values(table.metrics).filter(
+                (m) => !m.hidden,
+            );
+            const dimensions = Object.values(table.dimensions).filter(
+                (d) => !d.hidden,
+            );
+            const parameterEntries = parameters
+                ? Object.entries(parameters)
+                : [];
+
+            if (
+                metrics.length > 0 ||
+                joins.length > 0 ||
+                parameterEntries.length > 0
+            ) {
                 lines.push(`    meta:`);
-                lines.push(`      metrics:`);
-                for (const m of fields.metrics) {
-                    lines.push(`        ${m.name}:`);
-                    lines.push(`          type: metric`);
-                    if (m.label && m.label !== m.name) {
-                        lines.push(`          label: ${yamlStr(m.label)}`);
+                if (metrics.length > 0) {
+                    lines.push(`      metrics:`);
+                    for (const m of metrics) {
+                        metricCount += 1;
+                        lines.push(`        ${m.name}:`);
+                        lines.push(`          type: ${m.type}`);
+                        if (m.label && m.label !== m.name) {
+                            lines.push(
+                                `          label: ${AppGenerateService.yamlQuote(m.label)}`,
+                            );
+                        }
+                        if (m.description) {
+                            lines.push(
+                                `          description: ${AppGenerateService.yamlQuote(truncate(m.description))}`,
+                            );
+                        }
                     }
-                    if (m.description) {
+                }
+                if (joins.length > 0) {
+                    lines.push(`      joins:`);
+                    for (const j of joins) {
+                        lines.push(`        - join: ${j.table}`);
+                        if (j.relationship) {
+                            lines.push(
+                                `          relationship: ${j.relationship}`,
+                            );
+                        }
+                        if (j.sqlOn) {
+                            lines.push(
+                                `          sql_on: ${AppGenerateService.yamlQuote(j.sqlOn)}`,
+                            );
+                        }
+                    }
+                }
+                if (parameterEntries.length > 0) {
+                    lines.push(`      parameters:`);
+                    for (const [key, param] of parameterEntries) {
                         lines.push(
-                            `          description: ${yamlStr(truncate(m.description))}`,
+                            ...AppGenerateService.renderParameterYaml(
+                                key,
+                                param,
+                                '        ',
+                            ),
                         );
                     }
                 }
             }
-            if (fields.dimensions.length > 0) {
+
+            if (dimensions.length > 0) {
                 lines.push(`    columns:`);
-                for (const d of fields.dimensions) {
+                for (const d of dimensions) {
+                    dimensionCount += 1;
                     lines.push(`      - name: ${d.name}`);
                     if (d.label && d.label !== d.name) {
-                        lines.push(`        label: ${yamlStr(d.label)}`);
+                        lines.push(
+                            `        label: ${AppGenerateService.yamlQuote(d.label)}`,
+                        );
                     }
                     if (d.description) {
                         lines.push(
-                            `        description: ${yamlStr(truncate(d.description))}`,
+                            `        description: ${AppGenerateService.yamlQuote(truncate(d.description))}`,
                         );
                     }
+                    lines.push(`        meta:`);
+                    lines.push(`          dimension:`);
+                    lines.push(`            type: ${d.type}`);
+                }
+            }
+        };
+
+        // Pass 1: every explore becomes a model keyed by its queryable name.
+        for (const explore of explores) {
+            const baseTable = explore.tables[explore.baseTable];
+            if (baseTable) {
+                const joins = (explore.joinedTables ?? []).filter(
+                    (j) => !j.hidden,
+                );
+                emitTableModel(
+                    explore.name,
+                    baseTable,
+                    joins,
+                    explore.parameters,
+                );
+            }
+        }
+
+        // Pass 2: inline join targets with no standalone model (seeds, aliased
+        // joins) so their dot-notation fields remain discoverable.
+        const inlined = new Set<string>();
+        for (const explore of explores) {
+            for (const join of explore.joinedTables ?? []) {
+                const key = join.table; // alias-aware key into explore.tables
+                const joinedTable = explore.tables[key];
+                if (
+                    !join.hidden &&
+                    joinedTable &&
+                    !emittedModelNames.has(key) &&
+                    !inlined.has(key)
+                ) {
+                    inlined.add(key);
+                    emitTableModel(key, joinedTable, [], undefined);
                 }
             }
         }
 
-        return lines.join('\n');
+        return {
+            yaml: lines.join('\n'),
+            tableCount,
+            dimensionCount,
+            metricCount,
+        };
     }
 
     private static getContentType(filePath: string): string {

--- a/sandboxes/data-apps/template/skill.md
+++ b/sandboxes/data-apps/template/skill.md
@@ -107,6 +107,8 @@ query('orders')
 
 **Never prefix joined table fields with the base explore name.** `'customers.name'` is correct. `'name'` alone would resolve to `orders_name` which doesn't exist.
 
+Each entry under `meta.joins` may carry a `relationship` (`one-to-many`, `many-to-one`, `one-to-one`, `many-to-many`) and a `sql_on` condition — either can be absent. When a `relationship` is present, use it to reason about grain and fan-out: joining a `one-to-many` table multiplies base rows, so aggregating a base metric across that join can double-count — prefer a metric defined on the "many" side, or aggregate before joining.
+
 ### Understanding data grain
 
 When designing queries, consider the model's grain — what combination of dimensions produces one unique row. If the grain includes dimensions you aren't selecting, you may need filters to avoid duplicates. Estimate row counts from the grain to set appropriate `.limit()` values.


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8402/data-apps-synthetic-schemayml-missing-join-definitions-ai-agent-cannot

Closes: https://linear.app/lightdash/issue/PROD-8399/data-apps-agent-doesnt-recognise-parameters-without-manual-workarounds

### Description:
The data-app sandbox agent reads a synthetic schema.yml generated from the Lightdash catalog. That catalog summary is a flattened search index with no relationship data, so the YAML never contained join definitions, real field types, or parameters — the agent reported models had "zero joins" even when joins were defined in dbt and visible in the Explore UI.

Source the YAML from the compiled explore cache instead (getAllExploresFromCache). The cache is the source of truth that the catalog is itself derived from, so it's at least as reliable. exploresToYaml now emits one model per explore with meta.joins (target, relationship, sql_on), real metric/dimension types, and model-level parameters; join targets that aren't standalone explores (seeds, aliased joins) are inlined so their dot-notation fields stay discoverable. Hidden fields are skipped.

skill.md documents the new relationship/sql_on join metadata.


### Spot comparison of the schema.yml before/after:

<img width="2711" height="1599" alt="yaml-comparison" src="https://github.com/user-attachments/assets/1b3a74ef-3a81-4983-ae4e-94aa03750094" />


### Asking the agent about joins/params:

Before:
<img width="768" height="490" alt="before" src="https://github.com/user-attachments/assets/a49fff57-260a-43bf-a7f9-ced9deec1441" />


After:
<img width="768" height="1336" alt="after" src="https://github.com/user-attachments/assets/29aa3fcf-d155-4312-8b59-f8b83cc33519" />

