### PR TITLE
fix(promote): allow space admins to promote charts and dashboards

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -1240,6 +1240,83 @@ describe('Organization member permissions', () => {
                     ).toEqual(false);
                 });
             });
+
+            describe('Promote', () => {
+                const promoteSubject = (
+                    entity: 'SavedChart' | 'Dashboard',
+                    role: SpaceMemberRole,
+                ) =>
+                    subject(entity, {
+                        organizationUuid:
+                            ORGANIZATION_DEVELOPER.organizationUuid,
+                        access: [
+                            {
+                                userUuid: ORGANIZATION_DEVELOPER.userUuid,
+                                role,
+                            },
+                        ],
+                    });
+
+                it('can promote charts in spaces with admin access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject('SavedChart', SpaceMemberRole.ADMIN),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can promote charts in spaces with editor access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject(
+                                'SavedChart',
+                                SpaceMemberRole.EDITOR,
+                            ),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot promote charts in spaces with viewer access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject(
+                                'SavedChart',
+                                SpaceMemberRole.VIEWER,
+                            ),
+                        ),
+                    ).toEqual(false);
+                });
+
+                it('can promote dashboards in spaces with admin access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject('Dashboard', SpaceMemberRole.ADMIN),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('can promote dashboards in spaces with editor access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject('Dashboard', SpaceMemberRole.EDITOR),
+                        ),
+                    ).toEqual(true);
+                });
+
+                it('cannot promote dashboards in spaces with viewer access', () => {
+                    expect(
+                        ability.can(
+                            'promote',
+                            promoteSubject('Dashboard', SpaceMemberRole.VIEWER),
+                        ),
+                    ).toEqual(false);
+                });
+            });
         });
 
         describe('when user is a member', () => {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -315,12 +315,30 @@ export const applyOrganizationMemberStaticAbilities: Record<
                 },
             },
         });
+        can('promote', 'SavedChart', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.ADMIN,
+                },
+            },
+        });
         can('promote', 'Dashboard', {
             organizationUuid: member.organizationUuid,
             access: {
                 $elemMatch: {
                     userUuid: member.userUuid,
                     role: SpaceMemberRole.EDITOR,
+                },
+            },
+        });
+        can('promote', 'Dashboard', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.ADMIN,
                 },
             },
         });

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -1420,11 +1420,92 @@ describe('scopeAbilityBuilder', () => {
                 ),
             ).toBe(true);
 
