### PR TITLE
fix(ai): rename `toolFieldDescriptionMaxChars` to `toolDescriptionMaxChars`

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -5,11 +5,17 @@ export const DEFAULT_ANTHROPIC_MODEL_NAME = 'claude-sonnet-4-6';
 export const DEFAULT_DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_OPENROUTER_MODEL_NAME = 'openai/gpt-5.2-2025-12-11';
 export const DEFAULT_BEDROCK_MODEL_NAME = 'claude-sonnet-4-5';
-export const DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS = 600;
 
 export const DEFAULT_OPENAI_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_AZURE_EMBEDDING_MODEL = 'text-embedding-3-small';
 export const DEFAULT_BEDROCK_EMBEDDING_MODEL = 'cohere.embed-english-v3';
+
+/**
+ * Caps tool-result descriptions to keep AI agent context windows under control.
+ * Oversized tool outputs accumulate across the agent loop and can exceed the
+ * model's context limit.
+ */
+export const DEFAULT_AI_TOOL_DESCRIPTION_MAX_CHARS = 600;
 
 const customHeadersSchema = z.record(z.string()).default({});
 
@@ -146,11 +152,11 @@ export const aiCopilotConfigSchema = z
             .default(0.6),
         mcpConnectionTimeoutMs: z.number().positive().default(20_000),
         mcpAllowPrivateAddresses: z.boolean().default(false),
-        toolFieldDescriptionMaxChars: z
+        toolDescriptionMaxChars: z
             .number()
             .int()
             .positive()
-            .default(DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS),
+            .default(DEFAULT_AI_TOOL_DESCRIPTION_MAX_CHARS),
     })
     .refine(
         ({ providers, defaultProvider, enabled }) =>

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -248,7 +248,7 @@ export const lightdashConfigMock: LightdashConfig = {
             verifiedAnswerSimilarityThreshold: 0.6,
             mcpConnectionTimeoutMs: 20_000,
             mcpAllowPrivateAddresses: false,
-            toolFieldDescriptionMaxChars: 600,
+            toolDescriptionMaxChars: 600,
             defaultEmbeddingModelProvider: 'openai',
         },
     },

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -249,14 +249,14 @@ test('Should parse bedrock inference profile prefix from env', () => {
     });
 });
 
