### PR TITLE
feat(ai): show Ask AI admin settings to project-scoped users

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -30,6 +30,7 @@ const THREAD_UUID = '00000000-0000-0000-0000-000000000006';
 const PROMPT_UUID = '00000000-0000-0000-0000-000000000007';
 const PREVIEW_PROJECT_UUID = '00000000-0000-0000-0000-000000000008';
 const PREVIEW_AGENT_UUID = '00000000-0000-0000-0000-000000000009';
+const OTHER_PROJECT_UUID = '00000000-0000-0000-0000-000000000099';
 const PREVIEW_THREAD_UUID = '00000000-0000-0000-0000-000000000010';
 const COMPILE_JOB_UUID = '00000000-0000-0000-0000-000000000011';
 const WORK_THREAD_UUID = '00000000-0000-0000-0000-000000000012';
@@ -128,6 +129,11 @@ const makeAdminUser = (): SessionUser => ({
             subject: 'AiAgent',
             conditions: { organizationUuid: ORGANIZATION_UUID },
         },
+        {
+            action: 'manage',
+            subject: 'OrganizationAiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
     ]),
     abilityRules: [],
 });
@@ -139,6 +145,49 @@ const makeDeveloperUser = (): SessionUser => ({
         {
             action: 'manage',
             subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'manage',
+            subject: 'OrganizationAiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+    ]),
+});
+
+// Project-scoped AI admin: org member, no org-level OrganizationAiAgent, only
+// project-level manage:AiAgent on PROJECT_UUID. Should see only that project's
+// resources. (manage implies view in CASL.)
+const makeProjectUser = (): SessionUser => ({
+    ...makeAdminUser(),
+    role: OrganizationMemberRole.MEMBER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'AiAgent',
+            conditions: {
+                organizationUuid: ORGANIZATION_UUID,
+                projectUuid: PROJECT_UUID,
+            },
+        },
+    ]),
+});
+
+// Org interactive_viewer-like principal: holds org-wide VIEW of AiAgent and
+// OrganizationAiAgent but no MANAGE anywhere. Must NOT receive org-wide admin
+// reads (regression guard against the view-gated widening).
+const makeOrgViewerUser = (): SessionUser => ({
+    ...makeAdminUser(),
+    role: OrganizationMemberRole.MEMBER,
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'view',
+            subject: 'AiAgent',
+            conditions: { organizationUuid: ORGANIZATION_UUID },
+        },
+        {
+            action: 'view',
+            subject: 'OrganizationAiAgent',
             conditions: { organizationUuid: ORGANIZATION_UUID },
         },
     ]),
