### PR TITLE
fix(ai): configure field description limit

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -5,6 +5,7 @@ export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-6';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-5.2-2025-12-11';
 export const DEFAULT_BEDROCK_MODEL_NAME = 'claude-sonnet-4-5';
+export const DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS = 600;
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_AZURE_EMBEDDING_MODEL = 'text-embedding-3-small';
@@ -145,6 +146,11 @@ export const aiCopilotConfigSchema = z
             .default(0.6),
         mcpConnectionTimeoutMs: z.number().positive().default(20_000),
         mcpAllowPrivateAddresses: z.boolean().default(false),
+        toolFieldDescriptionMaxChars: z
+            .number()
+            .int()
+            .positive()
+            .default(DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -248,6 +248,7 @@ export const lightdashConfigMock: LightdashConfig = {
             verifiedAnswerSimilarityThreshold: 0.6,
             mcpConnectionTimeoutMs: 20_000,
             mcpAllowPrivateAddresses: false,
+            toolFieldDescriptionMaxChars: 600,
             defaultEmbeddingModelProvider: 'openai',
         },
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -249,6 +249,16 @@ test('Should parse bedrock inference profile prefix from env', () => {
     });
 });
 
+test('Should default AI tool field description max chars to 600', () => {
+    expect(parseConfig().ai.copilot.toolFieldDescriptionMaxChars).toEqual(600);
+});
+
+test('Should parse AI tool field description max chars from env', () => {
+    process.env.AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS = '2500';
+
+    expect(parseConfig().ai.copilot.toolFieldDescriptionMaxChars).toEqual(2500);
+});
+
 test('Should parse valid integer', () => {
     process.env.MY_NUMBER = '100';
     expect(getIntegerFromEnvironmentVariable('MY_NUMBER')).toEqual(100);

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -37,6 +37,7 @@ import { VERSION } from '../version';
 import {
     aiCopilotConfigSchema,
     AiCopilotConfigSchemaType,
+    DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS,
     DEFAULT_ANTHROPIC_MODEL_NAME,
     DEFAULT_BEDROCK_MODEL_NAME,
     DEFAULT_DEFAULT_AI_PROVIDER,
@@ -1189,6 +1190,10 @@ export const getAiConfig = () => ({
         20_000,
     mcpAllowPrivateAddresses:
         process.env.AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES === 'true',
+    toolFieldDescriptionMaxChars:
+        getIntegerFromEnvironmentVariable(
+            'AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS',
+        ) ?? DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS,
 });
 
 export type LoggingConfig = {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7373,6 +7373,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
             findExploresFieldSearchSize: 200,
             findFieldsPageSize: 30,
+            toolFieldDescriptionMaxChars:
+                this.lightdashConfig.ai.copilot.toolFieldDescriptionMaxChars,
             getDashboardChartsPageSize: 20,
             maxQueryLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
             runSqlMaxLimit: this.lightdashConfig.ai.copilot.runSqlMaxLimit,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1397,6 +1397,9 @@ export class McpService extends BaseService {
                     findFields: toolsRuntime.findFields,
                     updateProgress: async () => {}, // No-op for MCP context
                     pageSize: 15,
+                    fieldDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot
+                            .toolFieldDescriptionMaxChars,
                 });
                 const result = await findFieldsTool.execute!(argsWithProject, {
                     toolCallId: '',

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -225,6 +225,7 @@ const getAgentTools = (
             availableExplores,
             findExploresFieldSearchSize: args.findExploresFieldSearchSize,
             findFieldsPageSize: args.findFieldsPageSize,
+            fieldDescriptionMaxChars: args.toolFieldDescriptionMaxChars,
             promptUuid: args.promptUuid,
             telemetry: {
                 agentSettings: args.agentSettings,
@@ -406,6 +407,7 @@ const getAgentTools = (
         // unbounded payload while still letting an audit grab the inventory in
         // one or two round-trips.
         maxPageSize: 500,
+        fieldDescriptionMaxChars: args.toolFieldDescriptionMaxChars,
     });
 
     const listKnowledgeDocuments = getListKnowledgeDocuments({

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -45,6 +45,7 @@ export type DiscoverFieldsAgentArgs = {
     providerOptions: AiAgentArgs['providerOptions'];
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
+    fieldDescriptionMaxChars: number;
     abortSignal?: AbortSignal;
     promptUuid: string;
     parentToolCallId: string;
@@ -105,6 +106,7 @@ export const runDiscoverFieldsAgent = (
         findFields: dependencies.findFields,
         updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,
+        fieldDescriptionMaxChars: args.fieldDescriptionMaxChars,
     });
 
     const messages: ModelMessage[] = [

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -147,6 +147,7 @@ type ToolArgs = {
     availableExplores: Explore[];
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
+    fieldDescriptionMaxChars: number;
     promptUuid: string;
     telemetry: Pick<
         AiAgentArgs,
@@ -185,6 +186,7 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                         findExploresFieldSearchSize:
                             args.findExploresFieldSearchSize,
                         findFieldsPageSize: args.findFieldsPageSize,
+                        fieldDescriptionMaxChars: args.fieldDescriptionMaxChars,
                         promptUuid: args.promptUuid,
                         parentToolCallId: toolCallId,
                         telemetry: args.telemetry,

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -74,6 +74,7 @@ const makeAgentTools = () => {
                 availableExplores: [],
                 findExploresFieldSearchSize: 25,
                 findFieldsPageSize: 25,
+                fieldDescriptionMaxChars: 600,
                 promptUuid: 'prompt-uuid',
                 telemetry: {
                     agentSettings: {
@@ -112,6 +113,7 @@ const makeAgentTools = () => {
             getExplore: noop,
             pageSize: 25,
             updateProgress: noopAsync,
+            fieldDescriptionMaxChars: 600,
         }),
         generateDashboard: getGenerateDashboardV2({
             createOrUpdateArtifact: noop,

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -18,7 +18,7 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { FIELD_DESCRIPTION_MAX_CHARS, truncate } from '../utils/truncation';
+import { truncate } from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
@@ -26,6 +26,7 @@ type Dependencies = {
     findFields: FindFieldFn;
     updateProgress: UpdateProgressFn;
     pageSize: number;
+    fieldDescriptionMaxChars: number;
 };
 
 const toolDefinition = findFieldsToolDefinition.for('agent');
@@ -51,7 +52,11 @@ const getFieldCaseSensitive = (
     );
 };
 
-const renderField = (catalogField: CatalogField, explore?: Explore) => {
+const renderField = (
+    catalogField: CatalogField,
+    fieldDescriptionMaxChars: number,
+    explore?: Explore,
+) => {
     const isFromJoinedTable =
         explore &&
         catalogField.tableName !== explore.baseTable &&
@@ -103,7 +108,7 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
                 <description>
                     {truncate(
                         catalogField.description,
-                        FIELD_DESCRIPTION_MAX_CHARS,
+                        fieldDescriptionMaxChars,
                     )}
                 </description>
             )}
@@ -123,6 +128,7 @@ const renderField = (catalogField: CatalogField, explore?: Explore) => {
 
 const getFieldsText = (
     args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
+    fieldDescriptionMaxChars: number,
     explore?: Explore,
 ) => (
     <searchresult
@@ -132,7 +138,9 @@ const getFieldsText = (
         totalPageCount={args.pagination?.totalPageCount}
         totalResults={args.pagination?.totalResults}
     >
-        {args.fields.map((field) => renderField(field, explore))}
+        {args.fields.map((field) =>
+            renderField(field, fieldDescriptionMaxChars, explore),
+        )}
     </searchresult>
 );
 
@@ -141,6 +149,7 @@ export const getFindFields = ({
     findFields,
     updateProgress,
     pageSize,
+    fieldDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -175,7 +184,11 @@ export const getFindFields = ({
 
                 const fieldsText = fieldSearchQueryResults
                     .map((fieldSearchQueryResult) =>
-                        getFieldsText(fieldSearchQueryResult, explore),
+                        getFieldsText(
+                            fieldSearchQueryResult,
+                            fieldDescriptionMaxChars,
+                            explore,
+                        ),
                     )
                     .join('\n\n');
 

--- a/packages/backend/src/ee/services/ai/tools/searchSemanticLayer.tsx
+++ b/packages/backend/src/ee/services/ai/tools/searchSemanticLayer.tsx
@@ -6,7 +6,7 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { FIELD_DESCRIPTION_MAX_CHARS, truncate } from '../utils/truncation';
+import { truncate } from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
@@ -14,6 +14,7 @@ type Dependencies = {
     updateProgress: UpdateProgressFn;
     /** Upper bound for the agent-supplied pageSize; also the fallback default. */
     maxPageSize: number;
+    fieldDescriptionMaxChars: number;
 };
 
 /** Used when the agent does not specify a pageSize. */
@@ -24,7 +25,10 @@ const toolDefinition = searchSemanticLayerToolDefinition.for('agent');
 const generateResponse = ({
     fields,
     pagination,
-}: Awaited<ReturnType<SearchSemanticLayerFn>>) => (
+    fieldDescriptionMaxChars,
+}: Awaited<ReturnType<SearchSemanticLayerFn>> & {
+    fieldDescriptionMaxChars: number;
+}) => (
     <semanticLayerFields
         page={pagination?.page}
         pageSize={pagination?.pageSize}
@@ -50,10 +54,7 @@ const generateResponse = ({
             >
                 {field.description && (
                     <description>
-                        {truncate(
-                            field.description,
-                            FIELD_DESCRIPTION_MAX_CHARS,
-                        )}
+                        {truncate(field.description, fieldDescriptionMaxChars)}
                     </description>
                 )}
             </field>
@@ -65,6 +66,7 @@ export const getSearchSemanticLayer = ({
     searchSemanticLayer,
     updateProgress,
     maxPageSize,
+    fieldDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -91,7 +93,11 @@ export const getSearchSemanticLayer = ({
                 });
 
                 return {
-                    result: generateResponse({ fields, pagination }).toString(),
+                    result: generateResponse({
+                        fields,
+                        pagination,
+                        fieldDescriptionMaxChars,
+                    }).toString(),
                     metadata: {
                         status: 'success',
                         ranking: {

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -125,6 +125,7 @@ export type AiAgentArgs = AnyAiModel & {
 
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
+    toolFieldDescriptionMaxChars: number;
     getDashboardChartsPageSize: number;
     maxQueryLimit: number;
     runSqlMaxLimit: number;

--- a/packages/backend/src/ee/services/ai/utils/truncation.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.ts
@@ -4,10 +4,14 @@
  * model's context limit — see PROD-6017.
  */
 export const EXPLORE_DESCRIPTION_MAX_CHARS = 600;
-export const FIELD_DESCRIPTION_MAX_CHARS = 600;
 export const CONTENT_DESCRIPTION_MAX_CHARS = 600;
 
 export const DASHBOARD_CHARTS_PREVIEW_COUNT = 5;
 
-export const truncate = (value: string, max: number) =>
-    value.length > max ? `${value.slice(0, max)}…` : value;
+const TRUNCATED_SUFFIX = '...(truncated)';
+
+export const truncate = (value: string, max: number) => {
+    if (value.length <= max) return value;
+    if (max <= TRUNCATED_SUFFIX.length) return TRUNCATED_SUFFIX.slice(0, max);
+    return `${value.slice(0, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+};


### PR DESCRIPTION
### Description
- Adds `AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS` with a default of 600.
- Applies it to AI/MCP field-description truncation in `findFields` and semantic-layer field search outputs.
- Threads the config through `discoverFields` and MCP `find_fields`.
- Makes truncated tool descriptions explicit with `...(truncated)` while keeping output within the configured max length.

### Testing
- `sfw pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -F common build:fast`
- `pnpm -F formula build:fast`
- `pnpm -F warehouses build:fast`
- `pnpm -F backend typecheck:fast`
- `pnpm -F backend test src/config/parseConfig.test.ts --runInBand`
- `pnpm -F backend exec eslint -c .eslintrc.js --ignore-path ./../../.gitignore --rulesdir eslint-rules <modified files>`
- `pnpm -F backend exec oxfmt <modified files> --check`