### PR TITLE
feat: expose required filter metadata

### DIFF
--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -2,12 +2,14 @@ import {
     Account,
     CatalogType,
     Explore,
+    FilterOperator,
     ForbiddenError,
     JobStatusType,
     NotFoundError,
     QueryExecutionContext,
     RequestMethod,
     SessionUser,
+    UnitOfTime,
 } from '@lightdash/common';
 import { CatalogSearchContext } from '../../../models/CatalogModel/CatalogModel';
 import { AiAgentContentValidation } from '../ai/utils/AiAgentContentValidation';
@@ -40,12 +42,14 @@ const makeExplore = ({
     requiredAttributes = {},
     dimensions = {},
     metrics = {},
+    requiredFilters = [],
 }: {
     name: string;
     tags?: string[];
     requiredAttributes?: Record<string, string>;
     dimensions?: Record<string, unknown>;
     metrics?: Record<string, unknown>;
+    requiredFilters?: NonNullable<Explore['tables'][string]['requiredFilters']>;
 }): Explore =>
     ({
         name,
@@ -59,6 +63,7 @@ const makeExplore = ({
                 label: name,
                 requiredAttributes,
                 anyAttributes: {},
+                requiredFilters,
                 dimensions,
                 metrics,
             },
@@ -281,6 +286,83 @@ describe('AiAgentToolsService', () => {
         });
         expect(mcpResults.topMatchingFields?.[0]).not.toHaveProperty(
             'verifiedChartUsage',
+        );
+    });
+
+    it('adds required filters to AI runtime explore search metadata only', async () => {
+        const requiredFilters = [
+            {
+                id: 'required-created-date',
+                target: { fieldRef: 'created_date' },
+                operator: FilterOperator.IN_THE_PAST,
+                values: [30],
+                settings: { unitOfTime: UnitOfTime.days },
+                required: true,
+            },
+        ];
+        const searchCatalog = jest.fn(async ({ catalogSearch }) => ({
+            data:
+                catalogSearch.type === CatalogType.Table
+                    ? [
+                          {
+                              type: CatalogType.Table,
+                              name: 'orders',
+                              label: 'Orders',
+                              description: null,
+                              aiHints: null,
+                              searchRank: 1,
+                              joinedTables: [],
+                          },
+                      ]
+                    : [
+                          {
+                              type: CatalogType.Field,
+                              name: 'created_date',
+                              label: 'Created Date',
+                              tableName: 'orders',
+                              fieldType: 'dimension',
+                              searchRank: 1,
+                              description: null,
+                              chartUsage: 3,
+                          },
+                      ],
+            pagination: undefined,
+        }));
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    requiredFilters,
+                }),
+            },
+            searchCatalog,
+        });
+        const runtime = service.createRuntime(makeRuntimeContext());
+
+        const results = await runtime.findExplores({
+            fieldSearchSize: 50,
+            searchQuery: 'orders',
+        });
+
+        expect(results).toMatchObject({
+            exploreSearchResults: [
+                expect.objectContaining({
+                    requiredFilters: [
+                        {
+                            fieldId: 'orders_created_date',
+                            fieldRef: 'created_date',
+                            tableName: 'orders',
+                            operator: FilterOperator.IN_THE_PAST,
+                            values: [30],
+                            settings: { unitOfTime: UnitOfTime.days },
+                            required: true,
+                        },
+                    ],
+                }),
+            ],
+        });
+        expect(results.topMatchingFields?.[0]).not.toHaveProperty(
+            'requiredFilter',
         );
     });
 

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -6,6 +6,7 @@ import {
     CatalogFilter,
     CatalogType,
     ContentType,
+    convertFieldRefToFieldId,
     Explore,
     filterExploreByTags,
     ForbiddenError,
@@ -16,6 +17,7 @@ import {
     isDashboardChartTileType,
     isExploreError,
     isGitProjectType,
+    isJoinModelRequiredFilter,
     JobStatusType,
     NotFoundError,
     ParameterError,
@@ -28,6 +30,7 @@ import {
     WarehouseQueryError,
     type ChartAsCode,
     type DashboardAsCode,
+    type ModelRequiredFilterRule,
 } from '@lightdash/common';
 import * as JsonPatch from 'fast-json-patch';
 import Logger from '../../../logging/logger';
@@ -62,6 +65,7 @@ import { AiAgentDocumentModel } from '../../models/AiAgentDocumentModel';
 import { ProjectContextModel } from '../../models/ProjectContextModel';
 import type { BuiltInSkills } from '../ai/skills/builtInSkills';
 import {
+    AiAgentRequiredFilterMetadata,
     AnalyzeFieldImpactFn,
     CreateContentFn,
     DescribeWarehouseTableFn,
@@ -252,6 +256,42 @@ export class AiAgentToolsService extends BaseService {
 
     loadAgentSkill(name: string) {
         return this.builtInSkills.getAiAgentSkill(name);
+    }
+
+    private static getRequiredFilterMetadata(
+        filter: ModelRequiredFilterRule,
+        fallbackTableName: string,
+    ): AiAgentRequiredFilterMetadata {
+        const tableName = isJoinModelRequiredFilter(filter)
+            ? filter.target.tableName
+            : fallbackTableName;
+
+        return {
+            fieldId: convertFieldRefToFieldId(
+                filter.target.fieldRef,
+                tableName,
+            ),
+            fieldRef: filter.target.fieldRef,
+            tableName,
+            operator: filter.operator,
+            values: filter.values,
+            settings: filter.settings,
+            required: filter.required ?? true,
+        };
+    }
+
+    private static getExploreRequiredFilters(
+        explore: Explore | undefined,
+    ): AiAgentRequiredFilterMetadata[] {
+        if (!explore) return [];
+
+        return (explore.tables[explore.baseTable].requiredFilters ?? []).map(
+            (filter) =>
+                AiAgentToolsService.getRequiredFilterMetadata(
+                    filter,
+                    explore.baseTable,
+                ),
+        );
     }
 
     listMcpSkills() {
@@ -498,6 +538,9 @@ export class AiAgentToolsService extends BaseService {
                 const userAttributes =
                     await this.getRuntimeUserAttributes(context);
                 const filteredExplores = await this.listExplores(context);
+                const filteredExploresByName = new Map(
+                    filteredExplores.map((explore) => [explore.name, explore]),
+                );
 
                 const tableSearchResults =
                     await this.catalogService.searchCatalog({
@@ -518,14 +561,24 @@ export class AiAgentToolsService extends BaseService {
 
                 const exploreSearchResults = tableSearchResults.data
                     .filter((item) => item.type === CatalogType.Table)
-                    .map((table) => ({
-                        name: table.name,
-                        label: table.label,
-                        description: table.description,
-                        aiHints: table.aiHints ?? undefined,
-                        searchRank: table.searchRank,
-                        joinedTables: table.joinedTables ?? undefined,
-                    }));
+                    .map((table) => {
+                        const requiredFilters =
+                            AiAgentToolsService.getExploreRequiredFilters(
+                                filteredExploresByName.get(table.name),
+                            );
+
+                        return {
+                            name: table.name,
+                            label: table.label,
+                            description: table.description,
+                            aiHints: table.aiHints ?? undefined,
+                            searchRank: table.searchRank,
+                            joinedTables: table.joinedTables ?? undefined,
+                            ...(requiredFilters.length > 0
+                                ? { requiredFilters }
+                                : {}),
+                        };
+                    });
 
                 const fieldSearchResults =
                     await this.catalogService.searchCatalog({

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -123,7 +123,7 @@ Usage Tips:
       "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
@@ -132,6 +132,7 @@ Parameters:
 Output:
 - Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
+- Required filters set on matching explores, including default values
 ",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -72,6 +72,8 @@ If findExplores returns nothing relevant at all → status: "no_match". Call sub
 
 Call findFields on the chosen explore with the user's intent as the search query.
 
+If findExplores returned requiredFilters for the chosen explore, copy them into the resolved explore handoff exactly. These are explore-level required/default filter rules, not field-level metadata. Omit requiredFilters when findExplores did not return any.
+
 Pick a FILTERED set of fields the parent will plausibly need:
 - The 1–3 metrics most relevant to the query.
 - The dimensions implied by the query (groupings, breakdowns).

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -37,6 +37,28 @@ const renderResolved = (
                     ))}
                 </joinedTables>
             )}
+            {result.explore.requiredFilters &&
+                result.explore.requiredFilters.length > 0 && (
+                    <requiredFilters
+                        count={result.explore.requiredFilters.length}
+                    >
+                        {result.explore.requiredFilters.map((filter) => (
+                            <filter
+                                fieldId={filter.fieldId}
+                                fieldRef={filter.fieldRef}
+                                tableName={filter.tableName}
+                                operator={filter.operator}
+                                values={JSON.stringify(filter.values ?? [])}
+                                settings={
+                                    filter.settings
+                                        ? JSON.stringify(filter.settings)
+                                        : undefined
+                                }
+                                required={filter.required}
+                            />
+                        ))}
+                    </requiredFilters>
+                )}
         </explore>
         <fields count={result.fields.length}>
             {result.fields.map((f) => (

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -174,6 +174,43 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                             "name": {
                               "type": "string",
                             },
+                            "requiredFilters": {
+                              "description": "Explore-level required/default filters from findExplores. Only include when findExplores returned requiredFilters for the selected explore.",
+                              "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "fieldId": {
+                                    "type": "string",
+                                  },
+                                  "fieldRef": {
+                                    "type": "string",
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                  },
+                                  "required": {
+                                    "type": "boolean",
+                                  },
+                                  "settings": {},
+                                  "tableName": {
+                                    "type": "string",
+                                  },
+                                  "values": {
+                                    "items": {},
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "fieldRef",
+                                  "tableName",
+                                  "operator",
+                                  "required",
+                                ],
+                                "type": "object",
+                              },
+                              "type": "array",
+                            },
                           },
                           "required": [
                             "name",
@@ -842,7 +879,7 @@ Usage tips:
     "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
@@ -851,6 +888,7 @@ Parameters:
 Output:
 - Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
+- Required filters set on matching explores, including default values
 ",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
@@ -899,6 +937,42 @@ Output:
                       },
                       "name": {
                         "type": "string",
+                      },
+                      "requiredFilters": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "fieldId": {
+                              "type": "string",
+                            },
+                            "fieldRef": {
+                              "type": "string",
+                            },
+                            "operator": {
+                              "type": "string",
+                            },
+                            "required": {
+                              "type": "boolean",
+                            },
+                            "settings": {},
+                            "tableName": {
+                              "type": "string",
+                            },
+                            "values": {
+                              "items": {},
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "fieldId",
+                            "fieldRef",
+                            "tableName",
+                            "operator",
+                            "required",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
                       },
                       "searchRank": {
                         "type": [

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -92,6 +92,32 @@ const generateExploreResponse = ({
                                     ))}
                                 </joinedTables>
                             )}
+                        {result.requiredFilters &&
+                            result.requiredFilters.length > 0 && (
+                                <requiredFilters
+                                    count={result.requiredFilters.length}
+                                >
+                                    {result.requiredFilters.map((filter) => (
+                                        <filter
+                                            fieldId={filter.fieldId}
+                                            fieldRef={filter.fieldRef}
+                                            tableName={filter.tableName}
+                                            operator={filter.operator}
+                                            values={JSON.stringify(
+                                                filter.values ?? [],
+                                            )}
+                                            settings={
+                                                filter.settings
+                                                    ? JSON.stringify(
+                                                          filter.settings,
+                                                      )
+                                                    : undefined
+                                            }
+                                            required={filter.required}
+                                        />
+                                    ))}
+                                </requiredFilters>
+                            )}
                     </alternative>
                 ))}
             </searchResults>
@@ -147,6 +173,13 @@ export const getFindExplores = ({
                                     label: result.label,
                                     searchRank: result.searchRank,
                                     joinedTables: result.joinedTables ?? [],
+                                    ...(result.requiredFilters &&
+                                    result.requiredFilters.length > 0
+                                        ? {
+                                              requiredFilters:
+                                                  result.requiredFilters,
+                                          }
+                                        : {}),
                                 }),
                             ),
                             topMatchingFields: topMatchingFields?.map(

--- a/packages/backend/src/ee/services/ai/tools/mcpListExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/mcpListExplores.tsx
@@ -1,7 +1,10 @@
 import {
+    convertFieldRefToFieldId,
     Explore,
+    isJoinModelRequiredFilter,
     listExploresToolDefinition,
     mcpToolListExploresOutputSchema,
+    type ModelRequiredFilterRule,
 } from '@lightdash/common';
 import { tool } from 'ai';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -14,26 +17,76 @@ type Dependencies = {
 
 const toolDefinition = listExploresToolDefinition.for('mcp');
 
-const renderExplore = (explore: Explore) => (
-    <explore
-        name={explore.name}
-        label={explore.label}
-        baseTable={explore.baseTable}
-    >
-        {explore.tags && explore.tags.length > 0 && (
-            <tags>
-                {explore.tags.map((tag) => (
-                    <tag>{tag}</tag>
+const getRequiredFilterMetadata = (
+    filter: ModelRequiredFilterRule,
+    fallbackTableName: string,
+) => {
+    const tableName = isJoinModelRequiredFilter(filter)
+        ? filter.target.tableName
+        : fallbackTableName;
+
+    return {
+        fieldId: convertFieldRefToFieldId(filter.target.fieldRef, tableName),
+        fieldRef: filter.target.fieldRef,
+        tableName,
+        operator: filter.operator,
+        values: filter.values,
+        settings: filter.settings,
+        required: filter.required ?? true,
+    };
+};
+
+const renderExplore = (explore: Explore) => {
+    const requiredFilters =
+        explore.tables[explore.baseTable].requiredFilters ?? [];
+
+    return (
+        <explore
+            name={explore.name}
+            label={explore.label}
+            baseTable={explore.baseTable}
+        >
+            {explore.tags && explore.tags.length > 0 && (
+                <tags>
+                    {explore.tags.map((tag) => (
+                        <tag>{tag}</tag>
+                    ))}
+                </tags>
+            )}
+            <joinedTables count={explore.joinedTables.length}>
+                {explore.joinedTables.map((joinedTable) => (
+                    <table>{joinedTable.table}</table>
                 ))}
-            </tags>
-        )}
-        <joinedTables count={explore.joinedTables.length}>
-            {explore.joinedTables.map((joinedTable) => (
-                <table>{joinedTable.table}</table>
-            ))}
-        </joinedTables>
-    </explore>
-);
+            </joinedTables>
+            {requiredFilters.length > 0 && (
+                <requiredFilters count={requiredFilters.length}>
+                    {requiredFilters.map((filter) => {
+                        const metadata = getRequiredFilterMetadata(
+                            filter,
+                            explore.baseTable,
+                        );
+
+                        return (
+                            <filter
+                                fieldId={metadata.fieldId}
+                                fieldRef={metadata.fieldRef}
+                                tableName={metadata.tableName}
+                                operator={metadata.operator}
+                                values={JSON.stringify(metadata.values ?? [])}
+                                settings={
+                                    metadata.settings
+                                        ? JSON.stringify(metadata.settings)
+                                        : undefined
+                                }
+                                required={metadata.required}
+                            />
+                        );
+                    })}
+                </requiredFilters>
+            )}
+        </explore>
+    );
+};
 
 export const getMcpListExplores = ({ listExplores }: Dependencies) =>
     tool({

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -48,6 +48,16 @@ type Pagination = KnexPaginateArgs & {
     totalResults: number;
 };
 
+export type AiAgentRequiredFilterMetadata = {
+    fieldId: string;
+    fieldRef: string;
+    tableName: string;
+    operator: string;
+    values?: unknown[];
+    settings?: unknown;
+    required: boolean;
+};
+
 export type ListExploresFn = () => Promise<Explore[]>;
 
 export type FindExploresFn = (args: {
@@ -61,6 +71,7 @@ export type FindExploresFn = (args: {
         aiHints?: string[];
         searchRank?: number;
         joinedTables?: string[] | null;
+        requiredFilters?: AiAgentRequiredFilterMetadata[];
     }>;
     topMatchingFields?: Array<{
         name: string;

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
@@ -36,6 +36,22 @@ const discoverFieldsExploreSummarySchema = z.object({
     label: z.string(),
     baseTable: z.string(),
     joinedTables: z.array(z.string()),
+    requiredFilters: z
+        .array(
+            z.object({
+                fieldId: z.string(),
+                fieldRef: z.string(),
+                tableName: z.string(),
+                operator: z.string(),
+                values: z.array(z.unknown()).optional(),
+                settings: z.unknown().optional(),
+                required: z.boolean(),
+            }),
+        )
+        .optional()
+        .describe(
+            'Explore-level required/default filters from findExplores. Only include when findExplores returned requiredFilters for the selected explore.',
+        ),
 });
 
 const discoverFieldsFieldSummarySchema = z.object({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -5,7 +5,7 @@ import { createToolSchema } from '../toolSchemaBuilder';
 export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
@@ -14,6 +14,7 @@ Parameters:
 Output:
 - Matching explores with searchRank scores
 - Top matching fields with their explore names and searchRank scores
+- Required filters set on matching explores, including default values
 `;
 
 export const toolFindExploresArgsSchemaV1 = createToolSchema()
@@ -57,6 +58,19 @@ export const findExploresRankingMetadataSchema = z.object({
                 label: z.string(),
                 searchRank: z.number().nullable().optional(),
                 joinedTables: z.array(z.string()).nullable().optional(),
+                requiredFilters: z
+                    .array(
+                        z.object({
+                            fieldId: z.string(),
+                            fieldRef: z.string(),
+                            tableName: z.string(),
+                            operator: z.string(),
+                            values: z.array(z.unknown()).optional(),
+                            settings: z.unknown().optional(),
+                            required: z.boolean(),
+                        }),
+                    )
+                    .optional(),
             }),
         )
         .optional(),


### PR DESCRIPTION
### Summary
- Expose explore-level required/default filter metadata in AI findExplores results
- Forward explore-level required filters through discoverFields structured handoff and XML
- Include required filters in MCP list explores output
- Add coverage and update agent tool contract snapshot

### Verification
- pnpm -F backend test -- src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts --runInBand
- pnpm -F backend typecheck:fast
- pnpm -F common typecheck
- pnpm -F backend exec jest --config jest.config.js src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts --runInBand -u
- Browser verified in thread ce7c1544-eb84-4e9c-aaca-97fbe0b87229 that discoverFields exposes <requiredFilters count="4"> under <explore> and the agent classifies them as explore-level rules

Closes: https://linear.app/lightdash/issue/PROD-6800/allow-ai-agent-to-override-required-filter-default-values-when-user