### PR TITLE
fix: invisible bars when stacked chart has date dimension on x-axis

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -477,6 +477,63 @@ describe('getCategoryDateAxisConfig', () => {
         });
     });
 
+    // Regression: xAxis.data used ISO format ("2024-04-01T00:00:00Z") while
+    // series data read raw values from the backend ("2024-04-01"). ECharts
+    // uses strict string equality for category matching, so bars were invisible.
+    describe('date format matches raw input format', () => {
+        test('uses date-only format (YYYY-MM-DD) when raw values are date-only', () => {
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.MONTH),
+                createRows(['2024-01-01', '2024-03-01']),
+                'category',
+            );
+            expect(result.data?.[0]).toBe('2024-01-01');
+            expect(result.data?.[1]).toBe('2024-02-01');
+            expect(result.data?.[2]).toBe('2024-03-01');
+        });
+
+        test('uses ISO format when raw values are ISO timestamps', () => {
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.MONTH),
+                createRows([
+                    '2024-01-01T00:00:00.000Z',
+                    '2024-03-01T00:00:00.000Z',
+                ]),
+                'category',
+            );
+            expect(result.data?.[0]).toContain('T');
+            expect(result.data?.[0]).toContain('2024-01');
+        });
+
+        test('WEEK: uses date-only format when raw values are date-only', () => {
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.WEEK),
+                createRows(['2024-01-01', '2024-01-22']),
+                'category',
+            );
+            expect(result.data?.[0]).toBe('2024-01-01');
+            expect(result.data?.[1]).toBe('2024-01-08');
+            for (const d of result.data ?? []) {
+                expect(d).not.toContain('T');
+            }
+        });
+
+        test('YEAR: uses date-only format when raw values are date-only', () => {
+            const result = getCategoryDateAxisConfig(
+                axisId,
+                createAxisField(TimeFrames.YEAR),
+                createRows(['2024-01-01', '2026-01-01']),
+                'category',
+            );
+            expect(result.data?.[0]).toBe('2024-01-01');
+            expect(result.data?.[1]).toBe('2025-01-01');
+            expect(result.data?.[2]).toBe('2026-01-01');
+        });
+    });
+
     // Regression: iteration landing exactly on maxX produced a duplicate
     // trailing category due to dayjs.tz .isBefore drift.
     describe('no duplicate entries when range lands exactly on maxX', () => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1586,6 +1586,14 @@ export const getCategoryDateAxisConfig = (
     const maxDateValue = dayjs.utc(maxX);
     if (!minDateValue.isValid() || !maxDateValue.isValid()) return {};
 
+    // Match the date format used by the backend's raw values so that
+    // xAxis.data strings equal the category values in series.data tuples
+    // (ECharts uses strict string equality for category matching).
+    // If the raw value is a date-only string (e.g. "2024-04-01"), format
+    // without the time component; otherwise use full ISO format.
+    const minXStr = String(minX);
+    const isDateOnly = !minXStr.includes('T');
+
     // Bar charts need boundary gap for proper bar spacing, but line/area charts
     // look better extending to the edges
     const hasBarSeries = series?.some(
@@ -1608,15 +1616,18 @@ export const getCategoryDateAxisConfig = (
     const reAnchor = (d: dayjs.Dayjs) =>
         tz === 'UTC' ? d : dayjs.tz(d.format('YYYY-MM-DD HH:mm:ss'), tz);
 
+    const formatDate = (d: dayjs.Dayjs): string =>
+        isDateOnly ? d.utc().format('YYYY-MM-DD') : d.utc().format();
+
     if (timeInterval === TimeFrames.WEEK) {
         const continuousRange: string[] = [];
         let nextDate = inTz(minX);
         const endDate = inTz(maxX);
         while (nextDate.isBefore(endDate)) {
-            continuousRange.push(nextDate.utc().format());
+            continuousRange.push(formatDate(nextDate));
             nextDate = reAnchor(nextDate.add(1, 'week'));
         }
-        continuousRange.push(endDate.utc().format());
+        continuousRange.push(formatDate(endDate));
         return {
             data: continuousRange,
             axisTick: { alignWithLabel: true, interval: 0 },
@@ -1629,7 +1640,7 @@ export const getCategoryDateAxisConfig = (
         let nextDate = inTz(minX).startOf('year');
         const endDate = inTz(maxX).startOf('year');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.utc().format());
+            continuousRange.push(formatDate(nextDate));
             nextDate = reAnchor(nextDate.add(1, 'year'));
         }
         return {
@@ -1644,7 +1655,7 @@ export const getCategoryDateAxisConfig = (
         let nextDate = inTz(minX).startOf('quarter');
         const endDate = inTz(maxX).startOf('quarter');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.utc().format());
+            continuousRange.push(formatDate(nextDate));
             // dayjs requires quarterOfYear plugin for .add(1, 'quarter')
             nextDate = reAnchor(nextDate.add(3, 'months'));
         }
@@ -1660,7 +1671,7 @@ export const getCategoryDateAxisConfig = (
         let nextDate = inTz(minX).startOf('month');
         const endDate = inTz(maxX).startOf('month');
         while (!nextDate.isAfter(endDate)) {
-            continuousRange.push(nextDate.utc().format());
+            continuousRange.push(formatDate(nextDate));
             nextDate = reAnchor(nextDate.add(1, 'month'));
         }
         return {


### PR DESCRIPTION
Closes: #24597
Closes: PROD-8429

## Summary

Fixes #24597 — bar charts with a month/week/quarter/year date dimension on the x-axis render invisible bars when the x-axis is sorted.

**Root cause**: a date-format mismatch between `xAxis.data` and the series category values in the ECharts category-axis config.

- `getCategoryDateAxisConfig()` builds the continuous category range with `dayjs.utc().format()` → full ISO strings (`"2024-04-01T00:00:00Z"`).
- The category values the series are matched against come from the warehouse's **raw** values, which for a date dimension are **date-only** (`"2024-04-01"`).
- ECharts matches series points to category-axis slots by **strict string equality**, so `"2024-04-01" !== "2024-04-01T00:00:00Z"` → the series render nothing.

The mismatch surfaces when the x-axis **Sort** is `category`/`bar_totals` (Ascending / Descending / Bars ascending / Bars descending): `sortedAxes` overwrites `xAxis.data` with the raw date-only values while the series keep the ISO range. The same date-only-vs-ISO divergence also affects `applyRoundedCornersToStackData()`. The **Default** sort keeps both sides in the ISO range, so it renders — which is why recreating a chart appears to "fix" it.

**Fix**: detect the backend's raw date format (date-only vs ISO timestamp) in `getCategoryDateAxisConfig()` and format the continuous range the same way, so the axis categories match the series values at the common source regardless of sort or rounded-corner handling.

## Steps to reproduce

1. Bar chart with a **Month** (or Week/Quarter/Year) date dimension on the x-axis, a metric on Y, and a second dimension to group/pivot the series.
2. **Configure chart → Axes → Sort → Ascending** (or Descending / Bars ascending / Bars descending).
3. Bars disappear even though the Results table has data. Setting Sort back to **Default**, or using a non-date x-axis, restores them.

Note: **Day** granularity is unaffected — the continuous-range builder only runs for week/month/quarter/year.

## Test plan

- [x] Added regression tests verifying format matching for MONTH, WEEK, YEAR intervals
- [x] Existing DST stability tests unaffected (ISO input → ISO output)
- [x] Manual: verified on Postgres and Snowflake (warehouse returns `2024-04-01`) — bars invisible with a category x-axis sort before the fix, render correctly after
- [ ] CI: `pnpm -F frontend test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
