### PR TITLE
feat: configurable project-default time intervals

### DIFF
--- a/docs/superpowers/plans/2026-06-25-glitch-265-project-default-time-intervals.md
+++ b/docs/superpowers/plans/2026-06-25-glitch-265-project-default-time-intervals.md
@@ -1,0 +1,707 @@
+# GLITCH-265 — Project-default time intervals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a project append extra time intervals (standard grains or custom-granularity names) to the built-in defaults for date/timestamp dimensions via `lightdash.config.yml`, so authors don't repeat `time_intervals` on every column.
+
+**Architecture:** Additive, fallback-only. A new `defaults.additional_time_intervals.{date,timestamp}` config field is validated once in `convertExplores` (`resolveAdditionalTimeIntervals`), threaded into `convertTable`, and merged with the built-in defaults by `getTimeFramesWithProjectDefaults` only on columns that don't declare their own `time_intervals`. Backend/`common` only — new sub-dimensions flow into compiled explores automatically.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Jest (`packages/common`).
+
+## Global Constraints
+
+- Package manager: **pnpm** only. Prefix any install with `sfw` (e.g. `sfw pnpm install`).
+- Git commits: end the message with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`; prefix git with `NODE_OPTIONS= ` (e.g. `NODE_OPTIONS= git commit ...`) to avoid the husky preload crash.
+- Work on branch `feature/glitch-265` (already created).
+- Use package-specific commands: `pnpm -F common test`, `pnpm -F common typecheck:fast`, `pnpm -F common lint`.
+- Code style: no duck typing / intentional types; prefer `null` over optional where it means "absent"; `assertUnreachable` for exhaustive switches; minimal comments.
+- The canonical source of field types is `packages/common/src/types/field.ts`; the `TimeFrames` enum is in `packages/common/src/types/timeFrames.ts`.
+- **Semantics (locked):** additive only; field named `additional_time_intervals` (NOT `time_intervals`, which replaces at the per-column level); fallback-only precedence (explicit per-column `time_intervals` always wins); validation is one-shot at resolution via `console.warn`.
+
+---
+
+### Task 1: Config type + merge helper (`timeFrames.ts`)
+
+Adds the input config type, the resolved-shape type, the date-invalid set, and the pure merge helper. `getDefaultTimeFrames` stays unchanged.
+
+**Files:**
+- Modify: `packages/common/src/types/lightdashProjectConfig.ts` (add import + `ProjectDefaults.additional_time_intervals`)
+- Modify: `packages/common/src/utils/timeFrames.ts` (add `ResolvedAdditionalTimeIntervals`, `DATE_INVALID_TIME_FRAMES`, `getTimeFramesWithProjectDefaults`)
+- Test: `packages/common/src/utils/timeFrames.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `ProjectDefaults.additional_time_intervals?: { date?: (TimeFrames | string)[]; timestamp?: (TimeFrames | string)[] }`
+  - `type ResolvedAdditionalTimeIntervals = { date: (TimeFrames | string)[]; timestamp: (TimeFrames | string)[] }`
+  - `DATE_INVALID_TIME_FRAMES: ReadonlySet<TimeFrames>`
+  - `getTimeFramesWithProjectDefaults(type: DimensionType, additionalTimeIntervals?: ResolvedAdditionalTimeIntervals): (TimeFrames | string)[]`
+
+- [ ] **Step 1: Add the config field to `ProjectDefaults`**
+
+In `packages/common/src/types/lightdashProjectConfig.ts`, add the `TimeFrames` import at the top (next to the existing `DimensionType` import):
+
+```typescript
+import { type DimensionType } from './field';
+import { type TimeFrames } from './timeFrames';
+```
+
+Then extend `ProjectDefaults` (keep the existing fields, add the new one before the closing brace):
+
+```typescript
+export type ProjectDefaults = {
+    case_sensitive?: boolean;
+    column_totals?: boolean;
+    /**
+     * Extra time intervals appended to the built-in defaults for date/timestamp
+     * dimensions that do not declare their own `time_intervals`. Values may be
+     * standard granularities (e.g. `hour`) or `custom_granularities` keys.
+     */
+    additional_time_intervals?: {
+        date?: (TimeFrames | string)[];
+        timestamp?: (TimeFrames | string)[];
+    };
+};
+```
+
+- [ ] **Step 2: Write the failing test for the merge helper**
+
+In `packages/common/src/utils/timeFrames.test.ts`, add the helper to the existing import from `'./timeFrames'` (it currently imports e.g. `isSubDayGranularity`, `getDateDimension`), then add this `describe` block inside the top-level `describe('TimeFrames', ...)`:
+
+```typescript
+describe('getTimeFramesWithProjectDefaults', () => {
+    it('returns built-in defaults unchanged when no additions are given', () => {
+        expect(getTimeFramesWithProjectDefaults(DimensionType.DATE)).toEqual([
+            TimeFrames.DAY,
+            TimeFrames.WEEK,
+            TimeFrames.MONTH,
+            TimeFrames.QUARTER,
+            TimeFrames.YEAR,
+        ]);
+        expect(
+            getTimeFramesWithProjectDefaults(DimensionType.TIMESTAMP),
+        ).toEqual([
+            TimeFrames.RAW,
+            TimeFrames.DAY,
+            TimeFrames.WEEK,
+            TimeFrames.MONTH,
+            TimeFrames.QUARTER,
+            TimeFrames.YEAR,
+        ]);
+    });
+
+    it('appends timestamp additions after the built-in defaults', () => {
+        expect(
+            getTimeFramesWithProjectDefaults(DimensionType.TIMESTAMP, {
+                date: [],
+                timestamp: [TimeFrames.HOUR],
+            }),
+        ).toEqual([
+            TimeFrames.RAW,
+            TimeFrames.DAY,
+            TimeFrames.WEEK,
+            TimeFrames.MONTH,
+            TimeFrames.QUARTER,
+            TimeFrames.YEAR,
+            TimeFrames.HOUR,
+        ]);
+    });
+
+    it('appends a custom granularity name for date dimensions', () => {
+        expect(
+            getTimeFramesWithProjectDefaults(DimensionType.DATE, {
+                date: ['fiscal_week'],
+                timestamp: [],
+            }),
+        ).toEqual([
+            TimeFrames.DAY,
+            TimeFrames.WEEK,
+            TimeFrames.MONTH,
+            TimeFrames.QUARTER,
+            TimeFrames.YEAR,
+            'fiscal_week',
+        ]);
+    });
+
+    it('de-duplicates an addition that already exists in the built-in defaults', () => {
+        expect(
+            getTimeFramesWithProjectDefaults(DimensionType.DATE, {
+                date: [TimeFrames.DAY],
+                timestamp: [],
+            }),
+        ).toEqual([
+            TimeFrames.DAY,
+            TimeFrames.WEEK,
+            TimeFrames.MONTH,
+            TimeFrames.QUARTER,
+            TimeFrames.YEAR,
+        ]);
+    });
+});
+```
+
+- [ ] **Step 3: Run the test, verify it fails**
+
+Run: `pnpm -F common test -- timeFrames`
+Expected: FAIL — `getTimeFramesWithProjectDefaults is not a function` (not exported yet).
+
+- [ ] **Step 4: Implement the helper, type, and set**
+
+In `packages/common/src/utils/timeFrames.ts`, immediately after the `getDefaultTimeFrames` definition (ends around line 1030), add:
+
+```typescript
+export type ResolvedAdditionalTimeIntervals = {
+    date: (TimeFrames | string)[];
+    timestamp: (TimeFrames | string)[];
+};
+
+/** Standard time frames that are meaningless on a plain DATE dimension. */
+export const DATE_INVALID_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.RAW,
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+]);
+
+/**
+ * Built-in default time frames for a dimension type, with project-level
+ * `additional_time_intervals` appended (de-duplicated, built-ins first).
+ */
+export const getTimeFramesWithProjectDefaults = (
+    type: DimensionType,
+    additionalTimeIntervals?: ResolvedAdditionalTimeIntervals,
+): (TimeFrames | string)[] => {
+    const additions =
+        type === DimensionType.TIMESTAMP
+            ? additionalTimeIntervals?.timestamp ?? []
+            : additionalTimeIntervals?.date ?? [];
+    const seen = new Set<string>();
+    return [...getDefaultTimeFrames(type), ...additions].filter((value) => {
+        if (seen.has(value)) return false;
+        seen.add(value);
+        return true;
+    });
+};
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `pnpm -F common test -- timeFrames`
+Expected: PASS (all four new cases plus existing TimeFrames tests).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm -F common typecheck:fast`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/common/src/types/lightdashProjectConfig.ts packages/common/src/utils/timeFrames.ts packages/common/src/utils/timeFrames.test.ts
+NODE_OPTIONS= git commit -m "feat(glitch-265): add additional_time_intervals config type and merge helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Config resolver/validator (`compiler/lightdashProjectConfig.ts`)
+
+One-shot validation: standard grains kept (uppercased), sub-day grains under `date` dropped + warned, custom-granularity keys kept, unknowns dropped + warned.
+
+**Files:**
+- Modify: `packages/common/src/compiler/lightdashProjectConfig.ts` (add `resolveAdditionalTimeIntervals`)
+- Test: `packages/common/src/compiler/lightdashProjectConfig.test.ts`
+
+**Interfaces:**
+- Consumes (Task 1): `ResolvedAdditionalTimeIntervals`, `DATE_INVALID_TIME_FRAMES`, `isTimeInterval`, `ProjectDefaults`, `LightdashProjectConfig['custom_granularities']`.
+- Produces: `resolveAdditionalTimeIntervals(additionalTimeIntervals: ProjectDefaults['additional_time_intervals'], customGranularities: LightdashProjectConfig['custom_granularities']): ResolvedAdditionalTimeIntervals`
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/common/src/compiler/lightdashProjectConfig.test.ts`, add (mirror the file's existing import style — it imports helpers from `'./lightdashProjectConfig'`):
+
+```typescript
+import { TimeFrames } from '../types/timeFrames';
+import { resolveAdditionalTimeIntervals } from './lightdashProjectConfig';
+
+describe('resolveAdditionalTimeIntervals', () => {
+    const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+    afterEach(() => warnSpy.mockClear());
+    afterAll(() => warnSpy.mockRestore());
+
+    it('returns empty lists when config is undefined', () => {
+        expect(resolveAdditionalTimeIntervals(undefined, {})).toEqual({
+            date: [],
+            timestamp: [],
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('uppercases a standard timestamp grain', () => {
+        expect(
+            resolveAdditionalTimeIntervals({ timestamp: ['hour'] }, {}),
+        ).toEqual({ date: [], timestamp: [TimeFrames.HOUR] });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops a sub-day grain configured under date and warns', () => {
+        expect(
+            resolveAdditionalTimeIntervals({ date: ['hour'] }, {}),
+        ).toEqual({ date: [], timestamp: [] });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps a defined custom granularity key', () => {
+        expect(
+            resolveAdditionalTimeIntervals(
+                { date: ['fiscal_week'] },
+                { fiscal_week: { label: 'Fiscal Week', sql: '${COLUMN}' } },
+            ),
+        ).toEqual({ date: ['fiscal_week'], timestamp: [] });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops an unknown name and warns', () => {
+        expect(
+            resolveAdditionalTimeIntervals({ timestamp: ['nonsense'] }, {}),
+        ).toEqual({ date: [], timestamp: [] });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pnpm -F common test -- lightdashProjectConfig`
+Expected: FAIL — `resolveAdditionalTimeIntervals is not a function`.
+
+- [ ] **Step 3: Implement the resolver**
+
+In `packages/common/src/compiler/lightdashProjectConfig.ts`, add imports at the top:
+
+```typescript
+import type {
+    LightdashProjectConfig,
+    ProjectDefaults,
+} from '../types/lightdashProjectConfig';
+import {
+    DATE_INVALID_TIME_FRAMES,
+    isTimeInterval,
+    type ResolvedAdditionalTimeIntervals,
+} from '../utils/timeFrames';
+```
+
+(`LightdashProjectConfig` is already imported in this file — merge the `ProjectDefaults` addition into the existing import rather than duplicating it.)
+
+Then add the resolver:
+
+```typescript
+const resolveAdditionalTimeIntervalList = (
+    values: (string | undefined)[] | undefined,
+    key: 'date' | 'timestamp',
+    customGranularities: LightdashProjectConfig['custom_granularities'],
+): (string)[] =>
+    (values ?? []).reduce<string[]>((acc, raw) => {
+        const name = String(raw);
+        const upper = name.toUpperCase();
+        if (isTimeInterval(upper)) {
+            if (key === 'date' && DATE_INVALID_TIME_FRAMES.has(upper)) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                    `Ignoring sub-day time interval "${name}" in defaults.additional_time_intervals.date — not valid for DATE dimensions.`,
+                );
+                return acc;
+            }
+            return [...acc, upper];
+        }
+        if (customGranularities?.[name]) {
+            return [...acc, name];
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Ignoring unknown time interval "${name}" in defaults.additional_time_intervals.${key} — not a standard granularity or a defined custom_granularity.`,
+        );
+        return acc;
+    }, []);
+
+/**
+ * Validate `defaults.additional_time_intervals` once: keep standard grains
+ * (uppercased) and defined custom-granularity keys; drop sub-day grains under
+ * `date` and unknown names (each with a single console.warn).
+ */
+export const resolveAdditionalTimeIntervals = (
+    additionalTimeIntervals: ProjectDefaults['additional_time_intervals'],
+    customGranularities: LightdashProjectConfig['custom_granularities'],
+): ResolvedAdditionalTimeIntervals => ({
+    date: resolveAdditionalTimeIntervalList(
+        additionalTimeIntervals?.date,
+        'date',
+        customGranularities,
+    ),
+    timestamp: resolveAdditionalTimeIntervalList(
+        additionalTimeIntervals?.timestamp,
+        'timestamp',
+        customGranularities,
+    ),
+});
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+Run: `pnpm -F common test -- lightdashProjectConfig`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm -F common typecheck:fast`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/common/src/compiler/lightdashProjectConfig.ts packages/common/src/compiler/lightdashProjectConfig.test.ts
+NODE_OPTIONS= git commit -m "feat(glitch-265): resolve and validate additional_time_intervals config
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire into the compiler (`translator.ts`)
+
+Resolve once in `convertExplores`, thread into `convertTable`, use the merge helper in the model-column `else` branch.
+
+**Files:**
+- Modify: `packages/common/src/compiler/translator.ts`
+- Test: `packages/common/src/compiler/translator.test.ts`
+
+**Interfaces:**
+- Consumes (Task 1): `getTimeFramesWithProjectDefaults`, `ResolvedAdditionalTimeIntervals`. (Task 2): `resolveAdditionalTimeIntervals`.
+- Produces: `convertTable(..., additionalTimeIntervals?: ResolvedAdditionalTimeIntervals)` — new optional last parameter.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/common/src/compiler/translator.test.ts`, add a new `describe` block (place it near the existing custom-granularity convertExplores tests). It uses the existing `model`, `warehouseClientMock`, `DEFAULT_SPOTLIGHT_CONFIG`, `SupportedDbtAdapter`, `TimeFrames`, `DimensionType` already imported in the file:
+
+```typescript
+describe('project default additional_time_intervals', () => {
+    const TIMESTAMP_MODEL: DbtModelNode & { relation_name: string } = {
+        ...model,
+        columns: {
+            created_at: {
+                name: 'created_at',
+                data_type: DimensionType.TIMESTAMP,
+                meta: { dimension: { type: DimensionType.TIMESTAMP } },
+            },
+        },
+    };
+
+    it('appends a standard grain (HOUR) to a timestamp column with no explicit time_intervals', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            TIMESTAMP_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined, // startOfWeek
+            undefined, // disableTimestampConversion
+            undefined, // customGranularities
+            undefined, // allowPartialCompilation
+            { date: [], timestamp: [TimeFrames.HOUR] }, // additionalTimeIntervals
+        );
+        expect(result.dimensions).toHaveProperty('created_at_hour');
+        expect(result.dimensions).toHaveProperty('created_at_day');
+    });
+
+    it('appends a custom granularity to a timestamp column', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            TIMESTAMP_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            { fiscal_week: { label: 'Fiscal Week', sql: '${COLUMN}' } },
+            undefined,
+            { date: [], timestamp: ['fiscal_week'] },
+        );
+        expect(result.dimensions).toHaveProperty('created_at_fiscal_week');
+    });
+
+    it('does NOT add the project default to a column with explicit time_intervals', () => {
+        const EXPLICIT_MODEL: DbtModelNode & { relation_name: string } = {
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                    },
+                },
+            },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            EXPLICIT_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { date: [], timestamp: [TimeFrames.HOUR] },
+        );
+        expect(result.dimensions).toHaveProperty('created_at_day');
+        expect(result.dimensions).not.toHaveProperty('created_at_hour');
+    });
+
+    it('flows from convertExplores via lightdashProjectConfig.defaults', async () => {
+        const explores = await convertExplores(
+            [TIMESTAMP_MODEL],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            [],
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+                defaults: {
+                    additional_time_intervals: {
+                        timestamp: [TimeFrames.HOUR],
+                    },
+                },
+            },
+        );
+        const explore = explores[0];
+        expect('errors' in explore).toBe(false);
+        if (!('errors' in explore)) {
+            const table = explore.tables[explore.baseTable];
+            expect(table.dimensions).toHaveProperty('created_at_hour');
+        }
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `pnpm -F common test -- translator`
+Expected: FAIL — `convertTable` ignores the 9th arg, so `created_at_hour` is missing.
+
+- [ ] **Step 3: Add imports**
+
+In `packages/common/src/compiler/translator.ts`:
+- In the existing import from `'../utils/timeFrames'` (the one that already imports `getDefaultTimeFrames`, `validateTimeFrames`), add `getTimeFramesWithProjectDefaults` and `type ResolvedAdditionalTimeIntervals`.
+- In the existing import from `'./lightdashProjectConfig'` (line ~67), add `resolveAdditionalTimeIntervals`.
+
+- [ ] **Step 4: Add the `additionalTimeIntervals` parameter to `convertTable`**
+
+Change the `convertTable` signature (currently ends with `allowPartialCompilation?: boolean,`):
+
+```typescript
+export const convertTable = (
+    adapterType: SupportedDbtAdapter,
+    model: DbtModelNode,
+    dbtMetrics: DbtMetric[],
+    spotlightConfig: LightdashProjectConfig['spotlight'],
+    startOfWeek?: WeekDay | null,
+    disableTimestampConversion?: boolean,
+    customGranularities?: Record<string, CustomGranularity>,
+    allowPartialCompilation?: boolean,
+    additionalTimeIntervals?: ResolvedAdditionalTimeIntervals,
+): Omit<Table, 'lineageGraph'> => {
+```
+
+- [ ] **Step 5: Use the merge helper in the model-column `else` branch**
+
+In `convertTable`'s `processIntervalDimension`, replace the fallback `else` branch (currently `allIntervals = getDefaultTimeFrames(dim.type);`):
+
+```typescript
+                    } else {
+                        allIntervals = getTimeFramesWithProjectDefaults(
+                            dim.type,
+                            additionalTimeIntervals,
+                        );
+                    }
+```
+
+- [ ] **Step 6: Resolve once in `convertExplores` and pass it through**
+
+In `convertExplores`, just after `const tableLineage = translateDbtModelsToTableLineage(models);`, add:
+
+```typescript
+    const additionalTimeIntervals = resolveAdditionalTimeIntervals(
+        lightdashProjectConfig.defaults?.additional_time_intervals,
+        lightdashProjectConfig.custom_granularities,
+    );
+```
+
+Then in the `convertTable(...)` call inside `convertExplores`, add `additionalTimeIntervals` as the final argument (after `allowPartialCompilation,`):
+
+```typescript
+                const table = convertTable(
+                    adapterType,
+                    model,
+                    tableMetrics,
+                    lightdashProjectConfig.spotlight,
+                    warehouseSqlBuilder.getStartOfWeek(),
+                    disableTimestampConversion,
+                    lightdashProjectConfig.custom_granularities,
+                    allowPartialCompilation,
+                    additionalTimeIntervals,
+                );
+```
+
+- [ ] **Step 7: Run the tests, verify they pass**
+
+Run: `pnpm -F common test -- translator`
+Expected: PASS (all four new cases + existing translator tests unchanged).
+
+- [ ] **Step 8: Typecheck + lint**
+
+Run: `pnpm -F common typecheck:fast && pnpm -F common lint`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/common/src/compiler/translator.ts packages/common/src/compiler/translator.test.ts
+NODE_OPTIONS= git commit -m "feat(glitch-265): apply project default additional_time_intervals in compiler
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: JSON schema for `lightdash.config.yml`
+
+Add the `defaults` block (including the new field) to the project-config schema so editors validate/autocomplete it. (The `defaults` object is not in the schema today; add it with the existing `case_sensitive`/`column_totals` keys plus the new one. Values are typed as plain strings because custom-granularity names are open.)
+
+**Files:**
+- Modify: `packages/common/src/schemas/json/lightdash-project-config-1.0.json`
+
+- [ ] **Step 1: Add the `defaults` property**
+
+In `packages/common/src/schemas/json/lightdash-project-config-1.0.json`, inside the top-level `"properties"` object, add a `"defaults"` entry as a sibling of `"custom_granularities"`:
+
+```json
+        "defaults": {
+            "type": ["object", "null"],
+            "description": "Project-wide default settings that can be overridden at explore or field level",
+            "properties": {
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "Default case sensitivity for string filters. Defaults to true."
+                },
+                "column_totals": {
+                    "type": "boolean",
+                    "description": "Default behaviour for column totals in results tables. Defaults to true."
+                },
+                "additional_time_intervals": {
+                    "type": ["object", "null"],
+                    "description": "Extra time intervals appended to the built-in defaults for date/timestamp dimensions that do not declare their own time_intervals. Values may be standard granularities (e.g. hour) or custom_granularities keys.",
+                    "properties": {
+                        "date": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Appended to the built-in DAY/WEEK/MONTH/QUARTER/YEAR defaults for DATE dimensions."
+                        },
+                        "timestamp": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Appended to the built-in RAW/DAY/WEEK/MONTH/QUARTER/YEAR defaults for TIMESTAMP dimensions."
+                        }
+                    }
+                }
+            }
+        },
+```
+
+(Remember the trailing comma so the following `custom_granularities`/`table_groups` keys stay valid JSON. If you add `defaults` as the last property, omit the trailing comma instead.)
+
+- [ ] **Step 2: Verify the JSON parses and lint passes**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('packages/common/src/schemas/json/lightdash-project-config-1.0.json','utf8')); console.log('valid json')"`
+Expected: prints `valid json`.
+
+Run: `pnpm -F common lint`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/common/src/schemas/json/lightdash-project-config-1.0.json
+NODE_OPTIONS= git commit -m "feat(glitch-265): add defaults.additional_time_intervals to config schema
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Final verification (build, full tests, API spec, docs)
+
+**Files:**
+- Possibly modified by tooling: generated OpenAPI spec (only if `LightdashProjectConfig` surfaces in a controller return type).
+
+- [ ] **Step 1: Build common and run the full common test suite**
+
+Run: `pnpm -F common build && pnpm -F common test`
+Expected: build succeeds; all tests pass (new + existing).
+
+- [ ] **Step 2: Regenerate the API spec and check for drift**
+
+Run: `pnpm generate-api`
+Then: `git status --porcelain`
+Expected: usually no changes. If `packages/backend/src/generated` / swagger files changed, review them — the only expected change is the new optional `additional_time_intervals` field on `ProjectDefaults`. If changed, commit:
+
+```bash
+git add -A
+NODE_OPTIONS= git commit -m "chore(glitch-265): regenerate API spec for additional_time_intervals
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+If there are no changes, skip this commit.
+
+- [ ] **Step 3: Locate and update the config reference doc (if it lives in-repo)**
+
+Run: `grep -rln "custom_granularities" --include=*.md --include=*.mdx . | grep -iv node_modules`
+- If a `lightdash-config-yml` reference doc is found in-repo, add a short `additional_time_intervals` section next to the `custom_granularities` docs: explain it appends to the built-in defaults, applies only to columns without explicit `time_intervals`, accepts standard grains or custom-granularity keys, and show the `defaults.additional_time_intervals` YAML example. Then commit.
+- If no in-repo doc is found (docs.lightdash.com is a separate site), note in the PR description that the public docs page `references/lightdash-config-yml` needs an `additional_time_intervals` section, and skip the commit.
+
+- [ ] **Step 4: Manual smoke check (optional but recommended)**
+
+Suggest the user add to their local `lightdash.config.yml`:
+
+```yaml
+defaults:
+  additional_time_intervals:
+    timestamp: [hour]
+```
+
+then refresh dbt in the UI and confirm a timestamp dimension now exposes an `Hour` granularity (and appears in date zoom).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Config shape (`defaults.additional_time_intervals.{date,timestamp}`) → Task 1 (type) + Task 4 (schema). ✓
+- Additive merge, dedup, order → Task 1 (`getTimeFramesWithProjectDefaults`). ✓
+- Fallback-only precedence → Task 3 (`else` branch only) + explicit "untouched" test. ✓
+- Standard grains + custom-granularity names → Task 1/2/3 tests. ✓
+- One-shot validation with warnings (unknown / sub-day-on-date) → Task 2. ✓
+- Resolve once in `convertExplores`, thread through `convertTable` → Task 3. ✓
+- Backend/common only, no frontend → no frontend tasks. ✓
+- Model-column path only (scope note) → Task 3 changes only line ~693; line 309 untouched. ✓
+- Schema file updated → Task 4. ✓
+- Recompile-on-config-change is existing behavior → no task needed. ✓
+
+**Placeholder scan:** No TBD/TODO; all code blocks complete; Task 5 Step 3 has a concrete grep + conditional rather than a vague "update docs". ✓
+
+**Type consistency:** `ResolvedAdditionalTimeIntervals` defined in Task 1, consumed by name in Tasks 2 & 3. `getTimeFramesWithProjectDefaults` / `resolveAdditionalTimeIntervals` / `DATE_INVALID_TIME_FRAMES` spelled identically across tasks. `convertTable`'s new 9th param `additionalTimeIntervals` matches the call site in Task 3 Step 6. ✓

--- a/docs/superpowers/specs/2026-06-25-glitch-265-project-default-time-intervals-design.md
+++ b/docs/superpowers/specs/2026-06-25-glitch-265-project-default-time-intervals-design.md
@@ -1,0 +1,168 @@
+# GLITCH-265 — Project-default time intervals
+
+**Ticket:** [GLITCH-265](https://linear.app/lightdash/issue/GLITCH-265) — "I want to set a default set of time intervals for my Lightdash project."
+**Milestone:** Control the zoom (project: Make date zoom configurable)
+**Status:** Design approved 2026-06-25
+
+## Problem
+
+Lightdash hard-codes which time-interval sub-dimensions (granularities) a date/timestamp
+dimension gets by default:
+
+- **TIMESTAMP** → `RAW, DAY, WEEK, MONTH, QUARTER, YEAR`
+- **DATE** → `DAY, WEEK, MONTH, QUARTER, YEAR`
+
+To get anything else (e.g. `HOUR`, or a project's custom granularity) on a column, an author
+must add `time_intervals: [...]` to that column's dbt meta — and repeat it on every date column.
+
+### Customer evidence
+
+- **44pixels** (#14766): wants `HOUR` on *all* timestamps without per-column edits — *"is there a
+  way to override the default settings for timestamps? Or do I have to override it everywhere I
+  want hour?"* / *"set the default somewhere that then applies to all timestamps."*
+- **Octopus Energy** (Jacob Varley): wants a `custom_granularities` entry ("Week starting Friday")
+  applied to every date dimension — *"is it possible to configure the default `time_intervals` for
+  our dimensions to include it **in addition to the usual defaults** for dates/timestamps … and
+  also ensure any new dimensions include it by default."*
+
+Both frame the ask as **additive** ("in addition to the usual defaults"). Neither asked to remove a
+standard grain. Relabelling `Week` → `Week starting Monday` is a separate concern (GLITCH-264).
+
+## Goal
+
+Let a project set, in `lightdash.config.yml`, extra time intervals that are appended to the built-in
+defaults for date and/or timestamp dimensions — including custom-granularity names — so they apply
+to every date/timestamp dimension that doesn't already declare its own `time_intervals`.
+
+Non-goals:
+- Removing/replacing built-in default grains (additive only).
+- Configurable labels for standard granularities (GLITCH-264).
+- Per-dashboard / per-space scoping (handled elsewhere in the project).
+
+## Design
+
+### 1. Config shape
+
+New optional field under the existing `defaults` block of `lightdash.config.yml`:
+
+```yaml
+defaults:
+  additional_time_intervals:
+    date: [week_starting_friday]   # appended to built-in DAY/WEEK/MONTH/QUARTER/YEAR
+    timestamp: [HOUR]              # appended to built-in RAW/DAY/WEEK/MONTH/QUARTER/YEAR
+```
+
+- **Named `additional_time_intervals` (not `time_intervals`) on purpose.** Per-column
+  `time_intervals` (dbt meta) *replaces* the set; this project-level field *adds* to it. Reusing the
+  same word for opposite semantics one level apart is a footgun, so the name carries the meaning —
+  "added on top." It also fits existing Lightdash vocabulary ("additional dimensions").
+- Separate `date` / `timestamp` keys serve both customer asks directly and structurally keep sub-day
+  grains away from DATE columns.
+- Entries may be **standard `TimeFrames` or custom-granularity names** (keys of `custom_granularities`).
+
+Type change in `packages/common/src/types/lightdashProjectConfig.ts`:
+
+```typescript
+export type ProjectDefaults = {
+    case_sensitive?: boolean;
+    column_totals?: boolean;
+    additional_time_intervals?: {
+        date?: (TimeFrames | string)[];
+        timestamp?: (TimeFrames | string)[];
+    };
+};
+```
+
+**Future iteration path:** if removal/replace is ever requested, add a sibling `defaults.time_intervals`
+(replace semantics, matching per-column) — two distinct keys, no overloaded word, no migration of
+the meaning of an existing field.
+
+### 2. Merge semantics — additive (decided)
+
+`getDefaultTimeFrames(type)` in `packages/common/src/utils/timeFrames.ts` gains an optional second
+argument carrying the project additions and returns the built-in list with the additions appended,
+de-duplicated, order preserved (built-ins first):
+
+```
+getDefaultTimeFrames(type, projectDefaults?) =>
+    dedupe([ ...builtIn(type), ...(additionsFor(type, projectDefaults)) ])
+```
+
+When no config is present the output is byte-for-byte the current behavior.
+
+### 3. Precedence — fallback only (Decision A, approved)
+
+The project default replaces only the *fallback* used when a column has no explicit
+`time_intervals`. It changes the `else` branch in both call sites; it does not touch columns that
+declare their own list.
+
+| Column state | Resulting intervals |
+|---|---|
+| Explicit per-column `time_intervals: [...]` | unchanged (author owns it) |
+| No explicit list | built-in **+ project additions** |
+
+This delivers "every new/uncurated date dimension inherits the extra grain" while leaving
+explicitly-curated columns unsurprised.
+
+### 4. Call sites
+
+Both currently call `getDefaultTimeFrames(type)` in their no-explicit-list branch:
+
+1. `processIntervalDimension` — `translator.ts:693` (main column path). Already produces a mixed
+   `(TimeFrames | string)[]` array and splits standard vs custom via `validateTimeFrames` +
+   `customIntervalNames`, so project-default custom granularities flow through here for free.
+2. Synthetic / additional-dimension path — `translator.ts:309`. Standard `TimeFrames` only.
+
+`convertExplores` already threads `lightdashProjectConfig.defaults` (line 1361) and
+`custom_granularities` (line 1148) into the compile path, so the new field rides existing plumbing;
+`convertTable` gains a `timeIntervalDefaults` parameter alongside the `customGranularities` one.
+
+### 5. Validation — centralized, once at resolution (Decision B, approved)
+
+Validate `defaults.additional_time_intervals` a single time when the project config is resolved (not
+per column — that would emit one warning per date dimension):
+
+- Each entry must be a known standard `TimeFrame` **or** a defined `custom_granularities` key;
+  otherwise drop it and emit one warning.
+- Drop sub-day grains (`HOUR/MINUTE/SECOND/MILLISECOND/RAW`) listed under `date` (meaningless on a
+  DATE column) and warn.
+- `lightdash-project-config-1.0.json` gains the standard-`TimeFrames` enum under
+  `defaults.additional_time_intervals.{date,timestamp}` for editor autocomplete; custom-granularity
+  names remain open strings (the schema cannot know project-specific names).
+
+### 6. Scope / blast radius
+
+- **Backend / `common` only.** The new sub-dimensions land in the compiled explore; the date-zoom
+  dropdown, explorer sidebar, and queries consume them automatically. **No frontend changes.**
+- Changing the config triggers explore recompilation (existing behavior) — no new cache mechanism.
+
+### Known limitation (out of scope)
+
+The synthetic-dimension path (`translator.ts:309`) does not support custom granularities today, so a
+project-default *custom* granularity applies via the main column path (real model date columns) but
+not to synthetic/additional dimensions. This is a pre-existing gap; not fixed here.
+
+## Testing
+
+Unit (`packages/common`):
+- `getDefaultTimeFrames(type, defaults)`: additive merge; de-dup when an addition equals a built-in;
+  absent/empty config returns the built-in list unchanged; date vs timestamp keyed correctly.
+- Validation helper: unknown name dropped + warned; custom-granularity key accepted; sub-day grain
+  under `date` dropped + warned.
+
+Compiler (`translator` tests):
+- DATE column with no explicit list → built-in + the configured `date` additions.
+- TIMESTAMP column with no explicit list → built-in + `HOUR`.
+- Column with explicit `time_intervals` → untouched by the project default.
+- Project-default custom-granularity name expands to a sub-dimension on the main column path.
+- Invalid project-default entry is dropped and surfaced as a warning.
+
+## Files touched (anticipated)
+
+- `packages/common/src/types/lightdashProjectConfig.ts` — `ProjectDefaults.time_intervals`.
+- `packages/common/src/utils/timeFrames.ts` — `getDefaultTimeFrames` gains optional defaults arg;
+  validation helper for project additions.
+- `packages/common/src/compiler/translator.ts` — thread defaults through `convertTable`; use the new
+  fallback at both call sites.
+- `packages/common/src/schemas/json/lightdash-project-config-1.0.json` — schema for the new field.
+- Tests alongside the above.

--- a/docs/superpowers/specs/2026-06-25-glitch-265-project-default-time-intervals-design.md
+++ b/docs/superpowers/specs/2026-06-25-glitch-265-project-default-time-intervals-design.md
@@ -79,13 +79,14 @@ the meaning of an existing field.
 
 ### 2. Merge semantics — additive (decided)
 
-`getDefaultTimeFrames(type)` in `packages/common/src/utils/timeFrames.ts` gains an optional second
-argument carrying the project additions and returns the built-in list with the additions appended,
-de-duplicated, order preserved (built-ins first):
+A new helper `getTimeFramesWithProjectDefaults(type, additions?)` in
+`packages/common/src/utils/timeFrames.ts` returns the built-in list with the resolved project
+additions appended, de-duplicated, order preserved (built-ins first). `getDefaultTimeFrames` stays
+pure (built-ins only):
 
 ```
-getDefaultTimeFrames(type, projectDefaults?) =>
-    dedupe([ ...builtIn(type), ...(additionsFor(type, projectDefaults)) ])
+getTimeFramesWithProjectDefaults(type, additions?) =>
+    dedupe([ ...getDefaultTimeFrames(type), ...(additions?.[date|timestamp] ?? []) ])
 ```
 
 When no config is present the output is byte-for-byte the current behavior.
@@ -93,8 +94,8 @@ When no config is present the output is byte-for-byte the current behavior.
 ### 3. Precedence — fallback only (Decision A, approved)
 
 The project default replaces only the *fallback* used when a column has no explicit
-`time_intervals`. It changes the `else` branch in both call sites; it does not touch columns that
-declare their own list.
+`time_intervals`. It changes the `else` branch of the model-column path; it does not touch columns
+that declare their own list.
 
 | Column state | Resulting intervals |
 |---|---|
@@ -104,18 +105,23 @@ declare their own list.
 This delivers "every new/uncurated date dimension inherits the extra grain" while leaving
 explicitly-curated columns unsurprised.
 
-### 4. Call sites
+### 4. Call site (model-column path only)
 
-Both currently call `getDefaultTimeFrames(type)` in their no-explicit-list branch:
+The change targets the **model-column** path: `processIntervalDimension` — `translator.ts:693`. It
+already produces a mixed `(TimeFrames | string)[]` array and splits standard vs custom via
+`validateTimeFrames` + `customIntervalNames`, so project-default custom granularities flow through
+here for free.
 
-1. `processIntervalDimension` — `translator.ts:693` (main column path). Already produces a mixed
-   `(TimeFrames | string)[]` array and splits standard vs custom via `validateTimeFrames` +
-   `customIntervalNames`, so project-default custom granularities flow through here for free.
-2. Synthetic / additional-dimension path — `translator.ts:309`. Standard `TimeFrames` only.
+The **explore-scoped additional-dimension path** (`translator.ts:309`) is intentionally left on the
+built-in defaults: explore-scoped additional dimensions are hand-authored SQL, i.e. already curated,
+so applying a project-wide default to them would contradict the fallback-only precedence principle
+in §3. (They can still declare their own `time_intervals` explicitly.)
 
-`convertExplores` already threads `lightdashProjectConfig.defaults` (line 1361) and
-`custom_granularities` (line 1148) into the compile path, so the new field rides existing plumbing;
-`convertTable` gains a `timeIntervalDefaults` parameter alongside the `customGranularities` one.
+`convertExplores` already threads `lightdashProjectConfig.custom_granularities` (line 1148) into the
+compile path, so the new field rides existing plumbing; `convertTable` gains an
+`additionalTimeIntervals` parameter alongside the `customGranularities` one. The project config is
+resolved/validated once in `convertExplores` (which holds the whole `LightdashProjectConfig`) before
+the model loop.
 
 ### 5. Validation — centralized, once at resolution (Decision B, approved)
 
@@ -136,11 +142,11 @@ per column — that would emit one warning per date dimension):
   dropdown, explorer sidebar, and queries consume them automatically. **No frontend changes.**
 - Changing the config triggers explore recompilation (existing behavior) — no new cache mechanism.
 
-### Known limitation (out of scope)
+### Scope note
 
-The synthetic-dimension path (`translator.ts:309`) does not support custom granularities today, so a
-project-default *custom* granularity applies via the main column path (real model date columns) but
-not to synthetic/additional dimensions. This is a pre-existing gap; not fixed here.
+Project additions apply to **model columns** (the path real date/timestamp dbt columns flow
+through). Explore-scoped *additional dimensions* are hand-authored and keep the standard built-in
+defaults (see §4). Out of scope: GLITCH-264 (granularity labels), removal/replace semantics.
 
 ## Testing
 
@@ -159,10 +165,12 @@ Compiler (`translator` tests):
 
 ## Files touched (anticipated)
 
-- `packages/common/src/types/lightdashProjectConfig.ts` — `ProjectDefaults.time_intervals`.
-- `packages/common/src/utils/timeFrames.ts` — `getDefaultTimeFrames` gains optional defaults arg;
-  validation helper for project additions.
-- `packages/common/src/compiler/translator.ts` — thread defaults through `convertTable`; use the new
-  fallback at both call sites.
+- `packages/common/src/types/lightdashProjectConfig.ts` — `ProjectDefaults.additional_time_intervals`.
+- `packages/common/src/utils/timeFrames.ts` — `getTimeFramesWithProjectDefaults` merge helper;
+  `ResolvedAdditionalTimeIntervals` type; `DATE_INVALID_TIME_FRAMES` set.
+- `packages/common/src/compiler/lightdashProjectConfig.ts` — `resolveAdditionalTimeIntervals`
+  validation helper (one-shot, console.warn on invalid).
+- `packages/common/src/compiler/translator.ts` — resolve once in `convertExplores`; thread through
+  `convertTable`; use the new fallback in the model-column `else` branch.
 - `packages/common/src/schemas/json/lightdash-project-config-1.0.json` — schema for the new field.
 - Tests alongside the above.

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14203,17 +14203,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -14285,6 +14285,83 @@ const models: TsoaRoute.Models = {
                                                                                                                     enums: [
                                                                                                                         null,
                                                                                                                     ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                requiredFilters:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'nestedObjectLiteral',
+                                                                                                                        nestedProperties:
+                                                                                                                            {
+                                                                                                                                settings:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'any',
+                                                                                                                                    },
+                                                                                                                                values: {
+                                                                                                                                    dataType:
+                                                                                                                                        'union',
+                                                                                                                                    subSchemas:
+                                                                                                                                        [
+                                                                                                                                            {
+                                                                                                                                                dataType:
+                                                                                                                                                    'array',
+                                                                                                                                                array: {
+                                                                                                                                                    dataType:
+                                                                                                                                                        'any',
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                dataType:
+                                                                                                                                                    'undefined',
+                                                                                                                                            },
+                                                                                                                                        ],
+                                                                                                                                },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                fieldRef:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                fieldId:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                operator:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                            },
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -14484,17 +14561,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -14678,14 +14755,14 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'true',
+                                                                                                        'false',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'false',
+                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
@@ -14710,6 +14787,29 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -14730,30 +14830,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldType:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'metric',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'dimension',
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
-                                                                                table: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -14764,12 +14841,12 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                table: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -14802,6 +14879,83 @@ const models: TsoaRoute.Models = {
                                                                         'nestedObjectLiteral',
                                                                     nestedProperties:
                                                                         {
+                                                                            requiredFilters:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'array',
+                                                                                                array: {
+                                                                                                    dataType:
+                                                                                                        'nestedObjectLiteral',
+                                                                                                    nestedProperties:
+                                                                                                        {
+                                                                                                            settings:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'any',
+                                                                                                                },
+                                                                                                            values: {
+                                                                                                                dataType:
+                                                                                                                    'union',
+                                                                                                                subSchemas:
+                                                                                                                    [
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'array',
+                                                                                                                            array: {
+                                                                                                                                dataType:
+                                                                                                                                    'any',
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'undefined',
+                                                                                                                        },
+                                                                                                                    ],
+                                                                                                            },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldRef:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldId:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                        },
+                                                                                                },
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -14983,18 +15137,7 @@ const models: TsoaRoute.Models = {
                                                     },
                                                     required: true,
                                                 },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
-                                                    required: true,
-                                                },
                                                 href: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
-                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -15003,8 +15146,19 @@ const models: TsoaRoute.Models = {
                                                     enums: ['success'],
                                                     required: true,
                                                 },
+                                                slug: {
+                                                    dataType: 'string',
+                                                    required: true,
+                                                },
                                                 uuid: {
                                                     dataType: 'string',
+                                                    required: true,
+                                                },
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -15351,13 +15505,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
-                                                    dataType: 'string',
-                                                    required: true,
-                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
+                                                    required: true,
+                                                },
+                                                slug: {
+                                                    dataType: 'string',
                                                     required: true,
                                                 },
                                                 name: {
@@ -15553,17 +15707,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15582,14 +15736,14 @@ const models: TsoaRoute.Models = {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'metric',
+                                                                                    'dimension',
                                                                                 ],
                                                                             },
                                                                             {
                                                                                 dataType:
                                                                                     'enum',
                                                                                 enums: [
-                                                                                    'dimension',
+                                                                                    'metric',
                                                                                 ],
                                                                             },
                                                                             {
@@ -29053,6 +29207,31 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                additional_time_intervals: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        timestamp: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'TimeFrames' },
+                                    { dataType: 'string' },
+                                ],
+                            },
+                        },
+                        date: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { ref: 'TimeFrames' },
+                                    { dataType: 'string' },
+                                ],
+                            },
+                        },
+                    },
+                },
                 column_totals: { dataType: 'boolean' },
                 case_sensitive: { dataType: 'boolean' },
             },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15697,10 +15697,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -15709,8 +15709,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -15731,6 +15731,41 @@
                                                                             },
                                                                             "type": "array",
                                                                             "nullable": true
+                                                                        },
+                                                                        "requiredFilters": {
+                                                                            "items": {
+                                                                                "properties": {
+                                                                                    "settings": {},
+                                                                                    "values": {
+                                                                                        "items": {},
+                                                                                        "type": "array"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "tableName": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "fieldRef": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "fieldId": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "required",
+                                                                                    "tableName",
+                                                                                    "fieldRef",
+                                                                                    "fieldId",
+                                                                                    "operator"
+                                                                                ],
+                                                                                "type": "object"
+                                                                            },
+                                                                            "type": "array"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
@@ -15822,10 +15857,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -15834,8 +15869,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -15935,8 +15970,8 @@
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "true",
                                                                                         "false",
+                                                                                        "true",
                                                                                         "not_applicable"
                                                                                     ]
                                                                                 },
@@ -15946,27 +15981,27 @@
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "metric",
-                                                                                        "dimension"
-                                                                                    ]
-                                                                                },
-                                                                                "table": {
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "label": {
+                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
@@ -15975,12 +16010,12 @@
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
-                                                                                "description",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
+                                                                                "description",
                                                                                 "label",
-                                                                                "name"
+                                                                                "fieldId",
+                                                                                "name",
+                                                                                "table"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -15992,6 +16027,41 @@
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
+                                                                            "requiredFilters": {
+                                                                                "items": {
+                                                                                    "properties": {
+                                                                                        "settings": {},
+                                                                                        "values": {
+                                                                                            "items": {},
+                                                                                            "type": "array"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldRef": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldId": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "required",
+                                                                                        "tableName",
+                                                                                        "fieldRef",
+                                                                                        "fieldId",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
@@ -16126,16 +16196,7 @@
                                                         ],
                                                         "type": "object"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "href": {
-                                                        "type": "string"
-                                                    },
-                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -16143,8 +16204,17 @@
                                                         "enum": ["success"],
                                                         "nullable": false
                                                     },
+                                                    "slug": {
+                                                        "type": "string"
+                                                    },
                                                     "uuid": {
                                                         "type": "string"
+                                                    },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -16152,11 +16222,11 @@
                                                 },
                                                 "required": [
                                                     "versionUuids",
-                                                    "warnings",
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "uuid",
+                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -16258,13 +16328,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
-                                                        "type": "string"
-                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
                                                         "nullable": false
+                                                    },
+                                                    "slug": {
+                                                        "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
@@ -16272,8 +16342,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "slug",
                                                     "status",
+                                                    "slug",
                                                     "name"
                                                 ],
                                                 "type": "object"
@@ -16334,10 +16404,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16346,8 +16416,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -16357,8 +16427,8 @@
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
-                                                                    "metric",
                                                                     "dimension",
+                                                                    "metric",
                                                                     null
                                                                 ],
                                                                 "nullable": true
@@ -29815,6 +29885,38 @@
             },
             "ProjectDefaults": {
                 "properties": {
+                    "additional_time_intervals": {
+                        "properties": {
+                            "timestamp": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/TimeFrames"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            },
+                            "date": {
+                                "items": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/TimeFrames"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "description": "Extra time intervals appended to the built-in defaults for date/timestamp\ndimensions that do not declare their own `time_intervals`. Values may be\nstandard granularities (e.g. `hour`) or `custom_granularities` keys."
+                    },
                     "column_totals": {
                         "type": "boolean",
                         "description": "Default behavior for column totals in results tables.\nWhen false, the extra warehouse query that calculates column totals\nis not run by default for new queries. Charts that explicitly enable\n\"Show column totals\" still calculate them.\nDefaults to true if not specified."
@@ -41357,7 +41459,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3242.0",
+        "version": "0.3249.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/compiler/lightdashProjectConfig.test.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.test.ts
@@ -1,5 +1,9 @@
 import { FilterOperator, type MetricFilterRule } from '../types/filter';
-import { getSpotlightConfigurationForResource } from './lightdashProjectConfig';
+import { TimeFrames } from '../types/timeFrames';
+import {
+    getSpotlightConfigurationForResource,
+    resolveAdditionalTimeIntervals,
+} from './lightdashProjectConfig';
 
 describe('getSpotlightConfigurationForResource defaults', () => {
     it('threads defaultSegment and a parsed defaultFilter into spotlight', () => {
@@ -39,5 +43,54 @@ describe('getSpotlightConfigurationForResource defaults', () => {
         expect(
             getSpotlightConfigurationForResource({ defaultSegment: 'region' }),
         ).toEqual({});
+    });
+});
+
+describe('resolveAdditionalTimeIntervals', () => {
+    const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
+
+    afterEach(() => warnSpy.mockClear());
+    afterAll(() => warnSpy.mockRestore());
+
+    it('returns empty lists when config is undefined', () => {
+        expect(resolveAdditionalTimeIntervals(undefined, {})).toEqual({
+            date: [],
+            timestamp: [],
+        });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('uppercases a standard timestamp grain', () => {
+        expect(
+            resolveAdditionalTimeIntervals({ timestamp: ['hour'] }, {}),
+        ).toEqual({ date: [], timestamp: [TimeFrames.HOUR] });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops a sub-day grain configured under date and warns', () => {
+        expect(resolveAdditionalTimeIntervals({ date: ['hour'] }, {})).toEqual({
+            date: [],
+            timestamp: [],
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps a defined custom granularity key', () => {
+        expect(
+            resolveAdditionalTimeIntervals(
+                { date: ['fiscal_week'] },
+                { fiscal_week: { label: 'Fiscal Week', sql: '${COLUMN}' } },
+            ),
+        ).toEqual({ date: ['fiscal_week'], timestamp: [] });
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops an unknown name and warns', () => {
+        expect(
+            resolveAdditionalTimeIntervals({ timestamp: ['nonsense'] }, {}),
+        ).toEqual({ date: [], timestamp: [] });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -6,7 +6,24 @@ import type {
     LightdashProjectConfig,
     ProjectDefaults,
 } from '../types/lightdashProjectConfig';
+import { TimeFrames } from '../types/timeFrames';
 import type { ResolvedAdditionalTimeIntervals } from '../utils/timeFrames';
+
+const STANDARD_TIME_FRAMES: ReadonlySet<string> = new Set(
+    Object.values(TimeFrames),
+);
+
+const isStandardTimeFrame = (value: string): value is TimeFrames =>
+    STANDARD_TIME_FRAMES.has(value);
+
+/** Standard time frames that are meaningless on a plain DATE dimension. */
+const DATE_INVALID_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.RAW,
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+]);
 
 type SpotlightConfigArgs = {
     visibility?: LightdashProjectConfig['spotlight']['default_visibility'];
@@ -97,41 +114,31 @@ export const getCategoriesFromResource = (
 };
 
 const resolveAdditionalTimeIntervalList = (
-    values: (string | undefined)[] | undefined,
+    values: (TimeFrames | string)[] | undefined,
     key: 'date' | 'timestamp',
     customGranularities: LightdashProjectConfig['custom_granularities'],
-): string[] => {
-    // Lazy import to avoid circular dependency via dbt
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const {
-        DATE_INVALID_TIME_FRAMES,
-        isTimeInterval,
-    } = require('../utils/timeFrames');
-    return (values ?? []).reduce<string[]>((acc, raw) => {
-        const name = String(raw);
-        const upper = name.toUpperCase();
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        if (isTimeInterval(upper)) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+): string[] =>
+    (values ?? []).reduce<string[]>((acc, raw) => {
+        const upper = raw.toUpperCase();
+        if (isStandardTimeFrame(upper)) {
             if (key === 'date' && DATE_INVALID_TIME_FRAMES.has(upper)) {
                 // eslint-disable-next-line no-console
                 console.warn(
-                    `Ignoring sub-day time interval "${name}" in defaults.additional_time_intervals.date — not valid for DATE dimensions.`,
+                    `Ignoring sub-day time interval "${raw}" in defaults.additional_time_intervals.date — not valid for DATE dimensions.`,
                 );
                 return acc;
             }
             return [...acc, upper];
         }
-        if (customGranularities?.[name]) {
-            return [...acc, name];
+        if (customGranularities?.[raw]) {
+            return [...acc, raw];
         }
         // eslint-disable-next-line no-console
         console.warn(
-            `Ignoring unknown time interval "${name}" in defaults.additional_time_intervals.${key} — not a standard granularity or a defined custom_granularity.`,
+            `Ignoring unknown time interval "${raw}" in defaults.additional_time_intervals.${key} — not a standard granularity or a defined custom_granularity.`,
         );
         return acc;
     }, []);
-};
 
 /**
  * Validate `defaults.additional_time_intervals` once: keep standard grains

--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -2,7 +2,11 @@ import { ParseError } from '../types/errors';
 import type { Explore } from '../types/explore';
 import type { Metric } from '../types/field';
 import type { MetricFilterRule } from '../types/filter';
-import type { LightdashProjectConfig } from '../types/lightdashProjectConfig';
+import type {
+    LightdashProjectConfig,
+    ProjectDefaults,
+} from '../types/lightdashProjectConfig';
+import type { ResolvedAdditionalTimeIntervals } from '../utils/timeFrames';
 
 type SpotlightConfigArgs = {
     visibility?: LightdashProjectConfig['spotlight']['default_visibility'];
@@ -91,3 +95,61 @@ export const getCategoriesFromResource = (
 
     return resourceCategories;
 };
+
+const resolveAdditionalTimeIntervalList = (
+    values: (string | undefined)[] | undefined,
+    key: 'date' | 'timestamp',
+    customGranularities: LightdashProjectConfig['custom_granularities'],
+): string[] => {
+    // Lazy import to avoid circular dependency via dbt
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const {
+        DATE_INVALID_TIME_FRAMES,
+        isTimeInterval,
+    } = require('../utils/timeFrames');
+    return (values ?? []).reduce<string[]>((acc, raw) => {
+        const name = String(raw);
+        const upper = name.toUpperCase();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        if (isTimeInterval(upper)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+            if (key === 'date' && DATE_INVALID_TIME_FRAMES.has(upper)) {
+                // eslint-disable-next-line no-console
+                console.warn(
+                    `Ignoring sub-day time interval "${name}" in defaults.additional_time_intervals.date — not valid for DATE dimensions.`,
+                );
+                return acc;
+            }
+            return [...acc, upper];
+        }
+        if (customGranularities?.[name]) {
+            return [...acc, name];
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Ignoring unknown time interval "${name}" in defaults.additional_time_intervals.${key} — not a standard granularity or a defined custom_granularity.`,
+        );
+        return acc;
+    }, []);
+};
+
+/**
+ * Validate `defaults.additional_time_intervals` once: keep standard grains
+ * (uppercased) and defined custom-granularity keys; drop sub-day grains under
+ * `date` and unknown names (each with a single console.warn).
+ */
+export const resolveAdditionalTimeIntervals = (
+    additionalTimeIntervals: ProjectDefaults['additional_time_intervals'],
+    customGranularities: LightdashProjectConfig['custom_granularities'],
+): ResolvedAdditionalTimeIntervals => ({
+    date: resolveAdditionalTimeIntervalList(
+        additionalTimeIntervals?.date,
+        'date',
+        customGranularities,
+    ),
+    timestamp: resolveAdditionalTimeIntervalList(
+        additionalTimeIntervals?.timestamp,
+        'timestamp',
+        customGranularities,
+    ),
+});

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1939,3 +1939,102 @@ describe('convert_timezone dimension override', () => {
         ).toBeUndefined();
     });
 });
