### PR TITLE
fix(sentry): honor dashboard tracing opt-out under Spotlight

### DIFF
--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -61,14 +61,8 @@ const useSentry = (
                     replayIntegration(),
                 ],
                 tracesSampler(samplingContext) {
-                    if (sentrySpotlightEnabled) {
-                        return 1.0;
-                    }
-
-                    // Skip tracing on dashboard pages — Sentry's timer
-                    // wrapping causes significant main thread blocking
-                    // when dashboards unmount/mount many tiles at once.
-                    // Controlled by LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING=true
+                    // Skip dashboard tracing before the Spotlight branch so the
+                    // opt-out also applies in Spotlight dev (100% sampling).
                     if (disableDashboardTracing) {
                         const name =
                             samplingContext.name ||
@@ -77,6 +71,10 @@ const useSentry = (
                         if (name.includes('/dashboards/')) {
                             return 0;
                         }
+                    }
+
+                    if (sentrySpotlightEnabled) {
+                        return 1.0;
                     }
 
                     if (samplingContext.parentSampled !== undefined) {


### PR DESCRIPTION
## Summary

Large dashboards freeze for 20 to 30 seconds on load. Profiling with the JS Self-Profiling API traced the blocking work to Sentry browser tracing, which builds a span per `performance.measure` and walks them when the dashboard pageload transaction ends.

#21696 added `LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING` to skip tracing on `/dashboards/` routes, but the guard ran after the Spotlight `return 1.0` branch. In local dev, Spotlight (`VITE_SENTRY_SPOTLIGHT`) forces 100% sampling, so the flag was bypassed and dashboards stayed fully traced.

This moves the dashboard guard ahead of the Spotlight branch so the opt-out applies everywhere, including Spotlight dev. Spotlight still traces non-dashboard pages at 100%.

## Results

Cold load of a pivot-heavy dashboard with `LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING=true`, measuring the worst main-thread long task:

| Run | Worst task | Total blocking |
| --- | --- | --- |
| Before 1 | 24.1s | 28.3s |
| Before 2 | 30.6s | 34.8s |
| After 1 | 0.59s | 5.2s |
| After 2 | 0.50s | 4.3s |

Roughly 40 to 50x reduction in the worst task, and the dashboard still renders fully.

## Related

Relates: #21696
