### PR TITLE
feat(data-apps): add Continue building action to data app items menu

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -18,6 +18,7 @@ import {
     IconFolderPlus,
     IconFolderSymlink,
     IconLayoutGridAdd,
+    IconPencil,
     IconPin,
     IconPinnedOff,
     IconStar,
@@ -337,6 +338,27 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
 
                     {userCanManage && (
                         <>
+                            {item.type === ResourceViewItemType.DATA_APP && (
+                                <Menu.Item
+                                    component="button"
+                                    role="menuitem"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPencil}
+                                            size={18}
+                                        />
+                                    }
+                                    onClick={() => {
+                                        if (!projectUuid) return;
+                                        void navigate(
+                                            `/projects/${projectUuid}/apps/${item.data.uuid}`,
+                                        );
+                                    }}
+                                >
+                                    Continue building
+                                </Menu.Item>
+                            )}
+
                             <Menu.Item
                                 component="button"
                                 role="menuitem"


### PR DESCRIPTION
### Description:
Adds a 'Continue building' entry to the data app row menu in the content view (All data apps page and Space detail page), gated by the existing manage:DataApp permission. Navigates to the app builder route, mirroring the affordance already on the app preview page.
