### PR TITLE
fix(authorization): move ContentAsCode scopes to Content group

### DIFF
--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -582,14 +582,14 @@ const scopes: Scope[] = [
         name: 'view:ContentAsCode',
         description: 'Download content as code',
         isEnterprise: true,
-        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        group: ScopeGroup.CONTENT,
         getConditions: addDefaultUuidCondition,
     },
     {
         name: 'manage:ContentAsCode',
         description: 'Download and upload content as code',
         isEnterprise: true,
-        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        group: ScopeGroup.CONTENT,
         getConditions: addDefaultUuidCondition,
     },
     {
@@ -597,7 +597,7 @@ const scopes: Scope[] = [
         description:
             'Upload content as code to preview projects created by the user',
         isEnterprise: true,
-        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        group: ScopeGroup.CONTENT,
         getConditions: ownPreviewProjectConditions,
     },
     {


### PR DESCRIPTION
## Description:

The `ContentAsCode` scopes (`view`/`manage`/`manage@self`) were grouped under **Organization Management** in the custom-role scope picker, but they are project-level scopes enforced with project context. This moves them to the `CONTENT` group so the picker heading ("Content Management") matches their actual level — and sits next to the analogous `promote:*` scopes.

Surfaced by a scope-level audit. `group` only drives the section heading and search in the custom-role scope picker (`scopeUtils.ts` / `ScopeSelector.tsx`); it is **not** persisted in `scoped_roles` and has no effect on permission enforcement, so existing roles and assignments are unchanged.

Scope picker grouping:

    Before:  Organization Management
               └─ view:ContentAsCode, manage:ContentAsCode, manage:ContentAsCode@self   ← project-level, mislabeled
    After:   Content Management
               └─ view:ContentAsCode, manage:ContentAsCode, manage:ContentAsCode@self   ← matches actual level

## Test plan:

- `pnpm -F common typecheck:fast` — clean
- `pnpm -F common test -- authorization` — 540 passed, 1 skipped (incl. parity + `scopeAbilityBuilder` + `scopes.level` suites)
- No test asserts the `group` value; behavior (project-level, project-enforced) unchanged.