+
+describe('project default additional_time_intervals', () => {
+    const TIMESTAMP_MODEL: DbtModelNode & { relation_name: string } = {
+        ...model,
+        columns: {
+            created_at: {
+                name: 'created_at',
+                data_type: DimensionType.TIMESTAMP,
+                meta: { dimension: { type: DimensionType.TIMESTAMP } },
+            },
+        },
+    };
+
+    it('appends a standard grain (HOUR) to a timestamp column with no explicit time_intervals', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            TIMESTAMP_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined, // startOfWeek
+            undefined, // disableTimestampConversion
+            undefined, // customGranularities
+            undefined, // allowPartialCompilation
+            { date: [], timestamp: [TimeFrames.HOUR] }, // additionalTimeIntervals
+        );
+        expect(result.dimensions).toHaveProperty('created_at_hour');
+        expect(result.dimensions).toHaveProperty('created_at_day');
+    });
+
+    it('appends a custom granularity to a timestamp column', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            TIMESTAMP_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            { fiscal_week: { label: 'Fiscal Week', sql: '${COLUMN}' } },
+            undefined,
+            { date: [], timestamp: ['fiscal_week'] },
+        );
+        expect(result.dimensions).toHaveProperty('created_at_fiscal_week');
+    });
+
+    it('does NOT add the project default to a column with explicit time_intervals', () => {
+        const EXPLICIT_MODEL: DbtModelNode & { relation_name: string } = {
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                    },
+                },
+            },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            EXPLICIT_MODEL,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { date: [], timestamp: [TimeFrames.HOUR] },
+        );
+        expect(result.dimensions).toHaveProperty('created_at_day');
+        expect(result.dimensions).not.toHaveProperty('created_at_hour');
+    });
+
+    it('flows from convertExplores via lightdashProjectConfig.defaults', async () => {
+        const explores = await convertExplores(
+            [TIMESTAMP_MODEL],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            [],
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+                defaults: {
+                    additional_time_intervals: {
+                        timestamp: [TimeFrames.HOUR],
+                    },
+                },
+            },
+        );
+        const explore = explores[0];
+        expect('errors' in explore).toBe(false);
+        if (!('errors' in explore)) {
+            const table = explore.tables[explore.baseTable];
+            expect(table.dimensions).toHaveProperty('created_at_hour');
+        }
+    });
+});

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -55,15 +55,18 @@ import { type WarehouseSqlBuilder } from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     getDefaultTimeFrames,
+    getTimeFramesWithProjectDefaults,
     isTimeInterval,
     timeFrameConfigs,
     validateTimeFrames,
