### PR TITLE
feat(date-zoom): enable configurable date zoom by default

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -254,14 +254,6 @@ export enum FeatureFlags {
      * rolled out / disabled per-org at runtime without a deploy.
      */
     RedshiftIamAuth = 'redshift-iam-auth',
-
-    /**
-     * Enable configurable date zoom controls on dashboards: named controls that
-     * each own a granularity, with tiles attached through a tileTargets map and
-     * a per-tile date field. When off, dashboards use only the existing global
-     * date zoom picker and any saved control config is inert.
-     */
-    DateZoomConfiguration = 'date-zoom-configuration',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -451,10 +451,8 @@ describe('resolveTileDateZoom', () => {
 });
 
 // Locks the backwards-compatibility contract the config read path relies on:
-// with no config (existing dashboards) or the flag-off swap to
-// EMPTY_DATE_ZOOM_CONFIG in useDashboardChartReadyQuery, every tile resolves to
-// the single global date-zoom setting exactly as it did before configs existed.
-// This is what must hold before the DateZoomConfiguration flag can be removed.
+// with no config (existing dashboards), every tile resolves to the single
+// global date-zoom setting exactly as it did before configs existed.
 describe('resolveTileDateZoom — legacy single-setting backwards compatibility', () => {
     const legacyBase = {
         config: EMPTY_DATE_ZOOM_CONFIG,

--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -95,7 +95,7 @@ describe('Embedded dashboard', () => {
                     cy.contains('Export image');
 
                     // Check date zoom
-                    cy.contains('Date Zoom');
+                    cy.contains('Default zoom');
                 });
             });
         });
@@ -374,10 +374,10 @@ describe('Embedded dashboard', () => {
                     cy.url().should('not.include', 'dateZoom=');
 
                     // Check that Date Zoom dropdown is visible
-                    cy.contains('Date Zoom').should('be.visible');
+                    cy.contains('Default zoom').should('be.visible');
 
                     // Click the Date Zoom dropdown
-                    cy.contains('Date Zoom').click();
+                    cy.contains('Default zoom').click();
 
                     // Select a granularity (e.g., Month)
                     cy.contains('Month').click();

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,6 +1,5 @@
 import {
     DateGranularity,
-    FeatureFlags,
     getTileControl,
     isStandardDateGranularity,
 } from '@lightdash/common';
@@ -25,7 +24,6 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
-import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -154,39 +152,30 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
         (c) => c.availableCustomGranularities,
     );
     const { track } = useTracking();
-    const { data: dateZoomConfigFlag } = useServerFeatureFlag(
-        FeatureFlags.DateZoomConfiguration,
-    );
-    const isDateZoomConfigEnabled =
-        dateZoomConfigFlag?.enabled ?? import.meta.env.DEV;
     const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
     const chartZoomableFieldsByTileUuid = useDashboardContext(
         (c) => c.chartZoomableFieldsByTileUuid,
     );
 
     // Charts the Default governs: date-zoomable tiles not claimed by a control.
-    const defaultTileCount = useMemo(() => {
-        if (!isDateZoomConfigEnabled) return undefined;
-        return Object.entries(chartZoomableFieldsByTileUuid)
-            .filter(([, fields]) => fields.length > 0)
-            .filter(([uuid]) => !getTileControl(dateZoomConfig, uuid)).length;
-    }, [
-        isDateZoomConfigEnabled,
-        chartZoomableFieldsByTileUuid,
-        dateZoomConfig,
-    ]);
+    const defaultTileCount = useMemo(
+        () =>
+            Object.entries(chartZoomableFieldsByTileUuid)
+                .filter(([, fields]) => fields.length > 0)
+                .filter(([uuid]) => !getTileControl(dateZoomConfig, uuid))
+                .length,
+        [chartZoomableFieldsByTileUuid, dateZoomConfig],
+    );
 
     const isDefaultInert = defaultTileCount === 0;
     // Hide the inert Default from viewers; nothing falls through to it.
     const hideDefaultInView = !isEditMode && isDefaultInert;
     const defaultTooltip =
-        defaultTileCount === undefined
-            ? undefined
-            : defaultTileCount === 0
-              ? 'No charts use the default (every chart is in a zoom control)'
-              : `Applies to ${defaultTileCount} chart${
-                    defaultTileCount === 1 ? '' : 's'
-                } not in a zoom control`;
+        defaultTileCount === 0
+            ? 'No charts use the default (every chart is in a zoom control)'
+            : `Applies to ${defaultTileCount} chart${
+                  defaultTileCount === 1 ? '' : 's'
+              } not in a zoom control`;
 
     useEffect(() => {
         if (isEditMode) setDateZoomGranularity(undefined);
@@ -354,15 +343,11 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                                                 : undefined
                                         }
                                     >
-                                        {isDateZoomConfigEnabled
-                                            ? 'Default zoom'
-                                            : 'Date Zoom'}
+                                        Default zoom
                                     </Text>
                                     {!isEditMode && dateZoomGranularity ? (
                                         <>
-                                            {isDateZoomConfigEnabled
-                                                ? ' · '
-                                                : ': '}
+                                            {' · '}
                                             <Text
                                                 fz="inherit"
                                                 fw={500}
@@ -588,12 +573,8 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                     )}
                 </Group>
             )}
