### PR TITLE
fix(custom-roles): show correct scopes after switching role level

### DIFF
--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -159,9 +159,12 @@ const ScopePanel: FC<{
 export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [debouncedSearchTerm] = useDebouncedValue(searchTerm, 300);
-    const [selectedGroup, setSelectedGroup] = useState<GroupedScopes | null>(
-        null,
-    );
+    // Store the selected group's key, not the object. The group objects are
+    // rebuilt (with fresh scope lists) whenever `level` or the search term
+    // changes, so holding the object would render a stale group's scopes.
+    const [selectedGroupKey, setSelectedGroupKey] = useState<
+        GroupedScopes['group'] | null
+    >(null);
 
     const allGroupedScopes = useMemo(
         () => getScopesByGroup(true, level),
@@ -174,16 +177,15 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
     );
 
     const effectiveSelectedGroup = useMemo(() => {
-        // If user has selected a group and it's still in filtered results, use it
-        if (
-            selectedGroup &&
-            filteredScopes.find((g) => g.group === selectedGroup.group)
-        ) {
-            return selectedGroup;
-        }
-        // Otherwise, use the first available group (or null if none)
-        return filteredScopes[0] || null;
-    }, [selectedGroup, filteredScopes]);
+        // Always resolve from the freshly-built groups so a level/search change
+        // can't leave us rendering a stale group object. Fall back to the first
+        // available group (or null if none).
+        return (
+            filteredScopes.find((g) => g.group === selectedGroupKey) ??
+            filteredScopes[0] ??
+            null
+        );
+    }, [selectedGroupKey, filteredScopes]);
 
     const totalScopes = allGroupedScopes.reduce(
         (acc, group) => acc + group.scopes.length,
@@ -321,7 +323,9 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({ form, level }) => {
                                                     group.group
                                                 }
                                                 onClick={() =>
-                                                    setSelectedGroup(group)
+                                                    setSelectedGroupKey(
+                                                        group.group,
+                                                    )
                                                 }
                                                 selectedCount={
                                                     groupSelectedCount


### PR DESCRIPTION
## Summary

When editing a custom role, opening a scope group (e.g. **AI**), then switching the role **level** (Organization ↔ Project), the right-hand panel showed **0 selected** even though that group had scopes selected — while the left sidebar count for the same group correctly showed e.g. **12**. Switching to another group and back fixed it.

Stacks on #24779. Only affects the scope selector after a level/search change while a group is open; the persisted role data was always correct.

## Root cause

`ScopeSelector` stored the entire selected-group **object** in state. The grouped-scope objects are rebuilt with fresh, per-level scope lists whenever `level` or the search term changes, but `effectiveSelectedGroup` returned the **stale** object as long as a group with the same key still existed — and `AI` exists at both levels:

```ts
// effectiveSelectedGroup — returned the stale object, not the rebuilt one
if (selectedGroup && filteredScopes.find((g) => g.group === selectedGroup.group)) {
    return selectedGroup; // old level's scope names
}
```

So `ScopePanel` rendered the previous level's scope names, which the level switch had just re-derived to unchecked → nothing selected. The sidebar count is computed from the fresh `filteredScopes`, so the two disagreed. Clicking another group called `setSelectedGroup(freshObject)`, which healed the display.

## Fix

Store the group **key** instead of the object and resolve the active group from the freshly-built `filteredScopes` during render, so a level/search change can never leave a stale group object on screen.

- `ScopeSelector.tsx` — `selectedGroup: GroupedScopes` state → `selectedGroupKey: GroupedScopes['group']`; `effectiveSelectedGroup` now always `filteredScopes.find(g => g.group === selectedGroupKey) ?? filteredScopes[0] ?? null`; the group click stores `group.group`.

## Disagreement that the fix removes

```
group "AI", after Org → Project switch
                 before fix          after fix
  sidebar count   12  ✓ (fresh data)   12  ✓
  right panel      0  ✗ (stale object) 12  ✓
```

## Test plan

- [x] `pnpm -F frontend typecheck` (no ScopeSelector errors) + lint clean
- [ ] Manual repro: duplicate the Developer system role at Organization level → open AI → switch to Project level → the 12 project AI scopes show as selected (previously 0); sidebar and panel agree
- [ ] Manual: search filtering still selects/restores the right group; switching groups still works

## Related (not fixed here)

The edit/save path silently self-heals mis-leveled scopes in the DB: mis-leveled scopes load as unselected, and the first save diffs against the original list so they land in `scopes.remove` (the remove path isn't level-validated, unlike the add path's `validateScopesLevel`). Net: bad data is stripped on the next save with no warning. Worth a separate ticket — this PR only fixes the display bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
