### PR TITLE
feat(data-apps): show a placeholder name for unnamed data apps

### DIFF
--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -27,6 +27,17 @@ export type AppVersionStatus =
 export const isAppVersionInProgress = (status: AppVersionStatus): boolean =>
     !(APP_VERSION_TERMINAL_STATUSES as readonly string[]).includes(status);
 
+/**
+ * Data apps are created with an empty name and only get an auto-generated
+ * title after their first version builds successfully. If that build never
+ * completes the name stays blank. Everywhere an app name is shown to the user,
+ * fall back to a stable, identifiable placeholder instead of rendering nothing
+ * — the uuid suffix keeps two unnamed apps distinguishable. Use this as the
+ * single source of truth so the convention stays consistent across the UI.
+ */
+export const getAppDisplayName = (name: string, appUuid: string): string =>
+    name.trim().length > 0 ? name : `Untitled app ${appUuid.slice(0, 8)}`;
+
 export type ApiGenerateAppResponse = ApiSuccess<{
     appUuid: string;
     version: number;

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -1,4 +1,4 @@
-import { type AppVersionStatus } from '../ee/apps/types';
+import { getAppDisplayName, type AppVersionStatus } from '../ee/apps/types';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     ContentType as ResourceViewItemType,
@@ -138,6 +138,17 @@ export const isResourceViewDataAppItem = (
     item: ResourceViewItem,
 ): item is ResourceViewDataAppItem =>
     item.type === ResourceViewItemType.DATA_APP;
+
+/**
+ * Display name for any resource view item. Identical to `item.data.name` for
+ * every type except data apps, which fall back to a placeholder when unnamed
+ * (see `getAppDisplayName`). Use this anywhere a resource item's name is
+ * rendered so unnamed apps never show up blank.
+ */
+export const getResourceViewItemName = (item: ResourceViewItem): string =>
+    isResourceViewDataAppItem(item)
+        ? getAppDisplayName(item.data.name, item.data.uuid)
+        : item.data.name;
 
 export const wrapResource = <T extends ResourceViewAcceptedItems>(
     resource: T,

--- a/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/DataAppTileForm.tsx
@@ -1,5 +1,6 @@
 import {
     ContentType,
+    getAppDisplayName,
     type ApiContentResponse,
     type ApiError,
     type DashboardDataAppTileProperties,
@@ -51,7 +52,7 @@ const DataAppTileForm = ({ form }: DataAppTileFormProps) => {
             .filter((item) => item.contentType === ContentType.DATA_APP)
             .map((item) => ({
                 value: item.uuid,
-                label: item.name || 'Untitled app',
+                label: getAppDisplayName(item.name, item.uuid),
             }));
     }, [data]);
 

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -1,6 +1,7 @@
 import {
     assertUnreachable,
     FeatureFlags,
+    getResourceViewItemName,
     ResourceViewItemType,
     type ResourceViewItem,
 } from '@lightdash/common';
@@ -188,7 +189,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                                         }
                                     >
                                         <TruncatedText maxWidth={200}>
-                                            {item.data.name}
+                                            {getResourceViewItemName(item)}
                                         </TruncatedText>
                                     </Menu.Item>
                                 ))}

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -1,5 +1,6 @@
 import {
     ContentType,
+    getAppDisplayName,
     ResourceViewItemType,
     type ApiAppSummary,
 } from '@lightdash/common';
