### PR TITLE
feat(date-zoom): attach charts across tabs in control authoring

### DIFF
--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -19,6 +19,7 @@ import {
     normalizeDateZoomConfig,
     normalizeGranularityParam,
     pruneDateZoomConfig,
+    removeDateZoomTileTargets,
     resolveBaseDimension,
     resolveTileDateZoom,
 } from './dateZoom';
@@ -575,6 +576,39 @@ describe('lifecycle helpers', () => {
             },
         };
         expect(pruneDateZoomConfig(cfg)).toEqual(EMPTY_DATE_ZOOM_CONFIG);
+    });
+
+    it('removes a deleted tile and prunes the now-empty control', () => {
+        // tileA is the control's only target -> deleting it drops the control.
+        expect(removeDateZoomTileTargets(controlConfig(), ['tileA'])).toEqual(
+            EMPTY_DATE_ZOOM_CONFIG,
+        );
+    });
+
+    it('removes a deleted tile but keeps a control with surviving targets', () => {
+        const cfg: DateZoomConfig = {
+            controls: controlConfig().controls,
+            tileTargets: {
+                tileA: {
+                    controlUuid: 'ctrl-1',
+                    fieldId: 'orders_fiscal_date',
+                    tableName: 'orders',
+                },
+                tileB: {
+                    controlUuid: 'ctrl-1',
+                    fieldId: 'orders_fiscal_date',
+                    tableName: 'orders',
+                },
+            },
+        };
+        const next = removeDateZoomTileTargets(cfg, ['tileA']);
+        expect(next.controls).toHaveLength(1);
+        expect(Object.keys(next.tileTargets)).toEqual(['tileB']);
+    });
+
+    it('returns the same config when no deleted tile had a target', () => {
+        const cfg = controlConfig();
+        expect(removeDateZoomTileTargets(cfg, ['tileZ'])).toBe(cfg);
     });
 });
 

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -338,3 +338,27 @@ export const pruneDateZoomConfig = (config: DateZoomConfig): DateZoomConfig => {
         tileTargets: Object.fromEntries(liveTargets),
     };
 };
+
+/**
+ * Drops the date-zoom targets for the given tiles (e.g. tiles deleted from the
+ * dashboard) and prunes any control left with no targets. Returns the same
+ * reference when none of the tiles had a target, so callers can skip a no-op
+ * config update on dashboards that don't use controls.
+ */
+export const removeDateZoomTileTargets = (
+    config: DateZoomConfig,
+    tileUuids: string[],
+): DateZoomConfig => {
+    const removed = new Set(tileUuids);
+    if (![...removed].some((uuid) => config.tileTargets[uuid])) {
+        return config;
+    }
+    return pruneDateZoomConfig({
+        ...config,
+        tileTargets: Object.fromEntries(
+            Object.entries(config.tileTargets).filter(
+                ([uuid]) => !removed.has(uuid),
+            ),
+        ),
+    });
+};

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -33,6 +33,7 @@ import { EventName } from '../../../types/Events';
 import { getGranularityLabel } from '../utils';
 import styles from './DateZoom.module.css';
 import { DateZoomControlPills } from './DateZoomControlPills';
+import { DateZoomCrossTabFieldsLoader } from './DateZoomCrossTabFieldsLoader';
 
 type EditModeGranularityItemProps = {
     granularity: string;
@@ -589,6 +590,9 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
             )}
             {isDateZoomConfigEnabled && (
                 <DateZoomControlPills isEditMode={isEditMode} />
+            )}
+            {isDateZoomConfigEnabled && isEditMode && (
+                <DateZoomCrossTabFieldsLoader />
             )}
         </Group>
     );

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlModal.tsx
@@ -51,6 +51,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
     onClose,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const chartZoomableFieldsByTileUuid = useDashboardContext(
         (c) => c.chartZoomableFieldsByTileUuid,
     );
@@ -138,10 +139,42 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                     (tile.properties.title?.length
                         ? tile.properties.title
                         : tile.properties.chartName) || 'Untitled chart';
-                return { tile, zoomableFields, conflictControl, label };
+                return {
+                    tile,
+                    tabUuid: tile.tabUuid ?? undefined,
+                    zoomableFields,
+                    conflictControl,
+                    label,
+                };
             })
             .filter(({ zoomableFields }) => zoomableFields.length > 0);
     }, [dashboardTiles, chartZoomableFieldsByTileUuid, config, draft.uuid]);