-            // Cannot promote without editor access
+            // Can promote dashboard with admin access
             expect(
                 ability.can(
                     'promote',
                     subject('Dashboard', {
+                        projectUuid: 'project-123',
+                        access: [
+                            {
+                                userUuid: 'user-456',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                        ],
+                    }),
+                ),
+            ).toBe(true);
+
+            // Cannot promote without editor or admin access
+            expect(
+                ability.can(
+                    'promote',
+                    subject('Dashboard', {
+                        projectUuid: 'project-123',
+                        access: [
+                            {
+                                userUuid: 'user-456',
+                                role: SpaceMemberRole.VIEWER,
+                            },
+                        ],
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('should handle promote:saved_chart@space permissions', () => {
+            const contextWithUser = {
+                ...baseContext,
+                userUuid: 'user-456',
+            };
+
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    ...contextWithUser,
+                    scopes: ['promote:SavedChart@space'],
+                },
+                builder,
+            );
+            const ability = builder.build();
+
+            // Can promote chart with editor access
+            expect(
+                ability.can(
+                    'promote',
+                    subject('SavedChart', {
+                        projectUuid: 'project-123',
+                        access: [
+                            {
+                                userUuid: 'user-456',
+                                role: SpaceMemberRole.EDITOR,
+                            },
+                        ],
+                    }),
+                ),
+            ).toBe(true);
+
+            // Can promote chart with admin access
+            expect(
+                ability.can(
+                    'promote',
+                    subject('SavedChart', {
+                        projectUuid: 'project-123',
+                        access: [
+                            {
+                                userUuid: 'user-456',
+                                role: SpaceMemberRole.ADMIN,
+                            },
+                        ],
+                    }),
+                ),
+            ).toBe(true);
+
+            // Cannot promote without editor or admin access
+            expect(
+                ability.can(
+                    'promote',
+                    subject('SavedChart', {
                         projectUuid: 'project-123',
                         access: [
                             {

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -313,11 +313,12 @@ const scopes: Scope[] = [
     {
         name: 'promote:SavedChart@space',
         description:
-            'Promote saved charts to spaces where the member has editor access',
+            'Promote saved charts to spaces where the member has editor or admin access',
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
             addAccessCondition(context, SpaceMemberRole.EDITOR),
+            addAccessCondition(context, SpaceMemberRole.ADMIN),
         ],
     },
     {
@@ -330,11 +331,12 @@ const scopes: Scope[] = [
     {
         name: 'promote:Dashboard@space',
         description:
-            'Promote dashboards to spaces where the member has editor access',
+            'Promote dashboards to spaces where the member has editor or admin access',
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
             addAccessCondition(context, SpaceMemberRole.EDITOR),
+            addAccessCondition(context, SpaceMemberRole.ADMIN),
         ],
     },
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8446

## Summary

A user with **Space Admin** access (chosen via "full access" on a space) could not promote charts or dashboards, even though Space **Editors** could — the higher role had strictly less capability than the lower one. The promote action was denied everywhere, including the chart/dashboard header.

## Root cause

The `promote:SavedChart@space` and `promote:Dashboard@space` scopes matched the space role by exact equality, with only an `EDITOR` condition and no parallel `ADMIN` one:

```ts
getConditions: (context) => [
    addAccessCondition(context, SpaceMemberRole.EDITOR), // admin never matched
],
```

This bites the **custom-role** path, where `promote:*@space` is a *standalone* `promote` rule. On built-in/system roles the gap is masked: those roles also grant `manage:SavedChart`/`manage:Dashboard` with an admin condition, and CASL's `manage` is a wildcard that already covers `promote` — so a custom role that grants `promote:*@space` **without** a `manage` scope is where a space admin actually gets denied. The sibling `manage:*@space` scopes have always defined two conditions (one `EDITOR`, one `ADMIN`); promote was simply never given the matching admin rule.

## Fix

Grant `promote` to space admins alongside editors, mirroring `manage:*@space`.

- `scopes.ts` — adds an `ADMIN` access condition to `promote:SavedChart@space` and `promote:Dashboard@space` (descriptions updated to "editor or admin access"). This is the change that unblocks custom-role users.
- `organizationMemberAbility.ts` — adds the matching explicit `ADMIN` promote rules to the built-in `developer` role; behaviourally redundant with the `manage` wildcard but kept for consistency with the existing explicit promote rules and `roleToScopeMapping` parity.
- No `scoped_roles` migration: scope names are unchanged, only their conditions broaden, so existing custom roles holding these scopes gain admin coverage automatically.
- `serviceAccountAbility.ts` untouched — it already promotes org-wide with no space-role condition.

## Impact by space role

```
                 Before          After
Space Admin      x denied        can promote   <- the fix
Space Editor     can promote     can promote
Space Viewer     x denied        x denied
No access        x denied        x denied
```

## Test plan

- [x] `pnpm -F common typecheck:fast && pnpm -F common lint` — clean
- [x] `pnpm -F common test -- authorization` — 547 pass; added regression for both paths (`scopeAbilityBuilder.test.ts` promote:SavedChart/Dashboard@space admin assertions; `organizationMemberAbility.test.ts` developer-role promote admin/editor allowed, viewer denied)
- [x] End-to-end against a running instance: assigned a space-admin user a custom role with `promote:*@space` and no `manage` scope, fetched the real serialized abilities + chart access, and evaluated `can('promote', ...)` as the frontend does — **before: denied, after: allowed**; space viewer stays denied, editor unchanged