+    type ResolvedAdditionalTimeIntervals,
     type WeekDay,
 } from '../utils/timeFrames';
 import { ExploreCompiler } from './exploreCompiler';
 import {
     getCategoriesFromResource,
     getSpotlightConfigurationForResource,
+    resolveAdditionalTimeIntervals,
 } from './lightdashProjectConfig';
 
 const convertTimezone = (
@@ -644,6 +647,7 @@ export const convertTable = (
     disableTimestampConversion?: boolean,
     customGranularities?: Record<string, CustomGranularity>,
     allowPartialCompilation?: boolean,
+    additionalTimeIntervals?: ResolvedAdditionalTimeIntervals,
 ): Omit<Table, 'lineageGraph'> => {
     // Config block takes priority, then meta block
     const meta = merge({}, model.meta, model.config?.meta);
@@ -690,7 +694,10 @@ export const convertTable = (
                     ) {
                         allIntervals = overrideTimeIntervals;
                     } else {
-                        allIntervals = getDefaultTimeFrames(dim.type);
+                        allIntervals = getTimeFramesWithProjectDefaults(
+                            dim.type,
+                            additionalTimeIntervals,
+                        );
                     }
 
                     // Split into standard TimeFrames and custom granularity names
@@ -1116,6 +1123,10 @@ export const convertExplores = async (
         postProcessors,
     } = options ?? {};
     const tableLineage = translateDbtModelsToTableLineage(models);
+    const additionalTimeIntervals = resolveAdditionalTimeIntervals(
+        lightdashProjectConfig.defaults?.additional_time_intervals,
+        lightdashProjectConfig.custom_granularities,
+    );
     const [tables, exploreErrors] = models.reduce(
         ([accTables, accErrors], model) => {
             // Config block takes priority, then meta block
@@ -1147,6 +1158,7 @@ export const convertExplores = async (
                     disableTimestampConversion,
                     lightdashProjectConfig.custom_granularities,
                     allowPartialCompilation,
+                    additionalTimeIntervals,
                 );
 
                 // add lineage

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -161,6 +161,36 @@
                 }
             }
         },
+        "defaults": {
+            "type": ["object", "null"],
+            "description": "Project-wide default settings that can be overridden at explore or field level",
+            "properties": {
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "Default case sensitivity for string filters. Defaults to true."
+                },
+                "column_totals": {
+                    "type": "boolean",
+                    "description": "Default behaviour for column totals in results tables. Defaults to true."
+                },
+                "additional_time_intervals": {
+                    "type": ["object", "null"],
+                    "description": "Extra time intervals appended to the built-in defaults for date/timestamp dimensions that do not declare their own time_intervals. Values may be standard granularities (e.g. hour) or custom_granularities keys.",
+                    "properties": {
+                        "date": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Appended to the built-in DAY/WEEK/MONTH/QUARTER/YEAR defaults for DATE dimensions."
+                        },
+                        "timestamp": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Appended to the built-in RAW/DAY/WEEK/MONTH/QUARTER/YEAR defaults for TIMESTAMP dimensions."
+                        }
+                    }
+                }
+            }
+        },
         "table_groups": {
             "type": ["object", "null"],
             "description": "Define labels and descriptions for the group keys referenced by models in their meta.groups array. Used to render nested table groups in the sidebar.",

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -2,6 +2,7 @@ import { type DimensionType } from './field';
 import type { ParameterValue } from './parameters';
 import type { WarehouseTypes } from './projects';
 import type { GroupType } from './table';
+import { type TimeFrames } from './timeFrames';
 
 type SpotlightCategory = {
     label: string;
@@ -57,6 +58,15 @@ export type ProjectDefaults = {
      * Defaults to true if not specified.
      */
     column_totals?: boolean;
+    /**
+     * Extra time intervals appended to the built-in defaults for date/timestamp
+     * dimensions that do not declare their own `time_intervals`. Values may be
+     * standard granularities (e.g. `hour`) or `custom_granularities` keys.
+     */
+    additional_time_intervals?: {
+        date?: (TimeFrames | string)[];
+        timestamp?: (TimeFrames | string)[];
+    };
     // Room for future project-wide defaults like:
     // date_format?: string;
     // number_format?: string;

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -9,6 +9,7 @@ import {
     getSqlForDatePart,
     getSqlForDatePartName,
     getSqlForTruncatedDate,
+    getTimeFramesWithProjectDefaults,
     isSubDayGranularity,
     SUB_DAY_GRANULARITIES,
     timeFrameConfigs,
@@ -1365,5 +1366,77 @@ describe('TimeFrames', () => {
                 );
             },
         );
+    });
+
+    describe('getTimeFramesWithProjectDefaults', () => {
+        it('returns built-in defaults unchanged when no additions are given', () => {
+            expect(
+                getTimeFramesWithProjectDefaults(DimensionType.DATE),
+            ).toEqual([
+                TimeFrames.DAY,
+                TimeFrames.WEEK,
+                TimeFrames.MONTH,
+                TimeFrames.QUARTER,
+                TimeFrames.YEAR,
+            ]);
+            expect(
+                getTimeFramesWithProjectDefaults(DimensionType.TIMESTAMP),
+            ).toEqual([
+                TimeFrames.RAW,
+                TimeFrames.DAY,
+                TimeFrames.WEEK,
+                TimeFrames.MONTH,
+                TimeFrames.QUARTER,
+                TimeFrames.YEAR,
+            ]);
+        });
+
+        it('appends timestamp additions after the built-in defaults', () => {
+            expect(
+                getTimeFramesWithProjectDefaults(DimensionType.TIMESTAMP, {
+                    date: [],
+                    timestamp: [TimeFrames.HOUR],
+                }),
+            ).toEqual([
+                TimeFrames.RAW,
+                TimeFrames.DAY,
+                TimeFrames.WEEK,
+                TimeFrames.MONTH,
+                TimeFrames.QUARTER,
+                TimeFrames.YEAR,
+                TimeFrames.HOUR,
+            ]);
+        });
+
+        it('appends a custom granularity name for date dimensions', () => {
+            expect(
+                getTimeFramesWithProjectDefaults(DimensionType.DATE, {
+                    date: ['fiscal_week'],
+                    timestamp: [],
+                }),
+            ).toEqual([
+                TimeFrames.DAY,
+                TimeFrames.WEEK,
+                TimeFrames.MONTH,
+                TimeFrames.QUARTER,
+                TimeFrames.YEAR,
+                'fiscal_week',
+            ]);
+        });
+
+        it('de-duplicates an addition that already exists in the built-in defaults', () => {
+            expect(
+                getTimeFramesWithProjectDefaults(DimensionType.DATE, {
+                    date: [TimeFrames.DAY],
+                    timestamp: [],
+                }),
+            ).toEqual([
+                TimeFrames.DAY,
+                TimeFrames.WEEK,
+                TimeFrames.MONTH,
+                TimeFrames.QUARTER,
+                TimeFrames.YEAR,
+            ]);
+        });
     });
 });

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -1034,15 +1034,6 @@ export type ResolvedAdditionalTimeIntervals = {
     timestamp: (TimeFrames | string)[];
 };
 