-            {isDateZoomConfigEnabled && (
-                <DateZoomControlPills isEditMode={isEditMode} />
-            )}
-            {isDateZoomConfigEnabled && isEditMode && (
-                <DateZoomCrossTabFieldsLoader />
-            )}
+            <DateZoomControlPills isEditMode={isEditMode} />
+            {isEditMode && <DateZoomCrossTabFieldsLoader />}
         </Group>
     );
 };

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
@@ -6,7 +6,7 @@ import {
     type DateZoomConfig,
     type DateZoomControl,
 } from '@lightdash/common';
-import { Button, Group, Menu } from '@mantine-8/core';
+import { Button, Divider, Group, Menu, Tooltip } from '@mantine-8/core';
 import {
     IconChevronDown,
     IconEye,
@@ -107,137 +107,172 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                     controlGranularities,
                 );
                 return (
-                    <Menu
-                        key={control.uuid}
-                        withinPortal
-                        position="bottom-start"
-                        closeOnItemClick
-                    >
-                        <Menu.Target>
-                            <Button
-                                size="xs"
-                                variant="default"
-                                c={control.hidden ? 'dimmed' : undefined}
-                                leftSection={
-                                    control.hidden ? (
-                                        <MantineIcon icon={IconEyeOff} />
-                                    ) : undefined
-                                }
-                                rightSection={
-                                    <MantineIcon icon={IconChevronDown} />
-                                }
-                            >
-                                {control.name} ·{' '}
-                                {getGranularityLabel(
-                                    activeGranularity,
-                                    availableCustomGranularities,
+                    <Group key={control.uuid} gap={0} wrap="nowrap">
+                        <Menu
+                            withinPortal
+                            position="bottom-start"
+                            closeOnItemClick
+                        >
+                            <Menu.Target>
+                                <Button
+                                    size="xs"
+                                    variant="default"
+                                    styles={
+                                        isEditMode
+                                            ? {
+                                                  root: {
+                                                      borderRightWidth: '0px',
+                                                      borderTopRightRadius:
+                                                          '0px',
+                                                      borderBottomRightRadius:
+                                                          '0px',
+                                                  },
+                                              }
+                                            : undefined
+                                    }
+                                    rightSection={
+                                        <MantineIcon icon={IconChevronDown} />
+                                    }
+                                >
+                                    {control.name} ·{' '}
+                                    {getGranularityLabel(
+                                        activeGranularity,
+                                        availableCustomGranularities,
+                                    )}
+                                </Button>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                <Menu.Label>Granularity</Menu.Label>
+                                {standardGranularities.map((granularity) => (
+                                    <Menu.Item
+                                        key={granularity}
+                                        fz="xs"
+                                        disabled={
+                                            activeGranularity === granularity
+                                        }
+                                        onClick={() =>
+                                            setControlGranularity(
+                                                control.uuid,
+                                                granularity,
+                                            )
+                                        }
+                                    >
+                                        {granularity}
+                                    </Menu.Item>
+                                ))}
+                                {customGranularities.length > 0 && (
+                                    <>
+                                        <Menu.Divider />
+                                        <Menu.Label>Custom</Menu.Label>
+                                        {customGranularities.map(
+                                            (granularity) => (
+                                                <Menu.Item
+                                                    key={granularity}
+                                                    fz="xs"
+                                                    disabled={
+                                                        activeGranularity ===
+                                                        granularity
+                                                    }
+                                                    onClick={() =>
+                                                        setControlGranularity(
+                                                            control.uuid,
+                                                            granularity,
+                                                        )
+                                                    }
+                                                >
+                                                    {getGranularityLabel(
+                                                        granularity,
+                                                        availableCustomGranularities,
+                                                    )}
+                                                </Menu.Item>
+                                            ),
+                                        )}
+                                    </>
                                 )}
-                            </Button>
-                        </Menu.Target>
-                        <Menu.Dropdown>
-                            <Menu.Label>Granularity</Menu.Label>
-                            {standardGranularities.map((granularity) => (
+                                <Menu.Divider />
                                 <Menu.Item
-                                    key={granularity}
                                     fz="xs"
-                                    disabled={activeGranularity === granularity}
                                     onClick={() =>
                                         setControlGranularity(
                                             control.uuid,
-                                            granularity,
+                                            undefined,
                                         )
                                     }
                                 >
-                                    {granularity}
+                                    Reset to default
                                 </Menu.Item>
-                            ))}
-                            {customGranularities.length > 0 && (
-                                <>
-                                    <Menu.Divider />
-                                    <Menu.Label>Custom</Menu.Label>
-                                    {customGranularities.map((granularity) => (
+                                {isEditMode && (
+                                    <>
                                         <Menu.Item
-                                            key={granularity}
                                             fz="xs"
-                                            disabled={
-                                                activeGranularity ===
-                                                granularity
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconSettings}
+                                                />
                                             }
                                             onClick={() =>
-                                                setControlGranularity(
-                                                    control.uuid,
-                                                    granularity,
-                                                )
+                                                setEditingControl(control)
                                             }
                                         >
-                                            {getGranularityLabel(
-                                                granularity,
-                                                availableCustomGranularities,
-                                            )}
+                                            Configure
                                         </Menu.Item>
-                                    ))}
-                                </>
-                            )}
-                            <Menu.Divider />
-                            <Menu.Item
-                                fz="xs"
-                                onClick={() =>
-                                    setControlGranularity(
-                                        control.uuid,
-                                        undefined,
-                                    )
-                                }
-                            >
-                                Reset to default
-                            </Menu.Item>
-                            {isEditMode && (
-                                <>
-                                    <Menu.Item
-                                        fz="xs"
-                                        leftSection={
-                                            <MantineIcon icon={IconSettings} />
-                                        }
-                                        onClick={() =>
-                                            setEditingControl(control)
-                                        }
-                                    >
-                                        Configure
-                                    </Menu.Item>
-                                    <Menu.Item
-                                        fz="xs"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={
-                                                    control.hidden
-                                                        ? IconEye
-                                                        : IconEyeOff
-                                                }
-                                            />
-                                        }
+                                        <Menu.Item
+                                            fz="xs"
+                                            color="red"
+                                            leftSection={
+                                                <MantineIcon icon={IconTrash} />
+                                            }
+                                            onClick={() =>
+                                                handleDelete(control.uuid)
+                                            }
+                                        >
+                                            Remove
+                                        </Menu.Item>
+                                    </>
+                                )}
+                            </Menu.Dropdown>
+                        </Menu>
+
+                        {isEditMode && (
+                            <>
+                                <Divider orientation="vertical" />
+
+                                <Tooltip
+                                    label={
+                                        control.hidden
+                                            ? 'Hidden from viewers. Click to show.'
+                                            : 'Visible to viewers. Click to hide.'
+                                    }
+                                    withinPortal
+                                >
+                                    <Button
+                                        aria-label="Toggle zoom control visibility for viewers"
+                                        size="xs"
+                                        variant="default"
+                                        color="gray"
                                         onClick={() =>
                                             handleToggleHidden(control)
                                         }
+                                        styles={{
+                                            root: {
+                                                borderLeftWidth: '0px',
+                                                borderStartStartRadius: '0px',
+                                                borderEndStartRadius: '0px',
+                                            },
+                                        }}
                                     >
-                                        {control.hidden
-                                            ? 'Show to viewers'
-                                            : 'Hide from viewers'}
-                                    </Menu.Item>
-                                    <Menu.Item
-                                        fz="xs"
-                                        color="red"
-                                        leftSection={
-                                            <MantineIcon icon={IconTrash} />
-                                        }
-                                        onClick={() =>
-                                            handleDelete(control.uuid)
-                                        }
-                                    >
-                                        Remove
-                                    </Menu.Item>
-                                </>
-                            )}
-                        </Menu.Dropdown>
-                    </Menu>
+                                        <MantineIcon
+                                            icon={
+                                                control.hidden
+                                                    ? IconEyeOff
+                                                    : IconEye
+                                            }
+                                        />
+                                    </Button>
+                                </Tooltip>
+                            </>
+                        )}
+                    </Group>
                 );
             })}
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -1,6 +1,4 @@
 import {
-    EMPTY_DATE_ZOOM_CONFIG,
-    FeatureFlags,
     getAvailableParametersFromTables,
     getChartZoomableFields,
     getDateZoomCapabilities,
@@ -25,7 +23,6 @@ import { useExplore } from '../useExplore';
 import { useQueryRetryConfig } from '../useQueryRetry';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
-import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { useSessionTimezone } from '../useSessionTimezone';
 import useDashboardFiltersForTile from './useDashboardFiltersForTile';
 
@@ -106,18 +103,10 @@ export const useDashboardChartReadyQuery = (
         (c) => c.setTilesWithDateZoomApplied,
     );
 
-    // Date zoom controls (gated): when the flag is off, resolve against the
-    // empty config so every tile takes the Default branch and any saved controls
-    // are inert, keeping flag-off byte-for-byte identical to today.
-    const { data: dateZoomConfigFlag } = useServerFeatureFlag(
-        FeatureFlags.DateZoomConfiguration,
-    );
-    const isDateZoomConfigEnabled =
-        dateZoomConfigFlag?.enabled ?? import.meta.env.DEV;
-    const savedDateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
-    const dateZoomConfig = isDateZoomConfigEnabled
-        ? savedDateZoomConfig
-        : EMPTY_DATE_ZOOM_CONFIG;
+    // Configurable date zoom: tiles with a control resolve their control's
+    // grain; unassigned tiles (and dashboards with no config) fall through to
+    // the Default branch — the existing global picker.
+    const dateZoomConfig = useDashboardContext((c) => c.dateZoomConfig);
     const controlGranularities = useDashboardContext(
         (c) => c.controlGranularities,
     );


### PR DESCRIPTION
Removes the \`DateZoomConfiguration\` feature flag and its two gating sites so the configurable date-zoom control authoring UI and resolver are always active.

Backwards compatibility is **structural, not flag-gated**: dashboards with no \`dateZoomConfig\` resolve to the empty config, where every tile takes the Default branch and the legacy global date-zoom granularity applies exactly as before. This was locked by the resolver backwards-compat tests in the lower PRs, so flipping the switch is safe.

Relates to GLITCH-225