### PR TITLE
fix(mcp): surface queryUuid in metric query result text

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -1487,6 +1487,10 @@ describe('MCP async query polling', () => {
                     type: 'text',
                     text: 'orders_count\n1\n',
                 },
+                {
+                    type: 'text',
+                    text: `queryUuid: ${queryUuid}`,
+                },
             ],
             structuredContent: {
                 result: {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -964,11 +964,21 @@ export class McpService extends BaseService {
             columns: csvHeaders,
         });
 
+        // render_chart needs the queryUuid, and clients that only surface
+        // `content` (not structuredContent) can't otherwise recover it and may
+        // invent an invalid id. Emit it as a separate text block so the result
+        // block stays untouched for clients that render it directly.
+        const body = rows.length === 0 ? 'Query returned 0 rows.' : csv;
+
         return {
             content: [
                 {
                     type: 'text' as const,
-                    text: rows.length === 0 ? 'Query returned 0 rows.' : csv,
+                    text: body,
+                },
+                {
+                    type: 'text' as const,
+                    text: `queryUuid: ${queryUuid}`,
                 },
             ],
             structuredContent: {

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -4105,7 +4105,7 @@ Empty array or null: single partition (calculations across all rows)., ",
       "agentName": null,
       "description": "Render a chart for a completed query result in MCP App-capable clients.
 
-Use this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the queryUuid and chart configuration; Lightdash loads the completed metric query from query history.
+Use this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the exact queryUuid that run_metric_query (or get_query_result) returned for this query in the current conversation — it is included in that tool's response as a \`queryUuid: <id>\` text block. Never invent, guess, or reuse a queryUuid from a different query or session; an unknown id fails with "not found". Lightdash loads the completed metric query from query history.
 
 Current support: completed run_metric_query results. SQL Runner/run_sql results are not supported by render_chart. Other query result types are rejected until their chart rendering path is implemented.
 
@@ -4217,7 +4217,7 @@ Response shape (MCP CallToolResult):
             "type": "string",
           },
           "queryUuid": {
-            "description": "Completed query UUID returned by a query tool or get_query_result. Currently, render_chart supports UUIDs from run_metric_query and does not support SQL Runner/run_sql UUIDs.",
+            "description": "Completed query UUID returned by run_metric_query (or get_query_result) in this conversation, copied from the \`queryUuid: <id>\` text block of that response. Do not fabricate, guess, or reuse a UUID from another query. Currently render_chart supports UUIDs from run_metric_query and does not support SQL Runner/run_sql UUIDs.",
             "format": "uuid",
             "type": "string",
           },
@@ -6215,7 +6215,7 @@ Parameters:
 Response shape (MCP CallToolResult):
 - Running: content contains polling status text and structuredContent.result contains { status: "running", queryUuid, nextPollAfterMs, heartbeatAt }. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
 - Completed SQL: content contains CSV text and structuredContent.result contains { status: "done", queryUuid, rows, columns, rowCount, sqlRunnerUrl }.
-- Completed metric query: content contains bare CSV text and structuredContent.result contains { status: "done", queryUuid, rows, fields, exploreUrl }.
+- Completed metric query: content has the CSV text plus a separate \`queryUuid: <id>\` text block (copy this exact id for render_chart), and structuredContent.result contains { status: "done", queryUuid, rows, fields, exploreUrl }.
 - Failed/cancelled/expired: content contains status/error text and structuredContent.result contains { status, queryUuid, error }.
 
 Notes:

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolMcpQueryResultDescription.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolMcpQueryResultDescription.ts
@@ -54,5 +54,5 @@ ${completedResultShape}
 export const MCP_GET_QUERY_RESULT_RESPONSE_DESCRIPTION = `Response shape (MCP CallToolResult):
 - Running: content contains polling status text and structuredContent.result contains { status: "running", queryUuid, nextPollAfterMs, heartbeatAt }. ${MCP_QUERY_STRUCTURED_RUNNING_NOTE}
 - Completed SQL: content contains CSV text and structuredContent.result contains { status: "done", queryUuid, rows, columns, rowCount, sqlRunnerUrl }.
-- Completed metric query: content contains bare CSV text and structuredContent.result contains { status: "done", queryUuid, rows, fields, exploreUrl }.
+- Completed metric query: content has the CSV text plus a separate \`queryUuid: <id>\` text block (copy this exact id for render_chart), and structuredContent.result contains { status: "done", queryUuid, rows, fields, exploreUrl }.
 - Failed/cancelled/expired: content contains status/error text and structuredContent.result contains { status, queryUuid, error }.`;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -267,7 +267,7 @@ export const parsePersistedRunQueryArgs = (
 
 export const TOOL_RENDER_CHART_DESCRIPTION = `Render a chart for a completed query result in MCP App-capable clients.
 
-Use this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the queryUuid and chart configuration; Lightdash loads the completed metric query from query history.
+Use this after a query tool or get_query_result returns done and the user wants a visual chart. This tool does not start, poll, or rerun the query. If the query is still running, call get_query_result first. Pass the exact queryUuid that run_metric_query (or get_query_result) returned for this query in the current conversation — it is included in that tool's response as a \`queryUuid: <id>\` text block. Never invent, guess, or reuse a queryUuid from a different query or session; an unknown id fails with "not found". Lightdash loads the completed metric query from query history.
 
 Current support: completed run_metric_query results. SQL Runner/run_sql results are not supported by render_chart. Other query result types are rejected until their chart rendering path is implemented.
 
@@ -285,7 +285,7 @@ Response shape (MCP CallToolResult):
 export const toolRenderChartArgsSchema = createToolSchema()
     .extend({
         queryUuid: mcpAsyncQueryUuidSchema.describe(
-            'Completed query UUID returned by a query tool or get_query_result. Currently, render_chart supports UUIDs from run_metric_query and does not support SQL Runner/run_sql UUIDs.',
+            'Completed query UUID returned by run_metric_query (or get_query_result) in this conversation, copied from the `queryUuid: <id>` text block of that response. Do not fabricate, guess, or reuse a UUID from another query. Currently render_chart supports UUIDs from run_metric_query and does not support SQL Runner/run_sql UUIDs.',
         ),
         chartConfig: chartConfigSchema,
         title: z


### PR DESCRIPTION
## What & why

`render_chart` loads a completed query from query history by the `queryUuid` returned by a prior `run_metric_query`. That tool's machine-readable `structuredContent.result` includes the `queryUuid`, but its `content` was CSV only — the id appeared nowhere in the content blocks.

MCP clients/agents that act on `content` (rather than `structuredContent`) therefore had no way to recover the `queryUuid`, and would call `render_chart` with an **invented id**. That id doesn't exist in query history, so the call fails with:

> Error rendering chart: Query <id> not found for project <id>

…which the agent typically rationalises as a transient/timing issue. It reproduces regardless of role (admin and editor alike) and regardless of project — it's purely a response-contract gap, not a permissions problem.

## Change

- Emit the `queryUuid` as a **separate `text` content block** in the metric-query result (`buildMetricQueryPollResult`, shared by `run_metric_query` and `get_query_result`). The existing CSV block is left **byte-identical**, so anything that renders/parses it is unaffected; agents that read the content blocks can now recover the id.
- Tighten the `render_chart` tool + param descriptions: copy the `queryUuid` from the prior response's `queryUuid: <id>` block; never invent, guess, or reuse one from another query/session.
- Update the metric-query response-shape description, the affected unit test, and the contract snapshot.

`structuredContent` is unchanged — the spec's typed contract (`outputSchema` → `structuredContent`) is untouched, and multiple `content` blocks are explicitly allowed by the MCP spec.

## Testing

- `pnpm -F backend typecheck:fast` and `pnpm -F common typecheck:fast` pass.
- `McpService.queryPolling` and `mcpToolContracts.snapshot` suites pass (snapshot updated).
- Verified end-to-end against a live MCP server: `run_metric_query` returns the CSV block plus a `queryUuid: <id>` block, and `render_chart` succeeds with that id.

Closes: #24671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
