### PR TITLE
fix(mcp): expose structured field discovery

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -200,6 +200,7 @@ const makeMcpService = ({
     dashboardSearchResults = [],
     chartSearchResults = [],
     verifiedContent = [],
+    jsonRendererEnabled = false,
 }: {
     context?: {
         projectUuid: string;
@@ -220,6 +221,7 @@ const makeMcpService = ({
     })[];
     chartSearchResults?: ReturnType<typeof makeChartSearchResult>[];
     verifiedContent?: Record<string, unknown>[];
+    jsonRendererEnabled?: boolean;
 } = {}) => {
     const asyncQueryService = {
         executeAsyncSqlQuery: jest.fn(),
@@ -363,16 +365,6 @@ const makeMcpService = ({
                         searchRank: 1,
                         joinedTables: [],
                     })),
-                    topMatchingFields: [
-                        {
-                            name: 'orders_count',
-                            label: 'Orders Count',
-                            tableName: 'orders',
-                            fieldType: 'metric',
-                            searchRank: 1,
-                            description: null,
-                        },
-                    ],
                 };
             }),
             findFields: jest.fn(async () => ({ fields: [], pagination: {} })),
@@ -417,6 +409,10 @@ const makeMcpService = ({
         ),
     };
 
+    const featureFlagService = {
+        get: jest.fn().mockResolvedValue({ enabled: jsonRendererEnabled }),
+    };
+
     const service = new McpService({
         aiAgentService,
         aiAgentToolsService,
@@ -430,7 +426,7 @@ const makeMcpService = ({
         catalogService,
         contentService: {},
         contentVerificationService,
-        featureFlagService: {},
+        featureFlagService,
         lightdashConfig: {
             ai: {
                 copilot: {
@@ -458,6 +454,7 @@ const makeMcpService = ({
         asyncQueryService,
         catalogService,
         contentVerificationService,
+        featureFlagService,
         mcpContextModel,
         projectModel,
         projectService,
@@ -672,11 +669,67 @@ describe('MCP async query polling', () => {
             agentUuid: 'agent-uuid',
             searchQuery: 'Show me revenue by month',
         });
-        expect(getTextResult(result)).toContain('<verifiedAnswers count="1">');
-        expect(getTextResult(result)).toContain('Revenue by month');
+        expect(parseTextResult(result)).toMatchObject({
+            verifiedAnswers: {
+                count: 1,
+                items: [relevantVerifiedAnswer],
+            },
+        });
         expect(result).toMatchObject({
             structuredContent: {
-                relevantVerifiedAnswers: [relevantVerifiedAnswer],
+                verifiedAnswers: {
+                    count: 1,
+                    items: [relevantVerifiedAnswer],
+                },
+            },
+        });
+    });
+
+    it('returns structured content for discovery tools', async () => {
+        makeMcpService();
+
+        const findExploresResult = await getToolCallback(
+            McpToolName.FIND_EXPLORES,
+        )({ searchQuery: 'orders' }, extra);
+        expect(findExploresResult).toMatchObject({
+            structuredContent: {
+                explores: expect.any(Array),
+            },
+        });
+
+        const findFieldsResult = await getToolCallback(McpToolName.FIND_FIELDS)(
+            {
+                table: 'orders',
+                fieldSearchQueries: [{ label: 'Orders count' }],
+            },
+            extra,
+        );
+        expect(findFieldsResult).toMatchObject({
+            structuredContent: {
+                searchResults: expect.any(Array),
+            },
+        });
+
+        const listFieldsResult = await getToolCallback(McpToolName.LIST_FIELDS)(
+            {
+                fields: [
+                    {
+                        explore: 'orders',
+                        fieldId: 'orders_missing_field',
+                    },
+                ],
+            },
+            extra,
+        );
+        expect(listFieldsResult).toMatchObject({
+            structuredContent: {
+                count: 1,
+                results: [
+                    expect.objectContaining({
+                        status: 'error',
+                        fieldId: 'orders_missing_field',
+                    }),
+                ],
             },
         });
     });
@@ -813,11 +866,16 @@ describe('MCP async query polling', () => {
             extra,
         );
 
+        expect(parseTextResult(result)).toMatchObject({
+            explores: [
+                expect.objectContaining({
+                    exploreName: 'orders',
+                }),
+            ],
+        });
         expect(result).toMatchObject({
             content: [
-                expect.objectContaining({
-                    text: expect.stringContaining('name="orders"'),
-                }),
+                expect.any(Object),
                 expect.objectContaining({
                     text: expect.stringContaining('Active agent: Agent'),
                 }),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -34,6 +34,7 @@ import {
     listAgentsToolDefinition,
     listContentToolDefinition,
     listExploresToolDefinition,
+    listFieldsToolDefinition,
     listSkillsToolDefinition,
     listVerifiedContentToolDefinition,
     MCP_QUERY_POLL_INTERVAL_MS,
@@ -117,10 +118,12 @@ import { getFindContent } from '../ai/tools/findContent';
 import { getFindExplores } from '../ai/tools/findExplores';
 import { getFindFields } from '../ai/tools/findFields';
 import { getListContent } from '../ai/tools/listContent';
+import { getListFields } from '../ai/tools/listFields';
 import { getMcpListExplores } from '../ai/tools/mcpListExplores';
 import { getReadContent } from '../ai/tools/readContent';
 import { validateRunQueryTool } from '../ai/tools/runQuery';
 import { getSearchFieldValues } from '../ai/tools/searchFieldValues';
+import type { StructuredToolResult } from '../ai/tools/toolOutputFormat';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
 import {
     expandMetricsWithPopAdditionalMetrics,
@@ -146,6 +149,7 @@ export enum McpToolName {
     LIST_EXPLORES = 'list_explores',
     FIND_EXPLORES = 'find_explores',
     FIND_FIELDS = 'find_fields',
+    LIST_FIELDS = 'list_fields',
     FIND_CONTENT = 'find_content',
     LIST_CONTENT = 'list_content',
     READ_CONTENT = 'read_content',
@@ -179,6 +183,7 @@ const mcpGetLightdashVersionTool = getLightdashVersionToolDefinition.for('mcp');
 const mcpListExploresTool = listExploresToolDefinition.for('mcp');
 const mcpFindExploresTool = findExploresToolDefinition.for('mcp');
 const mcpFindFieldsTool = findFieldsToolDefinition.for('mcp');
+const mcpListFieldsTool = listFieldsToolDefinition.for('mcp');
 const mcpFindContentTool = findContentToolDefinition.for('mcp');
 const mcpListContentTool = listContentToolDefinition.for('mcp');
 const mcpReadContentTool = readContentToolDefinition.for('mcp');
@@ -473,14 +478,57 @@ export class McpService extends BaseService {
     static async streamToolResult<T extends { result: string }>(
         result: T | AsyncIterable<T>,
     ) {
-        if (Symbol.asyncIterator in result) {
-            let out = '';
-            for await (const chunk of result) {
-                out += chunk.result;
-            }
-            return out;
+        const { resultText } = await McpService.streamToolResponse(result);
+        return resultText;
+    }
+
+    private static isStructuredContent(
+        value: unknown,
+    ): value is Record<string, unknown> {
+        return typeof value === 'object' && value !== null;
+    }
+
+    private static getStructuredContentFromResult(
+        result: unknown,
+    ): Record<string, unknown> | undefined {
+        if (
+            typeof result === 'object' &&
+            result !== null &&
+            'structuredResult' in result &&
+            McpService.isStructuredContent(
+                (result as StructuredToolResult<unknown>).structuredResult,
+            )
+        ) {
+            return (result as StructuredToolResult<Record<string, unknown>>)
+                .structuredResult;
         }
-        return result.result;
+
+        return undefined;
+    }
+
+    static async streamToolResponse<T extends { result: string }>(
+        result: T | AsyncIterable<T>,
+    ): Promise<{
+        resultText: string;
+        structuredContent?: Record<string, unknown>;
+    }> {
+        if (Symbol.asyncIterator in result) {
+            let resultText = '';
+            let structuredContent: Record<string, unknown> | undefined;
+            for await (const chunk of result) {
+                resultText += chunk.result;
+                structuredContent =
+                    McpService.getStructuredContentFromResult(chunk) ??
+                    structuredContent;
+            }
+            return { resultText, structuredContent };
+        }
+
+        return {
+            resultText: result.result,
+            structuredContent:
+                McpService.getStructuredContentFromResult(result),
+        };
     }
 
     private static getMcpQueryWaitMs(
@@ -592,6 +640,19 @@ export class McpService extends BaseService {
             userAttributeOverrides:
                 await this.getUserAttributeOverridesFromContext(ctx),
         };
+    }
+
+    private static parseToolStructuredContent(
+        toolResult: string,
+    ): Record<string, unknown> | undefined {
+        try {
+            const parsed = JSON.parse(toolResult) as unknown;
+            return typeof parsed === 'object' && parsed !== null
+                ? (parsed as Record<string, unknown>)
+                : undefined;
+        } catch {
+            return undefined;
+        }
     }
 
     private async getToolsRuntime(
@@ -1339,9 +1400,6 @@ export class McpService extends BaseService {
                 const findExploresTool = getFindExplores({
                     findExplores: toolsRuntime.findExplores,
                     updateProgress: async () => {}, // No-op for MCP context
-                    fieldSearchSize: 200,
-                    toolDescriptionMaxChars:
-                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                 });
                 const result = await findExploresTool.execute!(
                     {
@@ -1354,7 +1412,8 @@ export class McpService extends BaseService {
                         experimental_context: { availableExplores },
                     },
                 );
-                const resultText = await McpService.streamToolResult(result);
+                const { resultText, structuredContent } =
+                    await McpService.streamToolResponse(result);
                 const metadata = await this.getActiveContextMetadata(ctx);
 
                 const verifiedAnswerContext = metadata.agentUuid
@@ -1368,19 +1427,30 @@ export class McpService extends BaseService {
                       )
                     : { relevantVerifiedAnswers: [] };
 
-                const verifiedAnswersText =
+                const verifiedAnswers =
                     verifiedAnswerContext.relevantVerifiedAnswers.length > 0
-                        ? `\n\n<verifiedAnswers count="${verifiedAnswerContext.relevantVerifiedAnswers.length}">\n${JSON.stringify(
-                              verifiedAnswerContext.relevantVerifiedAnswers,
-                              null,
-                              2,
-                          )}\n</verifiedAnswers>`
-                        : '';
+                        ? {
+                              count: verifiedAnswerContext
+                                  .relevantVerifiedAnswers.length,
+                              items: verifiedAnswerContext.relevantVerifiedAnswers,
+                          }
+                        : undefined;
+
+                const responseStructuredContent = verifiedAnswers
+                    ? {
+                          ...(structuredContent ?? {}),
+                          verifiedAnswers,
+                      }
+                    : (structuredContent ?? verifiedAnswerContext);
+
+                const responseText = verifiedAnswers
+                    ? JSON.stringify(responseStructuredContent)
+                    : resultText;
 
                 return this.buildScopedResponse(
                     ctx,
-                    `${resultText}${verifiedAnswersText}`,
-                    verifiedAnswerContext,
+                    responseText,
+                    responseStructuredContent,
                     projectUuid,
                 );
             },
@@ -1412,18 +1482,60 @@ export class McpService extends BaseService {
                     findFields: toolsRuntime.findFields,
                     updateProgress: async () => {}, // No-op for MCP context
                     pageSize: 15,
-                    toolDescriptionMaxChars:
-                        this.lightdashConfig.ai.copilot.toolDescriptionMaxChars,
                 });
                 const result = await findFieldsTool.execute!(argsWithProject, {
                     toolCallId: '',
                     messages: [],
                 });
+                const { resultText, structuredContent } =
+                    await McpService.streamToolResponse(result);
 
                 return this.buildScopedResponse(
                     ctx,
-                    await McpService.streamToolResult(result),
-                    undefined,
+                    resultText,
+                    structuredContent ??
+                        McpService.parseToolStructuredContent(resultText),
+                    projectUuid,
+                );
+            },
+        );
+
+        this.mcpServer.registerTool(
+            mcpListFieldsTool.name,
+            {
+                title: mcpListFieldsTool.title,
+                description: mcpListFieldsTool.description,
+                inputSchema: mcpListFieldsTool.inputSchema.shape,
+                annotations: mcpListFieldsTool.annotations,
+            },
+            async (args, extra) => {
+                const ctx = getMcpContext(extra);
+
+                const projectUuid = await this.resolveProjectUuid(ctx);
+                const argsWithProject = { ...args, projectUuid };
+
+                this.trackToolCall(ctx, McpToolName.LIST_FIELDS, projectUuid);
+
+                const toolsRuntime = await this.getToolsRuntime(
+                    ctx,
+                    projectUuid,
+                );
+
+                const listFieldsTool = getListFields({
+                    getExplore: toolsRuntime.getExplore,
+                });
+                const result = await listFieldsTool.execute!(argsWithProject, {
+                    toolCallId: '',
+                    messages: [],
+                });
+                const { resultText, structuredContent } =
+                    await McpService.streamToolResponse(result);
+
+                return this.buildScopedResponse(
+                    ctx,
+                    resultText,
+                    structuredContent ??
+                        McpService.parseToolStructuredContent(resultText),
                     projectUuid,
                 );
             },

--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -20,26 +20,29 @@ exports[`MCP tool contracts matches the current MCP tool and prompt contract sna
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
-   - Review the \`topMatchingFields\` to understand which explores match
-   - If multiple explores match with similar scores, ask the user which data source they mean
-2. **Get fields**: Use \`find_fields\` for the chosen explore to see all available dimensions and metrics
-   - Read field labels, descriptions, and hints carefully — hints are written specifically for AI guidance
-   - Never invent field IDs; only use exact values returned by \`find_fields\`
+   - Review explore descriptions, AI hints, and joined tables to understand which explores match
+   - If multiple explores match with similar scores and field searches do not disambiguate, ask the user which data source they mean
+2. **Search fields**: Use \`find_fields\` for the chosen explore when you are not yet sure which exact dimensions or metrics to use
+   - Read field labels, full descriptions, and hints carefully — hints are written specifically for AI guidance
+   - Never invent field IDs; only use exact values returned by \`find_fields\` or \`list_fields\`
    - Search for business terms, not technical field names
-   - Use multiple search queries in one call to find related fields efficiently
+   - Use multiple search queries in one call to find related candidate fields efficiently
    - Look for both dimensions (for grouping) and metrics (for aggregation)
-3. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
-4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
-5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
-6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
-7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
-8. **Find content**: Use \`find_content\` to search for existing dashboards and charts
+3. **List exact fields**: Use \`list_fields\` once you know exact field ids that are likely to be used and need full field details before final query construction
+   - Do not keep calling \`find_fields\` to re-fetch known ids
+   - Fetch only exact fields that matter for the answer
+4. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
+5. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
+6. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
+7. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
+8. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
+9. **Find content**: Use \`find_content\` to search for existing dashboards and charts
 
 ## Critical Rules
 
 ### Explore Selection
 - When the user's query contains a domain word matching an explore name, use that explore
-- When multiple explores match, check \`usageInCharts\` to find the most commonly used one
+- When multiple explores match, use \`find_fields\` on plausible explores to compare relevant metrics/dimensions and chart usage
 - If still ambiguous, ask the user which data source they want — do NOT guess
 
 ### When to Use run_sql vs run_metric_query
@@ -104,7 +107,7 @@ Purpose:
 Lists all Explores available to the user in the current project. Returns a summary of each explore including its name, label, base table, and tags.
 
 Usage Tips:
-- Use this to discover what data sources are available before using findExplores for detailed field information
+- Use this to discover what data sources are available before using findExplores for detailed explore descriptions
 - No arguments needed - automatically uses the current project context
 - Results are filtered based on user permissions and selected tags
 - Returns explore metadata without field details for quick overview
@@ -123,23 +126,25 @@ Usage Tips:
       "description": "Tool: findExplores
 
 Purpose:
-Returns explores matching the query with their joined tables, required filters, AI hints and descriptions, plus the top 50 matching fields across ALL explores. Search matches explore and field name, label, and description. A follow-up query runs against a single explore, so this tool is meant to identify the explore whose fields can answer the user's question.
+Returns explores matching the query with joined tables, required filters, AI hints, full descriptions, and compact lists of all dimension/metric field ids available in each matched explore. Search matches explore name, label, description, and AI hints. A follow-up query runs against a single explore, so this tool is meant to identify the explore to inspect next with findFields or listFields.
+
 IMPORTANT: Each explore may include fields from multiple joined tables. Check the "joinedTables" elements to see which tables are included in the explore.
 
 Parameters:
 - searchQuery: Keyword terms for finding relevant explores
 
 Output:
-- Matching explores with searchRank scores
-- Top matching fields with their explore names and searchRank scores
-- Required filters set on matching explores, including default values
+- Matching explores with searchRank scores, joined tables, required filters, AI hints, and full descriptions
+- Compact all-field inventories split into dimension and metric field ids
+
+Field descriptions are not included in the compact field inventories. Use findFields to search/compare fields by label/description, or listFields when you need exact full metadata for known field ids.
 ",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "properties": {
           "searchQuery": {
-            "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore and field name, label, and description. Prefer metric/entity/dimension nouns that capture the user's analytical intent.",
+            "description": "set of high-signal keyword terms for query. Search uses PostgreSQL websearch_to_tsquery after joining whitespace-separated terms with OR. It searches explore name, label, description, and AI hints. Prefer entity/domain nouns that capture the user's analytical intent.",
             "type": "string",
           },
         },
@@ -156,15 +161,17 @@ Output:
       "description": "Tool: "findFields"
 
 Purpose:
-Finds the most relevant Fields (Metrics & Dimensions) within Explores, returning detailed info about each.
+Searches for candidate Fields (Metrics & Dimensions) within an Explore when you are not yet sure which exact field id to use. Returns ranked field matches with full, untruncated descriptions.
 
 Usage tips:
-- Use "findExplores" first to discover available Explores and their field labels.
+- Use "findExplores" first to discover the relevant Explore, then use this tool to search fields inside it.
 - Use full field labels in search terms (e.g. "Total Revenue", "Order Date").
-- Pass all needed fields in one request.
+- Pass all needed candidate searches in one request.
 - Fields are sorted by relevance, with a maximum score of 1 and a minimum of 0, so the top results are the most relevant.
 - If results aren't relevant, retry with clearer or more specific terms.
 - Results are paginated — use the next page token to get more results if needed.
+- Once you know the exact field id(s) you likely want to use, switch to listFields for exact full details. Do not keep using findFields to re-fetch known field ids.
+- Field descriptions are full, untruncated catalog descriptions. Use listFields for exact lookup/validation once you know likely-final field ids.
 ",
       "inputSchema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -204,6 +211,62 @@ Usage tips:
       },
       "name": "find_fields",
       "title": "Find fields",
+    },
+    {
+      "agentName": null,
+      "description": "Tool: listFields
+
+Purpose:
+Fetch exact fields from exact explores by field id. Use this when you already know the field id(s) you likely want to use and need exact full field context before final selection or query construction.
+
+Usage tips:
+- This is not a search tool. Use findExplores/findFields when you are still discovering or comparing candidates.
+- Use listFields when you are fairly sure a metric or dimension should be used and want exact details for that known field id.
+- Pass exact field ids returned by findExplores, findFields, query errors, or other semantic-layer tools.
+- Never infer field ids from labels or desired concepts (for example, do not guess "orders_country" or "airports_city"). If the exact field id was not returned by a tool, call findFields first.
+- Pass multiple fields in one request only when each field is likely relevant to the final answer.
+- Do not use this to fetch broad field inventories; use findExplores/findFields for search and only fetch exact fields that matter.
+- Results are returned per field. If one field cannot be resolved, other valid fields are still returned.
+
+Output:
+- Full untruncated field details for each resolved field.
+- Per-field errors for missing explores or field ids.
+",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "properties": {
+          "fields": {
+            "description": "Fields to fetch by exact explore name and field id.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "explore": {
+                  "description": "Exact explore name that contains the field.",
+                  "type": "string",
+                },
+                "fieldId": {
+                  "description": "Exact field id to fetch, e.g. "orders_total_revenue".",
+                  "type": "string",
+                },
+              },
+              "required": [
+                "explore",
+                "fieldId",
+              ],
+              "type": "object",
+            },
+            "minItems": 1,
+            "type": "array",
+          },
+        },
+        "required": [
+          "fields",
+        ],
+        "type": "object",
+      },
+      "name": "list_fields",
+      "title": "List fields",
     },
     {
       "agentName": null,
@@ -6841,6 +6904,7 @@ exports[`MCP tool contracts matches the shared MCP tool definition names snapsho
 [
   "find_explores",
   "find_fields",
+  "list_fields",
   "find_content",
   "search_field_values",
   "run_metric_query",

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -6,26 +6,29 @@ export const MCP_ANALYST_PROMPT = `# Lightdash MCP Tools — Usage Guidelines
 1. **Find explores first**: Use \`find_explores\` with a natural language search query to discover relevant data models and any matching verified answers
    - If the response includes a verified answer that clearly matches, prefer its returned config over constructing a new query from scratch
    - Use matching verified answers as the starting point, then adapt only if the user asked for a clear modification
-   - Review the \`topMatchingFields\` to understand which explores match
-   - If multiple explores match with similar scores, ask the user which data source they mean
-2. **Get fields**: Use \`find_fields\` for the chosen explore to see all available dimensions and metrics
-   - Read field labels, descriptions, and hints carefully — hints are written specifically for AI guidance
-   - Never invent field IDs; only use exact values returned by \`find_fields\`
+   - Review explore descriptions, AI hints, and joined tables to understand which explores match
+   - If multiple explores match with similar scores and field searches do not disambiguate, ask the user which data source they mean
+2. **Search fields**: Use \`find_fields\` for the chosen explore when you are not yet sure which exact dimensions or metrics to use
+   - Read field labels, full descriptions, and hints carefully — hints are written specifically for AI guidance
+   - Never invent field IDs; only use exact values returned by \`find_fields\` or \`list_fields\`
    - Search for business terms, not technical field names
-   - Use multiple search queries in one call to find related fields efficiently
+   - Use multiple search queries in one call to find related candidate fields efficiently
    - Look for both dimensions (for grouping) and metrics (for aggregation)
-3. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
-4. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
-5. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
-6. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
-7. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
-8. **Find content**: Use \`find_content\` to search for existing dashboards and charts
+3. **List exact fields**: Use \`list_fields\` once you know exact field ids that are likely to be used and need full field details before final query construction
+   - Do not keep calling \`find_fields\` to re-fetch known ids
+   - Fetch only exact fields that matter for the answer
+4. **Search field values**: Use \`search_field_values\` to discover valid filter values for a dimension
+5. **Run queries**: Use \`run_metric_query\` for semantic-layer metric queries, or \`run_sql\` for custom SQL
+6. **Poll long-running queries**: If a query returns \`status: "running"\`, call \`get_query_result\` with the \`queryUuid\` until it returns done/error/cancelled/expired
+7. **Render charts**: If the user wants a chart, call \`render_chart\` after \`run_metric_query\` or \`get_query_result\` returns done with a \`queryUuid\`
+8. **Browse content**: Use \`list_content\` to browse accessible spaces and direct content inside a space
+9. **Find content**: Use \`find_content\` to search for existing dashboards and charts
 
 ## Critical Rules
 
 ### Explore Selection
 - When the user's query contains a domain word matching an explore name, use that explore
-- When multiple explores match, check \`usageInCharts\` to find the most commonly used one
+- When multiple explores match, use \`find_fields\` on plausible explores to compare relevant metrics/dimensions and chart usage
 - If still ambiguous, ask the user which data source they want — do NOT guess
 
 ### When to Use run_sql vs run_metric_query

--- a/packages/backend/src/ee/services/ai/tools/findExplores.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findExplores.tsx
@@ -14,8 +14,6 @@ import { stringifyToolJson } from './toolOutputFormat';
 type Dependencies = {
     findExplores: FindExploresFn;
     updateProgress: UpdateProgressFn;
-    fieldSearchSize?: number;
-    toolDescriptionMaxChars?: number;
 };
 
 const toolDefinition = findExploresToolDefinition.for('agent');

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -19,7 +19,6 @@ type Dependencies = {
     findFields: FindFieldFn;
     updateProgress: UpdateProgressFn;
     pageSize: number;
-    toolDescriptionMaxChars?: number;
 };
 
 const toolDefinition = findFieldsToolDefinition.for('agent');

--- a/packages/common/src/ee/AiAgent/schemas/tools/mcpToolListExploresArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/mcpToolListExploresArgs.ts
@@ -7,7 +7,7 @@ Purpose:
 Lists all Explores available to the user in the current project. Returns a summary of each explore including its name, label, base table, and tags.
 
 Usage Tips:
-- Use this to discover what data sources are available before using findExplores for detailed field information
+- Use this to discover what data sources are available before using findExplores for detailed explore descriptions
 - No arguments needed - automatically uses the current project context
 - Results are filtered based on user permissions and selected tags
 - Returns explore metadata without field details for quick overview


### PR DESCRIPTION
Exposes list_fields and returns structuredContent for MCP field discovery tools using structuredResult with JSON fallback. Updates MCP guidance and contract tests.

Stack: 3/3