### PR TITLE
fix(ai): rehydrate discovered field selectors

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7372,7 +7372,6 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             availableSkills,
             enableAgentRevamp: agentRevampEnabled,
 
-            findExploresFieldSearchSize: 200,
             findFieldsPageSize: 30,
             toolDescriptionMaxChars:
                 this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.test.ts
@@ -224,37 +224,25 @@ describe('AiAgentToolsService', () => {
         ]);
     });
 
-    it('adds verified field usage for AI runtime searches but not MCP searches', async () => {
-        const searchCatalog = jest.fn(async ({ catalogSearch }) => ({
-            data:
-                catalogSearch.type === CatalogType.Table
-                    ? [
-                          {
-                              type: CatalogType.Table,
-                              name: 'orders',
-                              label: 'Orders',
-                              description: null,
-                              aiHints: null,
-                              searchRank: 1,
-                              joinedTables: [],
-                          },
-                      ]
-                    : [
-                          {
-                              type: CatalogType.Field,
-                              name: 'orders_count',
-                              label: 'Orders Count',
-                              tableName: 'orders',
-                              fieldType: 'metric',
-                              searchRank: 1,
-                              description: null,
-                              chartUsage: 3,
-                          },
-                      ],
+    it('adds verified field usage for AI field searches but not MCP field searches', async () => {
+        const searchCatalog = jest.fn(async () => ({
+            data: [
+                {
+                    type: CatalogType.Field,
+                    name: 'orders_count',
+                    label: 'Orders Count',
+                    tableName: 'orders',
+                    fieldType: 'metric',
+                    searchRank: 1,
+                    description: 'Field detail returned by findFields',
+                    chartUsage: 3,
+                },
+            ],
             pagination: undefined,
         }));
+        const explore = makeExplore({ name: 'orders' });
         const service = makeService({
-            explores: { orders: makeExplore({ name: 'orders' }) },
+            explores: { orders: explore },
             searchCatalog,
             verifiedFieldUsage: new Map([['orders_orders_count::metric', 7]]),
         });
@@ -270,22 +258,90 @@ describe('AiAgentToolsService', () => {
         );
 
         await expect(
-            aiRuntime.findExplores({
-                fieldSearchSize: 50,
+            aiRuntime.findFields({
+                table: 'orders',
+                fieldSearchQuery: { label: 'orders count' },
+                page: 1,
+                pageSize: 50,
+                explore,
+            }),
+        ).resolves.toMatchObject({
+            fields: [expect.objectContaining({ verifiedChartUsage: 7 })],
+        });
+
+        const mcpResults = await mcpRuntime.findFields({
+            table: 'orders',
+            fieldSearchQuery: { label: 'orders count' },
+            page: 1,
+            pageSize: 50,
+            explore,
+        });
+        expect(mcpResults.fields[0]).not.toHaveProperty('verifiedChartUsage');
+        expect(mcpResults.fields[0]).toHaveProperty(
+            'description',
+            'Field detail returned by findFields',
+        );
+        expect(searchCatalog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                catalogSearch: expect.objectContaining({
+                    type: CatalogType.Field,
+                }),
+                paginateArgs: { page: 1, pageSize: 50 },
+            }),
+        );
+    });
+
+    it('returns compact all-field ids for matched explores without field search', async () => {
+        const searchCatalog = jest.fn(async () => ({
+            data: [
+                {
+                    type: CatalogType.Table,
+                    name: 'orders',
+                    label: 'Orders',
+                    description: 'Orders explore',
+                    aiHints: ['Use for order analysis'],
+                    searchRank: 1,
+                    joinedTables: ['customers'],
+                },
+            ],
+            pagination: undefined,
+        }));
+        const service = makeService({
+            explores: {
+                orders: makeExplore({
+                    name: 'orders',
+                    dimensions: {
+                        status: { name: 'status', table: 'orders' },
+                    },
+                    metrics: {
+                        count: { name: 'count', table: 'orders' },
+                    },
+                }),
+            },
+            searchCatalog,
+        });
+
+        await expect(
+            service.createRuntime(makeRuntimeContext()).findExplores({
                 searchQuery: 'orders',
             }),
         ).resolves.toMatchObject({
-            topMatchingFields: [
-                expect.objectContaining({ verifiedChartUsage: 7 }),
+            exploreSearchResults: [
+                expect.objectContaining({
+                    name: 'orders',
+                    fields: {
+                        dimensions: ['orders_status'],
+                        metrics: ['orders_count'],
+                    },
+                }),
             ],
         });
-
-        const mcpResults = await mcpRuntime.findExplores({
-            fieldSearchSize: 50,
-            searchQuery: 'orders',
-        });
-        expect(mcpResults.topMatchingFields?.[0]).not.toHaveProperty(
-            'verifiedChartUsage',
+        expect(searchCatalog).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                catalogSearch: expect.objectContaining({
+                    type: CatalogType.Field,
+                }),
+            }),
         );
     });
 
@@ -340,7 +396,6 @@ describe('AiAgentToolsService', () => {
         const runtime = service.createRuntime(makeRuntimeContext());
 
         const results = await runtime.findExplores({
-            fieldSearchSize: 50,
             searchQuery: 'orders',
         });
 
@@ -361,8 +416,12 @@ describe('AiAgentToolsService', () => {
                 }),
             ],
         });
-        expect(results.topMatchingFields?.[0]).not.toHaveProperty(
-            'requiredFilter',
+        expect(searchCatalog).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                catalogSearch: expect.objectContaining({
+                    type: CatalogType.Field,
+                }),
+            }),
         );
     });
 

