### PR TITLE
fix(promote): show promote in list views for developer users

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -128,12 +128,21 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     // an upstream exists but the user has no promote access there.
     const promoteSubjectName =
         item.type === ResourceViewItemType.CHART ? 'SavedChart' : 'Dashboard';
+    const promoteItemAccess = isChartOrDashboard
+        ? (() => {
+              const userAccess = spaces.find(
+                  (space) => space.uuid === item.data.spaceUuid,
+              )?.userAccess;
+              return userAccess ? [userAccess] : [];
+          })()
+        : [];
     const userCanPromoteChart =
         user.data?.ability?.can(
             'promote',
             subject(promoteSubjectName, {
                 organizationUuid,
                 projectUuid,
+                access: promoteItemAccess,
             }),
         ) &&
         (project?.upstreamProjectUuid === undefined ||
@@ -142,6 +151,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                 subject(promoteSubjectName, {
                     organizationUuid,
                     projectUuid: project.upstreamProjectUuid,
+                    access: promoteItemAccess,
                 }),
             ));
 


### PR DESCRIPTION
Closes: PROD-8445
Closes: #24615

### Description:

Developer-role users couldn't see the **Promote chart / Promote dashboard** option in the `...` action menu of list views (home, all charts, all dashboards, space content), even though admins could and developers could from the chart/dashboard header. The `promote` ability for developers and custom roles is space-access gated, but the list-view action menu built the CASL subject without the resource's space access, so the condition never matched (admins were unaffected because their `manage` wildcard grants `promote` unconditionally). This derives the item's space access from the already-loaded spaces and passes it into both promote subject checks, matching the existing chart/dashboard header behaviour.