### PR TITLE
chore(ci): block unreviewed dependency install scripts via strictDepBuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,15 @@ sfw npm install -g @lightdash/cli
 
 This applies to any install Claude runs in this repo — lockfile regeneration, Snyk fixes, debug snippets, global CLI installs. CI workflows already wrap installs via `socketdev/action@<SHA>`.
 
+### Dependency Install Scripts — Blocked by Default
+
+Dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) are blocked by pnpm and enforced in CI via `strictDepBuilds: true` in `pnpm-workspace.yaml`. With it set, `pnpm install` (which every CI job runs) **fails** if any dependency has a build script that isn't reviewed in one of two lists in `pnpm-workspace.yaml`:
+
+- `onlyBuiltDependencies` — packages allowed to run their build scripts (native addons we depend on).
+- `ignoredBuiltDependencies` — packages whose build scripts we intentionally do NOT run (each entry documents why).
+
+This matters because these scripts also run on `npm install` for downstream consumers of our published packages (e.g. `@lightdash/cli`). When CI fails with `ERR_PNPM_IGNORED_BUILDS`, either remove/replace the dependency, add it to `ignoredBuiltDependencies` (with a reason) if its script is safe to skip, or `onlyBuiltDependencies` if the script must run. (pnpm 11 replaces these three settings with a single `allowBuilds` map.)
+
 ### Warehouse Credentials Protection
 
 **CRITICAL**: When adding new credential fields to warehouse configurations, always check if they contain sensitive data that should NOT be exposed via API responses.

--- a/package.json
+++ b/package.json
@@ -9,24 +9,6 @@
         "packages/frontend/sdk"
     ],
     "pnpm": {
-        "onlyBuiltDependencies": [
-            "@sentry-internal/node-cpu-profiler",
-            "@sentry/cli",
-            "@swc/core",
-            "bcrypt",
-            "canvas",
-            "core-js",
-            "core-js-pure",
-            "cpu-features",
-            "cypress",
-            "duckdb",
-            "esbuild",
-            "lz4",
-            "msgpackr-extract",
-            "protobufjs",
-            "sharp",
-            "ssh2"
-        ],
         "overrides": {
             "react-is": "19.2.0",
             "@types/react": "19.2.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,44 @@ minimumReleaseAgeExclude:
   # Renovate security update: undici@6.27.0
   - undici@6.27.0
 
+# Dependency lifecycle scripts (preinstall/install/postinstall) are a supply-chain
+# attack/breakage vector — they also run on `npm install` for downstream consumers
+# of our published packages (e.g. @lightdash/cli). pnpm blocks them by default;
+# strictDepBuilds makes `pnpm install` FAIL (instead of warn) when a dependency has
+# a build script that isn't reviewed in one of the two lists below. This blocks
+# un-vetted install scripts from landing in CI.
+# Note: in pnpm 11 these three settings are replaced by a single `allowBuilds` map.
+strictDepBuilds: true
+
+# Packages allowed to run their build scripts (native addons we depend on).
+onlyBuiltDependencies:
+  - '@sentry-internal/node-cpu-profiler'
+  - '@sentry/cli'
+  - '@swc/core'
+  - bcrypt
+  - canvas
+  - core-js
+  - core-js-pure
+  - cpu-features
+  - cypress
+  - duckdb
+  - esbuild
+  - lz4
+  - msgpackr-extract
+  - protobufjs
+  - sharp
+  - ssh2
+
+# Packages that ship build scripts we intentionally do NOT run. Each entry must
+# explain why skipping the script is safe.
+ignoredBuiltDependencies:
+  # Optional native Zstandard addon, pulled in transitively via just-bash → backend.
+  # Not compiled; the backend runs without the native build.
+  - '@mongodb-js/zstd'
+  # Optional native liblzma/XZ addon, pulled in transitively via just-bash → backend.
+  # Not compiled; the backend runs without the native build.
+  - node-liblzma
+
 packageExtensions:
   '@mastra/schema-compat@0.11.2':
     peerDependenciesMeta:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8368

### Description:

Enables pnpm's native `strictDepBuilds` so `pnpm install` (run by every CI job) **fails** when any dependency has a `preinstall`/`install`/`postinstall` script that isn't reviewed in `onlyBuiltDependencies` (allowed to run) or `ignoredBuiltDependencies` (intentionally skipped). This blocks un-vetted install scripts — a supply-chain attack/breakage vector that also runs on `npm install` for downstream consumers of our published packages — from landing without review. The build-script config is moved from `package.json` into `pnpm-workspace.yaml` so each ignored package documents why skipping its script is safe, and CLAUDE.md explains how to resolve an `ERR_PNPM_IGNORED_BUILDS` CI failure.