+
+    // Group eligible tiles by tab so editors can tell apart charts that live on
+    // different tabs. Tab headers only appear when the dashboard has tabs and
+    // more than one group ends up with charts.
+    const tileGroups = useMemo(() => {
+        const byTab = new Map<string | undefined, typeof eligibleTiles>();
+        eligibleTiles.forEach((entry) => {
+            const group = byTab.get(entry.tabUuid) ?? [];
+            group.push(entry);
+            byTab.set(entry.tabUuid, group);
+        });
+        const groups = dashboardTabs
+            .map((tab) => ({
+                tabUuid: tab.uuid as string | undefined,
+                name: tab.name,
+                tiles: byTab.get(tab.uuid) ?? [],
+            }))
+            .filter((group) => group.tiles.length > 0);
+        const untabbed = byTab.get(undefined) ?? [];
+        if (untabbed.length > 0) {
+            groups.unshift({ tabUuid: undefined, name: '', tiles: untabbed });
+        }
+        return groups;
+    }, [eligibleTiles, dashboardTabs]);
+
+    const showTabHeaders = tileGroups.length > 1;
 
     const toggleTile = (
         tileUuid: string,
@@ -218,6 +251,53 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
         );
 
         onSave({ controls, tileTargets });
+    };
+
+    const renderTileRow = ({
+        tile,
+        zoomableFields,
+        conflictControl,
+        label,
+    }: (typeof eligibleTiles)[number]) => {
+        const target = draftTargets[tile.uuid];
+        const isChecked = !!target;
+        return (
+            <Group key={tile.uuid} justify="space-between" wrap="nowrap">
+                <Checkbox
+                    label={label}
+                    checked={isChecked}
+                    disabled={!!conflictControl}
+                    onChange={(e) =>
+                        toggleTile(
+                            tile.uuid,
+                            zoomableFields,
+                            e.currentTarget.checked,
+                        )
+                    }
+                />
+                {conflictControl ? (
+                    <Badge color="gray" variant="light">
+                        in: {conflictControl.name}
+                    </Badge>
+                ) : (
+                    <Select
+                        size="xs"
+                        w={200}
+                        disabled={!isChecked}
+                        placeholder="Date field"
+                        data={zoomableFields.map((field) => ({
+                            value: field.fieldId,
+                            label: field.label,
+                        }))}
+                        value={target?.fieldId ?? null}
+                        onChange={(value) =>
+                            value &&
+                            setTileField(tile.uuid, zoomableFields, value)
+                        }
+                    />
+                )}
+            </Group>
+        );
     };
 
     return (
@@ -325,72 +405,24 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                                         Select all
                                     </Button>
                                 </Group>
-                                {eligibleTiles.map(
-                                    ({
-                                        tile,
-                                        zoomableFields,
-                                        conflictControl,
-                                        label,
-                                    }) => {
-                                        const target = draftTargets[tile.uuid];
-                                        const isChecked = !!target;
-                                        return (
-                                            <Group
-                                                key={tile.uuid}
-                                                justify="space-between"
-                                                wrap="nowrap"
+                                {tileGroups.map((group) => (
+                                    <Stack
+                                        key={group.tabUuid ?? 'untabbed'}
+                                        gap="xs"
+                                    >
+                                        {showTabHeaders && group.name && (
+                                            <Text
+                                                fz="xs"
+                                                fw={600}
+                                                c="dimmed"
+                                                tt="uppercase"
                                             >
-                                                <Checkbox
-                                                    label={label}
-                                                    checked={isChecked}
-                                                    disabled={!!conflictControl}
-                                                    onChange={(e) =>
-                                                        toggleTile(
-                                                            tile.uuid,
-                                                            zoomableFields,
-                                                            e.currentTarget
-                                                                .checked,
-                                                        )
-                                                    }
-                                                />
-                                                {conflictControl ? (
-                                                    <Badge
-                                                        color="gray"
-                                                        variant="light"
-                                                    >
-                                                        in:{' '}
-                                                        {conflictControl.name}
-                                                    </Badge>
-                                                ) : (
-                                                    <Select
-                                                        size="xs"
-                                                        w={200}
-                                                        disabled={!isChecked}
-                                                        placeholder="Date field"
-                                                        data={zoomableFields.map(
-                                                            (field) => ({
-                                                                value: field.fieldId,
-                                                                label: field.label,
-                                                            }),
-                                                        )}
-                                                        value={
-                                                            target?.fieldId ??
-                                                            null
-                                                        }
-                                                        onChange={(value) =>
-                                                            value &&
-                                                            setTileField(
-                                                                tile.uuid,
-                                                                zoomableFields,
-                                                                value,
-                                                            )
-                                                        }
-                                                    />
-                                                )}
-                                            </Group>
-                                        );
-                                    },
-                                )}
+                                                {group.name}
+                                            </Text>
+                                        )}
+                                        {group.tiles.map(renderTileRow)}
+                                    </Stack>
+                                ))}
                             </>
                         )}
                     </Stack>

