### PR TITLE
test(date-zoom): lock in config persistence and tileTargets narrowing

### DIFF
--- a/packages/api-tests/tests/dashboard.test.ts
+++ b/packages/api-tests/tests/dashboard.test.ts
@@ -6,11 +6,14 @@ import {
     DashboardChartTile,
     DashboardTile,
     DashboardTileTypes,
+    DateGranularity,
+    DateZoomConfig,
     isDashboardVersionedFields,
     SavedChart,
     SEED_PROJECT,
     UpdateDashboard,
 } from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import { ApiClient } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import { chartMock, dashboardMock } from '../helpers/mocks';
@@ -438,6 +441,194 @@ describe('Lightdash dashboard', () => {
             }>(`${apiUrl}/projects/${projectUuid}/spaces`);
             const spaceUuids = spacesResponse.body.results.map((s) => s.uuid);
             expect(spaceUuids).toContain(dashboard.spaceUuid);
+        });
+    });
+
+    describe('Date zoom config', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const emptyFilters = {
+            dimensions: [],
+            metrics: [],
+            tableCalculations: [],
+        };
+
+        const dateZoomTarget = (controlUuid: string) => ({
+            controlUuid,
+            fieldId: 'orders_order_date_month',
+            tableName: 'orders',
+        });
+
+        const controlConfig = (
+            controlUuid: string,
+            tileUuids: string[],
+        ): DateZoomConfig => ({
+            controls: [
+                {
+                    uuid: controlUuid,
+                    name: uniqueName('Revenue zoom'),
+                    granularity: DateGranularity.MONTH,
+                },
+            ],
+            tileTargets: Object.fromEntries(
+                tileUuids.map((tileUuid) => [
+                    tileUuid,
+                    dateZoomTarget(controlUuid),
+                ]),
+            ),
+        });
+
+        async function getDashboard(uuid: string): Promise<Dashboard> {
+            const resp = await admin.get<{ results: Dashboard }>(
+                `${apiUrl}/dashboards/${uuid}`,
+            );
+            expect(resp.status).toBe(200);
+            return resp.body.results;
+        }
+
+        // Creates a dashboard with two saved-chart tiles and returns the tiles
+        // carrying their backend-assigned uuids, so tests can build a
+        // tileTargets map keyed by real tile uuids.
+        async function createDashboardWithTwoChartTiles(): Promise<{
+            dashboardUuid: string;
+            tiles: DashboardTile[];
+        }> {
+            const dashboard = await createDashboard(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('Date zoom dashboard'),
+            });
+            tracker.trackDashboard(dashboard.uuid);
+
+            const charts = await Promise.all(
+                [0, 1].map(async () => {
+                    const resp = await admin.post<{ results: SavedChart }>(
+                        `${apiUrl}/projects/${projectUuid}/saved`,
+                        {
+                            ...chartMock,
+                            name: uniqueName('Date zoom chart'),
+                            dashboardUuid: dashboard.uuid,
+                            spaceUuid: null,
+                        },
+                    );
+                    expect(resp.status).toBe(200);
+                    return resp.body.results;
+                }),
+            );
+
+            const updated = await updateDashboard(admin, dashboard.uuid, {
+                tiles: charts.map((chart, index) => ({
+                    tabUuid: undefined,
+                    type: DashboardTileTypes.SAVED_CHART,
+                    x: 0,
+                    y: index * 5,
+                    h: 5,
+                    w: 5,
+                    properties: {
+                        savedChartUuid: chart.uuid,
+                    },
+                })),
+                tabs: [],
+                filters: emptyFilters,
+            });
+
+            expect(updated.tiles).toHaveLength(2);
+            return { dashboardUuid: dashboard.uuid, tiles: updated.tiles };
+        }
+
+        it('persists dateZoomConfig through create and get', async () => {
+            const { dashboardUuid, tiles } =
+                await createDashboardWithTwoChartTiles();
+            const controlUuid = randomUUID();
+            const dateZoomConfig = controlConfig(controlUuid, [
+                tiles[0].uuid,
+                tiles[1].uuid,
+            ]);
+
+            await updateDashboard(admin, dashboardUuid, {
+                tiles,
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            const dashboard = await getDashboard(dashboardUuid);
+            expect(dashboard.config?.dateZoomConfig).toEqual(dateZoomConfig);
+        });
+
+        it('narrows tileTargets to surviving tiles when a tile is removed', async () => {
+            const { dashboardUuid, tiles } =
+                await createDashboardWithTwoChartTiles();
+            const controlUuid = randomUUID();
+            const dateZoomConfig = controlConfig(controlUuid, [
+                tiles[0].uuid,
+                tiles[1].uuid,
+            ]);
+
+            await updateDashboard(admin, dashboardUuid, {
+                tiles,
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            // Remove the second tile but resend the same config (still
+            // referencing both). The backend narrowing drops the orphaned
+            // target without any frontend wiring.
+            await updateDashboard(admin, dashboardUuid, {
+                tiles: [tiles[0]],
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            const dashboard = await getDashboard(dashboardUuid);
+            const targets = dashboard.config?.dateZoomConfig?.tileTargets ?? {};
+            expect(Object.keys(targets)).toEqual([tiles[0].uuid]);
+            expect(targets[tiles[1].uuid]).toBeUndefined();
+            // Narrowing touches targets only; the control is left for the
+            // frontend prune to remove.
+            expect(dashboard.config?.dateZoomConfig?.controls).toHaveLength(1);
+        });
+
+        it('drops all targets but keeps controls when every tile is removed', async () => {
+            const { dashboardUuid, tiles } =
+                await createDashboardWithTwoChartTiles();
+            const controlUuid = randomUUID();
+            const dateZoomConfig = controlConfig(controlUuid, [
+                tiles[0].uuid,
+                tiles[1].uuid,
+            ]);
+
+            await updateDashboard(admin, dashboardUuid, {
+                tiles,
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            await updateDashboard(admin, dashboardUuid, {
+                tiles: [],
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            const dashboard = await getDashboard(dashboardUuid);
+            expect(dashboard.config?.dateZoomConfig?.tileTargets).toEqual({});
+            expect(dashboard.config?.dateZoomConfig?.controls).toHaveLength(1);
+        });
+
+        it('omits dateZoomConfig for dashboards that never set one', async () => {
+            const { dashboardUuid, tiles } =
+                await createDashboardWithTwoChartTiles();
+
+            await updateDashboard(admin, dashboardUuid, {
+                tiles,
+                tabs: [],
+                filters: emptyFilters,
+            });
+
+            const dashboard = await getDashboard(dashboardUuid);
+            expect(dashboard.config?.dateZoomConfig).toBeUndefined();
         });
     });
 });

--- a/packages/api-tests/tests/embedDashboard.test.ts
+++ b/packages/api-tests/tests/embedDashboard.test.ts
@@ -1,6 +1,15 @@
-import { CreateEmbedJwt, SEED_PROJECT, UpdateEmbed } from '@lightdash/common';
+import {
+    CreateEmbedJwt,
+    DashboardTileTypes,
+    DateGranularity,
+    DateZoomConfig,
+    SEED_PROJECT,
+    UpdateEmbed,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
+import { uniqueName } from '../helpers/test-isolation';
 
 const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
 
@@ -367,6 +376,180 @@ describe('Embed Dashboard JWT API', () => {
                 // Should fail - no JWT token provided
                 expect(resp.status).toBe(403);
             });
+        });
+    });
+
+    // The embed dashboard payload must surface the persisted dateZoomConfig:
+    // embedded dashboards seed their date-zoom controls from this, so if the
+    // backend stopped returning it the embed picker would silently lose its
+    // configured controls.
+    describe('Date zoom config in embed payload', () => {
+        const apiV1 = '/api/v1';
+        let embedDashboardUuid: string;
+        let dateZoomConfig: DateZoomConfig;
+        let snapshot: {
+            dashboardUuids?: string[];
+            allowAllDashboards?: boolean;
+            chartUuids?: string[];
+            allowAllCharts?: boolean;
+        };
+
+        beforeAll(async () => {
+            if (!embedEnabled) return;
+
+            // Snapshot the embed config so afterAll can restore it.
+            const snap = await getEmbedConfig(admin);
+            snapshot = snap.body.results;
+
+            // Create a throwaway dashboard with one chart tile.
+            const dashResp = await admin.post<Body<{ uuid: string }>>(
+                `${apiV1}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+                { name: uniqueName('Embed date zoom'), tiles: [], tabs: [] },
+            );
+            expect(dashResp.status).toBe(201);
+            embedDashboardUuid = dashResp.body.results.uuid;
+
+            const chartResp = await admin.post<Body<{ uuid: string }>>(
+                `${apiV1}/projects/${SEED_PROJECT.project_uuid}/saved`,
+                {
+                    name: uniqueName('Embed date zoom chart'),
+                    tableName: 'orders',
+                    metricQuery: {
+                        exploreName: 'orders',
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_average_order_size'],
+                        filters: {},
+                        sorts: [],
+                        limit: 1,
+                        tableCalculations: [],
+                    },
+                    chartConfig: { type: 'table' },
+                    tableConfig: { columnOrder: [] },
+                    dashboardUuid: embedDashboardUuid,
+                    spaceUuid: null,
+                },
+            );
+            expect(chartResp.status).toBe(200);
+
+            const emptyFilters = {
+                dimensions: [],
+                metrics: [],
+                tableCalculations: [],
+            };
+
+            // Attach the chart as a tile, then read back its assigned uuid.
+            await admin.patch(`${apiV1}/dashboards/${embedDashboardUuid}`, {
+                tiles: [
+                    {
+                        tabUuid: undefined,
+                        type: DashboardTileTypes.SAVED_CHART,
+                        x: 0,
+                        y: 0,
+                        h: 5,
+                        w: 5,
+                        properties: {
+                            savedChartUuid: chartResp.body.results.uuid,
+                        },
+                    },
+                ],
+                tabs: [],
+                filters: emptyFilters,
+            });
+
+            const getResp = await admin.get<
+                Body<{ tiles: Array<{ uuid: string }> }>
+            >(`${apiV1}/dashboards/${embedDashboardUuid}`);
+            const tileUuid = getResp.body.results.tiles[0].uuid;
+
+            const controlUuid = randomUUID();
+            dateZoomConfig = {
+                controls: [
+                    {
+                        uuid: controlUuid,
+                        name: uniqueName('Revenue zoom'),
+                        granularity: DateGranularity.MONTH,
+                    },
+                ],
+                tileTargets: {
+                    [tileUuid]: {
+                        controlUuid,
+                        fieldId: 'orders_order_date_month',
+                        tableName: 'orders',
+                    },
+                },
+            };
+
+            await admin.patch(`${apiV1}/dashboards/${embedDashboardUuid}`, {
+                tiles: getResp.body.results.tiles,
+                tabs: [],
+                filters: emptyFilters,
+                config: { isDateZoomDisabled: false, dateZoomConfig },
+            });
+
+            // Allow the throwaway dashboard through the embed config.
+            await updateEmbedConfig(admin, {
+                dashboardUuids: [
+                    ...(snapshot.dashboardUuids ?? []),
+                    embedDashboardUuid,
+                ],
+                allowAllDashboards: snapshot.allowAllDashboards ?? false,
+                chartUuids: snapshot.chartUuids ?? [],
+                allowAllCharts: true,
+            });
+            await waitForEmbedConfigWithDashboards(admin, [embedDashboardUuid]);
+        });
+
+        afterAll(async () => {
+            if (!embedEnabled) return;
+            if (snapshot) {
+                await updateEmbedConfig(admin, {
+                    dashboardUuids: snapshot.dashboardUuids ?? [],
+                    allowAllDashboards: snapshot.allowAllDashboards ?? false,
+                    chartUuids: snapshot.chartUuids ?? [],
+                    allowAllCharts: snapshot.allowAllCharts ?? true,
+                });
+            }
+            if (embedDashboardUuid) {
+                await admin
+                    .delete(`${apiV1}/dashboards/${embedDashboardUuid}`, {
+                        failOnStatusCode: false,
+                    })
+                    .catch(() => {});
+            }
+        });
+
+        it('returns the saved dateZoomConfig in the embed dashboard payload', async () => {
+            const urlResp = await getEmbedUrl(admin, {
+                user: {
+                    externalId: 'date-zoom-user@example.com',
+                    email: 'date-zoom-user@example.com',
+                },
+                content: {
+                    type: 'dashboard',
+                    dashboardUuid: embedDashboardUuid,
+                    canExportCsv: true,
+                    canExportImages: false,
+                    canViewUnderlyingData: true,
+                    canDateZoom: true,
+                    projectUuid: SEED_PROJECT.project_uuid,
+                },
+                expiresIn: '24h',
+            });
+            expect(urlResp.status).toBe(200);
+            const token = urlResp.body.results.url.split('#')[1];
+
+            const client = new ApiClient();
+            const resp = await client.post<
+                Body<{ config?: { dateZoomConfig?: DateZoomConfig } }>
+            >(
+                `${EMBED_API_PREFIX}/dashboard`,
+                {},
+                { headers: { 'Lightdash-Embed-Token': token } },
+            );
+            expect(resp.status).toBe(200);
+            expect(resp.body.results.config?.dateZoomConfig).toEqual(
+                dateZoomConfig,
+            );
         });
     });
 });

--- a/packages/e2e/cypress/e2e/app/dateZoom.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dateZoom.cy.ts
@@ -176,8 +176,12 @@ describe('Date zoom', () => {
                     });
 
                     // None resets back to the chart's native day granularity.
+                    // Read dayCount inside the callback so it is evaluated at
+                    // run time (after it was captured), not at queue-build time.
                     selectDefaultGrain('None');
-                    cy.get(barSelector).should('have.length', dayCount);
+                    expectBarCount((count) => {
+                        expect(count).to.equal(dayCount);
+                    });
                 });
             });
         });
@@ -254,9 +258,13 @@ describe('Date zoom', () => {
                     });
 
                     // Reset returns the control to its persisted default (Month).
+                    // Read monthCount inside the callback so it is evaluated at
+                    // run time (after it was captured), not at queue-build time.
                     cy.contains(controlName).click();
                     cy.contains('Reset to default').click();
-                    cy.get(barSelector).should('have.length', monthCount);
+                    expectBarCount((count) => {
+                        expect(count).to.equal(monthCount);
+                    });
                 });
             });
         });

--- a/packages/e2e/cypress/e2e/app/dateZoom.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dateZoom.cy.ts
@@ -2,24 +2,35 @@ import { SEED_PROJECT } from '@lightdash/common';
 
 const apiUrl = '/api/v1';
 
-const createChart = async (fieldX: string, fieldY: string) =>
-    new Promise((resolve) => {
-        cy.request({
+// All blue bars in an ECharts cartesian chart.
+const barSelector = 'path[fill="#5470c6"]';
+
+const emptyFilters = {
+    dimensions: [],
+    metrics: [],
+    tableCalculations: [],
+};
+
+// Create a standalone bar chart over a day-grained date dimension. Returns the
+// chart uuid as a Cypress chainable so the rest of the flow stays inside the
+// command queue (a floating native Promise here would let the test "pass"
+// without ever running its assertions).
+const createDateChart = (name: string) =>
+    cy
+        .request({
             url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/saved`,
             method: 'POST',
             body: {
-                name: `Chart ${fieldX} x ${fieldY}`,
-                description: ``,
-                tableName: 'payments',
+                name,
+                description: '',
+                tableName: 'orders',
                 metricQuery: {
-                    dimensions: [fieldX],
-                    metrics: [fieldY],
+                    exploreName: 'orders',
+                    dimensions: ['orders_order_date_day'],
+                    metrics: ['orders_total_order_amount'],
                     filters: {},
                     sorts: [
-                        {
-                            fieldId: fieldX,
-                            descending: true,
-                        },
+                        { fieldId: 'orders_order_date_day', descending: true },
                     ],
                     limit: 500,
                     tableCalculations: [],
@@ -31,16 +42,18 @@ const createChart = async (fieldX: string, fieldY: string) =>
                     config: {
                         layout: {
                             flipAxes: false,
-                            xField: fieldX,
-                            yField: [fieldY],
+                            xField: 'orders_order_date_day',
+                            yField: ['orders_total_order_amount'],
                         },
                         eChartsConfig: {
                             series: [
                                 {
                                     encode: {
-                                        xRef: { field: fieldX },
+                                        xRef: {
+                                            field: 'orders_order_date_day',
+                                        },
                                         yRef: {
-                                            field: fieldY,
+                                            field: 'orders_total_order_amount',
                                         },
                                     },
                                     type: 'bar',
@@ -51,16 +64,43 @@ const createChart = async (fieldX: string, fieldY: string) =>
                     },
                 },
                 tableConfig: {
-                    columnOrder: [fieldX, fieldY],
+                    columnOrder: [
+                        'orders_order_date_day',
+                        'orders_total_order_amount',
+                    ],
                 },
-                pivotConfig: {
-                    columns: [],
-                },
+                pivotConfig: { columns: [] },
             },
-        }).then((r) => {
+        })
+        .then((r) => {
             expect(r.status).to.eq(200);
-            resolve(r.body.results.uuid);
+            return r.body.results.uuid as string;
         });
+
+const chartTile = (chartUuid: string, chartName: string) => ({
+    uuid: chartUuid,
+    type: 'saved_chart',
+    properties: {
+        belongsToDashboard: false,
+        savedChartUuid: chartUuid,
+        chartName,
+    },
+    h: 9,
+    w: 15,
+    x: 0,
+    y: 0,
+});
+
+const visitDashboard = (dashboardUuid: string) =>
+    cy.visit(
+        `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}`,
+    );
+
+// Bar counts depend on seed row counts, so assert on granularity ordering
+// (coarser grain => fewer bars) instead of brittle absolute numbers.
+const expectBarCount = (assert: (count: number) => void) =>
+    cy.get(barSelector).should(($bars) => {
+        assert($bars.length);
     });
 
 describe('Date zoom', () => {
@@ -68,14 +108,14 @@ describe('Date zoom', () => {
         cy.login();
     });
 
-    it('I can use date zoom', () => {
-        // This barSelector will select all the blue bars in the chart
-        const barSelector = 'path[fill="#5470c6"]';
+    it('applies the Default date zoom picker to a chart', () => {
+        const chartName = 'Date zoom default chart';
+        const selectDefaultGrain = (grain: string) => {
+            cy.contains('Default zoom').click();
+            cy.contains(grain).click();
+        };
 
-        void createChart(
-            'orders_order_date_day',
-            'orders_total_order_amount',
-        ).then((chartUuid) => {
+        createDateChart(chartName).then((chartUuid) => {
             cy.request({
                 url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
                 method: 'POST',
@@ -83,6 +123,7 @@ describe('Date zoom', () => {
                     name: 'zoom test',
                     description: '',
                     tiles: [],
+                    tabs: [],
                 },
             }).then((r) => {
                 const dashboardUuid = r.body.results.uuid;
@@ -90,67 +131,133 @@ describe('Date zoom', () => {
                     url: `${apiUrl}/dashboards/${dashboardUuid}`,
                     method: 'PATCH',
                     body: {
-                        tiles: [
-                            {
-                                uuid: chartUuid,
-                                type: 'saved_chart',
-                                properties: {
-                                    belongsToDashboard: false,
-                                    savedChartUuid: chartUuid,
-                                    chartName: 'test',
-                                },
-                                h: 9,
-                                w: 15,
-                                x: 0,
-                                y: 0,
-                            },
-                        ],
-                        filters: {
-                            dimensions: [],
-                            metrics: [],
-                            tableCalculations: [],
-                        },
                         name: 'zoom test',
+                        tiles: [chartTile(chartUuid, chartName)],
+                        tabs: [],
+                        filters: emptyFilters,
                     },
+                }).then(() => {
+                    visitDashboard(dashboardUuid);
+
+                    cy.contains('zoom test'); // dashboard title
+                    cy.contains(chartName); // chart tile title
+
+                    // The chart's own granularity is day.
+                    let dayCount = 0;
+                    let monthCount = 0;
+                    cy.get(barSelector)
+                        .should('have.length.greaterThan', 0)
+                        .then(($bars) => {
+                            dayCount = $bars.length;
+                        });
+
+                    // Month is coarser than day => fewer bars.
+                    selectDefaultGrain('Month');
+                    expectBarCount((count) => {
+                        expect(count).to.be.greaterThan(0);
+                        expect(count).to.be.lessThan(dayCount);
+                    });
+                    cy.get(barSelector).then(($bars) => {
+                        monthCount = $bars.length;
+                    });
+
+                    // Week sits between month and day.
+                    selectDefaultGrain('Week');
+                    expectBarCount((count) => {
+                        expect(count).to.be.greaterThan(monthCount);
+                        expect(count).to.be.lessThan(dayCount);
+                    });
+
+                    // Year is the coarsest => fewer bars than month.
+                    selectDefaultGrain('Year');
+                    expectBarCount((count) => {
+                        expect(count).to.be.greaterThan(0);
+                        expect(count).to.be.lessThan(monthCount);
+                    });
+
+                    // None resets back to the chart's native day granularity.
+                    selectDefaultGrain('None');
+                    cy.get(barSelector).should('have.length', dayCount);
                 });
+            });
+        });
+    });
 
-                cy.visit(
-                    `/projects/${SEED_PROJECT.project_uuid}/dashboards/${dashboardUuid}`,
-                );
+    it('applies a named control grain to its attached tile and supports runtime override', () => {
+        const chartName = 'Date zoom control chart';
+        const controlUuid = crypto.randomUUID();
+        const controlName = 'Revenue zoom';
 
-                // Wait until the chart appears
-                cy.contains('zoom test'); // dashboard title
-                cy.contains(
-                    'Chart orders_order_date_day x orders_total_order_amount',
-                ); // Chart title
-                cy.contains('Total order amount'); // axis label
+        createDateChart(chartName).then((chartUuid) => {
+            cy.request({
+                url: `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+                method: 'POST',
+                body: {
+                    name: 'control zoom test',
+                    description: '',
+                    tiles: [],
+                    tabs: [],
+                },
+            }).then((r) => {
+                const dashboardUuid = r.body.results.uuid;
+                cy.request({
+                    url: `${apiUrl}/dashboards/${dashboardUuid}`,
+                    method: 'PATCH',
+                    body: {
+                        name: 'control zoom test',
+                        tiles: [chartTile(chartUuid, chartName)],
+                        tabs: [],
+                        filters: emptyFilters,
+                        config: {
+                            isDateZoomDisabled: false,
+                            dateZoomConfig: {
+                                controls: [
+                                    {
+                                        uuid: controlUuid,
+                                        name: controlName,
+                                        granularity: 'Month',
+                                    },
+                                ],
+                                tileTargets: {
+                                    [chartUuid]: {
+                                        controlUuid,
+                                        fieldId: 'orders_order_date_day',
+                                        tableName: 'orders',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }).then(() => {
+                    visitDashboard(dashboardUuid);
 
-                // Count how many bars appear in the chart
-                cy.get(barSelector).should('have.length', 69); // default chart time frame is day
+                    cy.contains('control zoom test');
+                    cy.contains(chartName);
 
-                cy.contains('Date Zoom').click();
-                cy.contains('Month').click();
-                cy.get(barSelector).should('have.length', 4);
+                    // The persisted control renders as a pill at its saved
+                    // grain (Month), applied on load without the Default picker.
+                    cy.contains(controlName).should('contain.text', 'Month');
 
-                cy.contains('Date Zoom').click();
-                cy.contains('Day').click();
-                cy.get(barSelector).should('have.length', 69);
+                    let monthCount = 0;
+                    cy.get(barSelector)
+                        .should('have.length.greaterThan', 0)
+                        .then(($bars) => {
+                            monthCount = $bars.length;
+                        });
 
-                cy.contains('Date Zoom').click();
-                cy.contains('Week').click();
-                cy.get(barSelector).should('have.length', 15);
+                    // A viewer overrides the control grain at runtime via its
+                    // pill; Week is finer than Month => more bars.
+                    cy.contains(controlName).click();
+                    cy.contains('Week').click();
+                    expectBarCount((count) => {
+                        expect(count).to.be.greaterThan(monthCount);
+                    });
 
-                cy.contains('Date Zoom').click();
-                cy.contains('Quarter').click();
-                cy.get(barSelector).should('have.length', 2);
-
-                cy.contains('Date Zoom').click();
-                cy.contains('Year').click();
-                cy.get(barSelector).should('have.length', 1);
-
-                cy.contains('Date Zoom').click();
-                cy.contains('Default').click();
-                cy.get(barSelector).should('have.length', 69); // back to default (day)
+                    // Reset returns the control to its persisted default (Month).
+                    cy.contains(controlName).click();
+                    cy.contains('Reset to default').click();
+                    cy.get(barSelector).should('have.length', monthCount);
+                });
             });
         });
     });


### PR DESCRIPTION
Tests-only branch locking in the date-zoom-config behavior added in this stack.

## api-tests (`packages/api-tests`)
- `dashboard.test.ts` → `Date zoom config`:
  - `dateZoomConfig` round-trips through create/get.
  - `DashboardModel.createVersion` narrows `tileTargets` to surviving tiles when a tile is removed.
  - narrowing drops targets but keeps controls (backend narrows targets only; control pruning is a frontend concern).
  - dashboards that never set a config keep it absent (no JSONB churn).
- `embedDashboard.test.ts`: the embed `POST /dashboard` payload surfaces the saved `dateZoomConfig` (the path the embed seed fix consumes). Snapshots/restores the embed config and uses a throwaway dashboard.

## e2e (`packages/e2e`)
The existing `dateZoom.cy.ts` was a vacuous no-op: it enqueued `cy.*` inside a floating native-promise `.then()`, so it passed in ~464ms without ever visiting the dashboard or asserting anything.
- Rewired the flow through `cy.request` chains so assertions actually run.
- Granularity-ordering assertions (coarser grain → fewer bars) instead of brittle seed-dependent counts.
- Updated selectors to the current UI (`Default zoom` button, `None` reset).
- Added a named-control test: a control seeded at Month applies its grain on load, a runtime override re-grains the tile, and reset restores the persisted grain.

Closes https://linear.app/lightdash/issue/GLITCH-225/make-date-zoom-more-configurable-like-dashboard-filters