### PR TITLE
fix(formatting): apply field separator to ECMA-376 expressions on cartesian charts (#24758)

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -28,6 +28,7 @@ import {
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     getEffectiveSeparator,
+    getFormatExpressionLocale,
     getFormatterTimezone,
     isCalendarValueItem,
     isItemTimezoneAffected,
@@ -3371,6 +3372,36 @@ describe('Formatting', () => {
             test('returns undefined when nothing sets one', () => {
                 expect(getEffectiveSeparator(metric)).toBeUndefined();
                 expect(getEffectiveSeparator(undefined)).toBeUndefined();
+            });
+        });
+
+        describe('getFormatExpressionLocale', () => {
+            // Render paths that call formatValueWithExpression directly (e.g.
+            // chart series formatters) rely on this to localise ECMA-376
+            // expressions the same way formatItemValue does.
+            test('derives a numfmt locale from a non-default separator', () => {
+                const locale = getFormatExpressionLocale({
+                    ...metric,
+                    separator: NumberSeparator.PERIOD_COMMA,
+                });
+                expect(locale).toBeDefined();
+                // The derived locale must actually flip the separators on an
+                // ECMA-376 currency expression (the bug was passing undefined,
+                // which silently rendered US separators on charts).
+                expect(
+                    formatValueWithExpression('[$€]#,##0.00', 1234.56, locale),
+                ).toEqual('€1.234,56');
+            });
+
+            test('returns undefined for the default/US separator', () => {
+                expect(
+                    getFormatExpressionLocale({
+                        ...metric,
+                        separator: NumberSeparator.COMMA_PERIOD,
+                    }),
+                ).toBeUndefined();
+                expect(getFormatExpressionLocale(metric)).toBeUndefined();
+                expect(getFormatExpressionLocale(undefined)).toBeUndefined();
             });
         });
     });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -584,6 +584,22 @@ export function getEffectiveSeparator(
     return undefined;
 }
 
+// The numfmt locale string used to render an ECMA-376 format expression for an
+// item, derived from its effective separator. Exported so render paths that call
+// formatValueWithExpression directly (e.g. chart series formatters) localise
+// expressions the same way formatItemValue does. Returns undefined for the
+// default/US separator so output stays byte-identical.
+export function getFormatExpressionLocale(
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomDimension
+        | undefined,
+): string | undefined {
+    return separatorToNumfmtLocale(getEffectiveSeparator(item));
+}
+
 export function getCustomFormat(
     item:
         | Field
@@ -1117,9 +1133,7 @@ export function formatItemValue(
         if (hasValidFormatExpression(item)) {
             // A field-level separator localises the ECMA-376 expression, which
             // numfmt otherwise renders with US separators regardless of locale.
-            const separatorLocale = separatorToNumfmtLocale(
-                getEffectiveSeparator(item),
-            );
+            const separatorLocale = getFormatExpressionLocale(item);
 
             // Check if format uses parameter placeholders
             const hasParameterPlaceholders =

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -25,6 +25,7 @@ import {
     getBarTotalLabelStyle,
     getCustomFormatFromLegacy,
     getDateGroupLabel,
+    getFormatExpressionLocale,
     getFormattedValue,
     getFormatterTimezone,
     getGranularityMapFromItems,
@@ -807,7 +808,7 @@ const seriesValueFormatter = (
         return formatValueWithExpression(
             formatExpression,
             value,
-            undefined,
+            getFormatExpressionLocale(item),
             expressionTimezone,
         );
     }


### PR DESCRIPTION
## Summary

The per-field number `separator` (e.g. `periodComma` → `1.234,56`) is honoured in the **results table** (`formatItemValue`), but **bar/line/area charts** render series labels, tooltips and values through a separate code path that called `formatValueWithExpression` with the separator locale hardcoded to `undefined`.

As a result, a metric with an ECMA-376 format expression like `[$€]#,##0.00` **plus** `separator: periodComma` rendered US-style `€1,234.56` on charts instead of the expected `€1.234,56` — even though the same field rendered correctly in the results table. This surfaced from an investigation into a European number-formatting report.

### Root cause

`packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts` — `seriesValueFormatter`:

```ts
// before
formatValueWithExpression(formatExpression, value, undefined, expressionTimezone)
//                                                  ^^^^^^^^^ separator locale dropped
```

numfmt localises an ECMA-376 expression via a per-call `locale` option; passing `undefined` silently renders US separators. Only `formatItemValue` (table path) derived that locale; the chart path never did.

## Changes

- **common** (`utils/formatting.ts`): extract `getFormatExpressionLocale(item)` (effective separator → numfmt locale) and reuse it inside `formatItemValue`.
- **frontend** (`useEchartsCartesianConfig.ts`): thread `getFormatExpressionLocale(item)` into the cartesian series value formatter instead of `undefined`.
- **tests** (`formatting.test.ts`): cover the helper, including that it flips separators on a currency ECMA-376 expression.

## Verification

- Repro before fix → `€1,234.56`; after fix → `€1.234,56`.
- `formatting.test.ts` passes (incl. 2 new tests); common typecheck and lint clean.

## Note (follow-up, out of scope here)

The same separator-threading gap exists on a few other surfaces and is worth a separate pass: period-over-period metrics (`periodOverPeriodComparison.ts`), Lightdash-native YAML dimensions (`lightdashModelConverter.ts`), and the Big Number comparison sub-value (`useBigNumberConfig.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)