### PR TITLE
fix(custom-roles): use "Type" instead of "Level" in role UI

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -143,7 +143,7 @@ export const CustomRolesTable: FC<TableProps> = ({
                         <Table.Tr>
                             <Table.Th>Name</Table.Th>
                             <Table.Th>Description</Table.Th>
-                            <Table.Th>Level</Table.Th>
+                            <Table.Th>Type</Table.Th>
                             <Table.Th>Created</Table.Th>
                             <Table.Th></Table.Th>
                         </Table.Tr>

--- a/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/RoleBuilder/RoleBuilder.tsx
@@ -130,7 +130,7 @@ export const RoleBuilder: FC<Props> = ({
     const isLevelDisabled = isWorking || mode === 'edit' || levelLocked;
     const levelHint =
         mode === 'edit'
-            ? "Level can't be changed after creation."
+            ? "Type can't be changed after creation."
             : levelLocked
               ? levelLockedHint
               : undefined;
@@ -156,7 +156,7 @@ export const RoleBuilder: FC<Props> = ({
                                 {...form.getInputProps('description')}
                             />
                             <Stack gap="two">
-                                <Input.Label>Level</Input.Label>
+                                <Input.Label>Type</Input.Label>
                                 <SegmentedControl
                                     data={[
                                         {

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoleDuplicate.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoleDuplicate.tsx
@@ -107,7 +107,7 @@ export const CustomRoleDuplicate = () => {
                     isWorking={createRole.isLoading}
                     mode="create"
                     levelLocked={isCustomSource}
-                    levelLockedHint="Level matches the role being duplicated and cannot be changed."
+                    levelLockedHint="Type matches the role being duplicated and cannot be changed."
                     rederiveScopesOnLevelChange
                 />
             )}

--- a/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
+++ b/packages/frontend/src/ee/pages/customRoles/CustomRoles.tsx
@@ -64,8 +64,8 @@ export const CustomRoles = () => {
         ) : (
             <Text c="dimmed" fz="sm">
                 {level === 'organization'
-                    ? 'No organization-level roles yet.'
-                    : 'No project-level roles yet.'}
+                    ? 'No organization roles yet.'
+                    : 'No project roles yet.'}
             </Text>
         );
 


### PR DESCRIPTION
## Description:

Relabels the custom-role project/organization control from **Level** to **Type** across the custom-roles UI, so the wording matches how people describe a role (an "organization" or "project" role). UI strings only — internal `RoleLevel` types, props, and logic are unchanged.

    Surface          Before                                       After
    -------          ------                                       -----
    Roles table      column "Level"                               column "Type"
    Role builder     label "Level"                                label "Type"
    Builder hint     "Level can't be changed after creation."     "Type can't be changed after creation."
    Duplicate hint   "Level matches the role being duplicated…"   "Type matches the role being duplicated…"
    Empty state      "No organization-level / project-level…"     "No organization / project roles yet."

## Test plan:

- `pnpm -F frontend lint` — clean
- Visual check: custom-roles list, create, edit, and duplicate flows show "Type" in the column header, the selector label, and the locked hints.

## Notes:

"Type" avoids overloading **scope**: the role builder already lists permission *scopes*, so an earlier "Scope" label collided with that on the same screen.