### PR TITLE
fix(date-zoom): seed embed date zoom config from embed dashboard

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -177,6 +177,13 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         },
     });
 
+    // Embedded dashboards populate `embedDashboard` instead of the query hook,
+    // so config-derived state must read from whichever holds the dashboard.
+    const currentDashboardConfig = useMemo(
+        () => (dashboard ?? embedDashboard)?.config,
+        [dashboard, embedDashboard],
+    );
+
     const { data: dashboardComments } = useGetComments(
         dashboardUuid,
         projectUuid,
@@ -321,8 +328,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     // Persisted config, used to seed editable state on load and after save.
     const persistedDateZoomConfig = useMemo(
-        () => normalizeDateZoomConfig(dashboard?.config),
-        [dashboard?.config],
+        () => normalizeDateZoomConfig(currentDashboardConfig),
+        [currentDashboardConfig],
     );
     const [syncedDateZoomConfig, setSyncedDateZoomConfig] =
         useState<DateZoomConfig | null>(null);
@@ -386,24 +393,24 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // Sync date zoom granularities from dashboard config
     // Note: Custom granularities from explores are added by DashboardGranularitySync
     useEffect(() => {
-        if (dashboard?.config?.dateZoomGranularities !== undefined) {
+        if (currentDashboardConfig?.dateZoomGranularities !== undefined) {
             setDateZoomGranularitiesState(
-                dashboard.config.dateZoomGranularities,
+                currentDashboardConfig.dateZoomGranularities,
             );
         } else {
             setDateZoomGranularitiesState(defaultStandardGranularities);
         }
     }, [
-        dashboard?.config?.dateZoomGranularities,
+        currentDashboardConfig?.dateZoomGranularities,
         defaultStandardGranularities,
     ]);
 
     // Sync default date zoom granularity from dashboard config
     useEffect(() => {
         setDefaultDateZoomGranularityState(
-            dashboard?.config?.defaultDateZoomGranularity,
+            currentDashboardConfig?.defaultDateZoomGranularity,
         );
-    }, [dashboard?.config?.defaultDateZoomGranularity]);
+    }, [currentDashboardConfig?.defaultDateZoomGranularity]);
 
     // Reset per-control runtime overrides when the dashboard identity changes;
     // each control's default comes from its persisted granularity. Skip when the
@@ -1253,21 +1260,21 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     useEffect(() => {
         if (isEditMode) return;
         if (
-            dashboard?.config?.defaultDateZoomGranularity &&
-            !dashboard?.config?.isDateZoomDisabled
+            currentDashboardConfig?.defaultDateZoomGranularity &&
+            !currentDashboardConfig?.isDateZoomDisabled
         ) {
             const searchParams = new URLSearchParams(searchRef.current);
             const dateZoomParam = searchParams.get('dateZoom');
             // Only apply default if no URL override is present
             if (!dateZoomParam) {
                 setDateZoomGranularity(
-                    dashboard.config.defaultDateZoomGranularity,
+                    currentDashboardConfig.defaultDateZoomGranularity,
                 );
             }
         }
     }, [
-        dashboard?.config?.defaultDateZoomGranularity,
-        dashboard?.config?.isDateZoomDisabled,
+        currentDashboardConfig?.defaultDateZoomGranularity,
+        currentDashboardConfig?.isDateZoomDisabled,
         isEditMode,
         setDateZoomGranularity,
     ]);


### PR DESCRIPTION
## What

Configurable date zoom controls now render on **embedded** dashboards when `canDateZoom` is enabled. Previously an embed showed only the global "Default zoom" control, never the dashboard's configured date-zoom control pills.

## Why

Embedded dashboards don't load through the `useDashboardQuery` hook — they populate a separate `embedDashboard` state in `DashboardProvider`. All the date-zoom config seeding read `dashboard?.config`, which is always `undefined` for embeds. As a result `dateZoomConfig` fell back to the empty config, so `DateZoomControlPills` had no controls to render and only the Default zoom button appeared.

## How

Added a combined source `currentDashboardConfig = (dashboard ?? embedDashboard)?.config` and used it for the date-zoom seeds in `DashboardProvider`:

- `dateZoomConfig` (the named controls + per-tile targets) — the primary fix
- `dateZoomGranularities` (granularities each control offers)
- `defaultDateZoomGranularity`
- the load-time "apply configured default granularity" effect

The regular (non-embed) path is unchanged: `dashboard` is set there and takes precedence.

## Testing

- Verified against a dashboard whose persisted `config.dateZoomConfig` defines a control with a tile target: the old embed path discarded it (empty config → no pills), the new path surfaces it.
- Frontend typecheck clean.
<img width="1263" height="733" alt="CleanShot 2026-06-25 at 17 19 16" src="https://github.com/user-attachments/assets/2618a1c2-7d8f-49da-a3ec-9a0f581f3cee" />


Relates: GLITCH-225