### PR TITLE
feat(ai-agents): schedule delivery from a conversation

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -16,6 +16,7 @@ import {
     IconExternalLink,
     IconEye,
     IconLayoutDashboard,
+    IconSend,
     IconTableShortcut,
     IconTerminal2,
 } from '@tabler/icons-react';
@@ -45,6 +46,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { AiScheduleDeliveryModal } from './AiScheduleDeliveryModal';
 
 type Props = {
     projectUuid: string;
@@ -81,6 +83,8 @@ export const AiChartQuickOptions = ({
     const [isSavingToDashboard, setIsSavingToDashboard] = useState(false);
 
     const [opened, { open, close }] = useDisclosure(false);
+    const [scheduleOpened, { open: openSchedule, close: closeSchedule }] =
+        useDisclosure(false);
     const [
         verifyModalOpened,
         { open: openVerifyModal, close: closeVerifyModal },
@@ -353,16 +357,28 @@ export const AiChartQuickOptions = ({
                         <Menu.Label>Quick actions</Menu.Label>
                         {message.savedQueryUuid ? (
                             !isEmbed && (
-                                <Menu.Item
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
-                                    target="_blank"
-                                    leftSection={
-                                        <MantineIcon icon={IconTableShortcut} />
-                                    }
-                                >
-                                    View saved chart
-                                </Menu.Item>
+                                <>
+                                    <Menu.Item
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
+                                        target="_blank"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconTableShortcut}
+                                            />
+                                        }
+                                    >
+                                        View saved chart
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        onClick={openSchedule}
+                                        leftSection={
+                                            <MantineIcon icon={IconSend} />
+                                        }
+                                    >
+                                        Schedule delivery
+                                    </Menu.Item>
+                                </>
                             )
                         ) : (
                             <>
@@ -508,6 +524,15 @@ export const AiChartQuickOptions = ({
                     </Button>
                 }
             />
+            {scheduleOpened && message.savedQueryUuid && (
+                <AiScheduleDeliveryModal
+                    chartUuid={message.savedQueryUuid}
+                    chartName={saveChartOptions.name ?? ''}
+                    agentUuid={agentUuid}
+                    sourceThreadUuid={message.threadUuid}
+                    onClose={closeSchedule}
+                />
+            )}
         </Fragment>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiScheduleDeliveryModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiScheduleDeliveryModal.tsx
@@ -1,0 +1,59 @@
+import { SchedulerFormat } from '@lightdash/common';
+import { type FC } from 'react';
+import SchedulerModal from '../../../../../features/scheduler/components/SchedulerModal';
+import {
+    useChartSchedulerCreateMutation,
+    useChartSchedulers,
+} from '../../../../../features/scheduler/hooks/useChartSchedulers';
+
+const DELIVERY_FORMATS = [
+    SchedulerFormat.CSV,
+    SchedulerFormat.XLSX,
+    SchedulerFormat.IMAGE,
+    SchedulerFormat.PDF,
+];
+
+type Props = {
+    chartUuid: string;
+    chartName: string;
+    agentUuid: string;
+    sourceThreadUuid: string;
+    onClose: () => void;
+};
+
+// Opens the saved chart's scheduled-delivery form in create mode, pre-filled to
+// run the conversation's agent over the chart and pin the originating thread as
+// context. Mounted only while open so the schedulers query isn't fetched for
+// every chat message.
+export const AiScheduleDeliveryModal: FC<Props> = ({
+    chartUuid,
+    chartName,
+    agentUuid,
+    sourceThreadUuid,
+    onClose,
+}) => {
+    const schedulersQuery = useChartSchedulers({
+        chartUuid,
+        formats: DELIVERY_FORMATS,
+        includeLatestRun: true,
+    });
+    const createMutation = useChartSchedulerCreateMutation();
+
+    return (
+        <SchedulerModal
+            isOpen
+            isChart
+            defaultCreate
+            resourceUuid={chartUuid}
+            name={chartName}
+            schedulersQuery={schedulersQuery}
+            createMutation={createMutation}
+            initialFormValues={{
+                agentUuid,
+                sourceThreadUuid,
+                format: SchedulerFormat.IMAGE,
+            }}
+            onClose={onClose}
+        />
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -27,6 +27,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useFetchRunLogs } from '../hooks/useScheduler';
 import { States } from '../utils';
+import { type SchedulerFormValues } from './SchedulerForm/schedulerFormContext';
 import { SchedulerModalCreateOrEdit } from './SchedulerModalCreateOrEdit';
 import SchedulerRunsHistoryModal from './SchedulerRunsHistoryModal';
 import SchedulersList from './SchedulersList';
@@ -59,6 +60,10 @@ const SchedulersModal: FC<
         >;
         /** If provided, opens directly in edit mode for this scheduler */
         initialSchedulerUuid?: string;
+        /** Opens directly in create mode (skips the list). */
+        defaultCreate?: boolean;
+        /** Create-mode only: pre-fills the new delivery. */
+        initialFormValues?: Partial<SchedulerFormValues>;
         searchQuery?: string;
         onSearchQueryChange?: (searchQuery: string | undefined) => void;
     }
@@ -75,11 +80,17 @@ const SchedulersModal: FC<
     availableParameters,
     onClose = () => {},
     initialSchedulerUuid,
+    defaultCreate = false,
+    initialFormValues,
     searchQuery,
     onSearchQueryChange,
 }) => {
     const [modalState, setModalState] = useState<States>(
-        initialSchedulerUuid ? States.EDIT : States.LIST,
+        initialSchedulerUuid
+            ? States.EDIT
+            : defaultCreate
+              ? States.CREATE
+              : States.LIST,
     );
     const [schedulerUuidToEdit, setSchedulerUuidToEdit] = useState<
         string | undefined
@@ -266,6 +277,9 @@ const SchedulersModal: FC<
                 resourceUuid={resourceUuid}
                 schedulerUuidToEdit={
                     modalState === States.EDIT ? schedulerUuidToEdit : undefined
+                }
+                initialFormValues={
+                    modalState === States.CREATE ? initialFormValues : undefined
                 }
                 createMutation={createMutation}
                 onClose={onClose}

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -44,6 +44,7 @@ import {
     SchedulerFormProvider,
     transformFormValues,
     useSchedulerForm,
+    type SchedulerFormValues,
 } from './SchedulerForm/schedulerFormContext';
 import { Limit } from './types';
 
@@ -61,6 +62,7 @@ interface UseSchedulerFormModalProps {
     onBack: () => void;
     itemsMap?: ItemsMap;
     currentParameterValues?: ParametersValuesMap;
+    initialFormValues?: Partial<SchedulerFormValues>;
 }
 
 const useSchedulerFormModal = ({
@@ -73,6 +75,7 @@ const useSchedulerFormModal = ({
     onBack,
     itemsMap,
     currentParameterValues,
+    initialFormValues,
 }: UseSchedulerFormModalProps) => {
     const isEditMode = !!schedulerUuid;
 
@@ -166,6 +169,7 @@ const useSchedulerFormModal = ({
                             Object.keys(dashboardParameterValues).length > 0
                                 ? dashboardParameterValues
                                 : undefined,
+                        ...initialFormValues,
                     },
         validateInputOnBlur: ['options.customLimit'],
 
@@ -407,6 +411,8 @@ interface Props {
     availableParameters?: ParameterDefinitions;
     /** undefined = create mode, string = edit mode */
     schedulerUuidToEdit: string | undefined;
+    /** Create-mode only: pre-fills the new delivery. */
+    initialFormValues?: Partial<SchedulerFormValues>;
 }
 
 export const SchedulerModalCreateOrEdit: FC<Props> = ({
@@ -421,6 +427,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
     availableParameters,
     onClose,
     onBack,
+    initialFormValues,
 }) => {
     // URL param handling is done in SchedulerModal parent component
     const schedulerUuid = schedulerUuidToEdit;
@@ -452,6 +459,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         onBack,
         itemsMap,
         currentParameterValues,
+        initialFormValues,
     });
 
     return (


### PR DESCRIPTION
### Description

Lets users turn an AI conversation into a recurring delivery. Builds on #24772 (AI-augmented scheduled deliveries).

When an agent has saved a chart in a thread, the chart's quick-actions menu gains a **Schedule delivery** action. It opens the scheduler form in create mode, pre-filled to run that conversation's agent over the chart on every send and to pin the originating thread as context — so the scheduled report continues from where the conversation left off.

**Changes (frontend only)**

- `AiChartQuickOptions`: new **Schedule delivery** menu item for messages with a saved chart (hidden in embeds).
- New `AiScheduleDeliveryModal`: opens the chart's `SchedulerModal` in create mode, pre-filled with `agentUuid`, `sourceThreadUuid`, and an image format. Mounted only while open so the schedulers query isn't fetched for every chat message.
- `SchedulerModal` / `SchedulerModalCreateOrEdit`: new `defaultCreate` prop (open straight into create, skipping the list) and `initialFormValues` (pre-fill the new delivery in create mode only).