@@ -178,8 +179,10 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                 ),
                 Cell: ({ row }) => {
                     const app = row.original;
-                    const displayName =
-                        app.name || `Untitled app ${app.appUuid.slice(0, 8)}`;
+                    const displayName = getAppDisplayName(
+                        app.name,
+                        app.appUuid,
+                    );
 
                     return (
                         <Anchor

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -1,5 +1,6 @@
 import {
     FeatureFlags,
+    getResourceViewItemName,
     isResourceViewDataAppItem,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
@@ -193,7 +194,7 @@ const InfiniteResourceTableColumnName = ({
                             lineClamp={1}
                             style={{ overflowWrap: 'anywhere' }}
                         >
-                            {item.data.name}
+                            {getResourceViewItemName(item)}
                         </Text>
                         <ResourceVerifiedInlineBadge
                             verification={verification}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDataAppItem.tsx
@@ -1,4 +1,7 @@
-import { type ResourceViewDataAppItem } from '@lightdash/common';
+import {
+    getAppDisplayName,
+    type ResourceViewDataAppItem,
+} from '@lightdash/common';
 import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconEye } from '@tabler/icons-react';
@@ -57,7 +60,7 @@ const ResourceViewGridDataAppItem: FC<ResourceViewGridDataAppItemProps> = ({
                     disabled={!item.data.description}
                 >
                     <Text lineClamp={2} fz="sm" fw={600}>
-                        {item.data.name}
+                        {getAppDisplayName(item.data.name, item.data.uuid)}
                     </Text>
                 </Tooltip>
             </Group>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -1,4 +1,5 @@
 import {
+    getResourceViewItemName,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     isResourceViewSpaceItem,
@@ -200,7 +201,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                             lineClamp={1}
                                             className={classes.itemName}
                                         >
-                                            {item.data.name}
+                                            {getResourceViewItemName(item)}
                                         </Text>
                                         {!isResourceViewSpaceItem(item) &&
                                             // If there is no description, don't show the info icon on dashboards.

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    getResourceViewItemName,
     ResourceViewItemType,
     type ResourceViewItem,
 } from '@lightdash/common';
@@ -36,7 +37,7 @@ const ItemName = ({ name }: { name: string }) => {
 const getItemsText = <T extends ResourceViewItem>(items: T[]) => {
     if (items.length === 1) {
         return {
-            name: <ItemName name={items[0].data.name} />,
+            name: <ItemName name={getResourceViewItemName(items[0])} />,
             type: items[0].type,
         };
     }

--- a/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
@@ -1,3 +1,4 @@
+import { getAppDisplayName } from '@lightdash/common';
 import { type ModalProps } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useDeleteApp } from '../../../features/apps/hooks/useDeleteApp';
@@ -41,7 +42,7 @@ const AppDeleteModal: FC<AppDeleteModalProps> = ({
             title="Delete app"
             variant="delete"
             resourceType="app"
-            resourceLabel={name || `Untitled app ${uuid.slice(0, 8)}`}
+            resourceLabel={getAppDisplayName(name, uuid)}
             description={description}
             onConfirm={handleConfirm}
             confirmLoading={isDeleting}

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
@@ -1,4 +1,5 @@
 import {
+    getAppDisplayName,
     type DashboardBasicDetails,
     type DecodedEmbed,
     type EmbedProjectApp,
@@ -128,7 +129,10 @@ const EmbedAllowListForm: FC<{
                                 label={'Data apps'}
                                 data={apps.map((app) => ({
                                     value: app.appUuid,
-                                    label: app.name,
+                                    label: getAppDisplayName(
+                                        app.name,
+                                        app.appUuid,
+                                    ),
                                 }))}
                                 disabled={
                                     disabled ||

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAppForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewAppForm.tsx
@@ -1,4 +1,5 @@
 import {
+    getAppDisplayName,
     type ApiError,
     type CreateEmbedJwt,
     type EmbedJwtContentDataApp,
@@ -174,7 +175,7 @@ const EmbedPreviewAppForm: FC<{
                     label="Data app"
                     data={apps.map((app) => ({
                         value: app.appUuid,
-                        label: app.name,
+                        label: getAppDisplayName(app.name, app.appUuid),
                     }))}
                     placeholder={
                         apps.length === 0

--- a/packages/frontend/src/features/apps/components/AppHeader.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeader.tsx
@@ -1,8 +1,10 @@
+import { getAppDisplayName } from '@lightdash/common';
 import { Box, Text, Title } from '@mantine-8/core';
 import { type FC, type ReactNode } from 'react';
 import classes from './AppHeader.module.css';
 
 type Props = {
+    appUuid: string;
     name: string;
     description: string | null;
     /** Space indicator shown next to the title (folder chip / "Add to space").
@@ -20,6 +22,7 @@ type Props = {
  * chrome instead of diverging.
  */
 const AppHeader: FC<Props> = ({
+    appUuid,
     name,
     description,
     spaceChip,
@@ -37,7 +40,7 @@ const AppHeader: FC<Props> = ({
                     lineClamp={1}
                     className={classes.title}
                 >
-                    {name || 'Untitled app'}
+                    {getAppDisplayName(name, appUuid)}
                 </Title>
             </Box>
             {description && (

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -1,4 +1,8 @@
-import { FeatureFlags, type AppVersionStatus } from '@lightdash/common';
+import {
+    FeatureFlags,
+    getAppDisplayName,
+    type AppVersionStatus,
+} from '@lightdash/common';
 import { ActionIcon, Menu, Tooltip } from '@mantine-8/core';
 import {
     IconCopy,
@@ -274,7 +278,7 @@ const AppHeaderActions: FC<Props> = ({
                 <AppSchedulersModal
                     projectUuid={projectUuid}
                     appUuid={appUuid}
-                    name={appName || 'Data app'}
+                    name={getAppDisplayName(appName, appUuid)}
                     isOpen
                     onClose={() => setSchedulerModalOpen(false)}
                 />
@@ -307,7 +311,7 @@ const AppHeaderActions: FC<Props> = ({
                     onClose={() => setFavoriteSpaceModalOpen(false)}
                     app={{
                         uuid: appUuid,
-                        name: appName || 'Untitled app',
+                        name: appName,
                         description: appDescription || undefined,
                         spaceUuid: appSpaceUuid,
                         createdByUserUuid: appCreatedByUserUuid,

--- a/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
+++ b/packages/frontend/src/features/omnibar/utils/getSearchItemMap.ts
@@ -1,6 +1,7 @@
 import {
     ChartType,
     FieldType,
+    getAppDisplayName,
     getItemId,
     isTableErrorSearchResult,
     SearchItemType,
@@ -151,7 +152,7 @@ export const getSearchItemMap = (
 
     const dataApps = results.dataApps.map<SearchItem>((item) => ({
         type: SearchItemType.DATA_APP,
-        title: item.name,
+        title: getAppDisplayName(item.name, item.uuid),
         description: item.description || undefined,
         item: item,
         searchRank: item.search_rank,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -2734,6 +2734,7 @@ const AppGenerate: FC = () => {
                         <Box className={classes.previewPanel}>
                             {activeAppUuid && (
                                 <AppHeader
+                                    appUuid={activeAppUuid}
                                     name={appName}
                                     description={appDescription || null}
                                     spaceChip={

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -167,6 +167,7 @@ export default function AppPreviewTest() {
     return (
         <Box className={classes.previewContainer}>
             <AppHeader
+                appUuid={appUuid}
                 name={appName}
                 description={appDescription}
                 spaceChip={


### PR DESCRIPTION
### Description:
Data apps that never finish their first build keep an empty name and rendered blank across the UI. Add a single shared convention, "Untitled app <first 8 chars of uuid>", and apply it everywhere an app name is displayed, replacing the inconsistent ad-hoc fallbacks.

- getAppDisplayName(name, appUuid) in common is the source of truth
- getResourceViewItemName(item) applies it for DATA_APP resource items and is a no-op for charts/dashboards/spaces
- applied to browse grid/list/table, favorites menu, global search, app header, scheduler/move/favorite/delete modals, dashboard-tile and embed pickers, and the "My apps" settings list

Fallback is display-only: the raw empty name is preserved so the rename input still shows an empty field for an unnamed app.