--- a/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
+++ b/packages/backend/src/ee/services/AiAgentToolsService/AiAgentToolsService.ts
@@ -11,6 +11,7 @@ import {
     filterExploreByTags,
     ForbiddenError,
     getContentAsCodePathFromLtreePath,
+    getItemId,
     getItemMap,
     getLtreePathFromContentAsCodePath,
     getValidAiQueryLimit,
@@ -317,6 +318,32 @@ export class AiAgentToolsService extends BaseService {
         return this.builtInSkills.getMcpResourceBody(uri);
     }
 
+    private static getExploreFieldIds(explore: Explore): {
+        dimensions: string[];
+        metrics: string[];
+    } {
+        const dimensions = Object.entries(explore.tables).flatMap(
+            ([tableName, table]) =>
+                Object.values(table.dimensions).map((dimension) =>
+                    getItemId({
+                        table: dimension.table ?? tableName,
+                        name: dimension.name,
+                    }),
+                ),
+        );
+        const metrics = Object.entries(explore.tables).flatMap(
+            ([tableName, table]) =>
+                Object.values(table.metrics).map((metric) =>
+                    getItemId({
+                        table: metric.table ?? tableName,
+                        name: metric.name,
+                    }),
+                ),
+        );
+
+        return { dimensions, metrics };
+    }
+
     constructor({
         builtInSkills,
         projectModel,
@@ -562,9 +589,16 @@ export class AiAgentToolsService extends BaseService {
                 const exploreSearchResults = tableSearchResults.data
                     .filter((item) => item.type === CatalogType.Table)
                     .map((table) => {
+                        const explore = filteredExploresByName.get(table.name);
+                        if (!explore) {
+                            throw new Error(
+                                `Catalog search returned explore "${table.name}" outside the filtered explore set.`,
+                            );
+                        }
+
                         const requiredFilters =
                             AiAgentToolsService.getExploreRequiredFilters(
-                                filteredExploresByName.get(table.name),
+                                explore,
                             );
 
                         return {
@@ -577,51 +611,15 @@ export class AiAgentToolsService extends BaseService {
                             ...(requiredFilters.length > 0
                                 ? { requiredFilters }
                                 : {}),
+                            fields: AiAgentToolsService.getExploreFieldIds(
+                                explore,
+                            ),
                         };
                     });
 
-                const fieldSearchResults =
-                    await this.catalogService.searchCatalog({
-                        projectUuid: context.projectUuid,
-                        userAttributes,
-                        catalogSearch: {
-                            searchQuery: args.searchQuery,
-                            type: CatalogType.Field,
-                        },
-                        context: context.catalogSearchContext,
-                        paginateArgs: { page: 1, pageSize: 50 },
-                        fullTextSearchOperator: 'OR',
-                        filteredExplores,
-                    });
-
-                const verifiedFieldUsage =
-                    context.source === 'ai_agent'
-                        ? await this.getVerifiedFieldUsage(context)
-                        : null;
-                const topMatchingFields = fieldSearchResults.data
-                    .filter((item) => item.type === CatalogType.Field)
-                    .map((field) => ({
-                        name: field.name,
-                        label: field.label,
-                        tableName: field.tableName,
-                        fieldType: field.fieldType,
-                        searchRank: field.searchRank,
-                        description: field.description,
-                        chartUsage: field.chartUsage ?? 0,
-                        ...(verifiedFieldUsage
-                            ? {
-                                  verifiedChartUsage:
-                                      AiAgentToolsService.lookupVerifiedChartUsage(
-                                          verifiedFieldUsage,
-                                          field.tableName,
-                                          field.name,
-                                          field.fieldType,
-                                      ),
-                              }
-                            : {}),
-                    }));
-
-                return { exploreSearchResults, topMatchingFields };
+                return {
+                    exploreSearchResults,
+                };
             },
         );
     }

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -223,9 +223,7 @@ const getAgentTools = (
             callOptions: args.callOptions,
             providerOptions: args.providerOptions,
             availableExplores,
-            findExploresFieldSearchSize: args.findExploresFieldSearchSize,
             findFieldsPageSize: args.findFieldsPageSize,
-            toolDescriptionMaxChars: args.toolDescriptionMaxChars,
             promptUuid: args.promptUuid,
             telemetry: {
                 agentSettings: args.agentSettings,
@@ -239,6 +237,7 @@ const getAgentTools = (
             findExplores: dependencies.findExplores,
             findFields: dependencies.findFields,
             getExplore: dependencies.getExplore,
+            listExplores: dependencies.listExplores,
             updateProgress: dependencies.updateProgress,
             storeToolCall: dependencies.storeToolCall,
             storeToolResults: dependencies.storeToolResults,

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/agent.ts
@@ -1,4 +1,4 @@
-import { AgentToolOutput, Explore } from '@lightdash/common';
+import { Explore } from '@lightdash/common';
 import {
     hasToolCall,
     smoothStream,
@@ -13,26 +13,23 @@ import {
 import Logger from '../../../../../logging/logger';
 import { getFindExplores } from '../../tools/findExplores';
 import { getFindFields } from '../../tools/findFields';
+import { getListFields } from '../../tools/listFields';
+import { getMcpListExplores } from '../../tools/mcpListExplores';
+import { stringifyToolJson } from '../../tools/toolOutputFormat';
 import type { AiAgentArgs, AiAgentDependencies } from '../../types/aiAgent';
 import { AgentContext } from '../../utils/AgentContext';
 import { getAgentTelemetryConfig } from '../telemetry';
-import { DiscoverFieldsInput, discoverFieldsResultSchema } from './schema';
+import { DiscoverFieldsInput, discoverFieldsSelectionSchemaV2 } from './schema';
 import { getDiscoverFieldsSystemPrompt } from './systemPrompt';
 
 const SUBAGENT_STEP_CAP = 50;
-
-const SUBAGENT_PERSISTED_TOOL_NAMES = ['findExplores', 'findFields'] as const;
-type SubagentPersistedToolName = (typeof SUBAGENT_PERSISTED_TOOL_NAMES)[number];
-const isSubagentPersistedToolName = (
-    name: string,
-): name is SubagentPersistedToolName =>
-    (SUBAGENT_PERSISTED_TOOL_NAMES as readonly string[]).includes(name);
 
 export type DiscoverFieldsAgentDependencies = Pick<
     AiAgentDependencies,
     | 'findExplores'
     | 'findFields'
     | 'getExplore'
+    | 'listExplores'
     | 'updateProgress'
     | 'storeToolCall'
     | 'storeToolResults'
@@ -44,9 +41,7 @@ export type DiscoverFieldsAgentArgs = {
     model: LanguageModel;
     callOptions: CallSettings;
     providerOptions: AiAgentArgs['providerOptions'];
-    findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
-    toolDescriptionMaxChars: number;
     abortSignal?: AbortSignal;
     promptUuid: string;
     parentToolCallId: string;
@@ -60,35 +55,55 @@ export type DiscoverFieldsAgentArgs = {
     >;
 };
 
-/**
- * Internal tool the subagent must call as its FINAL step. Its inputSchema
- * IS `discoverFieldsResultSchema`, so AI SDK validates the handoff payload
- * at the tool-call boundary — there's no free-form JSON to parse and no
- * fence stripping. If validation fails, the model gets a tool-call error
- * and retries (or hits the step cap). The handoff is then extracted from
- * the tool call's `input` field after the stream completes.
- */
 const submitResult = tool({
     description:
-        'Submit the final discovery handoff. Call this as your LAST step after deciding the explore + fields (or that the query is ambiguous / has no match). The arguments are returned to the parent agent verbatim.',
-    inputSchema: discoverFieldsResultSchema,
-    execute: async (input) => input,
+        'Submit final discovery selectors. Call this as your LAST step. For resolved, pass only exploreName, ordered dimensionIds, ordered metricIds, rationale, and uncertainties; use uncertainties: null when selection was straightforward. The parent rehydrates exact field/explore details.',
+    inputSchema: discoverFieldsSelectionSchemaV2,
+    execute: async (input) => ({
+        result: stringifyToolJson(input),
+        structuredResult: input,
+        metadata: { status: 'success' as const },
+    }),
 });
 
 export type DiscoverFieldsSubagentTools = {
+    listExplores: ReturnType<typeof getMcpListExplores>;
     findExplores: ReturnType<typeof getFindExplores>;
     findFields: ReturnType<typeof getFindFields>;
+    listFields: ReturnType<typeof getListFields>;
     submitResult: typeof submitResult;
+};
+
+const isPersistableToolOutput = (
+    output: unknown,
+): output is {
+    result: string;
+    metadata?: Record<string, unknown> | null;
+} =>
+    typeof output === 'object' &&
+    output !== null &&
+    'result' in output &&
+    typeof output.result === 'string';
+
+const normalizePersistedToolResult = (
+    toolName: string,
+    output: unknown,
+): { result: string; metadata?: Record<string, unknown> | null } => {
+    if (isPersistableToolOutput(output)) {
+        return {
+            result: output.result,
+            metadata: output.metadata,
+        };
+    }
+
+    return {
+        result: stringifyToolJson(output),
+        metadata: toolName === 'submitResult' ? { status: 'success' } : null,
+    };
 };
 
 export type DiscoverFieldsAgentHandle = {
     stream: StreamTextResult<DiscoverFieldsSubagentTools, never>;
-    /**
-     * Waits for any in-flight `storeToolCall` writes triggered by the
-     * subagent's `onChunk` to settle. Call this after the stream has
-     * been fully consumed but before yielding the final tool output, so
-     * the parent's `tool-result` row never commits before its children.
-     */
     flushPersistence: () => Promise<void>;
 };
 
@@ -96,11 +111,13 @@ export const runDiscoverFieldsAgent = (
     args: DiscoverFieldsAgentArgs,
     dependencies: DiscoverFieldsAgentDependencies,
 ): DiscoverFieldsAgentHandle => {
+    const listExplores = getMcpListExplores({
+        listExplores: dependencies.listExplores,
+    });
+
     const findExplores = getFindExplores({
-        fieldSearchSize: args.findExploresFieldSearchSize,
         findExplores: dependencies.findExplores,
         updateProgress: dependencies.updateProgress,
-        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
     });
 
     const findFields = getFindFields({
@@ -108,7 +125,10 @@ export const runDiscoverFieldsAgent = (
         findFields: dependencies.findFields,
         updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,
-        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
+    });
+
+    const listFields = getListFields({
+        getExplore: dependencies.getExplore,
     });
 
     const messages: ModelMessage[] = [
@@ -128,7 +148,13 @@ export const runDiscoverFieldsAgent = (
         model: args.model,
         ...args.callOptions,
         providerOptions: args.providerOptions,
-        tools: { findExplores, findFields, submitResult },
+        tools: {
+            listExplores,
+            findExplores,
+            listFields,
+            findFields,
+            submitResult,
+        },
         toolChoice: 'auto',
         stopWhen: [hasToolCall('submitResult'), stepCountIs(SUBAGENT_STEP_CAP)],
         messages,
@@ -144,7 +170,6 @@ export const runDiscoverFieldsAgent = (
         ),
         onChunk: ({ chunk }) => {
             if (chunk.type === 'tool-call') {
-                if (!isSubagentPersistedToolName(chunk.toolName)) return;
                 inflightWrites.push(
                     dependencies
                         .storeToolCall({
@@ -164,8 +189,10 @@ export const runDiscoverFieldsAgent = (
                 return;
             }
             if (chunk.type === 'tool-result') {
-                if (!isSubagentPersistedToolName(chunk.toolName)) return;
-                const output = chunk.output as AgentToolOutput;
+                const output = normalizePersistedToolResult(
+                    chunk.toolName,
+                    chunk.output,
+                );
                 inflightWrites.push(
                     dependencies
                         .storeToolResults([

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/schema.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/schema.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export {
     discoverFieldsInputSchema,
     discoverFieldsResultSchema,
@@ -5,3 +7,45 @@ export {
     type DiscoverFieldsResult,
     type ToolDiscoverFieldsOutput,
 } from '@lightdash/common';
+
+const uncertaintiesSchema = z
+    .string()
+    .nullable()
+    .describe(
+        'Free-form uncertainties or caveats encountered during discovery. Use null when none.',
+    );
+
+const discoverFieldsSelectionCandidateSchemaV2 = z.object({
+    exploreName: z.string(),
+    reason: z.string(),
+});
+
+const discoverFieldsSelectionUnionSchemaV2 = z.discriminatedUnion('status', [
+    z.object({
+        status: z.literal('resolved'),
+        exploreName: z.string(),
+        dimensionIds: z.array(z.string()),
+        metricIds: z.array(z.string()),
+        rationale: z.string().nullable(),
+        uncertainties: uncertaintiesSchema,
+    }),
+    z.object({
+        status: z.literal('ambiguous'),
+        candidates: z.array(discoverFieldsSelectionCandidateSchemaV2).min(2),
+        suggestedQuestion: z.string(),
+        uncertainties: uncertaintiesSchema,
+    }),
+    z.object({
+        status: z.literal('no_match'),
+        reason: z.string(),
+        uncertainties: uncertaintiesSchema,
+    }),
+]);
+
+export const discoverFieldsSelectionSchemaV2 = z.object({
+    handoff: discoverFieldsSelectionUnionSchemaV2,
+});
+
+export type DiscoverFieldsSelectionV2 = z.infer<
+    typeof discoverFieldsSelectionUnionSchemaV2
+>;

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/systemPrompt.ts
@@ -4,8 +4,6 @@ import { renderAvailableExplores } from '../../prompts/availableExplores';
 
 const CONTEXT_MATCH_SEARCH_RANK_MIN = 0.7;
 const AI_HINTS_SEARCH_RANK_MIN = 0.6;
-const AMBIGUITY_RANK_WINDOW = 0.15;
-const CHART_USAGE_TIEBREAKER_MULTIPLIER = 3;
 
 const TEMPLATE = `You are the data-discovery subagent for the Lightdash AI Analyst.
 
@@ -13,68 +11,56 @@ Your sole job is to take the user's question and return a structured handoff des
 
 ## Tools available to you
 
-- **findExplores**: searches across explores, returns matching explores and the top fields across all explores.
-- **findFields**: once an explore is chosen, returns its fields (dimensions + metrics, including joined tables).
+- **listExplores**: lists every explore available to this agent. Use it when you need the full available data-source menu before searching.
+- **findExplores**: searches across explores, returns matching explores with full descriptions, AI hints, joined tables, required filters, and compact dimension/metric field id inventories. It does not search fields.
+- **findFields**: candidate search inside a chosen explore. Returns matching fields with full untruncated descriptions. Use it when you are not yet sure which exact metric or dimension field id should be used.
+- **listFields**: exact lookup by explore + fieldId. Returns the same field JSON shape as findFields, including full untruncated descriptions. Use it when you already have field id(s) that are likely final and need full context before selecting or submitting them.
 - **submitResult**: how you return your final answer. ALWAYS call this exactly once as your LAST step. Its arguments are the structured handoff payload. The argument schema is validated automatically — wrong shape = the call fails and you must retry.
 
 ## How you return your result
 
-Finish with a single \`submitResult\` call. Don't write prose explaining the answer; the parent reads the call's arguments verbatim. The argument schema is the source of truth — what follows is the *when* and *what to populate*, not the *shape*.
+Finish with a single \`submitResult\` call. Don't write prose explaining the answer; the parent reads the call's arguments verbatim. The argument schema is the source of truth.
 
 Pick exactly one status:
 
-- **\`resolved\`** — exactly one explore is the right answer. Populate \`explore\` and a FILTERED \`fields\` shortlist (typical size 5–20: metrics, dimensions, date grains, and filter dimensions the parent will plausibly need for a generateVisualization). Set each field's \`description\` only when keeping it distinguishes two similar fields you also kept; otherwise leave null. Add a brief \`rationale\`.
-- **\`ambiguous\`** — multiple explores plausibly fit and you cannot pick one. Populate \`candidates\` (≥2, with a one-line \`reason\` each) and a \`suggestedQuestion\` the parent can echo to disambiguate. **Do NOT call findFields.**
-- **\`no_match\`** — no explore plausibly covers the query. Populate \`reason\` with a single sentence the parent can relay to the user.
+- **\`resolved\`** — exactly one explore is the right answer. Populate only the chosen \`exploreName\`, ordered FILTERED \`dimensionIds\`, ordered FILTERED \`metricIds\`, a brief \`rationale\`, and free-form \`uncertainties\` (use null when selection was straightforward). Include the dimensions/date/filter fields and metrics the parent will plausibly need for generateVisualization. The parent rehydrates exact explore and field objects from Lightdash metadata.
+- **\`ambiguous\`** — multiple explores plausibly fit and you cannot pick one. Populate \`candidates\` with \`exploreName\` + one-line \`reason\` (≥2), a \`suggestedQuestion\` the parent can echo to disambiguate, and \`uncertainties\` explaining what prevented a confident choice.
+- **\`no_match\`** — no explore plausibly covers the query. Populate \`reason\` with a single sentence the parent can relay to the user and \`uncertainties\` explaining what was missing.
 
 ## Decision procedure
 
 Execute these steps in order. Do NOT skip steps.
 
-### Step 1: Context matching
+### Step 1: Explore search
 
-Scan the user's query for a domain word that matches an explore name (singular/plural counts — "order" matches "orders"). Call findExplores with high-signal metric/entity/dimension keywords.
+Scan the user's query for domain words that match an explore name, label, description, AI hints, or joined table. Call findExplores with high-signal entity/domain keywords.
 
-- If exactly one explore matches with searchRank > ${CONTEXT_MATCH_SEARCH_RANK_MIN} and there's a clear context word match → status: "resolved". Proceed to Step 5.
-- If no clear context match → continue to Step 2.
+- If findExplores returns no relevant explores → status: "no_match". Call submitResult.
+- If exactly one explore matches with searchRank > ${CONTEXT_MATCH_SEARCH_RANK_MIN} and there's a clear context word match → choose that explore and proceed to Step 4.
+- Otherwise → continue to Step 2.
 
-### Step 2: AI hints check
+### Step 2: Explore description and AI hints check
 
-Look at the topMatchingFields and exploreSearchResults from findExplores. Compare their aiHints + descriptions against the user's intent.
+Compare the full descriptions, aiHints, labels, joinedTables, and requiredFilters from findExplores against the user's intent.
 
-- If one explore's aiHints semantically match the request and it appears with searchRank > ${AI_HINTS_SEARCH_RANK_MIN} → status: "resolved". Proceed to Step 5.
+- If one explore's description or aiHints semantically match the request and it appears with searchRank > ${AI_HINTS_SEARCH_RANK_MIN} → choose that explore and proceed to Step 4.
+- If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → choose that explore and proceed to Step 4.
 - Otherwise → continue to Step 3.
 
-### Step 3: Verified-content fast path
+### Step 3: Field-level disambiguation
 
-Verified charts are admin-approved as canonical for this project — when an admin has marked a chart as verified, they've explicitly endorsed the metrics and explore it uses as the authoritative answer for that kind of question. This is the strongest decision signal available; trust it.
+When multiple explores remain plausible, call findFields on each plausible explore using the user's metric/dimension terms. Compare returned metrics and dimensions, including usageInVerifiedCharts and usageInCharts.
 
-Look at the usageInVerifiedCharts attribute on every field in topMatchingFields.
+Verified charts are admin-approved as canonical for this project. If exactly one candidate explore has relevant fields with usageInVerifiedCharts > 0 and all other candidate explores have none, choose that explore.
 
-- If exactly one candidate explore has fields with usageInVerifiedCharts > 0 and all other candidate explores have usageInVerifiedCharts = 0 across all their fields → status: "resolved" for that explore. The admin has already answered the question. Do NOT enter the ambiguity check below. Do NOT enumerate alternatives to the user. Proceed directly to Step 5.
-- Otherwise (multiple explores have verified usage, or none do) → continue to Step 4.
+If no verified-content signal resolves it, prefer the explore whose fields best match the requested metric/entity/date/filter concepts. If still tied, or if the user's request is a generic metric with no context (for example "what's our revenue?", "show me cost", "total sales"), return status: "ambiguous" with the plausible explores and a suggestedQuestion.
 
-### Step 4: Ambiguity check
+### Step 4: Field shortlist
 
-Count the distinct exploreName values across topMatchingFields. If 2+ distinct explores appear with scores within ${AMBIGUITY_RANK_WINDOW} of each other:
+Call findFields on the chosen explore if you have not already done so for the needed metric/dimension concepts.
 
-- First check joined tables. If one explore's joinedTables include another entity the user mentioned, that explore can handle the whole query → status: "resolved". Proceed to Step 5.
-- Then check usageInCharts. If one explore's fields have meaningfully higher aggregate usage (${CHART_USAGE_TIEBREAKER_MULTIPLIER}x+), prefer it → status: "resolved". Proceed to Step 5.
-- If still tied (or all usages are 0 / equal) → status: "ambiguous". DO NOT call findFields. Call submitResult with the candidate explores and a suggestedQuestion.
+Pick a FILTERED set of fields the parent will plausibly need. Treat searchRank as a discovery signal, not a final output field: do not include it in submitResult, and reorder/omit fields according to your judgment of what best answers the user's query.
 
-If only 1 distinct exploreName appears across topMatchingFields → status: "resolved". Proceed to Step 5.
-
-If findExplores returns nothing relevant at all → status: "no_match". Call submitResult.
-
-**Generic metric queries are ambiguous unless Step 3 resolved them**: "what's our revenue?", "show me cost", "total sales" without context — if multiple explores have similar metrics AND no single explore carries the verified-content signal, return "ambiguous".
-
-### Step 5: Field shortlist
-
-Call findFields on the chosen explore with the user's intent as the search query.
-
-If findExplores returned requiredFilters for the chosen explore, copy them into the resolved explore handoff exactly. These are explore-level required/default filter rules, not field-level metadata. Omit requiredFilters when findExplores did not return any.
-
-Pick a FILTERED set of fields the parent will plausibly need:
 - The 1–3 metrics most relevant to the query.
 - The dimensions implied by the query (groupings, breakdowns).
 - Relevant date dimensions at appropriate granularities (e.g. include both order_date and order_date_month if the user might want either).
@@ -83,21 +69,17 @@ Pick a FILTERED set of fields the parent will plausibly need:
 
 When two candidate fields are equally relevant, prefer the one with non-zero usageInVerifiedCharts — admins have endorsed that field as canonical for this project. Use this as a tiebreaker, not as a hard filter: a clearly more relevant field with usageInVerifiedCharts=0 still beats an irrelevant field with usageInVerifiedCharts=5.
 
-**Joined vs base table fields with similar names**: base tables represent events (an order, a visit, a payment) — their fields describe attributes at the time of that event. Joined tables represent entities (a customer, a product) — their fields describe persistent attributes. When the user mentions an entity by name and both tables expose a similar-looking field, prefer the joined-table field unless the description clearly says event-level granularity. Set isFromJoinedTable accordingly so the parent can display the right marker.
+Before submitResult, call listFields for selected or likely-final field ids whenever exact definitions, descriptions, filter behavior, or joined-table semantics could affect the answer. Do not copy field objects or descriptions into submitResult.
 
-DO NOT include every field in the explore. The parent will re-call discoverFields if it needs different fields.
-
-For each chosen field, include a short description ONLY when keeping it distinguishes two similar fields you also kept. Omit description otherwise.
-
-Then call submitResult with the resolved handoff.
+Then call submitResult with the resolved selector handoff: \`exploreName\`, ordered \`dimensionIds\`, ordered \`metricIds\`, \`rationale\`, and \`uncertainties\`.
 
 ## Hard rules
 
-- Never invent fieldIds. Only return fieldIds returned by findFields.
-- Copy selected field attributes from findFields.
-- Never call findFields when the status will be "ambiguous". If two explores are tied, call submitResult with the ambiguous handoff directly.
+- Never invent fieldIds. Do not infer ids from labels or desired concepts. Only call listFields or submitResult with ids returned by findExplores, findFields, query errors, or other semantic-layer tools.
+- Submit only dimensionIds and metricIds, never field objects. Put dimensions/date/filter fields in dimensionIds and metric fields in metricIds.
+- Use findFields for uncertainty/search; use listFields for exact known field ids that are likely to be selected. If you want a field that was not returned by a tool, search for it with findFields before calling listFields.
+- Sort selected dimensionIds and metricIds by final usefulness to the parent within each list, not raw searchRank.
 - Never return all fields. Always filter.
-- Keep field descriptions short — one sentence max. Many fields should have no description.
 - ALWAYS finish with a single \`submitResult\` call. The schema is enforced at the tool boundary — getting the shape wrong returns a tool error and forces a retry.
 
 {{available_explores}}

--- a/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
+++ b/packages/backend/src/ee/services/ai/agents/discoverFields/tool.tsx
@@ -1,4 +1,18 @@
-import { discoverFieldsToolDefinition, Explore } from '@lightdash/common';
+import {
+    assertUnreachable,
+    DEFAULT_FILTER_CASE_SENSITIVE,
+    DimensionType,
+    discoverFieldsToolDefinition,
+    Explore,
+    Field,
+    FieldType,
+    getFilterTypeFromItemType,
+    getItemMap,
+    isDimension,
+    isMetric,
+    type Dimension,
+    type Metric,
+} from '@lightdash/common';
 import {
     readUIMessageStream,
     tool,
@@ -6,139 +20,269 @@ import {
     type LanguageModel,
     type UIMessage,
 } from 'ai';
+import { stringifyToolJson } from '../../tools/toolOutputFormat';
 import type { AiAgentArgs } from '../../types/aiAgent';
 import { toModelOutput } from '../../utils/toModelOutput';
 import { toolErrorHandler } from '../../utils/toolErrorHandler';
-import { xmlBuilder } from '../../xmlBuilder';
 import {
     runDiscoverFieldsAgent,
     type DiscoverFieldsAgentDependencies,
 } from './agent';
 import {
-    discoverFieldsResultSchema,
+    discoverFieldsSelectionSchemaV2,
     type DiscoverFieldsResult,
+    type DiscoverFieldsSelectionV2,
 } from './schema';
 
 const discoverFieldsTool = discoverFieldsToolDefinition.for('agent');
 
-const renderResolved = (
-    result: Extract<DiscoverFieldsResult, { status: 'resolved' }>,
-) => (
-    <discovery status="resolved">
-        <explore
-            name={result.explore.name}
-            label={result.explore.label}
-            baseTable={result.explore.baseTable}
-        >
-            {result.explore.joinedTables.length > 0 && (
-                <joinedTables>
-                    {result.explore.joinedTables.map((t) => (
-                        <table>{t}</table>
-                    ))}
-                </joinedTables>
-            )}
-            {result.explore.requiredFilters &&
-                result.explore.requiredFilters.length > 0 && (
-                    <requiredFilters
-                        count={result.explore.requiredFilters.length}
-                    >
-                        {result.explore.requiredFilters.map((filter) => (
-                            <filter
-                                fieldId={filter.fieldId}
-                                fieldRef={filter.fieldRef}
-                                tableName={filter.tableName}
-                                operator={filter.operator}
-                                values={JSON.stringify(filter.values ?? [])}
-                                settings={
-                                    filter.settings
-                                        ? JSON.stringify(filter.settings)
-                                        : undefined
-                                }
-                                required={filter.required}
-                            />
-                        ))}
-                    </requiredFilters>
-                )}
-        </explore>
-        <fields count={result.fields.length}>
-            {result.fields.map((f) => (
-                <field
-                    fieldId={f.fieldId}
-                    name={f.name}
-                    label={f.label}
-                    table={f.table}
-                    type={f.fieldType}
-                    fieldValueType={f.fieldValueType}
-                    fieldFilterType={f.fieldFilterType}
-                    isFromJoinedTable={f.isFromJoinedTable}
-                    {...(f.caseSensitiveFilters === 'not_applicable'
-                        ? {}
-                        : {
-                              caseSensitiveFilters:
-                                  f.caseSensitiveFilters === 'true',
-                          })}
-                >
-                    {f.description ? (
-                        <description>{f.description}</description>
-                    ) : null}
-                </field>
-            ))}
-        </fields>
-        {result.rationale && <rationale>{result.rationale}</rationale>}
-    </discovery>
-);
+const ambiguousNote =
+    'Multiple explores plausibly answer this. Ask the user the suggestedQuestion. Do NOT call generateVisualization.';
 
-const renderAmbiguous = (
-    result: Extract<DiscoverFieldsResult, { status: 'ambiguous' }>,
-) => (
-    <discovery status="ambiguous">
-        <note>
-            Multiple explores plausibly answer this. Ask the user the
-            suggestedQuestion. Do NOT call generateVisualization.
-        </note>
-        <candidates>
-            {result.candidates.map((c) => (
-                <candidate name={c.exploreName} label={c.exploreLabel}>
-                    {c.reason}
-                </candidate>
-            ))}
-        </candidates>
-        <suggestedQuestion>{result.suggestedQuestion}</suggestedQuestion>
-    </discovery>
-);
+const getCaseSensitiveFilters = (
+    field: Field,
+    explore: Explore,
+): 'true' | 'false' | 'not_applicable' => {
+    if (
+        field.fieldType !== FieldType.DIMENSION ||
+        field.type !== DimensionType.STRING
+    ) {
+        return 'not_applicable';
+    }
 
-const renderNoMatch = (
-    result: Extract<DiscoverFieldsResult, { status: 'no_match' }>,
-) => (
-    <discovery status="no_match">
-        <reason>{result.reason}</reason>
-    </discovery>
-);
+    const dimension = explore.tables[field.table]?.dimensions[field.name];
+    return (dimension?.caseSensitive ??
+        explore.caseSensitive ??
+        DEFAULT_FILTER_CASE_SENSITIVE)
+        ? 'true'
+        : 'false';
+};
 
-const renderResult = (result: DiscoverFieldsResult): string => {
-    switch (result.status) {
+const isFromJoinedTable = (field: Field, explore: Explore) =>
+    field.table !== explore.baseTable &&
+    explore.joinedTables.some((join) => join.table === field.table);
+
+const hydrateField = ({
+    fieldId,
+    field,
+    explore,
+}: {
+    fieldId: string;
+    field: Dimension | Metric;
+    explore: Explore;
+}) => ({
+    fieldId,
+    name: field.name,
+    label: field.label,
+    table: field.table,
+    fieldType: field.fieldType,
+    fieldValueType: String(field.type),
+    fieldFilterType: getFilterTypeFromItemType(field.type),
+    caseSensitiveFilters: getCaseSensitiveFilters(field, explore),
+    isFromJoinedTable: isFromJoinedTable(field, explore),
+    description: field.description ?? null,
+});
+
+const hydrateDimensionField = (args: {
+    fieldId: string;
+    field: Dimension;
+    explore: Explore;
+}) => ({
+    ...hydrateField(args),
+    fieldType: 'dimension' as const,
+});
+
+const hydrateMetricField = (args: {
+    fieldId: string;
+    field: Metric;
+    explore: Explore;
+}) => ({
+    ...hydrateField(args),
+    fieldType: 'metric' as const,
+});
+
+const hydrateResolvedSelection = async ({
+    selection,
+    getExplore,
+}: {
+    selection: Extract<DiscoverFieldsSelectionV2, { status: 'resolved' }>;
+    getExplore: DiscoverFieldsAgentDependencies['getExplore'];
+}): Promise<Extract<DiscoverFieldsResult, { status: 'resolved' }>> => {
+    if (
+        selection.dimensionIds.length === 0 &&
+        selection.metricIds.length === 0
+    ) {
+        throw new Error('Resolved discovery must select at least one field.');
+    }
+
+    const explore = await getExplore({ table: selection.exploreName });
+    const itemMap = getItemMap(explore);
+
+    const dimensions = selection.dimensionIds.map((fieldId) => {
+        const item = itemMap[fieldId];
+        if (!isDimension(item)) {
+            throw new Error(
+                `Dimension "${fieldId}" was not found in explore "${selection.exploreName}".`,
+            );
+        }
+
+        return hydrateDimensionField({ fieldId, field: item, explore });
+    });
+
+    const metrics = selection.metricIds.map((fieldId) => {
+        const item = itemMap[fieldId];
+        if (!isMetric(item)) {
+            throw new Error(
+                `Metric "${fieldId}" was not found in explore "${selection.exploreName}".`,
+            );
+        }
+
+        return hydrateMetricField({ fieldId, field: item, explore });
+    });
+
+    return {
+        status: 'resolved',
+        explore: {
+            name: explore.name,
+            label: explore.label,
+            baseTable: explore.baseTable,
+            joinedTables: explore.joinedTables.map((join) => join.table),
+        },
+        dimensions,
+        metrics,
+        fields: [...dimensions, ...metrics],
+        rationale: selection.rationale,
+        uncertainties: selection.uncertainties,
+    };
+};
+
+const hydrateSelection = async ({
+    selection,
+    availableExplores,
+    getExplore,
+}: {
+    selection: DiscoverFieldsSelectionV2;
+    availableExplores: Explore[];
+    getExplore: DiscoverFieldsAgentDependencies['getExplore'];
+}): Promise<DiscoverFieldsResult> => {
+    switch (selection.status) {
         case 'resolved':
-            return renderResolved(result).toString();
+            return hydrateResolvedSelection({ selection, getExplore });
         case 'ambiguous':
-            return renderAmbiguous(result).toString();
+            return {
+                status: 'ambiguous',
+                candidates: selection.candidates.map((candidate) => {
+                    const explore = availableExplores.find(
+                        (availableExplore) =>
+                            availableExplore.name === candidate.exploreName,
+                    );
+                    return {
+                        exploreName: candidate.exploreName,
+                        exploreLabel: explore?.label ?? candidate.exploreName,
+                        reason: candidate.reason,
+                    };
+                }),
+                suggestedQuestion: selection.suggestedQuestion,
+                uncertainties: selection.uncertainties,
+            };
         case 'no_match':
-            return renderNoMatch(result).toString();
+            return selection;
         default:
-            return '';
+            return assertUnreachable(selection, 'Unknown discovery status');
     }
 };
 
-/**
- * Locate the subagent's final `submitResult` tool call in the accumulated
- * UIMessage and parse its input through the result schema. AI SDK has
- * already validated the input against the same schema before invoking
- * the tool, so this `safeParse` is defence-in-depth — but we keep it
- * because the input is `unknown` at this point in the type system and
- * we'd rather surface a schema error than cast.
- */
-const extractHandoffFromSubmitResult = (
+const getStructuredField = (
+    field: Extract<
+        DiscoverFieldsResult,
+        { status: 'resolved' }
+    >['fields'][number],
+) => ({
+    fieldId: field.fieldId,
+    name: field.name,
+    label: field.label,
+    table: field.table,
+    type: field.fieldType,
+    fieldType: field.fieldType,
+    fieldValueType: field.fieldValueType,
+    fieldFilterType: field.fieldFilterType,
+    isFromJoinedTable: field.isFromJoinedTable,
+    ...(field.caseSensitiveFilters === 'not_applicable'
+        ? {}
+        : {
+              caseSensitiveFilters: field.caseSensitiveFilters === 'true',
+          }),
+    description: field.description,
+});
+
+const getResolvedStructuredResult = (
+    result: Extract<DiscoverFieldsResult, { status: 'resolved' }>,
+) => ({
+    status: 'resolved' as const,
+    explore: {
+        name: result.explore.name,
+        label: result.explore.label,
+        baseTable: result.explore.baseTable,
+        joinedTables: {
+            count: result.explore.joinedTables.length,
+            tables: result.explore.joinedTables,
+        },
+    },
+    dimensions: {
+        count: result.dimensions.length,
+        items: result.dimensions.map(getStructuredField),
+    },
+    metrics: {
+        count: result.metrics.length,
+        items: result.metrics.map(getStructuredField),
+    },
+    rationale: result.rationale,
+    uncertainties: result.uncertainties,
+});
+
+const getAmbiguousStructuredResult = (
+    result: Extract<DiscoverFieldsResult, { status: 'ambiguous' }>,
+) => ({
+    status: 'ambiguous' as const,
+    note: ambiguousNote,
+    candidates: {
+        count: result.candidates.length,
+        items: result.candidates.map((candidate) => ({
+            name: candidate.exploreName,
+            label: candidate.exploreLabel,
+            exploreName: candidate.exploreName,
+            exploreLabel: candidate.exploreLabel,
+            reason: candidate.reason,
+        })),
+    },
+    suggestedQuestion: result.suggestedQuestion,
+    uncertainties: result.uncertainties,
+});
+
+const getNoMatchStructuredResult = (
+    result: Extract<DiscoverFieldsResult, { status: 'no_match' }>,
+) => ({
+    status: 'no_match' as const,
+    reason: result.reason,
+    uncertainties: result.uncertainties,
+});
+
+const getStructuredResult = (result: DiscoverFieldsResult) => {
+    switch (result.status) {
+        case 'resolved':
+            return getResolvedStructuredResult(result);
+        case 'ambiguous':
+            return getAmbiguousStructuredResult(result);
+        case 'no_match':
+            return getNoMatchStructuredResult(result);
+        default:
+            return assertUnreachable(result, 'Unknown discovery status');
+    }
+};
+
+const extractSelectionFromSubmitResult = (
     message: UIMessage | undefined,
-): DiscoverFieldsResult | { error: string } => {
+): DiscoverFieldsSelectionV2 | { error: string } => {
     if (!message) {
         return { error: 'Subagent produced no output.' };
     }
@@ -151,7 +295,7 @@ const extractHandoffFromSubmitResult = (
             error: 'Subagent did not call submitResult before the stream ended.',
         };
     }
-    const parsed = discoverFieldsResultSchema.safeParse(submitPart.input);
+    const parsed = discoverFieldsSelectionSchemaV2.safeParse(submitPart.input);
     if (!parsed.success) {
         return {
             error: `submitResult payload failed schema validation: ${parsed.error.message}`,
@@ -167,9 +311,7 @@ type ToolArgs = {
     callOptions: CallSettings;
     providerOptions: AiAgentArgs['providerOptions'];
     availableExplores: Explore[];
-    findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
-    toolDescriptionMaxChars: number;
     promptUuid: string;
     telemetry: Pick<
         AiAgentArgs,
@@ -181,18 +323,6 @@ type ToolArgs = {
     >;
 };
 
-/**
- * Schema enforcement is structural, not prompt-based: the subagent's final
- * step is a `submitResult` tool call whose `inputSchema` is the result
- * union. AI SDK validates the args at the tool-call boundary, so the
- * handoff arrives already-typed — no JSON.parse, no fence stripping,
- * no post-stream coercion.
- *
- * The final yield extracts the handoff from the submitResult tool call
- * and renders the XML the parent model sees via `toModelOutput`.
- * Subagent's `storeToolCall` writes are awaited before the final yield
- * so the parent's tool-result row never commits before the children rows.
- */
 export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
     tool({
         ...discoverFieldsTool,
@@ -205,10 +335,7 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                         model: args.model,
                         callOptions: args.callOptions,
                         providerOptions: args.providerOptions,
-                        findExploresFieldSearchSize:
-                            args.findExploresFieldSearchSize,
                         findFieldsPageSize: args.findFieldsPageSize,
-                        toolDescriptionMaxChars: args.toolDescriptionMaxChars,
                         promptUuid: args.promptUuid,
                         parentToolCallId: toolCallId,
                         telemetry: args.telemetry,
@@ -218,50 +345,20 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                 );
 
                 let currentMessage: UIMessage | undefined;
-                // Yield only on tool-call structural changes; per-chunk
-                // yields re-emit the accumulated UIMessage and grow the
-                // parent stream quadratically.
-                let lastTraceSignature: string | null = null;
                 for await (const message of readUIMessageStream({
                     stream: stream.toUIMessageStream(),
                 })) {
                     currentMessage = message;
-                    const traceSignature = message.parts
-                        .filter((p) => p.type.startsWith('tool-'))
-                        .map((p) => {
-                            const toolPart = p as {
-                                type: string;
-                                toolCallId?: string;
-                                input?: unknown;
-                            };
-                            return `${toolPart.type}:${
-                                toolPart.toolCallId ?? ''
-                            }:${toolPart.input != null ? '1' : '0'}`;
-                        })
-                        .join('|');
-                    if (
-                        traceSignature &&
-                        traceSignature !== lastTraceSignature
-                    ) {
-                        lastTraceSignature = traceSignature;
-                        yield {
-                            result: '',
-                            metadata: {
-                                status: 'streaming' as const,
-                                streamingMessage: message,
-                            },
-                        };
-                    }
                 }
 
                 await flushPersistence();
 
-                const handoff = extractHandoffFromSubmitResult(currentMessage);
-                if ('error' in handoff) {
-                    // Soft, parent-recoverable model-output anomaly; parent retries on tool-error.
+                const selection =
+                    extractSelectionFromSubmitResult(currentMessage);
+                if ('error' in selection) {
                     yield {
                         result: toolErrorHandler(
-                            new Error(handoff.error),
+                            new Error(selection.error),
                             'Error discovering fields.',
                             { captureToSentry: false },
                         ),
@@ -270,12 +367,20 @@ export const getDiscoverFields = (args: ToolArgs, dependencies: Dependencies) =>
                     return;
                 }
 
+                const handoff = await hydrateSelection({
+                    selection,
+                    availableExplores: args.availableExplores,
+                    getExplore: dependencies.getExplore,
+                });
+
+                const structuredResult = getStructuredResult(handoff);
+
                 yield {
-                    result: renderResult(handoff),
+                    result: stringifyToolJson(structuredResult),
+                    structuredResult,
                     metadata: {
                         status: 'success' as const,
                         discovery: handoff,
-                        streamingMessage: currentMessage,
                     },
                 };
             } catch (error) {

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -80,12 +80,12 @@ Parameters:
     "description": "Tool: discoverFields
 
 Purpose:
-Run the data-discovery subagent. Given the latest user query, returns a structured handoff describing which explore and which fields to use to answer it.
+Run the data-discovery subagent. Given the latest user query, returns a structured handoff describing which explore, dimensions, and metrics to use to answer it.
 
 Use this tool as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, "what is", "show me", "how many"). Do NOT call this when the user is only asking about existing dashboards/charts (use findContent) or follow-up clarifications about a chart you already produced.
 
 You will receive one of three statuses:
-- "resolved" — proceed with generateVisualization (or generateDashboard) using the returned explore + fields.
+- "resolved" — proceed with generateVisualization (or generateDashboard) using the returned explore + dimensions/metrics.
 - "ambiguous" — surface the suggestedQuestion to the user; do NOT call generateVisualization.
 - "no_match" — explain back to the user that no data source covers the request.
 
@@ -123,39 +123,76 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
             "metadata": {
               "additionalProperties": false,
               "properties": {
-                "status": {
-                  "const": "streaming",
-                  "type": "string",
-                },
-                "streamingMessage": {},
-              },
-              "required": [
-                "status",
-              ],
-              "type": "object",
-            },
-            "result": {
-              "const": "",
-              "type": "string",
-            },
-          },
-          "required": [
-            "result",
-            "metadata",
-          ],
-          "type": "object",
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "metadata": {
-              "additionalProperties": false,
-              "properties": {
                 "discovery": {
                   "anyOf": [
                     {
                       "additionalProperties": false,
                       "properties": {
+                        "dimensions": {
+                          "description": "Filtered list of dimension fields relevant to the user query: groupings, dates, filters, and breakdowns. Not the full explore.",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "caseSensitiveFilters": {
+                                "description": "Use "true" or "false" only when the exact selected findFields result explicitly includes caseSensitiveFilters with that value; otherwise use "not_applicable".",
+                                "enum": [
+                                  "true",
+                                  "false",
+                                  "not_applicable",
+                                ],
+                                "type": "string",
+                              },
+                              "description": {
+                                "description": "Full field description copied exactly from listFields when fetched, otherwise a non-truncated findFields description; null when the field has no description.",
+                                "type": [
+                                  "string",
+                                  "null",
+                                ],
+                              },
+                              "fieldFilterType": {
+                                "type": "string",
+                              },
+                              "fieldId": {
+                                "description": "The fieldId to use in generateVisualization payloads.",
+                                "type": "string",
+                              },
+                              "fieldType": {
+                                "const": "dimension",
+                                "type": "string",
+                              },
+                              "fieldValueType": {
+                                "description": "The value type (e.g. number, string, date, timestamp, boolean).",
+                                "type": "string",
+                              },
+                              "isFromJoinedTable": {
+                                "type": "boolean",
+                              },
+                              "label": {
+                                "type": "string",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                              "table": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "fieldId",
+                              "name",
+                              "label",
+                              "table",
+                              "fieldValueType",
+                              "fieldFilterType",
+                              "caseSensitiveFilters",
+                              "isFromJoinedTable",
+                              "description",
+                              "fieldType",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
                         "explore": {
                           "additionalProperties": false,
                           "properties": {
@@ -221,7 +258,137 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                           "type": "object",
                         },
                         "fields": {
-                          "description": "Filtered list of fields relevant to the user query — typically 5–20 entries. Not the full explore.",
+                          "description": "Legacy combined list of selected dimensions and metrics. Prefer dimensions and metrics for new consumers.",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "caseSensitiveFilters": {
+                                    "description": "Use "true" or "false" only when the exact selected findFields result explicitly includes caseSensitiveFilters with that value; otherwise use "not_applicable".",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "not_applicable",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "description": {
+                                    "description": "Full field description copied exactly from listFields when fetched, otherwise a non-truncated findFields description; null when the field has no description.",
+                                    "type": [
+                                      "string",
+                                      "null",
+                                    ],
+                                  },
+                                  "fieldFilterType": {
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": "The fieldId to use in generateVisualization payloads.",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "const": "dimension",
+                                    "type": "string",
+                                  },
+                                  "fieldValueType": {
+                                    "description": "The value type (e.g. number, string, date, timestamp, boolean).",
+                                    "type": "string",
+                                  },
+                                  "isFromJoinedTable": {
+                                    "type": "boolean",
+                                  },
+                                  "label": {
+                                    "type": "string",
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                  },
+                                  "table": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "name",
+                                  "label",
+                                  "table",
+                                  "fieldValueType",
+                                  "fieldFilterType",
+                                  "caseSensitiveFilters",
+                                  "isFromJoinedTable",
+                                  "description",
+                                  "fieldType",
+                                ],
+                                "type": "object",
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "caseSensitiveFilters": {
+                                    "description": "Use "true" or "false" only when the exact selected findFields result explicitly includes caseSensitiveFilters with that value; otherwise use "not_applicable".",
+                                    "enum": [
+                                      "true",
+                                      "false",
+                                      "not_applicable",
+                                    ],
+                                    "type": "string",
+                                  },
+                                  "description": {
+                                    "description": "Full field description copied exactly from listFields when fetched, otherwise a non-truncated findFields description; null when the field has no description.",
+                                    "type": [
+                                      "string",
+                                      "null",
+                                    ],
+                                  },
+                                  "fieldFilterType": {
+                                    "type": "string",
+                                  },
+                                  "fieldId": {
+                                    "description": "The fieldId to use in generateVisualization payloads.",
+                                    "type": "string",
+                                  },
+                                  "fieldType": {
+                                    "const": "metric",
+                                    "type": "string",
+                                  },
+                                  "fieldValueType": {
+                                    "description": "The value type (e.g. number, string, date, timestamp, boolean).",
+                                    "type": "string",
+                                  },
+                                  "isFromJoinedTable": {
+                                    "type": "boolean",
+                                  },
+                                  "label": {
+                                    "type": "string",
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                  },
+                                  "table": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "fieldId",
+                                  "name",
+                                  "label",
+                                  "table",
+                                  "fieldValueType",
+                                  "fieldFilterType",
+                                  "caseSensitiveFilters",
+                                  "isFromJoinedTable",
+                                  "description",
+                                  "fieldType",
+                                ],
+                                "type": "object",
+                              },
+                            ],
+                          },
+                          "type": "array",
+                        },
+                        "metrics": {
+                          "description": "Filtered list of metric fields relevant to the user query. Not the full explore.",
                           "items": {
                             "additionalProperties": false,
                             "properties": {
@@ -235,7 +402,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                                 "type": "string",
                               },
                               "description": {
-                                "description": "Short description, only include when needed to distinguish similar fields.",
+                                "description": "Full field description copied exactly from listFields when fetched, otherwise a non-truncated findFields description; null when the field has no description.",
                                 "type": [
                                   "string",
                                   "null",
@@ -249,10 +416,7 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                                 "type": "string",
                               },
                               "fieldType": {
-                                "enum": [
-                                  "dimension",
-                                  "metric",
-                                ],
+                                "const": "metric",
                                 "type": "string",
                               },
                               "fieldValueType": {
@@ -277,12 +441,12 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                               "name",
                               "label",
                               "table",
-                              "fieldType",
                               "fieldValueType",
                               "fieldFilterType",
                               "caseSensitiveFilters",
                               "isFromJoinedTable",
                               "description",
+                              "fieldType",
                             ],
                             "type": "object",
                           },
@@ -299,12 +463,22 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                           "const": "resolved",
                           "type": "string",
                         },
+                        "uncertainties": {
+                          "description": "Free-form uncertainties or caveats encountered during discovery. Null when selection was straightforward.",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
                       },
                       "required": [
                         "status",
                         "explore",
+                        "dimensions",
+                        "metrics",
                         "fields",
                         "rationale",
+                        "uncertainties",
                       ],
                       "type": "object",
                     },
@@ -345,11 +519,19 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                           "description": "A clarification question the parent can echo to the user (e.g. 'Did you mean revenue from the orders explore or the payments explore?').",
                           "type": "string",
                         },
+                        "uncertainties": {
+                          "description": "Free-form uncertainties or caveats encountered during discovery. Null when selection was straightforward.",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
                       },
                       "required": [
                         "status",
                         "candidates",
                         "suggestedQuestion",
+                        "uncertainties",
                       ],
                       "type": "object",
                     },
@@ -364,10 +546,18 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                           "const": "no_match",
                           "type": "string",
                         },
+                        "uncertainties": {
+                          "description": "Free-form uncertainties or caveats encountered during discovery. Null when selection was straightforward.",
+                          "type": [
+                            "string",
+                            "null",
+                          ],
+                        },
                       },
                       "required": [
                         "status",
                         "reason",
+                        "uncertainties",
                       ],
                       "type": "object",
                     },
@@ -377,7 +567,6 @@ Re-call this tool if the user pivots mid-thread to a different data topic and yo
                   "const": "success",
                   "type": "string",
                 },
-                "streamingMessage": {},
               },
               "required": [
                 "status",
@@ -879,23 +1068,25 @@ Usage tips:
     "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with joined tables, required filters, AI hints, full descriptions, and compact lists of all dimension/metric field ids available in each matched explore. Search matches explore name, label, description, and AI hints. A follow-up query runs against a single explore, so this tool is meant to identify the explore to inspect next with findFields or listFields.
+
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Keyword terms for finding relevant explores
 
 Output:
-- Matching explores with searchRank scores
-- Top matching fields with their explore names and searchRank scores
-- Required filters set on matching explores, including default values
+- Matching explores with searchRank scores, joined tables, required filters, AI hints, and full descriptions
+- Compact all-field inventories split into dimension and metric field ids
+
+Field descriptions are not included in the compact field inventories. Use findFields to search/compare fields by label/description, or listFields when you need exact full metadata for known field ids.
 ",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
       "properties": {
         "searchQuery": {
-          "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
+          "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore name, label, description, and AI hints. Prefer entity/domain nouns that capture the user's analytical intent.",
           "type": "string",
         },
       },
@@ -915,28 +1106,45 @@ Output:
             "ranking": {
               "additionalProperties": false,
               "properties": {
-                "exploreSearchResults": {
+                "explores": {
                   "items": {
                     "additionalProperties": false,
                     "properties": {
-                      "joinedTables": {
-                        "anyOf": [
-                          {
-                            "items": {
-                              "type": "string",
-                            },
-                            "type": "array",
-                          },
-                          {
-                            "type": "null",
-                          },
+                      "aiHints": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "description": {
+                        "type": [
+                          "string",
+                          "null",
                         ],
+                      },
+                      "dimensions": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "exploreName": {
+                        "type": "string",
+                      },
+                      "joinedTables": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
                       },
                       "label": {
                         "type": "string",
                       },
-                      "name": {
-                        "type": "string",
+                      "metrics": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
                       },
                       "requiredFilters": {
                         "items": {
@@ -982,8 +1190,13 @@ Output:
                       },
                     },
                     "required": [
-                      "name",
+                      "exploreName",
                       "label",
+                      "aiHints",
+                      "joinedTables",
+                      "requiredFilters",
+                      "dimensions",
+                      "metrics",
                     ],
                     "type": "object",
                   },
@@ -992,54 +1205,10 @@ Output:
                 "searchQuery": {
                   "type": "string",
                 },
-                "topMatchingFields": {
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "chartUsage": {
-                        "type": [
-                          "number",
-                          "null",
-                        ],
-                      },
-                      "fieldType": {
-                        "type": "string",
-                      },
-                      "label": {
-                        "type": "string",
-                      },
-                      "name": {
-                        "type": "string",
-                      },
-                      "searchRank": {
-                        "type": [
-                          "number",
-                          "null",
-                        ],
-                      },
-                      "tableName": {
-                        "type": "string",
-                      },
-                      "verifiedChartUsage": {
-                        "type": [
-                          "number",
-                          "null",
-                        ],
-                      },
-                    },
-                    "required": [
-                      "name",
-                      "label",
-                      "tableName",
-                      "fieldType",
-                    ],
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
               },
               "required": [
                 "searchQuery",
+                "explores",
               ],
               "type": "object",
             },

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -73,9 +73,7 @@ const makeAgentTools = () => {
                 callOptions: {},
                 providerOptions: undefined,
                 availableExplores: [],
-                findExploresFieldSearchSize: 25,
                 findFieldsPageSize: 25,
-                toolDescriptionMaxChars: 600,
                 promptUuid: 'prompt-uuid',
                 telemetry: {
                     agentSettings: {
@@ -92,6 +90,7 @@ const makeAgentTools = () => {
                 findExplores: noop,
                 findFields: noop,
                 getExplore: noop,
+                listExplores: noop,
                 storeToolCall: noopAsync,
                 storeToolResults: noopAsync,
                 updateProgress: noopAsync,
@@ -106,17 +105,14 @@ const makeAgentTools = () => {
             trackCoverage: noop,
         }),
         findExplores: getFindExplores({
-            fieldSearchSize: 25,
             findExplores: noop,
             updateProgress: noopAsync,
-            toolDescriptionMaxChars: 600,
         }),
         findFields: getFindFields({
             findFields: noop,
             getExplore: noop,
             pageSize: 25,
             updateProgress: noopAsync,
-            toolDescriptionMaxChars: 600,
         }),
         listFields: getListFields({ getExplore: noop }),
         generateDashboard: getGenerateDashboardV2({

--- a/packages/backend/src/ee/services/ai/tools/fieldDiscoveryDescriptions.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/fieldDiscoveryDescriptions.test.ts
@@ -1,14 +1,26 @@
 import {
     DimensionType,
     FieldType,
+    type ToolFindExploresOutput,
     type ToolFindFieldsOutput,
     type ToolListFieldsOutput,
 } from '@lightdash/common';
+import { getFindExplores } from './findExplores';
 import { getFindFields } from './findFields';
 import { getListFields } from './listFields';
 
+type FindExploresTool = ReturnType<typeof getFindExplores>;
 type FindFieldsTool = ReturnType<typeof getFindFields>;
 type ListFieldsTool = ReturnType<typeof getListFields>;
+
+const executeFindExplores = (
+    tool: FindExploresTool,
+    args: Parameters<NonNullable<FindExploresTool['execute']>>[0],
+): Promise<ToolFindExploresOutput> =>
+    tool.execute!(args, {
+        messages: [],
+        toolCallId: 'test',
+    }) as Promise<ToolFindExploresOutput>;
 
 const executeFindFields = (
     tool: FindFieldsTool,
@@ -33,6 +45,39 @@ const longDescription = `Important grain and usage notes. ${'x'.repeat(
 )} Do not lose this final sentence.`;
 
 describe('field discovery descriptions', () => {
+    it('does not truncate explore descriptions and includes compact field ids only', async () => {
+        const tool = getFindExplores({
+            findExplores: jest.fn().mockResolvedValue({
+                exploreSearchResults: [
+                    {
+                        name: 'tickets',
+                        label: 'Tickets',
+                        description: longDescription,
+                        searchRank: 1,
+                        joinedTables: ['users'],
+                        requiredFilters: [],
+                        fields: {
+                            dimensions: ['tickets_feature_name'],
+                            metrics: ['tickets_count'],
+                        },
+                    },
+                ],
+            }),
+            updateProgress: jest.fn().mockResolvedValue(undefined),
+        });
+
+        const output = await executeFindExplores(tool, {
+            searchQuery: 'feature requests',
+        });
+        const result = JSON.parse(output.result);
+
+        expect(result.explores[0].description).toEqual(longDescription);
+        expect(result.explores[0].dimensions).toEqual(['tickets_feature_name']);
+        expect(result.explores[0].metrics).toEqual(['tickets_count']);
+        expect(output.result).not.toContain('topMatchingFields');
+        expect(output.result).not.toContain('Explore-only catalog search');
+    });
+
     it('returns full descriptions from findFields', async () => {
         const explore = {
             name: 'tickets',

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -1,4 +1,7 @@
-import { findExploresToolDefinition } from '@lightdash/common';
+import {
+    findExploresToolDefinition,
+    type ToolFindExploresOutput,
+} from '@lightdash/common';
 import { tool } from 'ai';
 import type {
     FindExploresFn,
@@ -6,148 +9,42 @@ import type {
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
-import { truncate } from '../utils/truncation';
-import { xmlBuilder } from '../xmlBuilder';
+import { stringifyToolJson } from './toolOutputFormat';
 
 type Dependencies = {
-    fieldSearchSize: number;
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
-    toolDescriptionMaxChars: number;
+    fieldSearchSize?: number;
+    toolDescriptionMaxChars?: number;
 };
 
 const toolDefinition = findExploresToolDefinition.for('agent');
 
-const generateExploreResponse = ({
+const getExploreStructuredResponse = ({
     searchQuery,
     exploreSearchResults,
-    topMatchingFields,
-    toolDescriptionMaxChars,
-}: Awaited<ReturnType<FindExploresFn>> & {
-    searchQuery: string;
-    toolDescriptionMaxChars: number;
-}) => {
-    const exploreCount = exploreSearchResults?.length ?? 0;
-    const fieldCount = topMatchingFields?.length ?? 0;
+}: Awaited<ReturnType<FindExploresFn>> & { searchQuery: string }) => ({
+    searchQuery,
+    explores: (exploreSearchResults ?? []).map((result) => ({
+        exploreName: result.name,
+        label: result.label,
+        searchRank: result.searchRank,
+        description: result.description,
+        aiHints: result.aiHints ?? [],
+        joinedTables: result.joinedTables ?? [],
+        requiredFilters: result.requiredFilters ?? [],
+        dimensions: result.fields?.dimensions ?? [],
+        metrics: result.fields?.metrics ?? [],
+    })),
+});
 
-    const searchResultsNote = (() => {
-        if (exploreCount === 0) {
-            return fieldCount > 0
-                ? 'No explore name/label/description/aiHints matched. Use topMatchingFields below and call findFields on the most relevant explore.'
-                : 'No explore matched your search. Try different terms or synonyms.';
-        }
-        if (exploreCount === 1) {
-            return 'One explore matched your search. Call findFields for this explore to get all its dimensions and metrics.';
-        }
-        return "Multiple explores matched. Pick the explore whose fields can answer the user's question (a follow-up query runs against a single explore), using topMatchingFields to compare field-level relevance. Then call findFields on it.";
-    })();
+export type FindExploresStructuredResult = ReturnType<
+    typeof getExploreStructuredResponse
+>;
 
-    const topFieldsNote =
-        fieldCount === 0
-            ? 'No field-level matches either.'
-            : "Per-field matches across all explores. Each field's `exploreName` shows where it lives — pick the explore whose fields can answer the user's question.";
-
-    return (
-        <findExplores searchQuery={searchQuery}>
-            <description>
-                Two-pass catalog search whose goal is to identify the single
-                explore for a follow-up query: a query runs against exactly one
-                explore, so the chosen explore must contain the fields needed to
-                answer the user's question. `searchResults` lists explores whose
-                name/label/description/aiHints matched the query.
-                `topMatchingFields` lists individual fields whose
-                name/label/description matched, across all explores — use it to
-                identify or disambiguate the explore to dig into when no explore
-                matched directly, or when several matched.
-            </description>
-            <searchResults count={exploreCount}>
-                <note>{searchResultsNote}</note>
-                {exploreSearchResults?.map((result) => (
-                    <alternative
-                        name={result.name}
-                        label={result.label}
-                        searchRank={result.searchRank?.toFixed(3) ?? 'N/A'}
-                    >
-                        {result.description && (
-                            <description>
-                                {truncate(
-                                    result.description,
-                                    toolDescriptionMaxChars,
-                                )}
-                            </description>
-                        )}
-                        {result.aiHints && result.aiHints.length > 0 && (
-                            <aiHints>
-                                {result.aiHints.map((hint) => (
-                                    <hint>{hint}</hint>
-                                ))}
-                            </aiHints>
-                        )}
-                        {result.joinedTables &&
-                            result.joinedTables.length > 0 && (
-                                <joinedTables
-                                    count={result.joinedTables.length}
-                                >
-                                    <note>
-                                        Fields from these joined tables are
-                                        available when querying this explore
-                                    </note>
-                                    {result.joinedTables.map((tableName) => (
-                                        <table>{tableName}</table>
-                                    ))}
-                                </joinedTables>
-                            )}
-                        {result.requiredFilters &&
-                            result.requiredFilters.length > 0 && (
-                                <requiredFilters
-                                    count={result.requiredFilters.length}
-                                >
-                                    {result.requiredFilters.map((filter) => (
-                                        <filter
-                                            fieldId={filter.fieldId}
-                                            fieldRef={filter.fieldRef}
-                                            tableName={filter.tableName}
-                                            operator={filter.operator}
-                                            values={JSON.stringify(
-                                                filter.values ?? [],
-                                            )}
-                                            settings={
-                                                filter.settings
-                                                    ? JSON.stringify(
-                                                          filter.settings,
-                                                      )
-                                                    : undefined
-                                            }
-                                            required={filter.required}
-                                        />
-                                    ))}
-                                </requiredFilters>
-                            )}
-                    </alternative>
-                ))}
-            </searchResults>
-            <topMatchingFields count={fieldCount}>
-                <note>{topFieldsNote}</note>
-                {topMatchingFields?.map((field) => (
-                    <field
-                        name={field.name}
-                        label={field.label}
-                        exploreName={field.tableName}
-                        fieldType={field.fieldType}
-                        searchRank={field.searchRank?.toFixed(3) ?? 'N/A'}
-                        usageInCharts={field.chartUsage ?? 0}
-                        usageInVerifiedCharts={field.verifiedChartUsage ?? 0}
-                    />
-                ))}
-            </topMatchingFields>
-        </findExplores>
-    ).toString();
-};
 export const getFindExplores = ({
     findExplores,
     updateProgress,
-    fieldSearchSize,
-    toolDescriptionMaxChars,
 }: Dependencies) =>
     tool({
         ...toolDefinition,
@@ -157,53 +54,23 @@ export const getFindExplores = ({
                     `Searching explores matching query: "${args.searchQuery}"...`,
                 );
 
-                const { exploreSearchResults, topMatchingFields } =
-                    await findExplores({
-                        fieldSearchSize,
-                        searchQuery: args.searchQuery,
-                    });
+                const { exploreSearchResults } = await findExplores({
+                    searchQuery: args.searchQuery,
+                });
+
+                const structuredResult = getExploreStructuredResponse({
+                    searchQuery: args.searchQuery,
+                    exploreSearchResults,
+                });
 
                 return {
-                    result: generateExploreResponse({
-                        searchQuery: args.searchQuery,
-                        exploreSearchResults,
-                        topMatchingFields,
-                        toolDescriptionMaxChars,
-                    }),
+                    result: stringifyToolJson(structuredResult),
+                    structuredResult,
                     metadata: {
                         status: 'success',
-                        ranking: {
-                            searchQuery: args.searchQuery,
-                            exploreSearchResults: exploreSearchResults?.map(
-                                (result) => ({
-                                    name: result.name,
-                                    label: result.label,
-                                    searchRank: result.searchRank,
-                                    joinedTables: result.joinedTables ?? [],
-                                    ...(result.requiredFilters &&
-                                    result.requiredFilters.length > 0
-                                        ? {
-                                              requiredFilters:
-                                                  result.requiredFilters,
-                                          }
-                                        : {}),
-                                }),
-                            ),
-                            topMatchingFields: topMatchingFields?.map(
-                                (field) => ({
-                                    name: field.name,
-                                    label: field.label,
-                                    tableName: field.tableName,
-                                    fieldType: field.fieldType,
-                                    searchRank: field.searchRank,
-                                    chartUsage: field.chartUsage,
-                                    verifiedChartUsage:
-                                        field.verifiedChartUsage,
-                                }),
-                            ),
-                        },
+                        ranking: structuredResult,
                     },
-                };
+                } as ToolFindExploresOutput;
             } catch (error) {
                 return {
                     result: toolErrorHandler(error, `Error listing explores.`),

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -123,7 +123,6 @@ export type AiAgentArgs = AnyAiModel & {
     availableSkills: AiAgentSkillReference[];
     enableAgentRevamp: boolean;
 
-    findExploresFieldSearchSize: number;
     findFieldsPageSize: number;
     toolDescriptionMaxChars: number;
     getDashboardChartsPageSize: number;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -60,10 +60,7 @@ export type AiAgentRequiredFilterMetadata = {
 
 export type ListExploresFn = () => Promise<Explore[]>;
 
-export type FindExploresFn = (args: {
-    fieldSearchSize: number;
-    searchQuery?: string;
-}) => Promise<{
+export type FindExploresFn = (args: { searchQuery?: string }) => Promise<{
     exploreSearchResults?: Array<{
         name: string;
         label: string;
@@ -72,16 +69,10 @@ export type FindExploresFn = (args: {
         searchRank?: number;
         joinedTables?: string[] | null;
         requiredFilters?: AiAgentRequiredFilterMetadata[];
-    }>;
-    topMatchingFields?: Array<{
-        name: string;
-        label: string;
-        tableName: string;
-        fieldType: string;
-        searchRank?: number;
-        description?: string;
-        chartUsage?: number;
-        verifiedChartUsage?: number;
+        fields?: {
+            dimensions: string[];
+            metrics: string[];
+        };
     }>;
 }>;
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14303,136 +14303,55 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                topMatchingFields:
-                                                                    {
+                                                                explores: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
                                                                         dataType:
-                                                                            'union',
-                                                                        subSchemas:
-                                                                            [
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
+                                                                                metrics:
+                                                                                    {
                                                                                         dataType:
-                                                                                            'nestedObjectLiteral',
-                                                                                        nestedProperties:
-                                                                                            {
-                                                                                                verifiedChartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                tableName:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
-                                                                                            },
+                                                                                            'array',
+                                                                                        array: {
+                                                                                            dataType:
+                                                                                                'string',
+                                                                                        },
+                                                                                        required: true,
                                                                                     },
-                                                                                },
-                                                                                {
-                                                                                    dataType:
-                                                                                        'undefined',
-                                                                                },
-                                                                            ],
-                                                                    },
-                                                                exploreSearchResults:
-                                                                    {
-                                                                        dataType:
-                                                                            'union',
-                                                                        subSchemas:
-                                                                            [
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
+                                                                                dimensions:
+                                                                                    {
                                                                                         dataType:
-                                                                                            'nestedObjectLiteral',
-                                                                                        nestedProperties:
-                                                                                            {
-                                                                                                requiredFilters:
-                                                                                                    {
+                                                                                            'array',
+                                                                                        array: {
+                                                                                            dataType:
+                                                                                                'string',
+                                                                                        },
+                                                                                        required: true,
+                                                                                    },
+                                                                                requiredFilters:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'array',
+                                                                                        array: {
+                                                                                            dataType:
+                                                                                                'nestedObjectLiteral',
+                                                                                            nestedProperties:
+                                                                                                {
+                                                                                                    required:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'boolean',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    settings:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'any',
+                                                                                                        },
+                                                                                                    values: {
                                                                                                         dataType:
                                                                                                             'union',
                                                                                                         subSchemas:
@@ -14442,64 +14361,7 @@ const models: TsoaRoute.Models = {
                                                                                                                         'array',
                                                                                                                     array: {
                                                                                                                         dataType:
-                                                                                                                            'nestedObjectLiteral',
-                                                                                                                        nestedProperties:
-                                                                                                                            {
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                settings:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'any',
-                                                                                                                                    },
-                                                                                                                                values: {
-                                                                                                                                    dataType:
-                                                                                                                                        'union',
-                                                                                                                                    subSchemas:
-                                                                                                                                        [
-                                                                                                                                            {
-                                                                                                                                                dataType:
-                                                                                                                                                    'array',
-                                                                                                                                                array: {
-                                                                                                                                                    dataType:
-                                                                                                                                                        'any',
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            {
-                                                                                                                                                dataType:
-                                                                                                                                                    'undefined',
-                                                                                                                                            },
-                                                                                                                                        ],
-                                                                                                                                },
-                                                                                                                                operator:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                fieldRef:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                fieldId:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                            },
+                                                                                                                            'any',
                                                                                                                     },
                                                                                                                 },
                                                                                                                 {
@@ -14508,75 +14370,115 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
+                                                                                                    operator:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    fieldRef:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
+                                                                                                    fieldId:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                 },
-                                                                                                name: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
-                                                                                            },
+                                                                                        },
+                                                                                        required: true,
                                                                                     },
-                                                                                },
-                                                                                {
+                                                                                joinedTables:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'array',
+                                                                                        array: {
+                                                                                            dataType:
+                                                                                                'string',
+                                                                                        },
+                                                                                        required: true,
+                                                                                    },
+                                                                                aiHints:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'array',
+                                                                                        array: {
+                                                                                            dataType:
+                                                                                                'string',
+                                                                                        },
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'undefined',
+                                                                                                },
+                                                                                            ],
+                                                                                    },
+                                                                                searchRank:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'double',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'undefined',
+                                                                                                },
+                                                                                            ],
+                                                                                    },
+                                                                                label: {
                                                                                     dataType:
-                                                                                        'undefined',
+                                                                                        'string',
+                                                                                    required: true,
                                                                                 },
-                                                                            ],
+                                                                                exploreName:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                            },
                                                                     },
+                                                                    required: true,
+                                                                },
                                                                 searchQuery: {
                                                                     dataType:
                                                                         'string',
@@ -14977,22 +14879,6 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                streamingMessage: {
-                                                    dataType: 'any',
-                                                },
-                                                status: {
-                                                    dataType: 'enum',
-                                                    enums: ['streaming'],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                streamingMessage: {
-                                                    dataType: 'any',
-                                                },
                                                 discovery: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15000,6 +14886,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                uncertainties: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 rationale: {
                                                                     dataType:
                                                                         'union',
@@ -15024,9 +14929,240 @@ const models: TsoaRoute.Models = {
                                                                         'array',
                                                                     array: {
                                                                         dataType:
+                                                                            'union',
+                                                                        subSchemas:
+                                                                            [
+                                                                                {
+                                                                                    dataType:
+                                                                                        'nestedObjectLiteral',
+                                                                                    nestedProperties:
+                                                                                        {
+                                                                                            fieldType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'dimension',
+                                                                                                    ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            description:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'union',
+                                                                                                    subSchemas:
+                                                                                                        [
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'string',
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    null,
+                                                                                                                ],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            isFromJoinedTable:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'boolean',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            caseSensitiveFilters:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'union',
+                                                                                                    subSchemas:
+                                                                                                        [
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'false',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'not_applicable',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'true',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            fieldFilterType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            fieldValueType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            table: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            label: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            name: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            fieldId:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                        },
+                                                                                },
+                                                                                {
+                                                                                    dataType:
+                                                                                        'nestedObjectLiteral',
+                                                                                    nestedProperties:
+                                                                                        {
+                                                                                            fieldType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'metric',
+                                                                                                    ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            description:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'union',
+                                                                                                    subSchemas:
+                                                                                                        [
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'string',
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    null,
+                                                                                                                ],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            isFromJoinedTable:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'boolean',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            caseSensitiveFilters:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'union',
+                                                                                                    subSchemas:
+                                                                                                        [
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'false',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'not_applicable',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                            {
+                                                                                                                dataType:
+                                                                                                                    'enum',
+                                                                                                                enums: [
+                                                                                                                    'true',
+                                                                                                                ],
+                                                                                                            },
+                                                                                                        ],
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            fieldFilterType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            fieldValueType:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                            table: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            label: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            name: {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                                required: true,
+                                                                                            },
+                                                                                            fieldId:
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
+                                                                                        },
+                                                                                },
+                                                                            ],
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                metrics: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
+                                                                                fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'metric',
+                                                                                        ],
+                                                                                        required: true,
+                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15095,7 +15231,75 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                            },
+                                                                    },
+                                                                    required: true,
+                                                                },
+                                                                dimensions: {
+                                                                    dataType:
+                                                                        'array',
+                                                                    array: {
+                                                                        dataType:
+                                                                            'nestedObjectLiteral',
+                                                                        nestedProperties:
+                                                                            {
                                                                                 fieldType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'dimension',
+                                                                                        ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                isFromJoinedTable:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'boolean',
+                                                                                        required: true,
+                                                                                    },
+                                                                                caseSensitiveFilters:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -15105,17 +15309,36 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'dimension',
+                                                                                                        'false',
                                                                                                     ],
                                                                                                 },
                                                                                                 {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
-                                                                                                        'metric',
+                                                                                                        'not_applicable',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldFilterType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                fieldValueType:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
                                                                                         required: true,
                                                                                     },
                                                                                 table: {
@@ -15268,6 +15491,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                uncertainties: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 suggestedQuestion:
                                                                     {
                                                                         dataType:
@@ -15317,6 +15559,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                uncertainties: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 reason: {
                                                                     dataType:
                                                                         'string',
@@ -16076,11 +16337,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15783,50 +15783,21 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "topMatchingFields": {
+                                                            "explores": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "verifiedChartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "metrics": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "dimensions": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
                                                                         },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "tableName": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "label": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "fieldType",
-                                                                        "tableName",
-                                                                        "label",
-                                                                        "name"
-                                                                    ],
-                                                                    "type": "object"
-                                                                },
-                                                                "type": "array"
-                                                            },
-                                                            "exploreSearchResults": {
-                                                                "items": {
-                                                                    "properties": {
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
@@ -15866,7 +15837,16 @@
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
-                                                                            "type": "array",
+                                                                            "type": "array"
+                                                                        },
+                                                                        "aiHints": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        "description": {
+                                                                            "type": "string",
                                                                             "nullable": true
                                                                         },
                                                                         "searchRank": {
@@ -15877,13 +15857,18 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "exploreName": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "metrics",
+                                                                        "dimensions",
+                                                                        "requiredFilters",
+                                                                        "joinedTables",
+                                                                        "aiHints",
                                                                         "label",
-                                                                        "name"
+                                                                        "exploreName"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -15894,6 +15879,7 @@
                                                             }
                                                         },
                                                         "required": [
+                                                            "explores",
                                                             "searchQuery"
                                                         ],
                                                         "type": "object"
@@ -16096,30 +16082,149 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "streamingMessage": {},
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": ["streaming"],
-                                                        "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "streamingMessage": {},
                                                     "discovery": {
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "uncertainties": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "rationale": {
                                                                         "type": "string",
                                                                         "nullable": true
                                                                     },
                                                                     "fields": {
                                                                         "items": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "fieldType": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "dimension"
+                                                                                            ],
+                                                                                            "nullable": false
+                                                                                        },
+                                                                                        "description": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "isFromJoinedTable": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "caseSensitiveFilters": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "false",
+                                                                                                "not_applicable",
+                                                                                                "true"
+                                                                                            ]
+                                                                                        },
+                                                                                        "fieldFilterType": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldValueType": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "table": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldId": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "fieldType",
+                                                                                        "description",
+                                                                                        "isFromJoinedTable",
+                                                                                        "caseSensitiveFilters",
+                                                                                        "fieldFilterType",
+                                                                                        "fieldValueType",
+                                                                                        "table",
+                                                                                        "label",
+                                                                                        "name",
+                                                                                        "fieldId"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                {
+                                                                                    "properties": {
+                                                                                        "fieldType": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "metric"
+                                                                                            ],
+                                                                                            "nullable": false
+                                                                                        },
+                                                                                        "description": {
+                                                                                            "type": "string",
+                                                                                            "nullable": true
+                                                                                        },
+                                                                                        "isFromJoinedTable": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "caseSensitiveFilters": {
+                                                                                            "type": "string",
+                                                                                            "enum": [
+                                                                                                "false",
+                                                                                                "not_applicable",
+                                                                                                "true"
+                                                                                            ]
+                                                                                        },
+                                                                                        "fieldFilterType": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldValueType": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "table": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "label": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "name": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldId": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "fieldType",
+                                                                                        "description",
+                                                                                        "isFromJoinedTable",
+                                                                                        "caseSensitiveFilters",
+                                                                                        "fieldFilterType",
+                                                                                        "fieldValueType",
+                                                                                        "table",
+                                                                                        "label",
+                                                                                        "name",
+                                                                                        "fieldId"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "metrics": {
+                                                                        "items": {
                                                                             "properties": {
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "metric"
+                                                                                    ],
+                                                                                    "nullable": false
+                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
@@ -16141,12 +16246,65 @@
                                                                                 "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "table",
+                                                                                "label",
+                                                                                "name",
+                                                                                "fieldId"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "dimensions": {
+                                                                        "items": {
+                                                                            "properties": {
                                                                                 "fieldType": {
                                                                                     "type": "string",
                                                                                     "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
+                                                                                        "dimension"
+                                                                                    ],
+                                                                                    "nullable": false
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "false",
+                                                                                        "not_applicable",
+                                                                                        "true"
                                                                                     ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
                                                                                 },
                                                                                 "table": {
                                                                                     "type": "string"
@@ -16162,12 +16320,12 @@
                                                                                 }
                                                                             },
                                                                             "required": [
+                                                                                "fieldType",
                                                                                 "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldFilterType",
                                                                                 "fieldValueType",
-                                                                                "fieldType",
                                                                                 "table",
                                                                                 "label",
                                                                                 "name",
@@ -16247,8 +16405,11 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "uncertainties",
                                                                     "rationale",
                                                                     "fields",
+                                                                    "metrics",
+                                                                    "dimensions",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -16256,6 +16417,10 @@
                                                             },
                                                             {
                                                                 "properties": {
+                                                                    "uncertainties": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "suggestedQuestion": {
                                                                         "type": "string"
                                                                     },
@@ -16290,6 +16455,7 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "uncertainties",
                                                                     "suggestedQuestion",
                                                                     "candidates",
                                                                     "status"
@@ -16298,6 +16464,10 @@
                                                             },
                                                             {
                                                                 "properties": {
+                                                                    "uncertainties": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "reason": {
                                                                         "type": "string"
                                                                     },
@@ -16310,6 +16480,7 @@
                                                                     }
                                                                 },
                                                                 "required": [
+                                                                    "uncertainties",
                                                                     "reason",
                                                                     "status"
                                                                 ],
@@ -16598,19 +16769,6 @@
                                                         "enum": [
                                                             "error",
                                                             "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
                                                         ]
                                                     }
                                                 },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDiscoverFieldsArgs.ts
@@ -3,12 +3,12 @@ import { z } from 'zod';
 export const DISCOVER_FIELDS_DESCRIPTION = `Tool: discoverFields
 
 Purpose:
-Run the data-discovery subagent. Given the latest user query, returns a structured handoff describing which explore and which fields to use to answer it.
+Run the data-discovery subagent. Given the latest user query, returns a structured handoff describing which explore, dimensions, and metrics to use to answer it.
 
 Use this tool as the FIRST step whenever the user asks a data question (counts, totals, breakdowns, trends, "what is", "show me", "how many"). Do NOT call this when the user is only asking about existing dashboards/charts (use findContent) or follow-up clarifications about a chart you already produced.
 
 You will receive one of three statuses:
-- "resolved" — proceed with generateVisualization (or generateDashboard) using the returned explore + fields.
+- "resolved" — proceed with generateVisualization (or generateDashboard) using the returned explore + dimensions/metrics.
 - "ambiguous" — surface the suggestedQuestion to the user; do NOT call generateVisualization.
 - "no_match" — explain back to the user that no data source covers the request.
 
@@ -54,14 +54,13 @@ const discoverFieldsExploreSummarySchema = z.object({
         ),
 });
 
-const discoverFieldsFieldSummarySchema = z.object({
+const discoverFieldsFieldSummaryBaseSchema = z.object({
     fieldId: z
         .string()
         .describe('The fieldId to use in generateVisualization payloads.'),
     name: z.string(),
     label: z.string(),
     table: z.string(),
-    fieldType: z.enum(['dimension', 'metric']),
     fieldValueType: z
         .string()
         .describe(
@@ -78,9 +77,24 @@ const discoverFieldsFieldSummarySchema = z.object({
         .string()
         .nullable()
         .describe(
-            'Short description, only include when needed to distinguish similar fields.',
+            'Full field description copied exactly from listFields when fetched, otherwise a non-truncated findFields description; null when the field has no description.',
         ),
 });
+
+const discoverFieldsDimensionSummarySchema =
+    discoverFieldsFieldSummaryBaseSchema.extend({
+        fieldType: z.literal('dimension'),
+    });
+
+const discoverFieldsMetricSummarySchema =
+    discoverFieldsFieldSummaryBaseSchema.extend({
+        fieldType: z.literal('metric'),
+    });
+
+const discoverFieldsFieldSummarySchema = z.union([
+    discoverFieldsDimensionSummarySchema,
+    discoverFieldsMetricSummarySchema,
+]);
 
 const discoverFieldsCandidateSchema = z.object({
     exploreName: z.string(),
@@ -90,19 +104,37 @@ const discoverFieldsCandidateSchema = z.object({
         .describe('Why this explore is a plausible candidate for the query.'),
 });
 
+const discoverFieldsUncertaintiesSchema = z
+    .string()
+    .nullable()
+    .describe(
+        'Free-form uncertainties or caveats encountered during discovery. Null when selection was straightforward.',
+    );
+
 export const discoverFieldsResultUnionSchema = z.discriminatedUnion('status', [
     z.object({
         status: z.literal('resolved'),
         explore: discoverFieldsExploreSummarySchema,
+        dimensions: z
+            .array(discoverFieldsDimensionSummarySchema)
+            .describe(
+                'Filtered list of dimension fields relevant to the user query: groupings, dates, filters, and breakdowns. Not the full explore.',
+            ),
+        metrics: z
+            .array(discoverFieldsMetricSummarySchema)
+            .describe(
+                'Filtered list of metric fields relevant to the user query. Not the full explore.',
+            ),
         fields: z
             .array(discoverFieldsFieldSummarySchema)
             .describe(
-                'Filtered list of fields relevant to the user query — typically 5–20 entries. Not the full explore.',
+                'Legacy combined list of selected dimensions and metrics. Prefer dimensions and metrics for new consumers.',
             ),
         rationale: z
             .string()
             .nullable()
             .describe('Brief justification for the explore + field selection.'),
+        uncertainties: discoverFieldsUncertaintiesSchema,
     }),
     z.object({
         status: z.literal('ambiguous'),
@@ -117,6 +149,7 @@ export const discoverFieldsResultUnionSchema = z.discriminatedUnion('status', [
             .describe(
                 "A clarification question the parent can echo to the user (e.g. 'Did you mean revenue from the orders explore or the payments explore?').",
             ),
+        uncertainties: discoverFieldsUncertaintiesSchema,
     }),
     z.object({
         status: z.literal('no_match'),
@@ -125,6 +158,7 @@ export const discoverFieldsResultUnionSchema = z.discriminatedUnion('status', [
             .describe(
                 'Why no explore covers the user query — used by the parent to explain back to the user.',
             ),
+        uncertainties: discoverFieldsUncertaintiesSchema,
     }),
 ]);
 
@@ -134,18 +168,10 @@ export const discoverFieldsResultSchema = z.object({
 
 export const toolDiscoverFieldsOutputSchema = z.union([
     z.object({
-        result: z.literal(''),
-        metadata: z.object({
-            status: z.literal('streaming'),
-            streamingMessage: z.unknown(),
-        }),
-    }),
-    z.object({
         result: z.string(),
         metadata: z.object({
             status: z.literal('success'),
             discovery: discoverFieldsResultUnionSchema,
-            streamingMessage: z.unknown().optional(),
         }),
     }),
     z.object({

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolFindExploresArgs.ts
@@ -2,19 +2,31 @@ import { z } from 'zod';
 import { baseOutputMetadataSchema } from '../outputMetadata';
 import { createToolSchema } from '../toolSchemaBuilder';
 
+const requiredFilterSchema = z.object({
+    fieldId: z.string(),
+    fieldRef: z.string(),
+    tableName: z.string(),
+    operator: z.string(),
+    values: z.array(z.unknown()).optional(),
+    settings: z.unknown().optional(),
+    required: z.boolean(),
+});
+
 export const TOOL_FIND_EXPLORES_DESCRIPTION = `Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with joined tables, required filters, AI hints, full descriptions, and compact lists of all dimension/metric field ids available in each matched explore. Search matches explore name, label, description, and AI hints. A follow-up query runs against a single explore, so this tool is meant to identify the explore to inspect next with findFields or listFields.
+
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Keyword terms for finding relevant explores
 
 Output:
-- Matching explores with searchRank scores
-- Top matching fields with their explore names and searchRank scores
-- Required filters set on matching explores, including default values
+- Matching explores with searchRank scores, joined tables, required filters, AI hints, and full descriptions
+- Compact all-field inventories split into dimension and metric field ids
+
+Field descriptions are not included in the compact field inventories. Use findFields to search/compare fields by label/description, or listFields when you need exact full metadata for known field ids.
 `;
 
 export const toolFindExploresArgsSchemaV1 = createToolSchema()
@@ -37,11 +49,10 @@ export const toolFindExploresArgsSchemaV2 = createToolSchema()
 
 export const toolFindExploresArgsSchemaV3 = createToolSchema()
     .extend({
-        // TODO: check if we need to add exploreName back in for backward compatibility
         searchQuery: z
             .string()
             .describe(
-                "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
+                "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore name, label, description, and AI hints. Prefer entity/domain nouns that capture the user's analytical intent.",
             ),
     })
     .build();
@@ -49,44 +60,21 @@ export const toolFindExploresArgsSchemaV3 = createToolSchema()
 export const toolFindExploresArgsSchemaTransformed =
     toolFindExploresArgsSchemaV3;
 
+const findExploresExploreResultSchema = z.object({
+    exploreName: z.string(),
+    label: z.string(),
+    searchRank: z.number().nullable().optional(),
+    description: z.string().nullable().optional(),
+    aiHints: z.array(z.string()),
+    joinedTables: z.array(z.string()),
+    requiredFilters: z.array(requiredFilterSchema),
+    dimensions: z.array(z.string()),
+    metrics: z.array(z.string()),
+});
+
 export const findExploresRankingMetadataSchema = z.object({
     searchQuery: z.string(),
-    exploreSearchResults: z
-        .array(
-            z.object({
-                name: z.string(),
-                label: z.string(),
-                searchRank: z.number().nullable().optional(),
-                joinedTables: z.array(z.string()).nullable().optional(),
-                requiredFilters: z
-                    .array(
-                        z.object({
-                            fieldId: z.string(),
-                            fieldRef: z.string(),
-                            tableName: z.string(),
-                            operator: z.string(),
-                            values: z.array(z.unknown()).optional(),
-                            settings: z.unknown().optional(),
-                            required: z.boolean(),
-                        }),
-                    )
-                    .optional(),
-            }),
-        )
-        .optional(),
-    topMatchingFields: z
-        .array(
-            z.object({
-                name: z.string(),
-                label: z.string(),
-                tableName: z.string(),
-                fieldType: z.string(),
-                searchRank: z.number().nullable().optional(),
-                chartUsage: z.number().nullable().optional(),
-                verifiedChartUsage: z.number().nullable().optional(),
-            }),
-        )
-        .optional(),
+    explores: z.array(findExploresExploreResultSchema),
 });
 
 export const toolFindExploresOutputSchema = z.object({


### PR DESCRIPTION
Changes discoverFields to submit compact selectors, then rehydrates exact explore and field metadata in the parent tool. Splits final output into dimensions and metrics.

Stack: 2/3