### PR TITLE
feat(ai): split org AI admin into OrganizationAiAgent scope

### DIFF
--- a/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
+++ b/packages/backend/src/ee/services/AiAgentReviewNotificationService.ts
@@ -71,7 +71,7 @@ export class AiAgentReviewNotificationService {
             .filter((member) =>
                 defineUserAbility(member, []).can(
                     'manage',
-                    subject('AiAgent', { organizationUuid }),
+                    subject('OrganizationAiAgent', { organizationUuid }),
                 ),
             )
             .map((member) => ({

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -51,7 +51,7 @@ export class AiOrganizationSettingsService extends BaseService {
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('AiAgent', {
+                subject('OrganizationAiAgent', {
                     organizationUuid: user.organizationUuid!,
                 }),
             )

--- a/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
+++ b/packages/backend/src/ee/services/AiRouterService/AiRouterService.ts
@@ -82,7 +82,10 @@ export class AiRouterService extends BaseService {
     ): void {
         const ability = this.createAuditedAbility(account);
         if (
-            ability.cannot('manage', subject('AiAgent', { organizationUuid }))
+            ability.cannot(
+                'manage',
+                subject('OrganizationAiAgent', { organizationUuid }),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -93,7 +96,12 @@ export class AiRouterService extends BaseService {
         organizationUuid: string,
     ): void {
         const ability = this.createAuditedAbility(account);
-        if (ability.cannot('view', subject('AiAgent', { organizationUuid }))) {
+        if (
+            ability.cannot(
+                'view',
+                subject('OrganizationAiAgent', { organizationUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
     }

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -234,6 +234,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'AiAgent', {
             organizationUuid: member.organizationUuid,
         });
+        can('view', 'OrganizationAiAgent', {
+            organizationUuid: member.organizationUuid,
+        });
         can('view', 'AiAgentDocument', {
             organizationUuid: member.organizationUuid,
         });
@@ -361,6 +364,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'AiAgent', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'OrganizationAiAgent', {
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'AiAgentDocument', {

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -64,6 +64,7 @@ const BASE_ROLE_SCOPES = {
 
         // Enterprise scopes
         'view:AiAgent',
+        'view:OrganizationAiAgent',
         'view:AiAgentDocument',
         'create:AiAgentThread',
         'view:DataApp', // Project-wide + space-access view (parity with manage:Explore)
@@ -144,6 +145,7 @@ const BASE_ROLE_SCOPES = {
         // `manage:ContentAsCode` and keep self-preview write.
         'manage:ContentAsCode@self',
         'manage:AiAgent',
+        'manage:OrganizationAiAgent',
         'manage:AiAgentDocument',
         'manage:AiAgentThread@self', // User's own threads
     ],
@@ -251,10 +253,12 @@ export const getNonEnterpriseScopesForRole = (
         'view:SpotlightTableConfig',
         'manage:SpotlightTableConfig',
         'view:AiAgent',
+        'view:OrganizationAiAgent',
         'view:AiAgentDocument',
         'view:AiAgentThread',
         'create:AiAgentThread',
         'manage:AiAgent',
+        'manage:OrganizationAiAgent',
         'manage:AiAgentDocument',
         'manage:AiAgentThread',
         'view:ContentAsCode',

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -75,6 +75,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     'MetricsTree',
     'SpotlightTableConfig',
     'AiAgent',
+    'OrganizationAiAgent',
     'AiAgentDocument',
     'AiAgentThread',
     'ContentAsCode',

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -21,6 +21,8 @@ const ORG_ASSIGNABLE_SCOPE_NAMES = [
     'impersonate:User',
     'view:OrganizationDesign',
     'manage:OrganizationDesign',
+    'view:OrganizationAiAgent',
+    'manage:OrganizationAiAgent',
 ];
 
 describe('scope levels', () => {
@@ -41,6 +43,10 @@ describe('scope levels', () => {
         expect(isOrgAssignableScope('manage:SpotlightTableConfig')).toBe(false);
         expect(isOrgAssignableScope('manage:ContentAsCode')).toBe(false);
         expect(isOrgAssignableScope('manage:ExternalConnection')).toBe(false);
+        // The project-level AI agent scopes stay project-assignable; only the
+        // dedicated OrganizationAiAgent scopes are org-assignable.
+        expect(isOrgAssignableScope('view:AiAgent')).toBe(false);
+        expect(isOrgAssignableScope('manage:AiAgent')).toBe(false);
     });
 
     it('keeps every org-assignable scope name backed by a real scope definition', () => {

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -755,15 +755,31 @@ const scopes: Scope[] = [
     // AI Agent
     {
         name: 'view:AiAgent',
-        description: 'View AI agent features',
+        description: 'View AI agents in a project',
         isEnterprise: true,
         group: ScopeGroup.AI,
         getConditions: addDefaultUuidCondition,
     },
     {
         name: 'manage:AiAgent',
-        description: 'Configure AI agent settings',
+        description: 'Create and manage AI agents in a project',
         isEnterprise: true,
+        group: ScopeGroup.AI,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'view:OrganizationAiAgent',
+        description: 'View organization AI settings',
+        isEnterprise: true,
+        level: 'organization',
+        group: ScopeGroup.AI,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'manage:OrganizationAiAgent',
+        description: 'Configure organization AI settings',
+        isEnterprise: true,
+        level: 'organization',
         group: ScopeGroup.AI,
         getConditions: addDefaultUuidCondition,
     },

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -175,6 +175,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('view', 'AiAgent', {
             organizationUuid,
         });
+        can('view', 'OrganizationAiAgent', {
+            organizationUuid,
+        });
         can('view', 'AiAgentDocument', {
             organizationUuid,
         });
@@ -309,6 +312,9 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
         });
         can('manage', 'AiAgent', {
+            organizationUuid,
+        });
+        can('manage', 'OrganizationAiAgent', {
             organizationUuid,
         });
         can('manage', 'AiAgentDocument', {

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -48,6 +48,7 @@ export type CaslSubjectNames =
     | 'JobStatus'
     | 'MetricsTree'
     | 'Organization'
+    | 'OrganizationAiAgent'
     | 'OrganizationDesign'
     | 'OrganizationMemberProfile'
     | 'OrganizationWarehouseCredentials'


### PR DESCRIPTION
## What this does

PR 1 of 2 (base of the stack; #24779 builds on it).

The `AiAgent` CASL subject was overloaded: it gated **both** project-level agent management and org-level AI administration (router config, org AI settings, review-notification recipients). Org grants condition only on `organizationUuid`, so an org grant satisfied project-scoped checks and vice-versa — the two capabilities could not be granted independently.

This keeps `AiAgent` as the **project-level** subject and adds a new **org-level** `OrganizationAiAgent` subject. The org-settings backend checks move to it. No behaviour change — see the per-principal table.

**Scope mapping**

```
Before:  view/manage:AiAgent  → project agents AND org AI settings (conflated)

After:   view/manage:AiAgent             → project agent management   (project-assignable only)
         view/manage:OrganizationAiAgent → org AI settings            (org-assignable, enterprise)
```

## Check sites moved to OrganizationAiAgent

| Check | Subject before | Subject after |
| --- | --- | --- |
| `AiRouterService.assertManage/ViewAiAgent` | `AiAgent {org}` | `OrganizationAiAgent {org}` |
| `AiOrganizationSettingsService.checkManageAiAgentAccess` | `AiAgent {org}` | `OrganizationAiAgent {org}` |
| `AiAgentReviewNotificationService` recipient filter | `AiAgent {org}` | `OrganizationAiAgent {org}` |

Project-level `subject('AiAgent', { projectUuid })` checks in `AiAgentService` are unchanged.

## Who's affected — nobody (reach-preserving)

| Principal | Before | After |
| --- | --- | --- |
| Org admin / developer (system) | org AI settings via `manage:AiAgent{org}` | same — `manage:OrganizationAiAgent{org}` added, `manage:AiAgent` retained |
| Org interactive_viewer (system) | view via `view:AiAgent{org}` | same — `view:OrganizationAiAgent{org}` added |
| Service accounts (ORG_READ / ORG_ADMIN) | view/manage via `AiAgent{org}` | same — `OrganizationAiAgent` added alongside |
| Project custom role (`manage:AiAgent`) | project agents only; no org settings | unchanged (`AiAgent` stays project-assignable) |
| Org custom role | could not hold `AiAgent` (not org-assignable) → no org AI | unchanged; may now opt into `OrganizationAiAgent` |

No `scoped_roles` migration: `AiAgent` was never org-assignable, so no existing custom role references it at the org level (verified against the database).

## Test plan

- [x] `pnpm -F common|backend typecheck` + lint clean
- [x] `pnpm -F common test src/authorization` — 540 pass (role↔scope parity, scope-level, vocabulary-coverage, and org/project ability suites updated for the new subject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