--- a/packages/frontend/src/features/dateZoom/components/DateZoomCrossTabFieldsLoader.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomCrossTabFieldsLoader.tsx
@@ -1,0 +1,68 @@
+import {
+    getChartZoomableFields,
+    isDashboardChartTileType,
+} from '@lightdash/common';
+import { useEffect, type FC } from 'react';
+import { useExplore } from '../../../hooks/useExplore';
+import { useSavedQuery } from '../../../hooks/useSavedQuery';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+
+type TileLoaderProps = {
+    tileUuid: string;
+    savedChartUuid: string;
+};
+
+// Reports a single tile's zoomable date fields without mounting the chart.
+// Only the active tab's tiles run useDashboardChartReadyQuery, so charts on
+// other tabs never report their fields; this fills the gap so the control
+// authoring modal can attach charts across tabs.
+const TileZoomableFieldsLoader: FC<TileLoaderProps> = ({
+    tileUuid,
+    savedChartUuid,
+}) => {
+    const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const setChartZoomableFields = useDashboardContext(
+        (c) => c.setChartZoomableFields,
+    );
+    const chartQuery = useSavedQuery({
+        uuidOrSlug: savedChartUuid,
+        projectUuid,
+    });
+    const { data: explore } = useExplore(
+        chartQuery.data?.metricQuery?.exploreName,
+    );
+
+    useEffect(() => {
+        if (chartQuery.data && explore) {
+            setChartZoomableFields(
+                tileUuid,
+                getChartZoomableFields(explore, chartQuery.data.metricQuery),
+            );
+        }
+    }, [chartQuery.data, explore, setChartZoomableFields, tileUuid]);
+
+    return null;
+};
+
+// Prefetches zoomable fields for every chart tile on the dashboard, so the
+// date-zoom control modal lists charts on all tabs, not just the active one.
+// Rendered only while authoring (edit mode).
+export const DateZoomCrossTabFieldsLoader: FC = () => {
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+
+    return (
+        <>
+            {(dashboardTiles ?? [])
+                .filter(isDashboardChartTileType)
+                .map((tile) =>
+                    tile.properties.savedChartUuid ? (
+                        <TileZoomableFieldsLoader
+                            key={tile.uuid}
+                            tileUuid={tile.uuid}
+                            savedChartUuid={tile.properties.savedChartUuid}
+                        />
+                    ) : null,
+                )}
+        </>
+    );
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import {
     isEmptyDateZoomConfig,
     normalizeDateZoomConfig,
     pruneDateZoomConfig,
+    removeDateZoomTileTargets,
     ContentType,
     DateGranularity,
     type UpdateDashboard,
@@ -549,8 +550,24 @@ const Dashboard: FC = () => {
             );
 
             setHaveTilesChanged(true);
+
+            // Drop the deleted tile's date-zoom target and prune any control
+            // left with no charts, so deleting the last attached tile doesn't
+            // leave a dangling control behind.
+            const nextDateZoomConfig = removeDateZoomTileTargets(
+                dateZoomConfig,
+                [tile.uuid],
+            );
+            if (nextDateZoomConfig !== dateZoomConfig) {
+                setDateZoomConfig(nextDateZoomConfig);
+            }
         },
-        [setDashboardTiles, setHaveTilesChanged],
+        [
+            setDashboardTiles,
+            setHaveTilesChanged,
+            dateZoomConfig,
+            setDateZoomConfig,
+        ],
     );
 
     const handleBatchDeleteTiles = (
@@ -562,6 +579,14 @@ const Dashboard: FC = () => {
             ),
         );
         setHaveTilesChanged(true);
+
+        const nextDateZoomConfig = removeDateZoomTileTargets(
+            dateZoomConfig,
+            tilesToDelete.map((tile) => tile.uuid),
+        );
+        if (nextDateZoomConfig !== dateZoomConfig) {
+            setDateZoomConfig(nextDateZoomConfig);
+        }
     };
 
     const handleEditTiles = useCallback(


### PR DESCRIPTION
Two authoring follow-ups for configurable date zoom, surfaced during browser verification.

**Attach charts across tabs**
Only the active tab's tiles run \`useDashboardChartReadyQuery\`, so charts on other tabs never reported their zoomable date fields and were absent from the control authoring modal. Adds an edit-mode prefetcher that loads every chart tile's saved query + explore and reports its zoomable fields, and groups the modal's tile list by tab.

**Prune empty controls on tile/tab deletion**
Deleting the last tile a control targeted left a dangling control with no charts: tile deletion didn't touch \`dateZoomConfig\`, the on-save prune is gated on \`hasDateZoomConfigChanged\`, and backend narrowing only strips targets. Now drops the deleted tiles' targets and prunes now-empty controls on tile/tab delete (new \`removeDateZoomTileTargets\` helper, unit-tested).

Still behind the \`DateZoomConfiguration\` flag; the flag removal is the PR stacked on top.

<img width="517" height="388" alt="CleanShot 2026-06-25 at 16 18 51" src="https://github.com/user-attachments/assets/25efd680-574e-46d2-80a2-c872804d7907" />

Relates to GLITCH-225
Closes: https://linear.app/lightdash/issue/GLITCH-226/i-want-to-enabledisable-date-zoom-on-a-subset-of-tabs-in-my-dashboard