### PR TITLE
fix(data-apps): validate method allowlist in external connection test

### DIFF
--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.test.ts
@@ -231,6 +231,30 @@ describe('ExternalConnectionService.testConnection', () => {
         );
     });
 
+    it('rejects a method not in the connection allowlist without fetching', async () => {
+        const { service, model } = buildService({
+            connection: { ...connection, allowedMethods: ['POST'] },
+        });
+        mockAbility(service, true);
+
+        const executeExternalFetchSpy = jest.spyOn(
+            service as unknown as {
+                executeExternalFetch: (...a: unknown[]) => Promise<unknown>;
+            },
+            'executeExternalFetch',
+        );
+
+        await expect(
+            service.testConnection(adminAccount, projectUuid, connectionUuid, {
+                method: 'GET',
+                path: '/v1/current',
+            }),
+        ).rejects.toThrow(ParameterError);
+
+        expect(executeExternalFetchSpy).not.toHaveBeenCalled();
+        expect(model.getDecryptedSecret).not.toHaveBeenCalled();
+    });
+
     it('throws NotFoundError for a connection in a different project', async () => {
         const { service } = buildService({
             connection: { ...connection, projectUuid: 'other-project' },

--- a/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
+++ b/packages/backend/src/ee/services/ExternalConnectionService/ExternalConnectionService.ts
@@ -918,6 +918,15 @@ export class ExternalConnectionService extends BaseService {
         );
         this.assertCanManage(account, conn.projectUuid, conn.organizationUuid);
 
+        // Method allowlist — mirror the runtime proxy so a test rejects a
+        // disallowed method instead of silently sending it.
+        const method: ExternalConnectionMethod = req.method ?? 'GET';
+        if (!conn.allowedMethods.includes(method)) {
+            throw new ParameterError(
+                `Method ${method} is not allowed by this connection`,
+            );
+        }
+
         const secret =
             conn.type === 'none'
                 ? null
@@ -926,7 +935,7 @@ export class ExternalConnectionService extends BaseService {
                   );
 
         const result = await this.executeExternalFetch(conn, secret, {
-            method: req.method ?? 'GET',
+            method,
             path: req.path,
             query: req.query,
             body: req.body,


### PR DESCRIPTION
### Description:
The connections Examples tab sent its test request without checking the HTTP method against the connection's allowedMethods, so a disallowed method (e.g. GET when only POST is allowed) was still forwarded — unlike the runtime proxy and sample-save paths, which both reject it. Add the missing method check in testConnection so a disallowed method now fails with a clear error, mirroring the existing path validation.
