### PR TITLE
feat(date-zoom): match dashboard filter styling for controls

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
+++ b/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
@@ -3,11 +3,20 @@ import {
     type ParametersValuesMap,
     type ParameterValue,
 } from '@lightdash/common';
-import { Button, Divider, Group, Text, Tooltip } from '@mantine-8/core';
+import {
+    ActionIcon,
+    Button,
+    Divider,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
 import {
     IconAdjustmentsHorizontal,
     IconCalendar,
     IconChevronUp,
+    IconEye,
+    IconEyeOff,
     IconFilter,
 } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
@@ -62,6 +71,9 @@ export const DashboardFiltersBar: FC<Props> = ({
         (c) => c.isAddFilterDisabled,
     );
     const allFilters = useDashboardContext((c) => c.allFilters);
+    const setIsDateZoomDisabled = useDashboardContext(
+        (c) => c.setIsDateZoomDisabled,
+    );
     const hasFilters =
         allFilters.dimensions.length > 0 ||
         allFilters.metrics.length > 0 ||
@@ -174,6 +186,35 @@ export const DashboardFiltersBar: FC<Props> = ({
                                         </div>
                                     }
                                 />
+                                {isEditMode && (
+                                    <Tooltip
+                                        withinPortal
+                                        label={
+                                            isDateZoomDisabled
+                                                ? 'Date zoom is hidden from viewers. Click to show.'
+                                                : 'Hide date zoom from viewers'
+                                        }
+                                    >
+                                        <ActionIcon
+                                            aria-label="Toggle date zoom visibility for viewers"
+                                            variant="subtle"
+                                            onClick={() =>
+                                                setIsDateZoomDisabled(
+                                                    !isDateZoomDisabled,
+                                                )
+                                            }
+                                        >
+                                            <MantineIcon
+                                                color="ldGray.6"
+                                                icon={
+                                                    isDateZoomDisabled
+                                                        ? IconEyeOff
+                                                        : IconEye
+                                                }
+                                            />
+                                        </ActionIcon>
+                                    </Tooltip>
+                                )}
                                 <DateZoom isEditMode={isEditMode} />
                             </>
                         )}

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
@@ -5,3 +5,49 @@
 .checkboxInput {
     cursor: pointer;
 }
+
+/* Master switch is off: the whole date-zoom section is hidden from viewers, so
+   dim it in edit mode to signal nothing here reaches the published dashboard. */
+.hiddenFromViewers {
+    opacity: 0.45;
+}
+
+/* Mantine mutes the disabled checkbox border to the surface colour, which makes
+   conflict (already-attached) tiles invisible in dark mode. Restore the standard
+   border token so the box still reads. */
+input.checkboxInput:disabled {
+    border-color: var(--mantine-color-default-border);
+}
+
+/* Pill-shaped control, matching the dashboard filter pills */
+.pill {
+    border-radius: 100px;
+}
+
+/* Leading segment of a joined pill: rounded left, flush right */
+.segmentStart {
+    border-radius: 100px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-width: 0;
+}
+
+/* Trailing segment of a joined pill: flush left, rounded right */
+.segmentEnd {
+    border-radius: 100px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left-width: 0;
+}
+
+/* "Add" trigger, matching the dashed "Add filter" button */
+.addControl {
+    border-radius: 100px;
+    border-style: dashed;
+}
+
+/* Scrollable tile list inside the config popover, matching the filters */
+.tileScrollArea {
+    max-height: min(50vh, calc(100vh - 200px));
+    overflow: auto;
+}

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -7,18 +7,16 @@ import {
     ActionIcon,
     Button,
     Checkbox,
-    Divider,
     Group,
     Menu,
     Text,
     Tooltip,
 } from '@mantine-8/core';
+import { clsx } from '@mantine/core';
 import {
     IconCheck,
     IconChevronDown,
     IconChevronUp,
-    IconEye,
-    IconEyeOff,
     IconPin,
     IconPinFilled,
 } from '@tabler/icons-react';
@@ -73,7 +71,7 @@ const EditModeGranularityItem: FC<EditModeGranularityItemProps> = ({
                     <ActionIcon
                         size="xs"
                         variant="subtle"
-                        color={isDefault ? 'blue' : 'gray'}
+                        color={isDefault ? 'blue' : 'ldGray'}
                         onClick={(e) => {
                             e.stopPropagation();
                             onSetDefault(granularity);
@@ -133,9 +131,6 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
         (c) => c.setDateZoomGranularity,
     );
     const isDateZoomDisabled = useDashboardContext((c) => c.isDateZoomDisabled);
-    const setIsDateZoomDisabled = useDashboardContext(
-        (c) => c.setIsDateZoomDisabled,
-    );
     const dateZoomGranularities = useDashboardContext(
         (c) => c.dateZoomGranularities,
     );
@@ -281,14 +276,23 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
 
     return (
         <Group gap="xs" wrap="nowrap">
-            {!hideDefaultInView && (
-                <Group gap={0} wrap="nowrap">
+            <Group
+                gap="xs"
+                wrap="nowrap"
+                className={
+                    isEditMode && isDateZoomDisabled
+                        ? styles.hiddenFromViewers
+                        : undefined
+                }
+            >
+                {!hideDefaultInView && (
                     <Menu
                         withinPortal
                         withArrow
                         closeOnItemClick={!isEditMode}
                         closeOnClickOutside
-                        offset={-1}
+                        offset={1}
+                        arrowOffset={14}
                         position="bottom-end"
                         classNames={{ dropdown: dropdownClassName }}
                         onOpen={() => setShowOpenIcon(true)}
@@ -304,26 +308,13 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                                 <Button
                                     size="xs"
                                     variant="default"
-                                    classNames={
-                                        !isEditMode && dateZoomGranularity
-                                            ? {
-                                                  root: styles.activeDateZoomButton,
-                                              }
-                                            : undefined
-                                    }
-                                    styles={
-                                        isEditMode
-                                            ? {
-                                                  root: {
-                                                      borderRightWidth: '0px',
-                                                      borderTopRightRadius:
-                                                          '0px',
-                                                      borderBottomRightRadius:
-                                                          '0px',
-                                                  },
-                                              }
-                                            : undefined
-                                    }
+                                    classNames={{
+                                        root: clsx(
+                                            styles.pill,
+                                            dateZoomGranularity &&
+                                                styles.activeDateZoomButton,
+                                        ),
+                                    }}
                                     rightSection={
                                         <MantineIcon
                                             icon={
@@ -334,37 +325,37 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                                         />
                                     }
                                 >
-                                    <Text
-                                        fz="inherit"
-                                        fw={600}
-                                        c={
-                                            isDefaultInert
-                                                ? 'dimmed'
-                                                : undefined
-                                        }
-                                    >
-                                        Default zoom
-                                    </Text>
-                                    {!isEditMode && dateZoomGranularity ? (
-                                        <>
-                                            {' · '}
+                                    <Text fz="inherit" span>
+                                        <Text
+                                            span
+                                            fz="inherit"
+                                            fw={600}
+                                            c={
+                                                isDefaultInert
+                                                    ? 'dimmed'
+                                                    : undefined
+                                            }
+                                        >
+                                            Default zoom
+                                        </Text>
+                                        {!isEditMode && dateZoomGranularity ? (
                                             <Text
+                                                span
                                                 fz="inherit"
                                                 fw={500}
-                                                ml="xxs"
                                                 c={
                                                     isDefaultInert
                                                         ? 'dimmed'
                                                         : undefined
                                                 }
                                             >
-                                                {getGranularityLabel(
+                                                {` · ${getGranularityLabel(
                                                     dateZoomGranularity,
                                                     availableCustomGranularities,
-                                                )}
+                                                )}`}
                                             </Text>
-                                        </>
-                                    ) : null}
+                                        ) : null}
+                                    </Text>
                                 </Button>
                             </Tooltip>
                         </Menu.Target>
@@ -529,51 +520,9 @@ export const DateZoom: FC<Props> = ({ isEditMode, dropdownClassName }) => {
                             )}
                         </Menu.Dropdown>
                     </Menu>
-
-                    {isEditMode && (
-                        <>
-                            <Divider orientation="vertical" />
-
-                            <Tooltip
-                                label={
-                                    isDateZoomDisabled
-                                        ? 'Hidden from viewers. Click to show.'
-                                        : 'Visible to viewers. Click to hide.'
-                                }
-                                withinPortal
-                            >
-                                <Button
-                                    aria-label="Toggle date zoom visibility for viewers"
-                                    size="xs"
-                                    variant="default"
-                                    color="gray"
-                                    onClick={() =>
-                                        setIsDateZoomDisabled(
-                                            !isDateZoomDisabled,
-                                        )
-                                    }
-                                    styles={{
-                                        root: {
-                                            borderLeftWidth: '0px',
-                                            borderStartStartRadius: '0px',
-                                            borderEndStartRadius: '0px',
-                                        },
-                                    }}
-                                >
-                                    <MantineIcon
-                                        icon={
-                                            isDateZoomDisabled
-                                                ? IconEyeOff
-                                                : IconEye
-                                        }
-                                    />
-                                </Button>
-                            </Tooltip>
-                        </>
-                    )}
-                </Group>
-            )}
-            <DateZoomControlPills isEditMode={isEditMode} />
+                )}
+                <DateZoomControlPills isEditMode={isEditMode} />
+            </Group>
             {isEditMode && <DateZoomCrossTabFieldsLoader />}
         </Group>
     );

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlConfig.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlConfig.tsx
@@ -8,9 +8,13 @@ import {
     type DateZoomTileTarget,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Badge,
+    Box,
     Button,
     Checkbox,
+    Collapse,
+    Flex,
     Group,
     Select,
     Stack,
@@ -18,37 +22,45 @@ import {
     Text,
     TextInput,
 } from '@mantine-8/core';
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconClock,
+} from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
-import MantineModal from '../../../components/common/MantineModal';
+import MantineIcon from '../../../components/common/MantineIcon';
+import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import { getGranularityLabel } from '../utils';
+import styles from './DateZoom.module.css';
 
-// The control modal owns a draft of one control plus that control's slice of
+// The control config owns a draft of one control plus that control's slice of
 // `tileTargets`, and returns the full updated config so the caller just stores it.
-export type DateZoomControlModalProps = {
+export type DateZoomControlConfigProps = {
     control: DateZoomControl;
     config: DateZoomConfig;
-    opened: boolean;
     onSave: (nextConfig: DateZoomConfig) => void;
-    onDelete: (controlUuid: string) => void;
-    onClose: () => void;
+    // Inner Select dropdowns portal outside this popover, so the caller tracks
+    // their open state to avoid closing the popover when one is clicked.
+    popoverProps: {
+        onDropdownOpen: () => void;
+        onDropdownClose: () => void;
+    };
 };
 
-enum ControlModalTab {
+enum ControlTab {
     SETTINGS = 'settings',
     TILES = 'tiles',
 }
 
 type DraftTarget = { fieldId: string; tableName: string };
 
-export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
+export const DateZoomControlConfig: FC<DateZoomControlConfigProps> = ({
     control,
     config,
-    opened,
     onSave,
-    onDelete,
-    onClose,
+    popoverProps,
 }) => {
     const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
@@ -66,8 +78,11 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
         (c) => c.dateZoomGranularities,
     );
 
-    const [selectedTab, setSelectedTab] = useState<ControlModalTab>(
-        ControlModalTab.SETTINGS,
+    const [selectedTab, setSelectedTab] = useState<ControlTab>(
+        ControlTab.SETTINGS,
+    );
+    const [collapsedTabs, setCollapsedTabs] = useState<Record<string, boolean>>(
+        {},
     );
 
     // Seeded once on mount; the parent remounts with `key={control.uuid}` when
@@ -150,11 +165,13 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
             .filter(({ zoomableFields }) => zoomableFields.length > 0);
     }, [dashboardTiles, chartZoomableFieldsByTileUuid, config, draft.uuid]);
 
+    type EligibleTile = (typeof eligibleTiles)[number];
+
     // Group eligible tiles by tab so editors can tell apart charts that live on
     // different tabs. Tab headers only appear when the dashboard has tabs and
     // more than one group ends up with charts.
     const tileGroups = useMemo(() => {
-        const byTab = new Map<string | undefined, typeof eligibleTiles>();
+        const byTab = new Map<string | undefined, EligibleTile[]>();
         eligibleTiles.forEach((entry) => {
             const group = byTab.get(entry.tabUuid) ?? [];
             group.push(entry);
@@ -175,6 +192,15 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
     }, [eligibleTiles, dashboardTabs]);
 
     const showTabHeaders = tileGroups.length > 1;
+
+    // Tiles a control can actually claim (conflict tiles belong to another).
+    const selectableTiles = useMemo(
+        () => eligibleTiles.filter(({ conflictControl }) => !conflictControl),
+        [eligibleTiles],
+    );
+
+    const isSelected = (tile: EligibleTile['tile']) =>
+        !!draftTargets[tile.uuid];
 
     const toggleTile = (
         tileUuid: string,
@@ -210,22 +236,30 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
         }));
     };
 
-    const handleSelectAll = () => {
+    // Select/deselect a group of tiles at once (used by "Select all" and the
+    // per-tab header checkbox). When already all selected, clears them.
+    const toggleMany = (tiles: EligibleTile[], allSelected: boolean) => {
         setDraftTargets((prev) => {
             const next = { ...prev };
-            eligibleTiles.forEach(
-                ({ tile, zoomableFields, conflictControl }) => {
-                    if (conflictControl || next[tile.uuid]) return;
-                    const firstField = zoomableFields[0];
+            tiles.forEach(({ tile, zoomableFields }) => {
+                if (allSelected) {
+                    delete next[tile.uuid];
+                } else if (!next[tile.uuid]) {
                     next[tile.uuid] = {
-                        fieldId: firstField.fieldId,
-                        tableName: firstField.tableName,
+                        fieldId: zoomableFields[0].fieldId,
+                        tableName: zoomableFields[0].tableName,
                     };
-                },
-            );
+                }
+            });
             return next;
         });
     };
+
+    const allSelected =
+        selectableTiles.length > 0 &&
+        selectableTiles.every(({ tile }) => isSelected(tile));
+    const someSelected = selectableTiles.some(({ tile }) => isSelected(tile));
+    const isIndeterminate = someSelected && !allSelected;
 
     const handleSave = () => {
         // Upsert this control.
@@ -258,15 +292,31 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
         zoomableFields,
         conflictControl,
         label,
-    }: (typeof eligibleTiles)[number]) => {
+    }: EligibleTile) => {
         const target = draftTargets[tile.uuid];
         const isChecked = !!target;
         return (
-            <Group key={tile.uuid} justify="space-between" wrap="nowrap">
+            <Box key={tile.uuid}>
                 <Checkbox
-                    label={label}
+                    size="xs"
+                    fw={500}
                     checked={isChecked}
                     disabled={!!conflictControl}
+                    classNames={{ input: styles.checkboxInput }}
+                    label={
+                        <Flex align="center" gap="xxs">
+                            <MantineIcon
+                                color="blue.6"
+                                icon={getChartIcon(
+                                    tile.properties.lastVersionChartKind ??
+                                        undefined,
+                                )}
+                            />
+                            <Text fz="xs" fw={500}>
+                                {label}
+                            </Text>
+                        </Flex>
+                    }
                     onChange={(e) =>
                         toggleTile(
                             tile.uuid,
@@ -276,71 +326,134 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                     }
                 />
                 {conflictControl ? (
-                    <Badge color="gray" variant="light">
-                        in: {conflictControl.name}
-                    </Badge>
-                ) : (
-                    <Select
+                    <Box ml="xl" mt="xxs">
+                        <Badge size="sm" color="gray" variant="light">
+                            In {conflictControl.name}
+                        </Badge>
+                    </Box>
+                ) : isChecked ? (
+                    <Box ml="xl" mt="sm">
+                        <Select
+                            w="100%"
+                            size="xs"
+                            allowDeselect={false}
+                            placeholder="Date field"
+                            leftSection={<MantineIcon icon={IconClock} />}
+                            data={zoomableFields.map((field) => ({
+                                value: field.fieldId,
+                                label: field.label,
+                            }))}
+                            value={target?.fieldId ?? null}
+                            comboboxProps={{ withinPortal: true }}
+                            onDropdownOpen={popoverProps.onDropdownOpen}
+                            onDropdownClose={popoverProps.onDropdownClose}
+                            onChange={(value) =>
+                                value &&
+                                setTileField(tile.uuid, zoomableFields, value)
+                            }
+                        />
+                    </Box>
+                ) : null}
+            </Box>
+        );
+    };
+
+    const renderTileGroup = (group: (typeof tileGroups)[number]) => {
+        if (!showTabHeaders || !group.name) {
+            return (
+                <Stack key={group.tabUuid ?? 'untabbed'} gap="md">
+                    {group.tiles.map(renderTileRow)}
+                </Stack>
+            );
+        }
+
+        const tabKey = group.tabUuid ?? 'untabbed';
+        // Default to collapsed, matching the dashboard filters' tab sections.
+        const isCollapsed = collapsedTabs[tabKey] ?? true;
+        const groupSelectable = group.tiles.filter(
+            ({ conflictControl }) => !conflictControl,
+        );
+        const groupSelectedCount = group.tiles.filter(({ tile }) =>
+            isSelected(tile),
+        ).length;
+        const groupAllSelected =
+            groupSelectable.length > 0 &&
+            groupSelectable.every(({ tile }) => isSelected(tile));
+        const groupIndeterminate =
+            !groupAllSelected &&
+            groupSelectable.some(({ tile }) => isSelected(tile));
+
+        return (
+            <Box key={tabKey}>
+                <Flex align="center" gap="xxs">
+                    <ActionIcon
                         size="xs"
-                        w={200}
-                        disabled={!isChecked}
-                        placeholder="Date field"
-                        data={zoomableFields.map((field) => ({
-                            value: field.fieldId,
-                            label: field.label,
-                        }))}
-                        value={target?.fieldId ?? null}
-                        onChange={(value) =>
-                            value &&
-                            setTileField(tile.uuid, zoomableFields, value)
+                        variant="subtle"
+                        aria-label={isCollapsed ? 'Expand tab' : 'Collapse tab'}
+                        onClick={() =>
+                            setCollapsedTabs((prev) => ({
+                                ...prev,
+                                [tabKey]: !(prev[tabKey] ?? true),
+                            }))
+                        }
+                    >
+                        <MantineIcon
+                            icon={
+                                isCollapsed ? IconChevronRight : IconChevronDown
+                            }
+                        />
+                    </ActionIcon>
+                    <Checkbox
+                        size="xs"
+                        fw={500}
+                        checked={groupAllSelected}
+                        indeterminate={groupIndeterminate}
+                        disabled={groupSelectable.length === 0}
+                        classNames={{ input: styles.checkboxInput }}
+                        label={
+                            <Group gap="xs">
+                                <Text fz="xs" fw={500}>
+                                    {group.name}
+                                </Text>
+                                {isCollapsed && (
+                                    <Text fz="xs" c="dimmed">
+                                        ({groupSelectedCount} of{' '}
+                                        {group.tiles.length} selected)
+                                    </Text>
+                                )}
+                            </Group>
+                        }
+                        onChange={() =>
+                            toggleMany(groupSelectable, groupAllSelected)
                         }
                     />
-                )}
-            </Group>
+                </Flex>
+                <Collapse in={!isCollapsed}>
+                    <Stack gap="md" mt="sm" ml={22}>
+                        {group.tiles.map(renderTileRow)}
+                    </Stack>
+                </Collapse>
+            </Box>
         );
     };
 
     return (
-        <MantineModal
-            opened={opened}
-            onClose={onClose}
-            title="Date zoom control"
-            size="lg"
-            onConfirm={handleSave}
-            confirmLabel="Save changes"
-            confirmDisabled={
-                draft.name.trim().length === 0 || targetCount === 0
-            }
-            leftActions={
-                <Button
-                    variant="subtle"
-                    color="red"
-                    onClick={() => onDelete(draft.uuid)}
-                >
-                    Delete
-                </Button>
-            }
-        >
+        <Stack gap="md">
             <Tabs
                 value={selectedTab}
                 onChange={(value) =>
-                    setSelectedTab(
-                        (value as ControlModalTab) ?? ControlModalTab.SETTINGS,
-                    )
+                    setSelectedTab((value as ControlTab) ?? ControlTab.SETTINGS)
                 }
             >
                 <Tabs.List mb="md">
-                    <Tabs.Tab value={ControlModalTab.SETTINGS}>
-                        Zoom settings
-                    </Tabs.Tab>
-                    <Tabs.Tab value={ControlModalTab.TILES}>
-                        Chart tiles
-                    </Tabs.Tab>
+                    <Tabs.Tab value={ControlTab.SETTINGS}>Settings</Tabs.Tab>
+                    <Tabs.Tab value={ControlTab.TILES}>Chart tiles</Tabs.Tab>
                 </Tabs.List>
 
-                <Tabs.Panel value={ControlModalTab.SETTINGS}>
+                <Tabs.Panel value={ControlTab.SETTINGS} w={360}>
                     <Stack gap="md">
                         <TextInput
+                            size="xs"
                             label="Control name"
                             placeholder="e.g. Revenue zoom"
                             value={draft.name}
@@ -351,10 +464,14 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                         />
 
                         <Select
+                            size="xs"
                             label="Default granularity"
                             data={granularityData}
                             value={String(draft.granularity)}
                             allowDeselect={false}
+                            comboboxProps={{ withinPortal: true }}
+                            onDropdownOpen={popoverProps.onDropdownOpen}
+                            onDropdownClose={popoverProps.onDropdownClose}
                             onChange={(value) =>
                                 value &&
                                 setDraft((prev) => ({
@@ -366,7 +483,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
 
                         <Group justify="space-between">
                             <Text
-                                fz="sm"
+                                fz="xs"
                                 c={targetCount === 0 ? 'red' : 'dimmed'}
                             >
                                 {targetCount === 0
@@ -378,9 +495,7 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                             <Button
                                 variant="subtle"
                                 size="xs"
-                                onClick={() =>
-                                    setSelectedTab(ControlModalTab.TILES)
-                                }
+                                onClick={() => setSelectedTab(ControlTab.TILES)}
                             >
                                 Edit charts
                             </Button>
@@ -388,46 +503,42 @@ export const DateZoomControlModal: FC<DateZoomControlModalProps> = ({
                     </Stack>
                 </Tabs.Panel>
 
-                <Tabs.Panel value={ControlModalTab.TILES}>
-                    <Stack gap="xs">
-                        {eligibleTiles.length === 0 ? (
-                            <Text fz="sm" c="dimmed">
-                                No chart tiles with a date dimension to zoom.
-                            </Text>
-                        ) : (
-                            <>
-                                <Group justify="flex-end">
-                                    <Button
-                                        variant="subtle"
-                                        size="xs"
-                                        onClick={handleSelectAll}
-                                    >
-                                        Select all
-                                    </Button>
-                                </Group>
-                                {tileGroups.map((group) => (
-                                    <Stack
-                                        key={group.tabUuid ?? 'untabbed'}
-                                        gap="xs"
-                                    >
-                                        {showTabHeaders && group.name && (
-                                            <Text
-                                                fz="xs"
-                                                fw={600}
-                                                c="dimmed"
-                                                tt="uppercase"
-                                            >
-                                                {group.name}
-                                            </Text>
-                                        )}
-                                        {group.tiles.map(renderTileRow)}
-                                    </Stack>
-                                ))}
-                            </>
-                        )}
-                    </Stack>
+                <Tabs.Panel value={ControlTab.TILES} w={440}>
+                    {eligibleTiles.length === 0 ? (
+                        <Text fz="xs" c="dimmed">
+                            No chart tiles with a date dimension to zoom.
+                        </Text>
+                    ) : (
+                        <Stack gap="xl" className={styles.tileScrollArea}>
+                            <Checkbox
+                                size="xs"
+                                fw={500}
+                                checked={allSelected}
+                                indeterminate={isIndeterminate}
+                                disabled={selectableTiles.length === 0}
+                                classNames={{ input: styles.checkboxInput }}
+                                label="Select all"
+                                onChange={() =>
+                                    toggleMany(selectableTiles, allSelected)
+                                }
+                            />
+                            {tileGroups.map(renderTileGroup)}
+                        </Stack>
+                    )}
                 </Tabs.Panel>
             </Tabs>
-        </MantineModal>
+
+            <Group justify="flex-end">
+                <Button
+                    size="xs"
+                    disabled={
+                        draft.name.trim().length === 0 || targetCount === 0
+                    }
+                    onClick={handleSave}
+                >
+                    Save changes
+                </Button>
+            </Group>
+        </Stack>
     );
 };

--- a/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoomControlPills.tsx
@@ -6,12 +6,20 @@ import {
     type DateZoomConfig,
     type DateZoomControl,
 } from '@lightdash/common';
-import { Button, Divider, Group, Menu, Tooltip } from '@mantine-8/core';
+import {
+    Box,
+    Button,
+    Divider,
+    Group,
+    Menu,
+    Popover,
+    Tooltip,
+} from '@mantine-8/core';
+import { useDisclosure } from '@mantine-8/hooks';
 import {
     IconChevronDown,
     IconEye,
     IconEyeOff,
-    IconPlus,
     IconSettings,
     IconTrash,
 } from '@tabler/icons-react';
@@ -21,7 +29,8 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import { getGranularityLabel } from '../utils';
-import { DateZoomControlModal } from './DateZoomControlModal';
+import styles from './DateZoom.module.css';
+import { DateZoomControlConfig } from './DateZoomControlConfig';
 
 type Props = {
     isEditMode: boolean;
@@ -68,6 +77,16 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
     );
 
     const [editingControl, setEditingControl] = useState<DateZoomControl>();
+    // Inner Select dropdowns portal outside the config popover; track them so a
+    // click on one doesn't dismiss the popover.
+    const [isSubPopoverOpen, { open: openSubPopover, close: closeSubPopover }] =
+        useDisclosure();
+
+    // A draft whose uuid isn't in the saved config yet is a brand-new control
+    // being added (anchors the popover to the "Add date zoom" button).
+    const isAddingNew =
+        !!editingControl &&
+        !dateZoomConfig.controls.some((c) => c.uuid === editingControl.uuid);
 
     const handleSave = (nextConfig: DateZoomConfig) => {
         setDateZoomConfig(nextConfig);
@@ -99,6 +118,26 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
         (control) => isEditMode || !control.hidden,
     );
 
+    // Controls sit at the right edge of the toolbar, so anchor the popover's
+    // right edge to the trigger (bottom-end) — bottom-start would overflow the
+    // viewport and get shifted left, away from the clicked pill.
+    const closeConfig = () => setEditingControl(undefined);
+    const popoverProps = {
+        position: 'bottom-end',
+        withArrow: true,
+        withinPortal: true,
+        trapFocus: true,
+        shadow: 'md',
+        offset: 1,
+        arrowOffset: 14,
+        closeOnEscape: !isSubPopoverOpen,
+        closeOnClickOutside: !isSubPopoverOpen,
+        onClose: closeConfig,
+        // For a controlled popover, Mantine fires onDismiss (not onClose) on
+        // outside-click/escape — without it the popover can't be dismissed.
+        onDismiss: !isSubPopoverOpen ? closeConfig : undefined,
+    } as const;
+
     return (
         <Group gap="xs" wrap="nowrap">
             {visibleControls.map((control) => {
@@ -106,132 +145,165 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                     control,
                     controlGranularities,
                 );
+                const isEditing = editingControl?.uuid === control.uuid;
                 return (
                     <Group key={control.uuid} gap={0} wrap="nowrap">
-                        <Menu
-                            withinPortal
-                            position="bottom-start"
-                            closeOnItemClick
-                        >
-                            <Menu.Target>
-                                <Button
-                                    size="xs"
-                                    variant="default"
-                                    styles={
-                                        isEditMode
-                                            ? {
-                                                  root: {
-                                                      borderRightWidth: '0px',
-                                                      borderTopRightRadius:
-                                                          '0px',
-                                                      borderBottomRightRadius:
-                                                          '0px',
-                                                  },
-                                              }
-                                            : undefined
-                                    }
-                                    rightSection={
-                                        <MantineIcon icon={IconChevronDown} />
-                                    }
-                                >
-                                    {control.name} ·{' '}
-                                    {getGranularityLabel(
-                                        activeGranularity,
-                                        availableCustomGranularities,
-                                    )}
-                                </Button>
-                            </Menu.Target>
-                            <Menu.Dropdown>
-                                <Menu.Label>Granularity</Menu.Label>
-                                {standardGranularities.map((granularity) => (
-                                    <Menu.Item
-                                        key={granularity}
-                                        fz="xs"
-                                        disabled={
-                                            activeGranularity === granularity
-                                        }
-                                        onClick={() =>
-                                            setControlGranularity(
-                                                control.uuid,
-                                                granularity,
-                                            )
-                                        }
+                        <Popover opened={isEditing} {...popoverProps}>
+                            <Popover.Target>
+                                <Box>
+                                    <Menu
+                                        withinPortal
+                                        withArrow
+                                        position="bottom-end"
+                                        offset={1}
+                                        arrowOffset={14}
+                                        closeOnItemClick
+                                        disabled={isEditing}
                                     >
-                                        {granularity}
-                                    </Menu.Item>
-                                ))}
-                                {customGranularities.length > 0 && (
-                                    <>
-                                        <Menu.Divider />
-                                        <Menu.Label>Custom</Menu.Label>
-                                        {customGranularities.map(
-                                            (granularity) => (
-                                                <Menu.Item
-                                                    key={granularity}
-                                                    fz="xs"
-                                                    disabled={
-                                                        activeGranularity ===
-                                                        granularity
-                                                    }
-                                                    onClick={() =>
-                                                        setControlGranularity(
-                                                            control.uuid,
-                                                            granularity,
-                                                        )
-                                                    }
-                                                >
-                                                    {getGranularityLabel(
-                                                        granularity,
-                                                        availableCustomGranularities,
+                                        <Menu.Target>
+                                            <Button
+                                                size="xs"
+                                                variant="default"
+                                                classNames={{
+                                                    root: isEditMode
+                                                        ? styles.segmentStart
+                                                        : styles.pill,
+                                                }}
+                                                rightSection={
+                                                    <MantineIcon
+                                                        icon={IconChevronDown}
+                                                    />
+                                                }
+                                            >
+                                                {control.name} ·{' '}
+                                                {getGranularityLabel(
+                                                    activeGranularity,
+                                                    availableCustomGranularities,
+                                                )}
+                                            </Button>
+                                        </Menu.Target>
+                                        <Menu.Dropdown>
+                                            <Menu.Label>Granularity</Menu.Label>
+                                            {standardGranularities.map(
+                                                (granularity) => (
+                                                    <Menu.Item
+                                                        key={granularity}
+                                                        fz="xs"
+                                                        disabled={
+                                                            activeGranularity ===
+                                                            granularity
+                                                        }
+                                                        onClick={() =>
+                                                            setControlGranularity(
+                                                                control.uuid,
+                                                                granularity,
+                                                            )
+                                                        }
+                                                    >
+                                                        {granularity}
+                                                    </Menu.Item>
+                                                ),
+                                            )}
+                                            {customGranularities.length > 0 && (
+                                                <>
+                                                    <Menu.Divider />
+                                                    <Menu.Label>
+                                                        Custom
+                                                    </Menu.Label>
+                                                    {customGranularities.map(
+                                                        (granularity) => (
+                                                            <Menu.Item
+                                                                key={
+                                                                    granularity
+                                                                }
+                                                                fz="xs"
+                                                                disabled={
+                                                                    activeGranularity ===
+                                                                    granularity
+                                                                }
+                                                                onClick={() =>
+                                                                    setControlGranularity(
+                                                                        control.uuid,
+                                                                        granularity,
+                                                                    )
+                                                                }
+                                                            >
+                                                                {getGranularityLabel(
+                                                                    granularity,
+                                                                    availableCustomGranularities,
+                                                                )}
+                                                            </Menu.Item>
+                                                        ),
                                                     )}
-                                                </Menu.Item>
-                                            ),
-                                        )}
-                                    </>
+                                                </>
+                                            )}
+                                            <Menu.Divider />
+                                            <Menu.Item
+                                                fz="xs"
+                                                onClick={() =>
+                                                    setControlGranularity(
+                                                        control.uuid,
+                                                        undefined,
+                                                    )
+                                                }
+                                            >
+                                                Reset to default
+                                            </Menu.Item>
+                                            {isEditMode && (
+                                                <>
+                                                    <Menu.Item
+                                                        fz="xs"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={
+                                                                    IconSettings
+                                                                }
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            setEditingControl(
+                                                                control,
+                                                            )
+                                                        }
+                                                    >
+                                                        Configure
+                                                    </Menu.Item>
+                                                    <Menu.Item
+                                                        fz="xs"
+                                                        color="red"
+                                                        leftSection={
+                                                            <MantineIcon
+                                                                icon={IconTrash}
+                                                            />
+                                                        }
+                                                        onClick={() =>
+                                                            handleDelete(
+                                                                control.uuid,
+                                                            )
+                                                        }
+                                                    >
+                                                        Remove
+                                                    </Menu.Item>
+                                                </>
+                                            )}
+                                        </Menu.Dropdown>
+                                    </Menu>
+                                </Box>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                                {isEditing && editingControl && (
+                                    <DateZoomControlConfig
+                                        control={editingControl}
+                                        config={dateZoomConfig}
+                                        onSave={handleSave}
+                                        popoverProps={{
+                                            onDropdownOpen: openSubPopover,
+                                            onDropdownClose: closeSubPopover,
+                                        }}
+                                    />
                                 )}
-                                <Menu.Divider />
-                                <Menu.Item
-                                    fz="xs"
-                                    onClick={() =>
-                                        setControlGranularity(
-                                            control.uuid,
-                                            undefined,
-                                        )
-                                    }
-                                >
-                                    Reset to default
-                                </Menu.Item>
-                                {isEditMode && (
-                                    <>
-                                        <Menu.Item
-                                            fz="xs"
-                                            leftSection={
-                                                <MantineIcon
-                                                    icon={IconSettings}
-                                                />
-                                            }
-                                            onClick={() =>
-                                                setEditingControl(control)
-                                            }
-                                        >
-                                            Configure
-                                        </Menu.Item>
-                                        <Menu.Item
-                                            fz="xs"
-                                            color="red"
-                                            leftSection={
-                                                <MantineIcon icon={IconTrash} />
-                                            }
-                                            onClick={() =>
-                                                handleDelete(control.uuid)
-                                            }
-                                        >
-                                            Remove
-                                        </Menu.Item>
-                                    </>
-                                )}
-                            </Menu.Dropdown>
-                        </Menu>
+                            </Popover.Dropdown>
+                        </Popover>
 
                         {isEditMode && (
                             <>
@@ -249,16 +321,12 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
                                         aria-label="Toggle zoom control visibility for viewers"
                                         size="xs"
                                         variant="default"
-                                        color="gray"
+                                        color="ldGray"
                                         onClick={() =>
                                             handleToggleHidden(control)
                                         }
-                                        styles={{
-                                            root: {
-                                                borderLeftWidth: '0px',
-                                                borderStartStartRadius: '0px',
-                                                borderEndStartRadius: '0px',
-                                            },
+                                        classNames={{
+                                            root: styles.segmentEnd,
                                         }}
                                     >
                                         <MantineIcon
@@ -277,35 +345,41 @@ export const DateZoomControlPills: FC<Props> = ({ isEditMode }) => {
             })}
 
             {isEditMode && (
-                <Button
-                    size="xs"
-                    variant="subtle"
-                    leftSection={<MantineIcon icon={IconPlus} />}
-                    onClick={() =>
-                        setEditingControl({
-                            uuid: uuid4(),
-                            name: 'Date zoom',
-                            granularity:
-                                defaultDateZoomGranularity ??
-                                dateZoomGranularities[0] ??
-                                DateGranularity.MONTH,
-                        })
-                    }
-                >
-                    Add zoom
-                </Button>
-            )}
-
-            {editingControl && (
-                <DateZoomControlModal
-                    key={editingControl.uuid}
-                    control={editingControl}
-                    config={dateZoomConfig}
-                    opened
-                    onSave={handleSave}
-                    onDelete={handleDelete}
-                    onClose={() => setEditingControl(undefined)}
-                />
+                <Popover opened={isAddingNew} {...popoverProps}>
+                    <Popover.Target>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            classNames={{ root: styles.addControl }}
+                            onClick={() =>
+                                setEditingControl({
+                                    uuid: uuid4(),
+                                    name: 'Date zoom',
+                                    granularity:
+                                        defaultDateZoomGranularity ??
+                                        dateZoomGranularities[0] ??
+                                        DateGranularity.MONTH,
+                                })
+                            }
+                        >
+                            Add date zoom
+                        </Button>
+                    </Popover.Target>
+                    <Popover.Dropdown>
+                        {isAddingNew && editingControl && (
+                            <DateZoomControlConfig
+                                key={editingControl.uuid}
+                                control={editingControl}
+                                config={dateZoomConfig}
+                                onSave={handleSave}
+                                popoverProps={{
+                                    onDropdownOpen: openSubPopover,
+                                    onDropdownClose: closeSubPopover,
+                                }}
+                            />
+                        )}
+                    </Popover.Dropdown>
+                </Popover>
             )}
         </Group>
     );


### PR DESCRIPTION
Stacked on #24757.

Aligns the date-zoom controls and authoring UI with the dashboard filters so they read as the same component family.

## Changes
- **Pill controls**: date-zoom pills are now pill-shaped (`border-radius: 100px`) and the add button is a dashed pill, matching the filter pills / "Add filter".
- **Popover, not modal**: control authoring moved from a modal into a `Popover` anchored to its trigger (`bottom-end`, since the controls are right-aligned), with the filters' sub-dropdown handling so picking a granularity/field doesn't dismiss it.
- **Tile selection**: mirrors the filters — top "Select all" checkbox, chart-kind icons, field `Select` below each tile, collapsible tab sections (default collapsed) with an "(N of M selected)" count, and a scroll area.
- **Sizing**: `size="xs"` inputs and `fz="xs"` text to match the filter popover.
- **Section visibility toggle**: the master date-zoom visibility eye moved onto the date-zoom section chip (instead of the Default pill); the section dims while it's off.
- **Dark mode**: checkbox colours match the filters (default border), disabled checkboxes get a visible border via `--mantine-color-default-border` (Mantine otherwise mutes it into the surface), and the conflict badge uses `gray` (dark-mode safe).

<img width="639" height="351" alt="CleanShot 2026-06-25 at 17 03 41" src="https://github.com/user-attachments/assets/809b13a0-b50d-4f1e-9c22-0c27a9591e8d" />

