### PR TITLE
refactor(data-apps): unify Rename and Continue building menu icons

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardDataAppTile.tsx
@@ -5,7 +5,7 @@ import {
     type DashboardDataAppTile,
 } from '@lightdash/common';
 import { Box, Loader, Stack, Text } from '@mantine-8/core';
-import { IconAppsOff, IconPencil } from '@tabler/icons-react';
+import { IconAppsOff, IconCode } from '@tabler/icons-react';
 import React, { useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import AppIframePreview from '../../features/apps/AppIframePreview';
@@ -120,7 +120,7 @@ const DataAppTile: FC<Props> = (props) => {
 
     const editMenuItem = canEditApp ? (
         <LinkMenuItem
-            leftSection={<MantineIcon icon={IconPencil} />}
+            leftSection={<MantineIcon icon={IconCode} />}
             href={`/projects/${projectUuid}/apps/${appUuid}`}
         >
             Continue building

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -18,12 +18,12 @@ import {
     IconClock,
     IconCode,
     IconDots,
+    IconEdit,
     IconExternalLink,
     IconFolder,
     IconFolderPlus,
     IconFolderSymlink,
     IconLayoutDashboard,
-    IconPencil,
     IconRadar,
     IconTextCaption,
     IconTrash,
@@ -354,7 +354,7 @@ const MyAppsPanel: FC<MyAppsPanelProps> = ({
                                 <Menu.Item
                                     leftSection={
                                         <MantineIcon
-                                            icon={IconPencil}
+                                            icon={IconEdit}
                                             size={14}
                                         />
                                     }

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -11,6 +11,7 @@ import { ActionIcon, Box, Menu, Tooltip } from '@mantine-8/core';
 import {
     IconCircleCheck,
     IconCircleCheckFilled,
+    IconCode,
     IconCopy,
     IconDatabaseExport,
     IconDots,
@@ -18,7 +19,6 @@ import {
     IconFolderPlus,
     IconFolderSymlink,
     IconLayoutGridAdd,
-    IconPencil,
     IconPin,
     IconPinnedOff,
     IconStar,
@@ -344,7 +344,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                     role="menuitem"
                                     leftSection={
                                         <MantineIcon
-                                            icon={IconPencil}
+                                            icon={IconCode}
                                             size={18}
                                         />
                                     }

--- a/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
+++ b/packages/frontend/src/features/apps/components/AppHeaderActions.tsx
@@ -5,9 +5,9 @@ import {
     IconDatabase,
     IconDatabaseExport,
     IconDots,
+    IconEdit,
     IconFolderPlus,
     IconFolderSymlink,
-    IconPencil,
     IconRefresh,
     IconSend,
     IconTrash,
@@ -183,7 +183,7 @@ const AppHeaderActions: FC<Props> = ({
                             <Menu.Divider />
                             <Menu.Item
                                 leftSection={
-                                    <MantineIcon icon={IconPencil} size={14} />
+                                    <MantineIcon icon={IconEdit} size={14} />
                                 }
                                 onClick={() => setIsUpdateModalOpen(true)}
                             >

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
-import { IconAppsOff, IconPencil } from '@tabler/icons-react';
+import { IconAppsOff, IconCode } from '@tabler/icons-react';
 import { useCallback, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
@@ -209,7 +209,7 @@ export default function AppPreviewTest() {
                                 <Menu.Item
                                     leftSection={
                                         <MantineIcon
-                                            icon={IconPencil}
+                                            icon={IconCode}
                                             size={14}
                                         />
                                     }


### PR DESCRIPTION
### Description:
Data app action menus used inconsistent icons for the same actions across the app. Standardise on:
- Continue building -> IconCode (the code icon, matching the My apps menu)
- Rename -> IconEdit (pencil-in-box, matching chart/dashboard renames)

Touches the content view action menu, app preview/builder headers, the dashboard data app tile, and the My apps settings panel.