### PR TITLE
feat(scheduler): build AI deliveries on previous runs

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4557,7 +4557,8 @@ export class AiAgentService extends BaseService {
     async generateScheduledReport(
         scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
         organizationUuid: string,
-    ): Promise<string> {
+        priorThreadUuids: string[] = [],
+    ): Promise<{ message: string; threadUuid: string }> {
         const { agentUuid, prompt, createdBy } = scheduler;
         if (!agentUuid || !prompt) {
             throw new UnexpectedServerError(
@@ -4592,6 +4593,9 @@ export class AiAgentService extends BaseService {
                 threadUuid: scheduler.sourceThreadUuid,
             });
         }
+        priorThreadUuids.forEach((threadUuid) => {
+            context.push({ type: 'thread', threadUuid });
+        });
 
         const thread = await this.createAgentThread(
             user,
@@ -4605,10 +4609,11 @@ export class AiAgentService extends BaseService {
             );
         }
 
-        return this.generateAgentThreadResponse(user, {
+        const message = await this.generateAgentThreadResponse(user, {
             agentUuid,
             threadUuid: thread.uuid,
         });
+        return { message, threadUuid: thread.uuid };
     }
 
     async generateThreadTitle(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9881,6 +9881,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                includeRunHistory: { dataType: 'boolean', required: true },
                 includeSourceThread: { dataType: 'boolean', required: true },
             },
             validators: {},

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -11196,11 +11196,14 @@
             },
             "AiSchedulerOptions": {
                 "properties": {
+                    "includeRunHistory": {
+                        "type": "boolean"
+                    },
                     "includeSourceThread": {
                         "type": "boolean"
                     }
                 },
-                "required": ["includeSourceThread"],
+                "required": ["includeRunHistory", "includeSourceThread"],
                 "type": "object"
             },
             "SchedulerCsvOptions": {

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1798,6 +1798,22 @@ export class SchedulerModel {
         }
     }
 
+    // The agent threads from this scheduler's most recent augmented runs, newest first
+    async getRecentAiThreadUuids(
+        schedulerUuid: string,
+        limit: number,
+    ): Promise<string[]> {
+        const rows = await this.database(SchedulerLogTableName)
+            .where('scheduler_uuid', schedulerUuid)
+            .whereRaw("details->>'aiThreadUuid' IS NOT NULL")
+            .orderBy('created_at', 'desc')
+            .limit(limit)
+            .select<{ thread_uuid: string }[]>(
+                this.database.raw("details->>'aiThreadUuid' AS thread_uuid"),
+            );
+        return rows.map((row) => row.thread_uuid);
+    }
+
     async deleteScheduledLogs(schedulerUuid: string): Promise<void> {
         await this.database.transaction(async (trx) => {
             await trx(SchedulerLogTableName)

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -192,8 +192,12 @@ export interface SchedulerAiAugmentation {
     generateScheduledReport(
         scheduler: SchedulerAndTargets | CreateSchedulerAndTargets,
         organizationUuid: string,
-    ): Promise<string>;
+        priorThreadUuids: string[],
+    ): Promise<{ message: string; threadUuid: string }>;
 }
+
+// How many recent runs of a delivery to pin as context for the agent.
+const AI_RUN_HISTORY_LIMIT = 3;
 
 export type SchedulerTaskArguments = {
     schedulerAiAugmentation?: SchedulerAiAugmentation;
@@ -3970,15 +3974,27 @@ export default class SchedulerTask {
         // Run the agent and use its report as the message, then fall through to
         // the normal render + send. Kept in a separate const so the type guard
         // doesn't leak into `scheduler` and break later `in scheduler` narrowing.
+        let aiThreadUuid: string | undefined;
         const augmentedScheduler = isAugmentedScheduler(scheduler)
             ? scheduler
             : null;
         if (augmentedScheduler && this.schedulerAiAugmentation) {
-            scheduler.message =
+            const priorThreadUuids =
+                augmentedScheduler.aiSchedulerOptions?.includeRunHistory &&
+                schedulerUuid
+                    ? await this.schedulerService.schedulerModel.getRecentAiThreadUuids(
+                          schedulerUuid,
+                          AI_RUN_HISTORY_LIMIT,
+                      )
+                    : [];
+            const report =
                 await this.schedulerAiAugmentation.generateScheduledReport(
                     augmentedScheduler,
                     schedulerPayload.organizationUuid,
+                    priorThreadUuids,
                 );
+            scheduler.message = report.message;
+            aiThreadUuid = report.threadUuid;
         }
 
         this.analytics.track({
@@ -4006,6 +4022,8 @@ export default class SchedulerTask {
                 projectUuid: schedulerPayload.projectUuid,
                 organizationUuid: schedulerPayload.organizationUuid,
                 createdByUserUuid: schedulerPayload.userUuid,
+                // Lets later runs of this delivery find and build on this run.
+                ...(aiThreadUuid ? { aiThreadUuid } : {}),
             },
         });
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -113,6 +113,7 @@ export type ThresholdOptions = {
 // in one jsonb column so new ones don't each need a migration.
 export type AiSchedulerOptions = {
     includeSourceThread: boolean;
+    includeRunHistory: boolean;
 };
 
 export type SchedulerBase = {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
@@ -68,6 +68,17 @@ export const SchedulerFormAiInput: FC<Props> = ({
                         minRows={2}
                         {...form.getInputProps('prompt')}
                     />
+                    <Switch
+                        label="Build on previous deliveries"
+                        description="The agent sees this delivery's recent runs, so it can report on what changed since last time."
+                        checked={form.values.includeRunHistory}
+                        onChange={(event) =>
+                            form.setFieldValue(
+                                'includeRunHistory',
+                                event.currentTarget.checked,
+                            )
+                        }
+                    />
                     {sourceThreadUuid && (
                         <Switch
                             label="Include the source conversation as context"

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -58,6 +58,7 @@ export interface SchedulerFormValues {
     prompt: string;
     sourceThreadUuid: string | null;
     includeSourceThread: boolean;
+    includeRunHistory: boolean;
 }
 
 const DEFAULT_AI_PROMPT =
@@ -98,6 +99,7 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     prompt: DEFAULT_AI_PROMPT,
     sourceThreadUuid: null,
     includeSourceThread: false,
+    includeRunHistory: true,
 };
 
 export const DEFAULT_VALUES_ALERT: SchedulerFormValues = {
@@ -207,6 +209,8 @@ export const getFormValuesFromScheduler = (
         sourceThreadUuid: schedulerData.sourceThreadUuid,
         includeSourceThread:
             schedulerData.aiSchedulerOptions?.includeSourceThread ?? false,
+        includeRunHistory:
+            schedulerData.aiSchedulerOptions?.includeRunHistory ?? false,
     };
 };
 
@@ -283,7 +287,10 @@ export const transformFormValues = (
         prompt: values.agentUuid ? values.prompt : null,
         sourceThreadUuid: values.agentUuid ? values.sourceThreadUuid : null,
         aiSchedulerOptions: values.agentUuid
-            ? { includeSourceThread: values.includeSourceThread }
+            ? {
+                  includeSourceThread: values.includeSourceThread,
+                  includeRunHistory: values.includeRunHistory,
+              }
             : null,
         ...(resourceType === 'dashboard' && {
             filters: values.dashboardFilters,


### PR DESCRIPTION
### Description

Lets an AI-augmented delivery build on its own history. Builds on #24774.

Each scheduled run normally starts a fresh agent thread with no memory of earlier runs. With the new **Build on previous deliveries** toggle, the agent is handed the threads from this scheduler's most recent runs as context, so its report can call out what changed since last time instead of describing the data from scratch.

**Storage** — folds into the `ai_scheduler_options` jsonb introduced in #24774 rather than adding its own column: `AiSchedulerOptions` gains `includeRunHistory`. (Behavioural flags live in the blob; only relational fields the DB reasons about stay as columns.)

**Changes**

- `AiSchedulerOptions.includeRunHistory` (common); the "Build on previous deliveries" switch in the scheduler form writes it via the blob.
- `SchedulerModel.getRecentAiThreadUuids(schedulerUuid, limit)` returns the last N runs' threads.
- `SchedulerTask`: when `includeRunHistory` is set, fetches those prior threads and passes them to `generateScheduledReport`.
- `AiAgentService.generateScheduledReport` accepts the prior threads and includes them as context for the run.