-/** Standard time frames that are meaningless on a plain DATE dimension. */
-export const DATE_INVALID_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
-    TimeFrames.RAW,
-    TimeFrames.MILLISECOND,
-    TimeFrames.SECOND,
-    TimeFrames.MINUTE,
-    TimeFrames.HOUR,
-]);
-
 /**
  * Built-in default time frames for a dimension type, with project-level
  * `additional_time_intervals` appended (de-duplicated, built-ins first).

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -1029,6 +1029,40 @@ export const getDefaultTimeFrames = (type: DimensionType) =>
               TimeFrames.YEAR,
           ];
 
+export type ResolvedAdditionalTimeIntervals = {
+    date: (TimeFrames | string)[];
+    timestamp: (TimeFrames | string)[];
+};
+
+/** Standard time frames that are meaningless on a plain DATE dimension. */
+export const DATE_INVALID_TIME_FRAMES: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.RAW,
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+]);
+
+/**
+ * Built-in default time frames for a dimension type, with project-level
+ * `additional_time_intervals` appended (de-duplicated, built-ins first).
+ */
+export const getTimeFramesWithProjectDefaults = (
+    type: DimensionType,
+    additionalTimeIntervals?: ResolvedAdditionalTimeIntervals,
+): (TimeFrames | string)[] => {
+    const additions =
+        type === DimensionType.TIMESTAMP
+            ? (additionalTimeIntervals?.timestamp ?? [])
+            : (additionalTimeIntervals?.date ?? []);
+    const seen = new Set<string>();
+    return [...getDefaultTimeFrames(type), ...additions].filter((value) => {
+        if (seen.has(value)) return false;
+        seen.add(value);
+        return true;
+    });
+};
+
 /** Time frames that use DATE_TRUNC (not EXTRACT/DATE_PART). */
 export const truncatableTimeFrames: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.MILLISECOND,