-test('Should default AI tool field description max chars to 600', () => {
-    expect(parseConfig().ai.copilot.toolFieldDescriptionMaxChars).toEqual(600);
+test('Should default AI tool description max chars to 600', () => {
+    expect(parseConfig().ai.copilot.toolDescriptionMaxChars).toEqual(600);
 });
 
-test('Should parse AI tool field description max chars from env', () => {
-    process.env.AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS = '2500';
+test('Should parse AI tool description max chars from env', () => {
+    process.env.AI_TOOL_DESCRIPTION_MAX_CHARS = '2500';
 
-    expect(parseConfig().ai.copilot.toolFieldDescriptionMaxChars).toEqual(2500);
+    expect(parseConfig().ai.copilot.toolDescriptionMaxChars).toEqual(2500);
 });
 
 test('Should parse valid integer', () => {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -37,7 +37,7 @@ import { VERSION } from '../version';
 import {
     aiCopilotConfigSchema,
     AiCopilotConfigSchemaType,
-    DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS,
+    DEFAULT_AI_TOOL_DESCRIPTION_MAX_CHARS,
     DEFAULT_ANTHROPIC_MODEL_NAME,
     DEFAULT_BEDROCK_MODEL_NAME,
     DEFAULT_DEFAULT_AI_PROVIDER,
@@ -1190,10 +1190,9 @@ export const getAiConfig = () => ({
         20_000,
     mcpAllowPrivateAddresses:
         process.env.AI_AGENT_MCP_ALLOW_PRIVATE_ADDRESSES === 'true',
-    toolFieldDescriptionMaxChars:
-        getIntegerFromEnvironmentVariable(
-            'AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS',
-        ) ?? DEFAULT_AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS,
+    toolDescriptionMaxChars:
+        getIntegerFromEnvironmentVariable('AI_TOOL_DESCRIPTION_MAX_CHARS') ??
+        DEFAULT_AI_TOOL_DESCRIPTION_MAX_CHARS,
 });
 
 export type LoggingConfig = {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7373,8 +7373,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
 
             findExploresFieldSearchSize: 200,
             findFieldsPageSize: 30,
-            toolFieldDescriptionMaxChars:
-                this.lightdashConfig.ai.copilot.toolFieldDescriptionMaxChars,
+            toolDescriptionMaxChars:
+                this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
             getDashboardChartsPageSize: 20,
             maxQueryLimit: this.lightdashConfig.ai.copilot.maxQueryLimit,
             runSqlMaxLimit: this.lightdashConfig.ai.copilot.runSqlMaxLimit,

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1330,6 +1330,8 @@ export class McpService extends BaseService {
                     findExplores: toolsRuntime.findExplores,
                     updateProgress: async () => {}, // No-op for MCP context
                     fieldSearchSize: 200,
+                    toolDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                 });
                 const result = await findExploresTool.execute!(
                     {
@@ -1400,9 +1402,8 @@ export class McpService extends BaseService {
                     findFields: toolsRuntime.findFields,
                     updateProgress: async () => {}, // No-op for MCP context
                     pageSize: 15,
-                    fieldDescriptionMaxChars:
-                        this.lightdashConfig.ai.copilot
-                            .toolFieldDescriptionMaxChars,
+                    toolDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                 });
                 const result = await findFieldsTool.execute!(argsWithProject, {
                     toolCallId: '',
@@ -1442,6 +1443,8 @@ export class McpService extends BaseService {
                 const findContentTool = getFindContent({
                     findContent: toolsRuntime.findContent,
                     siteUrl: this.lightdashConfig.siteUrl,
+                    toolDescriptionMaxChars:
+                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                     trackCoverage: () => {},
                 });
                 const result = await findContentTool.execute!(argsWithProject, {

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -225,7 +225,7 @@ const getAgentTools = (
             availableExplores,
             findExploresFieldSearchSize: args.findExploresFieldSearchSize,
             findFieldsPageSize: args.findFieldsPageSize,
-            fieldDescriptionMaxChars: args.toolFieldDescriptionMaxChars,
+            toolDescriptionMaxChars: args.toolDescriptionMaxChars,
             promptUuid: args.promptUuid,
             telemetry: {
                 agentSettings: args.agentSettings,
@@ -248,6 +248,7 @@ const getAgentTools = (
     const findContent = getFindContent({
         findContent: dependencies.findContent,
         siteUrl: args.siteUrl,
+        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
         trackCoverage: (coverage) => {
             dependencies.trackEvent({
                 event: 'ai_agent.find_content_coverage',
@@ -407,7 +408,7 @@ const getAgentTools = (
         // unbounded payload while still letting an audit grab the inventory in
         // one or two round-trips.
         maxPageSize: 500,
-        fieldDescriptionMaxChars: args.toolFieldDescriptionMaxChars,
+        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
     });
 
     const listKnowledgeDocuments = getListKnowledgeDocuments({

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -45,7 +45,7 @@ export type DiscoverFieldsAgentArgs = {
     providerOptions: AiAgentArgs['providerOptions'];
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
-    fieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
     abortSignal?: AbortSignal;
     promptUuid: string;
     parentToolCallId: string;
@@ -99,6 +99,7 @@ export const runDiscoverFieldsAgent = (
         fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
         updateProgress: dependencies.updateProgress,
+        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
     });
 
     const findFields = getFindFields({
@@ -106,7 +107,7 @@ export const runDiscoverFieldsAgent = (
         findFields: dependencies.findFields,
         updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,
-        fieldDescriptionMaxChars: args.fieldDescriptionMaxChars,
+        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
     });
 
     const messages: ModelMessage[] = [

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -147,7 +147,7 @@ type ToolArgs = {
     availableExplores: Explore[];
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
-    fieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
     promptUuid: string;
     telemetry: Pick<
         AiAgentArgs,
@@ -186,7 +186,7 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                         findExploresFieldSearchSize:
                             args.findExploresFieldSearchSize,
                         findFieldsPageSize: args.findFieldsPageSize,
-                        fieldDescriptionMaxChars: args.fieldDescriptionMaxChars,
+                        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
                         promptUuid: args.promptUuid,
                         parentToolCallId: toolCallId,
                         telemetry: args.telemetry,

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -74,7 +74,7 @@ const makeAgentTools = () => {
                 availableExplores: [],
                 findExploresFieldSearchSize: 25,
                 findFieldsPageSize: 25,
-                fieldDescriptionMaxChars: 600,
+                toolDescriptionMaxChars: 600,
                 promptUuid: 'prompt-uuid',
                 telemetry: {
                     agentSettings: {
@@ -101,19 +101,21 @@ const makeAgentTools = () => {
         findContent: getFindContent({
             findContent: noop,
             siteUrl: 'https://lightdash.example',
+            toolDescriptionMaxChars: 600,
             trackCoverage: noop,
         }),
         findExplores: getFindExplores({
             fieldSearchSize: 25,
             findExplores: noop,
             updateProgress: noopAsync,
+            toolDescriptionMaxChars: 600,
         }),
         findFields: getFindFields({
             findFields: noop,
             getExplore: noop,
             pageSize: 25,
             updateProgress: noopAsync,
-            fieldDescriptionMaxChars: 600,
+            toolDescriptionMaxChars: 600,
         }),
         generateDashboard: getGenerateDashboardV2({
             createOrUpdateArtifact: noop,

--- a/packages/backend/src/ee/services/ai/tools/findContent.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/findContent.test.ts
@@ -134,6 +134,7 @@ describe('getFindContent', () => {
             tool: getFindContent({
                 findContent: mockFindContent,
                 siteUrl: '',
+                toolDescriptionMaxChars: 600,
                 trackCoverage,
             }),
             mockFindContent,

--- a/packages/backend/src/ee/services/ai/tools/findContent.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findContent.tsx
@@ -18,11 +18,7 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import {
-    CONTENT_DESCRIPTION_MAX_CHARS,
-    DASHBOARD_CHARTS_PREVIEW_COUNT,
-    truncate,
-} from '../utils/truncation';
+import { DASHBOARD_CHARTS_PREVIEW_COUNT, truncate } from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
 const renderVerified = (verification: ContentVerificationInfo | null) =>
@@ -36,6 +32,7 @@ const renderVerified = (verification: ContentVerificationInfo | null) =>
 type Dependencies = {
     findContent: FindContentFn;
     siteUrl: string;
+    toolDescriptionMaxChars: number;
     trackCoverage: (coverage: {
         searchQuery: string;
         totalResultCount: number;
@@ -74,6 +71,7 @@ const renderSpace = (space: FindContentSpaceResult) => (
 const renderChart = (
     chart: AllChartsSearchResult & Pick<FindContentChartResult, 'space'>,
     siteUrl: string,
+    toolDescriptionMaxChars: number,
 ) => {
     const isSavedChart = isSavedChartSearchResult(chart);
     const isSqlChart = isSqlChartSearchResult(chart);
@@ -100,7 +98,7 @@ const renderChart = (
             {renderSpaceMetadata(chart.space)}
             {chart.description && (
                 <description>
-                    {truncate(chart.description, CONTENT_DESCRIPTION_MAX_CHARS)}
+                    {truncate(chart.description, toolDescriptionMaxChars)}
                 </description>
             )}
             {renderVerified(chart.verification)}
@@ -132,6 +130,7 @@ const renderDashboard = (
     dashboard: DashboardSearchResult &
         Pick<FindContentDashboardResult, 'space'>,
     siteUrl: string,
+    toolDescriptionMaxChars: number,
 ) => (
     <dashboard
         dashboardUuid={dashboard.uuid}
@@ -146,7 +145,7 @@ const renderDashboard = (
 
         {dashboard.description && (
             <description>
-                {truncate(dashboard.description, CONTENT_DESCRIPTION_MAX_CHARS)}
+                {truncate(dashboard.description, toolDescriptionMaxChars)}
             </description>
         )}
         {renderVerified(dashboard.verification)}
@@ -187,7 +186,7 @@ const renderDashboard = (
                             <description>
                                 {truncate(
                                     chart.description,
-                                    CONTENT_DESCRIPTION_MAX_CHARS,
+                                    toolDescriptionMaxChars,
                                 )}
                             </description>
                         )}
@@ -212,6 +211,7 @@ const isSpaceResult = (
 const renderContent = (
     args: Awaited<ReturnType<FindContentFn>> & { searchQuery: string },
     siteUrl: string,
+    toolDescriptionMaxChars: number,
 ) => {
     const sortedContent = [...args.content].sort(
         (a, b) =>
@@ -224,8 +224,8 @@ const renderContent = (
                     return renderSpace(content);
                 }
                 return isDashboardResult(content)
-                    ? renderDashboard(content, siteUrl)
-                    : renderChart(content, siteUrl);
+                    ? renderDashboard(content, siteUrl, toolDescriptionMaxChars)
+                    : renderChart(content, siteUrl, toolDescriptionMaxChars);
             })}
         </searchresult>
     );
@@ -234,6 +234,7 @@ const renderContent = (
 export const getFindContent = ({
     findContent,
     siteUrl,
+    toolDescriptionMaxChars,
     trackCoverage,
 }: Dependencies) =>
     tool({
@@ -270,7 +271,11 @@ export const getFindContent = ({
                     result: (
                         <searchresults>
                             {searchQueryResults.map((searchQueryResult) =>
-                                renderContent(searchQueryResult, siteUrl),
+                                renderContent(
+                                    searchQueryResult,
+                                    siteUrl,
+                                    toolDescriptionMaxChars,
+                                ),
                             )}
                         </searchresults>
                     ).toString(),

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -6,13 +6,14 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { EXPLORE_DESCRIPTION_MAX_CHARS, truncate } from '../utils/truncation';
+import { truncate } from '../utils/truncation';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
     fieldSearchSize: number;
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
+    toolDescriptionMaxChars: number;
 };
 
 const toolDefinition = findExploresToolDefinition.for('agent');
@@ -21,7 +22,11 @@ const generateExploreResponse = ({
     searchQuery,
     exploreSearchResults,
     topMatchingFields,
-}: Awaited<ReturnType<FindExploresFn>> & { searchQuery: string }) => {
+    toolDescriptionMaxChars,
+}: Awaited<ReturnType<FindExploresFn>> & {
+    searchQuery: string;
+    toolDescriptionMaxChars: number;
+}) => {
     const exploreCount = exploreSearchResults?.length ?? 0;
     const fieldCount = topMatchingFields?.length ?? 0;
 
@@ -67,7 +72,7 @@ const generateExploreResponse = ({
                             <description>
                                 {truncate(
                                     result.description,
-                                    EXPLORE_DESCRIPTION_MAX_CHARS,
+                                    toolDescriptionMaxChars,
                                 )}
                             </description>
                         )}
@@ -116,6 +121,7 @@ export const getFindExplores = ({
     findExplores,
     updateProgress,
     fieldSearchSize,
+    toolDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -136,6 +142,7 @@ export const getFindExplores = ({
                         searchQuery: args.searchQuery,
                         exploreSearchResults,
                         topMatchingFields,
+                        toolDescriptionMaxChars,
                     }),
                     metadata: {
                         status: 'success',

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -26,7 +26,7 @@ type Dependencies = {
     findFields: FindFieldFn;
     updateProgress: UpdateProgressFn;
     pageSize: number;
-    fieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
 };
 
 const toolDefinition = findFieldsToolDefinition.for('agent');
@@ -54,7 +54,7 @@ const getFieldCaseSensitive = (
 
 const renderField = (
     catalogField: CatalogField,
-    fieldDescriptionMaxChars: number,
+    toolDescriptionMaxChars: number,
     explore?: Explore,
 ) => {
     const isFromJoinedTable =
@@ -108,7 +108,7 @@ const renderField = (
                 <description>
                     {truncate(
                         catalogField.description,
-                        fieldDescriptionMaxChars,
+                        toolDescriptionMaxChars,
                     )}
                 </description>
             )}
@@ -128,7 +128,7 @@ const renderField = (
 
 const getFieldsText = (
     args: Awaited<ReturnType<FindFieldFn>> & { searchQuery: string },
-    fieldDescriptionMaxChars: number,
+    toolDescriptionMaxChars: number,
     explore?: Explore,
 ) => (
     <searchresult
@@ -139,7 +139,7 @@ const getFieldsText = (
         totalResults={args.pagination?.totalResults}
     >
         {args.fields.map((field) =>
-            renderField(field, fieldDescriptionMaxChars, explore),
+            renderField(field, toolDescriptionMaxChars, explore),
         )}
     </searchresult>
 );
@@ -149,7 +149,7 @@ export const getFindFields = ({
     findFields,
     updateProgress,
     pageSize,
-    fieldDescriptionMaxChars,
+    toolDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -186,7 +186,7 @@ export const getFindFields = ({
                     .map((fieldSearchQueryResult) =>
                         getFieldsText(
                             fieldSearchQueryResult,
-                            fieldDescriptionMaxChars,
+                            toolDescriptionMaxChars,
                             explore,
                         ),
                     )

--- a/packages/backend/src/ee/services/ai/tools/searchSemanticLayer.tsx
+++ b/packages/backend/src/ee/services/ai/tools/searchSemanticLayer.tsx
@@ -14,7 +14,7 @@ type Dependencies = {
     updateProgress: UpdateProgressFn;
     /** Upper bound for the agent-supplied pageSize; also the fallback default. */
     maxPageSize: number;
-    fieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
 };
 
 /** Used when the agent does not specify a pageSize. */
@@ -25,9 +25,9 @@ const toolDefinition = searchSemanticLayerToolDefinition.for('agent');
 const generateResponse = ({
     fields,
     pagination,
-    fieldDescriptionMaxChars,
+    toolDescriptionMaxChars,
 }: Awaited<ReturnType<SearchSemanticLayerFn>> & {
-    fieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
 }) => (
     <semanticLayerFields
         page={pagination?.page}
@@ -54,7 +54,7 @@ const generateResponse = ({
             >
                 {field.description && (
                     <description>
-                        {truncate(field.description, fieldDescriptionMaxChars)}
+                        {truncate(field.description, toolDescriptionMaxChars)}
                     </description>
                 )}
             </field>
@@ -66,7 +66,7 @@ export const getSearchSemanticLayer = ({
     searchSemanticLayer,
     updateProgress,
     maxPageSize,
-    fieldDescriptionMaxChars,
+    toolDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -96,7 +96,7 @@ export const getSearchSemanticLayer = ({
                     result: generateResponse({
                         fields,
                         pagination,
-                        fieldDescriptionMaxChars,
+                        toolDescriptionMaxChars,
                     }).toString(),
                     metadata: {
                         status: 'success',

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -125,7 +125,7 @@ export type AiAgentArgs = AnyAiModel & {
 
     findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
-    toolFieldDescriptionMaxChars: number;
+    toolDescriptionMaxChars: number;
     getDashboardChartsPageSize: number;
     maxQueryLimit: number;
     runSqlMaxLimit: number;

--- a/packages/backend/src/ee/services/ai/utils/truncation.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.test.ts
@@ -1,0 +1,17 @@
+import { truncate } from './truncation';
+
+describe('truncate', () => {
+    it('keeps the requested number of characters before the suffix', () => {
+        expect(truncate('abcdefghijklmnopq', 3)).toEqual('abc...(truncated)');
+    });
+
+    it('uses unicode characters for the limit', () => {
+        expect(truncate('売上高前年差', 3)).toEqual('売上高...(truncated)');
+    });
+
+    it('handles invalid max lengths safely', () => {
+        expect(truncate('abc', 0)).toEqual('');
+        expect(truncate('abc', -1)).toEqual('');
+        expect(truncate('abc', Number.NaN)).toEqual('');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/truncation.ts
+++ b/packages/backend/src/ee/services/ai/utils/truncation.ts
@@ -1,17 +1,15 @@
-/**
- * Caps on tool-result fields to keep AI agent context windows under control.
- * Oversized tool outputs accumulate across the agent loop and can exceed the
- * model's context limit — see PROD-6017.
- */
-export const EXPLORE_DESCRIPTION_MAX_CHARS = 600;
-export const CONTENT_DESCRIPTION_MAX_CHARS = 600;
-
-export const DASHBOARD_CHARTS_PREVIEW_COUNT = 5;
-
 const TRUNCATED_SUFFIX = '...(truncated)';
 
 export const truncate = (value: string, max: number) => {
-    if (value.length <= max) return value;
-    if (max <= TRUNCATED_SUFFIX.length) return TRUNCATED_SUFFIX.slice(0, max);
-    return `${value.slice(0, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+    if (max === Infinity) return value;
+    if (!Number.isFinite(max) || max <= 0) return '';
+
+    const maxChars = Math.floor(max);
+    const valueChars = Array.from(value);
+    if (valueChars.length <= maxChars) return value;
+
+    return `${valueChars.slice(0, maxChars).join('')}${TRUNCATED_SUFFIX}`;
 };
+
+// TODO: move this out...
+export const DASHBOARD_CHARTS_PREVIEW_COUNT = 5;


### PR DESCRIPTION
### Description:

Renames `toolFieldDescriptionMaxChars` to `toolDescriptionMaxChars` (and the corresponding env var from `AI_TOOL_FIELD_DESCRIPTION_MAX_CHARS` to `AI_TOOL_DESCRIPTION_MAX_CHARS`) to better reflect that the cap applies to all tool-result descriptions, not just field descriptions.

The `EXPLORE_DESCRIPTION_MAX_CHARS` and `CONTENT_DESCRIPTION_MAX_CHARS` constants have been removed in favour of passing `toolDescriptionMaxChars` directly through to `getFindContent`, `getFindExplores`, `getFindFields`, and `getSearchSemanticLayer`, so all tools now share a single configurable limit. The `McpService` has also been updated to pass this value through to the relevant tools where it was previously missing.

The `truncate` utility has been improved to handle unicode correctly by splitting on code points rather than UTF-16 code units, and now returns an empty string for invalid (zero, negative, or NaN) max lengths instead of silently misbehaving. Unit tests for these edge cases have been added.