@@ -257,6 +306,7 @@ const makeService = ({
                 .fn()
                 .mockResolvedValue(PREVIEW_AGENT_UUID),
             findExploresFromCache: jest.fn().mockResolvedValue({}),
+            getAllByOrganizationUuid: jest.fn().mockResolvedValue([]),
             ...projectModel,
         },
         aiAgentService: {
@@ -363,7 +413,7 @@ describe('AiAgentAdminService.getPromptActivity', () => {
         await expect(
             service.getPromptActivity(user, PROJECT_UUID, 14),
         ).rejects.toThrow(
-            'Insufficient permissions to access organization-wide AI agent data',
+            'Insufficient permissions to access AI agent features',
         );
         expect(findAdminPromptActivity).not.toHaveBeenCalled();
     });
@@ -1123,6 +1173,95 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
         expect(
             aiAgentReviewClassifierModel.listRemediationEvents,
         ).not.toHaveBeenCalled();
+    });
+});
+
+describe('AiAgentAdminService project-scoped read access', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const projectModel = {
+        getAllByOrganizationUuid: jest
+            .fn()
+            .mockResolvedValue([
+                { projectUuid: PROJECT_UUID },
+                { projectUuid: OTHER_PROJECT_UUID },
+            ]),
+    };
+
+    it('lets a project-scoped user read an item in a project they can access', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest
+                .fn()
+                .mockResolvedValue(
+                    makeReviewItem({ projectUuid: PROJECT_UUID }),
+                ),
+            listRemediationEvents: jest.fn().mockResolvedValue([]),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            projectModel,
+        });
+
+        // No remediation → empty feed, but the per-item project check passes.
+        const activity = await service.getReviewItemActivity(
+            makeProjectUser(),
+            'fingerprint-1',
+        );
+        expect(activity.events).toEqual([]);
+    });
+
+    it('forbids a project-scoped user from an item in another project', async () => {
+        const aiAgentReviewClassifierModel = {
+            getReviewItem: jest
+                .fn()
+                .mockResolvedValue(
+                    makeReviewItem({ projectUuid: OTHER_PROJECT_UUID }),
+                ),
+        };
+        const service = makeService({
+            aiAgentReviewClassifierModel,
+            projectModel,
+        });
+
+        await expect(
+            service.getReviewItemActivity(makeProjectUser(), 'fingerprint-1'),
+        ).rejects.toThrow(
+            'Insufficient permissions to access this AI agent resource',
+        );
+    });
+
+    it('forbids a user with no AI access at all', async () => {
+        const service = makeService({ projectModel });
+        const user = {
+            ...makeAdminUser(),
+            ability: new Ability<PossibleAbilities>([]),
+        };
+
+        await expect(
+            service.getReviewItemActivity(user, 'fingerprint-1'),
+        ).rejects.toThrow(
+            'Insufficient permissions to access AI agent features',
+        );
+    });
+
+    it('forbids an org view-only principal (no widening to interactive_viewer)', async () => {
+        // Holds org-wide view:AiAgent + view:OrganizationAiAgent but no manage.
+        // resolveReadScope gates on manage, so this principal must be denied
+        // rather than handed {kind:'all'} cross-project admin reads.
+        const service = makeService({ projectModel });
+
+        await expect(
+            service.getReviewItemActivity(makeOrgViewerUser(), 'fingerprint-1'),
+        ).rejects.toThrow(
+            'Insufficient permissions to access AI agent features',
+        );
+        await expect(
+            service.getAllThreads(makeOrgViewerUser()),
+        ).rejects.toThrow(
+            'Insufficient permissions to access AI agent features',
+        );
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -124,6 +124,16 @@ type ProjectWritebackAccess =
 
 type ProjectWritebackAccessEntry = [string, ProjectWritebackAccess];
 
+/**
+ * Read-access scope for the org-wide AI admin surfaces (threads, agents,
+ * reviews). `all` = org principal with `view:OrganizationAiAgent`; `projects`
+ * = principal limited to the projects where they hold project-level
+ * `view:AiAgent`.
+ */
+type AiAdminReadScope =
+    | { kind: 'all' }
+    | { kind: 'projects'; projectUuids: string[] };
+
 const terminalReviewStatuses = new Set<AiAgentReviewItemStatus>([
     'resolved',
     'dismissed',
@@ -379,7 +389,7 @@ export class AiAgentAdminService extends BaseService {
         if (
             auditedAbility.cannot(
                 'manage',
-                subject('AiAgent', {
+                subject('OrganizationAiAgent', {
                     organizationUuid,
                 }),
             )
@@ -391,8 +401,92 @@ export class AiAgentAdminService extends BaseService {
     }
 
     /**
-     * Get all threads across all agents in the organization
-     * Only accessible by organization admins
+     * Resolve which projects a principal may read across the org-wide AI admin
+     * surfaces (threads, agents, reviews, prompt activity). These are
+     * administration surfaces, so access requires the MANAGE capability — org
+     * admins/developers (`manage:OrganizationAiAgent`) get everything; otherwise
+     * the principal is scoped to the projects where they hold `manage:AiAgent`.
+     * Mirrors `OrganizationService.getProjects` access filtering. Using `manage`
+     * (not `view`) is deliberate: org `view:AiAgent`/`view:OrganizationAiAgent`
+     * is granted org-wide down to interactive_viewer, so a `view` check would
+     * hand every interactive_viewer full cross-project org-wide admin reads.
+     * Throws when the principal has neither org nor any project AI-admin access.
+     */
+    private async resolveReadScope(
+        user: SessionUser,
+        organizationUuid: string,
+    ): Promise<AiAdminReadScope> {
+        const ability = this.createAuditedAbility(user);
+        if (
+            ability.can(
+                'manage',
+                subject('OrganizationAiAgent', { organizationUuid }),
+            )
+        ) {
+            return { kind: 'all' };
+        }
+
+        const projects =
+            await this.projectModel.getAllByOrganizationUuid(organizationUuid);
+        const projectUuids = projects
+            .filter((project) =>
+                ability.can(
+                    'manage',
+                    subject('AiAgent', {
+                        organizationUuid,
+                        projectUuid: project.projectUuid,
+                    }),
+                ),
+            )
+            .map((project) => project.projectUuid);
+
+        if (projectUuids.length === 0) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access AI agent features',
+            );
+        }
+        return { kind: 'projects', projectUuids };
+    }
+
+    /** Narrows admin filters to a principal's readable projects. */
+    private static restrictFiltersToScope(
+        scope: AiAdminReadScope,
+        filters: AiAgentAdminFilters | undefined,
+    ): { filters: AiAgentAdminFilters | undefined; empty: boolean } {
+        if (scope.kind === 'all') {
+            return { filters, empty: false };
+        }
+        const allowed = new Set(scope.projectUuids);
+        const requested = filters?.projectUuids;
+        const projectUuids =
+            requested && requested.length > 0
+                ? requested.filter((uuid) => allowed.has(uuid))
+                : scope.projectUuids;
+        return {
+            filters: { ...filters, projectUuids },
+            empty: projectUuids.length === 0,
+        };
+    }
+
+    /** Per-item guard so project-scoped principals can't reach other projects. */
+    private static assertProjectInScope(
+        scope: AiAdminReadScope,
+        projectUuid: string | null,
+    ): void {
+        if (scope.kind === 'all') {
+            return;
+        }
+        if (projectUuid && scope.projectUuids.includes(projectUuid)) {
+            return;
+        }
+        throw new ForbiddenError(
+            'Insufficient permissions to access this AI agent resource',
+        );
+    }
+
+    /**
+     * Get all threads across all agents in the organization.
+     * Org principals see all; project-scoped principals see only their projects.
      */
     async getAllThreads(
         user: SessionUser,
@@ -405,16 +499,20 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        const scope = await this.resolveReadScope(user, organizationUuid);
+        const { filters: scopedFilters, empty } =
+            AiAgentAdminService.restrictFiltersToScope(scope, filters);
+        if (empty) {
+            return { data: { threads: [] } };
+        }
 
         // TODO: Check if filter contains userUuid and check if they exist in the organization
         // TODO: Check if filter contains agentUuid and check if they exist in the organization
-        // TODO: Check if filter contains projectUuid and check if they exist in the organization
 
         return this.aiAgentModel.findAdminThreadsPaginated({
             organizationUuid,
             paginateArgs,
-            filters,
+            filters: scopedFilters,
             sort,
         });
     }
@@ -429,7 +527,8 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        const scope = await this.resolveReadScope(user, organizationUuid);
+        AiAgentAdminService.assertProjectInScope(scope, projectUuid);
 
         const boundedDays = Math.max(1, Math.min(days, 30));
 
@@ -445,9 +544,13 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        const scope = await this.resolveReadScope(user, organizationUuid);
         return this.aiAgentModel.findAllAgents({
             organizationUuid,
+            filter:
+                scope.kind === 'projects'
+                    ? { projectFilter: { projectUuids: scope.projectUuids } }
+                    : undefined,
         });
     }
 
@@ -489,12 +592,21 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        const scope = await this.resolveReadScope(user, organizationUuid);
 
-        const items = await this.aiAgentReviewClassifierModel.listReviewItems({
-            organizationUuid,
-            statuses,
-        });
+        const allItems =
+            await this.aiAgentReviewClassifierModel.listReviewItems({
+                organizationUuid,
+                statuses,
+            });
+        const items =
+            scope.kind === 'all'
+                ? allItems
+                : allItems.filter(
+                      (item) =>
+                          item.projectUuid !== null &&
+                          scope.projectUuids.includes(item.projectUuid),
+                  );
 
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.areReviewsEnabled(user),
@@ -1630,13 +1742,19 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        const scope = await this.resolveReadScope(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
                 fingerprint,
             );
+        if (reviewItem) {
+            AiAgentAdminService.assertProjectInScope(
+                scope,
+                reviewItem.projectUuid,
+            );
+        }
         if (!reviewItem?.remediation) {
             return {
                 events: [],
@@ -2127,13 +2245,19 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        const scope = await this.resolveReadScope(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
                 fingerprint,
             );
+        if (reviewItem) {
+            AiAgentAdminService.assertProjectInScope(
+                scope,
+                reviewItem.projectUuid,
+            );
+        }
         if (!reviewItem?.linkedPrUrl) {
             throw new NotFoundError(
                 'No pull request is linked to this review item',
@@ -2174,7 +2298,9 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        // getReviewItem (delegated below) enforces the per-item project scope;
+        // resolve here too so a no-access principal fails before the lookup.
+        await this.resolveReadScope(user, organizationUuid);
 
         const remediation =
             await this.aiAgentReviewClassifierModel.findReviewRemediationByPreviewThread(
@@ -2198,7 +2324,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        const scope = await this.resolveReadScope(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2208,6 +2334,7 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
+        AiAgentAdminService.assertProjectInScope(scope, reviewItem.projectUuid);
 
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.areReviewsEnabled(user),
@@ -2255,7 +2382,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkReviewAccess(user, organizationUuid);
+        const scope = await this.resolveReadScope(user, organizationUuid);
 
         const reviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
@@ -2265,6 +2392,7 @@ export class AiAgentAdminService extends BaseService {
         if (!reviewItem) {
             throw new NotFoundError('Review item not found');
         }
+        AiAgentAdminService.assertProjectInScope(scope, reviewItem.projectUuid);
         const trackPreviewViewed = (
             available: boolean,
             strategy: AiAgentReviewItemWritebackStrategy | null,

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -7,7 +7,7 @@ import {
     useAiAgentAdminProjectPromptActivity,
     useAiAgentAdminReviewItems,
 } from '../../ee/features/aiCopilot/hooks/useAiAgentAdmin';
-import { useAiAgentPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentOrgPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 
@@ -22,7 +22,7 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
     const navigate = useNavigate();
     const [isPreviewOpen, setIsPreviewOpen] = useState(false);
     const isVisible = useAiAgentButtonVisibility();
-    const canViewReviews = useAiAgentPermission({ action: 'manage' });
+    const canViewReviews = useAiAgentOrgPermission({ action: 'manage' });
     const aiOrganizationSettingsQuery = useAiOrganizationSettings();
     const reviewsEnabled =
         aiOrganizationSettingsQuery.data?.aiAgentReviewsEnabled === true;

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -6,7 +6,7 @@ import {
 import { Button, getDefaultZIndex, Indicator, Menu } from '@mantine-8/core';
 import { IconBell } from '@tabler/icons-react';
 import { Fragment, type FC, useMemo } from 'react';
-import { useAiAgentPermission } from '../../../ee/features/aiCopilot/hooks/useAiAgentPermission';
+import { useAiAgentOrgPermission } from '../../../ee/features/aiCopilot/hooks/useAiAgentPermission';
 import { useDashboardCommentsCheck } from '../../../features/comments';
 import {
     AiReviewNotifications,
@@ -49,7 +49,7 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
     const hasDashboardCommentsNotifications =
         dashboardCommentsNotifications &&
         dashboardCommentsNotifications.length > 0;
-    const canViewAiReviews = useAiAgentPermission({ action: 'manage' });
+    const canViewAiReviews = useAiAgentOrgPermission({ action: 'manage' });
     const { data: aiReviewNotifications } = useGetNotifications(
         NotificationResourceType.AiReview,
         !!canViewAiReviews,

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -30,7 +30,10 @@ import {
 import { AiAgentIcon } from '../../../features/aiCopilot/components/AiAgentIcon';
 import { usePendingPrompt } from '../../../features/aiCopilot/components/PendingPromptContext/PendingPromptContext';
 import { useAiAgentAdminReviewItems } from '../../../features/aiCopilot/hooks/useAiAgentAdmin';
-import { useAiAgentPermission } from '../../../features/aiCopilot/hooks/useAiAgentPermission';
+import {
+    useAiAgentOrgPermission,
+    useAiAgentPermission,
+} from '../../../features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiOrganizationSettings } from '../../../features/aiCopilot/hooks/useAiOrganizationSettings';
 import { useAiRouterConfig } from '../../../features/aiCopilot/hooks/useAiRouter';
 import {
@@ -75,7 +78,7 @@ const AiSearchBoxInner: FC<Props> = ({
         action: 'manage',
         projectUuid,
     });
-    const canViewReviews = useAiAgentPermission({
+    const canViewReviews = useAiAgentOrgPermission({
         action: 'manage',
     });
     const showReviewsPromo =

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentPermission.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentPermission.ts
@@ -17,3 +17,17 @@ export const useAiAgentPermission = ({
         }),
     );
 };
+
+export const useAiAgentOrgPermission = ({
+    action,
+}: {
+    action: 'manage' | 'view';
+}) => {
+    const { user } = useApp();
+    return user.data?.ability.can(
+        action,
+        subject('OrganizationAiAgent', {
+            organizationUuid: user.data?.organizationUuid,
+        }),
+    );
+};

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -49,6 +49,11 @@ export type SettingsContext = {
     isServiceAccountsEnabled: boolean;
     isAiCopilotEnabledOrTrial: boolean;
     shouldShowAiAgentReviews: boolean;
+    // Org-level AI settings access (router config, org settings, review queue).
+    canManageOrgAiAgent: boolean;
+    // True when the user can manage org AI settings OR has AI agent access in at
+    // least one project they can reach. Gates visibility of the "Ask AI" area.
+    hasAnyAiAgentAccess: boolean;
     isAiOrganizationSettingsLoading: boolean;
     dataAppsFlag: FeatureFlag | undefined;
     embeddingEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
 import { useIsGitProject } from '../../components/Explorer/WriteBackModal/hooks';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
@@ -5,6 +6,7 @@ import useApp from '../../providers/App/useApp';
 import { useOrganization } from '../organization/useOrganization';
 import { useActiveProjectUuid } from '../useActiveProject';
 import { useProject } from '../useProject';
+import { useProjects } from '../useProjects';
 import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { type SettingsContext } from './types';
 
@@ -101,6 +103,32 @@ export const useSettingsContext = (): SettingsContext => {
 
     const isGitProject = useIsGitProject(activeProjectUuid ?? '');
 
+    // "Ask AI" settings are visible to org AI admins (all projects) and to
+    // project-scoped AI admins (only the projects they can reach). These are
+    // administration surfaces, so visibility mirrors the backend MANAGE gate
+    // (resolveReadScope): `manage:OrganizationAiAgent` org-wide, else
+    // `manage:AiAgent` over the access-filtered project list. Using `manage`
+    // (not `view`) keeps interactive_viewers — who hold org-wide view:AiAgent —
+    // out, matching what the backend actually authorizes.
+    const { data: projects } = useProjects();
+    const organizationUuid = organization?.organizationUuid;
+    const canManageOrgAiAgent =
+        user?.ability?.can(
+            'manage',
+            subject('OrganizationAiAgent', { organizationUuid }),
+        ) ?? false;
+    const hasAnyAiAgentAccess =
+        canManageOrgAiAgent ||
+        (projects ?? []).some((p) =>
+            user?.ability?.can(
+                'manage',
+                subject('AiAgent', {
+                    organizationUuid,
+                    projectUuid: p.projectUuid,
+                }),
+            ),
+        );
+
     const allowPasswordAuthentication =
         !health?.auth.disablePasswordAuthentication;
 
@@ -143,6 +171,8 @@ export const useSettingsContext = (): SettingsContext => {
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        canManageOrgAiAgent,
+        hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading:
             aiOrganizationSettingsQuery.isInitialLoading,
         dataAppsFlag,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -77,6 +77,8 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        canManageOrgAiAgent,
+        hasAnyAiAgentAccess,
         embeddingEnabled,
         dataAppsFlag,
         isGitProject,
@@ -376,24 +378,21 @@ export const useSettingsNavigation = (
             });
         }
 
-        if (
-            isAiCopilotEnabledOrTrial &&
-            ability?.can(
-                'manage',
-                subject('AiAgent', {
-                    organizationUuid: organization?.organizationUuid,
-                }),
-            )
-        ) {
-            const aiChildren: SettingsNavigationItem[] = [
-                {
+        if (isAiCopilotEnabledOrTrial && hasAnyAiAgentAccess) {
+            const aiChildren: SettingsNavigationItem[] = [];
+            // General is org-wide config (router, org settings) — org admins only.
+            if (canManageOrgAiAgent) {
+                aiChildren.push({
                     label: 'General',
                     to: '/generalSettings/ai/general',
                     icon: IconSettings,
                     keywords: ['ai', 'settings'],
                     children: [],
                     exact: true,
-                },
+                });
+            }
+            // Threads & Agents are project-filtered for project-scoped users.
+            aiChildren.push(
                 {
                     label: 'Threads',
                     to: '/generalSettings/ai/threads',
@@ -410,7 +409,7 @@ export const useSettingsNavigation = (
                     children: [],
                     exact: true,
                 },
-            ];
+            );
 
             if (shouldShowAiAgentReviews) {
                 aiChildren.push({
@@ -795,6 +794,8 @@ export const useSettingsNavigation = (
         isServiceAccountsEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        canManageOrgAiAgent,
+        hasAnyAiAgentAccess,
         isEmbeddingEnabled,
         isDataAppsEnabled,
         isGitProject,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -124,6 +124,8 @@ const Settings: FC = () => {
         dataAppsFlag,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        canManageOrgAiAgent,
+        hasAnyAiAgentAccess,
         isAiOrganizationSettingsLoading,
         showImpersonationPanel,
         isLeaveOrganizationEnabled,
@@ -544,23 +546,27 @@ const Settings: FC = () => {
             });
         }
 
-        if (
-            isAiCopilotEnabledOrTrial &&
-            user?.ability.can(
-                'manage',
-                subject('AiAgent', {
-                    organizationUuid: organization?.organizationUuid,
-                }),
-            )
-        ) {
+        if (isAiCopilotEnabledOrTrial && hasAnyAiAgentAccess) {
             allowedRoutes.push({
                 path: '/ai',
-                element: <Navigate to="/generalSettings/ai/general" replace />,
+                element: (
+                    <Navigate
+                        to={
+                            canManageOrgAiAgent
+                                ? '/generalSettings/ai/general'
+                                : '/generalSettings/ai/threads'
+                        }
+                        replace
+                    />
+                ),
             });
-            allowedRoutes.push({
-                path: '/ai/general',
-                element: <AiGeneralSettingsPage />,
-            });
+            // General is org-wide config (router, org settings) — org admins only.
+            if (canManageOrgAiAgent) {
+                allowedRoutes.push({
+                    path: '/ai/general',
+                    element: <AiGeneralSettingsPage />,
+                });
+            }
             allowedRoutes.push({
                 path: '/ai/threads',
                 element: (
@@ -640,6 +646,8 @@ const Settings: FC = () => {
         isLeaveOrganizationEnabled,
         isAiCopilotEnabledOrTrial,
         shouldShowAiAgentReviews,
+        canManageOrgAiAgent,
+        hasAnyAiAgentAccess,
     ]);
     const routeElements = useRoutes(routes);
 


### PR DESCRIPTION
## Summary

PR 2 of 2. Surfaces the org-wide AI admin pages (Threads, Agents, Reviews, prompt activity) to **project-scoped AI admins**, filtered to the projects they can manage. Previously these surfaces were org-admin-only and hidden from anyone who only administers AI in specific projects.

Stacks on #24778, which adds the `OrganizationAiAgent` scope this PR gates on.

## Changes

**Backend** — `AiAgentAdminService`
- New `resolveReadScope(user)` → `{ kind: 'all' }` for org AI admins (`manage:OrganizationAiAgent`), else `{ kind: 'projects', projectUuids }` filtered by `manage:AiAgent` over the org's projects (mirrors `OrganizationService.getProjects`). Throws when the principal has neither.
- `getAllThreads` (project allowlist via `filters.projectUuids`, empty-intersection short-circuits to `[]` so the model never falls back to all rows), `listAgents` (project allowlist), `listReviewItems` (in-memory filter), and `getPromptActivity` are now project-aware.
- The five per-item review getters call `assertProjectInScope(scope, item.projectUuid)` — guards fingerprint IDOR (an off-limits item returns 403, never its body).
- Writes (status / reorder / assignee / writeback / retest), review-signals, and notification settings stay org-only.

**Frontend**
- `useSettingsContext` computes `canManageOrgAiAgent` and `hasAnyAiAgentAccess` (org `manage:OrganizationAiAgent` OR project `manage:AiAgent` over the user's projects).
- The settings nav + routes show "Ask AI" for project-scoped users; **General** (router / org config) stays org-only; the `/ai` redirect lands project-scoped users on Threads.
- Org gating repointed to `OrganizationAiAgent` via a new `useAiAgentOrgPermission` hook (NavBar review badges, AiSearchBox).

## Read-scope resolution

```
manage:OrganizationAiAgent (org)   → { kind: 'all' }       → every project
  else manage:AiAgent per project   → { kind: 'projects' }  → only those projects
  else                              → ForbiddenError
```

Gating on `manage` (not `view`) is deliberate: org `view:AiAgent` / `view:OrganizationAiAgent` is granted org-wide down to interactive_viewer, so a `view` gate would hand every interactive_viewer full cross-project admin reads. `manage` preserves the prior admin/developer floor.

## Access matrix (verified live against a two-project org)

```
Principal                          Threads / Agents / Reviews / Activity
org admin / developer              all projects
project role (manage:AiAgent P)    project P only
org interactive_viewer / editor    denied (403)
no AI access                       denied (403)
```

## Test plan

- [x] backend typecheck + lint clean; frontend typecheck clean (only pre-existing jest-dom matcher errors in untouched test files)
- [x] `AiAgentAdminService.test.ts` — 38 pass (project-scoped allow, cross-project 403, and a regression test asserting an org view-only principal is denied)
- [x] Multi-agent review + live testing: 50/50 endpoint cases pass; no cross-project leak across threads / agents / reviews / per-item getters / prompt-activity; org-only writes / router / settings return 403 for project-scoped users; org admin still sees all projects
- [ ] Manual: as a project member with a `manage:AiAgent` custom role, Settings → Ask AI shows Threads/Agents/Reviews filtered to that project, General hidden

## Notes / follow-ups

- `listReviewItems` applies the model `LIMIT` to the org-wide set before the in-memory project filter — push `projectUuids` into the query for large orgs (latent; cannot leak, only under-fetch).
- Per-item getters return 403 (vs 404) for off-limits fingerprints — a benign existence oracle on non-enumerable ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