### PR DESCRIPTION
## Summary

Adds a project-level **`defaults.additional_time_intervals`** setting in `lightdash.config.yml` that appends extra time-interval granularities to the built-in defaults for date/timestamp dimensions — so authors don't have to repeat `time_intervals` on every column. Values can be standard granularities (e.g. `hour`) or custom-granularity names.

Motivated by customer requests to (a) default a grain like `hour` onto **all** timestamps, and (b) default a project's custom granularity onto **all** date dimensions, without editing every model column.

## Config

```yaml
defaults:
  additional_time_intervals:
    timestamp: [hour]            # appended to the built-in RAW/DAY/WEEK/MONTH/QUARTER/YEAR
    date: [my_custom_grain]      # appended to the built-in DAY/WEEK/MONTH/QUARTER/YEAR
```

## Behavior

- **Additive.** Appended to the built-in defaults (de-duplicated, built-ins first). Named `additional_time_intervals` (not `time_intervals`) on purpose: the per-column `time_intervals` field *replaces* the set, whereas this one *adds* to it — distinct names avoid the same word meaning opposite things.
- **Fallback-only precedence.** Applies only to columns that don't declare their own `time_intervals`; explicitly-curated columns are untouched.
- **One-shot validation.** Resolved once at config load: unknown names and sub-day grains configured under `date` are dropped with a single warning; standard grains are normalized.
- **Scope.** Model-column dimensions only, in `common`/backend — the new sub-dimensions flow into compiled explores automatically, so there are no frontend changes. (Surfacing these grains in the Date Zoom *control* is governed by the separate date-zoom-configuration work, not this PR.)

## Testing

- **Unit:** merge helper, resolver/validator, and compiler wiring — additive merge + dedup, custom-granularity default, fallback-only precedence, and validation warnings (unknown name / sub-day-under-date).
- **Manual e2e** against the demo project: `hour` appears on a timestamp dimension, a project custom granularity appears on date dimensions, and a dimension with an explicit `time_intervals` list is unaffected.

Design & plan live under `docs/superpowers/specs/` and `docs/superpowers/plans/` (`2026-06-25-glitch-265-…`).

> The OpenAPI spec was regenerated (`pnpm generate-api`) to include the new optional field; this also reconciles pre-existing drift in the committed spec (it was several releases behind).

Closes: GLITCH-265
Closes: #14766

🤖 Generated with [Claude Code](https://claude.com/claude-code)
