### PR TITLE
feat(dev): /k8s-dev skill — production-like Lightdash on AWS EKS

### DIFF
--- a/.claude/commands/k8s-dev.md
+++ b/.claude/commands/k8s-dev.md
@@ -1,0 +1,193 @@
+Manage a production-like Lightdash deployment on AWS EKS. Args: (none) = show status, `up` = idempotently provision + deploy, `deploy` = build this branch → ECR → roll the deployment, `logs` = tail backend/scheduler, `psql` = shell into the bundled postgres, `down` = tear everything down to stop spend.
+
+This is the **cloud testbed** for experimenting with running agent/data-app sandboxes in AWS instead of E2B (see `packages/backend/src/ee/services/SandboxRuntime/DESIGN.md` — a Kubernetes `SandboxProvider` is the Phase-3 endgame). `/k8s-dev` only stands up the host cluster + a public, HTTPS, EE-enabled Lightdash; the sandbox provider itself is a later, separate backend change.
+
+It mirrors `/docker-dev`'s philosophy: an idempotent deterministic script (`scripts/k8s-dev/up.sh`) plus agentic **self-repair** when a step fails. Re-running `up` reconciles drift.
+
+## Architecture
+
+```
+Terraform (scripts/k8s-dev/terraform/)          Helm (~/code/helm-charts/charts/lightdash)
+  VPC · EKS + EC2 node group · S3 · IRSA   →     Lightdash backend (scheduler inline)
+  ECR · EBS-CSI addon                             bundled postgres (pgvector, ephemeral)
+                                                  bundled browserless-chrome
+ingress-nginx (NLB) + cert-manager (LE)   →       migration Job (core + EE)
+sslip.io hostname, real HTTPS                      ServiceAccount → IRSA → S3
+```
+
+- **Terraform** owns cloud infra only (no cluster creds at plan time). **EC2 node group, not Fargate** — deliberately, so the future Kubernetes sandbox provider can run DaemonSets / privileged / gVisor pods.
+- The chart is deployed **unmodified** via the `scripts/k8s-dev/values.aws.yaml.tpl` overlay (rendered by `up.sh`). We never fork it.
+- Postgres is the chart's **bundled, ephemeral** Bitnami `pgvector` (the "temporary DB" — dies with the cluster). S3 is a real bucket reached via **IRSA** (no static keys).
+- **EE is wired from the start** (license from 1Password) so the data-app/agent features are unlocked.
+
+## First-time setup
+
+1. **Tools:** `terraform`, `kubectl`, `helm` are present; `docker buildx` is only needed for `deploy`.
+   - **AWS CLI — do NOT use `brew install awscli` on recent macOS.** The Homebrew `python@3.14` bottle has a broken `pyexpat` (`Symbol not found: _XML_SetAllocTrackerActivationThreshold`, resolves system `libexpat`); `aws --version` works but every real command errors. Use the **official self-contained installer** instead:
+     ```bash
+     curl -fsSL https://awscli.amazonaws.com/AWSCLIV2.pkg -o /tmp/AWSCLIV2.pkg
+     sudo installer -pkg /tmp/AWSCLIV2.pkg -target /     # installs /usr/local/bin/aws
+     # if a broken brew awscli is on PATH first, `brew uninstall awscli` so it doesn't shadow it
+     ```
+2. **Config:** `cp scripts/k8s-dev/config.example.env scripts/k8s-dev/config.env` and edit (`AWS_REGION`, `IMAGE_TAG`, `LETSENCRYPT_EMAIL`). `config.env` is gitignored. **Leave `AWS_PROFILE` unset (commented) when using `aws login` / the default chain** — `lib.sh` unsets an empty value, but never export it as `""`.
+3. **AWS auth — two paths:**
+   - `aws login` (new CLI v2 — temp creds from your Console browser session): simplest, no SSO start URL needed. **But the token is short-lived** (see token-expiry below). `lib.sh::export_aws_creds` bridges these into `AWS_*` env vars because the Terraform SDK does **not** read the `~/.aws/login` cache (without it Terraform falls back to EC2 IMDS → "No valid credential sources").
+   - SSO profile (`aws configure sso` once, then `aws sso login --profile <p>`) or **static IAM access keys** (`aws configure`). Static keys don't expire — **prefer them for the full ~15-min apply** so it can't expire mid-cluster-create.
+   - The scripts run `aws sts get-caller-identity` first and `FAIL: aws-auth` with guidance if you need to re-auth.
+
+## Commands
+
+All commands `source scripts/k8s-dev/lib.sh`, load `config.env`, and verify tools + AWS identity before doing anything.
+
+### `up` — provision + deploy (idempotent)
+
+```bash
+./scripts/k8s-dev/up.sh
+```
+
+Steps (each prints `STEP:`/`OK:`/`SKIP:`, fails with `FAIL: <step> -- <reason>`):
+1. `terraform init` + `apply` — VPC, EKS, node group, S3, IRSA roles, ECR, EBS-CSI addon.
+2. `aws eks update-kubeconfig`; ensure namespace.
+3. Apply the **gp3** default StorageClass (so the postgres PVC binds).
+4. `helm upgrade --install ingress-nginx` (NLB, cross-zone on); wait for the NLB hostname.
+5. Resolve the public host: **sslip mode** → `lightdash.<nlb-ip>.sslip.io` (with a DNS retry loop);
+   **custom mode** → your `SITE_HOST` (it prints the CNAME → NLB you must add).
+6. `helm upgrade --install cert-manager` + the `letsencrypt` ClusterIssuer (HTTP-01).
+7. Create k8s secrets **idempotently**: `lightdash-pg` (random pw) and `lightdash-app`
+   (random `LIGHTDASH_SECRET` + EE license + Anthropic + E2B + GitHub App, pulled from 1Password).
+8. Render the values overlay (envsubst with TF outputs) and `helm upgrade --install lightdash`.
+9. Wait for the TLS cert (auto-reissue on the cert-manager `orderNotReady` race), poll
+   `/api/v1/health`; print `READY: https://<host>`.
+
+Ends by reminding you the cluster is **billing** — run `down` when finished.
+
+### `deploy` — code "reload" (production-style)
+
+The answer to "how does code reloading work": there is **no hot reload** — build an immutable image and roll the deployment onto it.
+
+```bash
+./scripts/k8s-dev/deploy.sh
+```
+
+ECR login → `docker buildx build --platform linux/amd64` of the repo root `Dockerfile` → push tagged with the short git SHA → `helm upgrade --reuse-values --set image.*` → `kubectl rollout status`. Needed to run **this branch's** unreleased code (e.g. the sandbox-runtime work).
+
+### `logs`, `psql`, status
+
+```bash
+kubectl -n lightdash logs -l app.kubernetes.io/component=backend -f --tail=100   # logs
+kubectl -n lightdash exec -it statefulset/lightdash-postgresql -- psql -U lightdash   # psql
+./scripts/k8s-dev/status.sh        # or just /k8s-dev with no args
+```
+
+### `down` — stop all spend
+
+```bash
+./scripts/k8s-dev/down.sh
+```
+
+`helm uninstall` lightdash + ingress-nginx (releases the NLB), delete PVCs (releases EBS), then `terraform destroy`. Verify no orphan ELB/EBS in the console afterward.
+
+## Self-repair protocol (when `up.sh` fails)
+
+Same contract as `dev-fast-start.sh`: a `FAIL: <step> -- <reason>` line names the failing phase.
+1. Diagnose the root cause (read the relevant logs — `kubectl get events`, `kubectl describe`, `terraform plan`, cert-manager `kubectl describe certificate -n lightdash`).
+2. Fix it, then **patch the failing script** so the same failure can't recur. Keep the `STEP:/OK:/SKIP:/FAIL:` contract and idempotency.
+3. Re-run `up.sh` — it reconciles and should reach `READY:`.
+
+Common cases (battle-tested — these all happened on real bring-ups):
+
+**AWS auth / credentials**
+- **`FAIL: aws-auth` but `aws sts get-caller-identity` works in your shell**: usually an exported empty `AWS_PROFILE` ("config profile () could not be found"). `lib.sh` now unsets it when blank; make sure `config.env` doesn't `export AWS_PROFILE=""`.
+- **Terraform: `No valid credential sources found` / falls back to IMDS `169.254.169.254`**: the AWS SDK can't see `aws login` creds. Handled by `lib.sh::export_aws_creds` (`aws configure export-credentials --format env`). If it recurs, run `aws login` then re-run `up`.
+- **Terraform: `ExpiredTokenException: The security token ... is expired` mid-apply**: `aws login` creds are short-lived and EKS create/node-group updates take ~10-15 min. Run `aws login` again, then re-run `up.sh` (idempotent — it continues). To avoid entirely, use **static IAM keys** (`aws configure`) for the apply.
+
+**Terraform state drift (from a mid-apply failure)**
+- **`ResourceInUseException: Cluster already exists` on re-run**: the `CreateCluster` API succeeded but the post-create *wait* failed (e.g. token expiry), so Terraform **tainted** the cluster and now wants to destroy+recreate it. The cluster is actually fine. Fix: `terraform -chdir=scripts/k8s-dev/terraform untaint 'module.eks.aws_eks_cluster.this[0]'` then re-run `up`. (Do **not** `import` — it's already in state.)
+- General rule: after a partial apply, prefer `untaint` (resource exists and is healthy) over `import` (resource missing from state) over destroy+recreate (slowest).
+
+**AWS account limits**
+- **`VpcLimitExceeded: The maximum number of VPCs has been reached`**: the region is at its 5-VPC default quota. Pick a region with headroom (`aws ec2 describe-vpcs --region <r> --query 'length(Vpcs)'`) and set `AWS_REGION` in `config.env`, request a quota bump, or reuse an existing VPC. If you switch region after a partial apply, run `down` first so resources like the S3 bucket aren't stranded in the old region.
+
+**Nodes / scheduling**
+- **Node disk only ~20 GiB / `ephemeral-storage` evictions / migration pod OOM-137**: EKS managed node groups using a launch template **ignore `disk_size`** (AL2023 defaults to 20 GiB), and two Lightdash images (~2.4 GiB each) fill it. Fixed: `eks.tf` sets the root volume via **`block_device_mappings`** (default 100 GiB). Changing it does a rolling node replacement.
+- **Node-group rolling update stuck `UPDATING`, old node won't drain**: a PodDisruptionBudget with `minAvailable:1` on a single-replica workload = `ALLOWED DISRUPTIONS: 0`, so the pod can't be evicted. The overlay sets `podDisruptionBudget.enabled: false`. Unblock a live one by deleting the pod (`kubectl delete pod` bypasses the PDB) + the PDB.
+
+**Kubernetes / app**
+- **`dns -- could not resolve <nlb>`**: the NLB isn't live yet. `up.sh` retries ~6 min; if it still fails, re-run `up`.
+- **TLS still pending**: cert-manager HTTP-01 takes a few minutes on first issue. The site is reachable over HTTP meanwhile.
+- **TLS cert `errored` with `Failed to finalize Order: orderNotReady` (challenge `valid`)**: a known cert-manager finalize race. `up.sh` auto-heals it (deletes the Certificate to force a clean re-issue). Manual: `kubectl -n lightdash delete certificate lightdash-tls certificaterequest --all order --all`.
+- **postgres PVC Pending**: the gp3 StorageClass / EBS-CSI addon isn't ready — check `kubectl get sc` and the `aws-ebs-csi-driver` addon.
+- **migration Job CrashLoop / `knex migrate` exits 1 with `ParseError: S3-compatible storage is required`**: recent versions ENFORCE `S3_ENDPOINT` (`parseBaseS3Config`), and the migration job doesn't inherit the main `extraEnv`. The overlay sets `S3_ENDPOINT`/`BUCKET`/`REGION` in `migrationJob.extraEnv`. A migration `Completed` pod alongside failed retries is fine (`job.status.succeeded=1` is authoritative).
+- **502 on `/assets/*` (`/api/v1/health` is 200, pods healthy)**: ingress-nginx `upstream sent too big header` — Lightdash's CSP header exceeds nginx's default 4k proxy buffer. The overlay sets `nginx.ingress.kubernetes.io/proxy-buffer-size: 16k`.
+- **"Create data app" missing / `GET /api/v2/feature-flag/enable-data-apps` → 404 "not found"**: the deployed **image is too old**. The chart's appVersion (`0.2248.0`) predates data-apps and the `LIGHTDASH_ENABLE_FEATURE_FLAGS` env mechanism (older `FeatureFlagModel` *throws* NotFound instead of honoring the env allowlist), so the flag never resolves and the ability builder grants no `DataApp` rules even to an admin. Fix: deploy a **recent** image — `IMAGE_TAG=latest` (or a release ≥ the one that added `enable-data-apps`), or `/k8s-dev deploy` to run this branch. Verify: `curl -H "Authorization: ApiKey <pat>" https://<host>/api/v2/feature-flag/enable-data-apps` returns `enabled:true`. (Diagnostic tip: PATs are bcrypt-hashed with a *deterministic* salt from `LIGHTDASH_SECRET`, so you can mint a test PAT directly in the DB.)
+- **data-app generation interrupted by a backend restart**: `scheduler.enabled=false` runs the worker inline in the backend, so a `helm upgrade`/rollout aborts in-flight app/writeback jobs. Consider `scheduler.enabled=true` (dedicated worker) for the testbed.
+- **data-app generation fails (E2B template not found)**: the `E2B_API_KEY` must belong to the E2B team owning `lightdash/lightdash-data-app`; `E2B_TEMPLATE_TAG=latest` avoids a missing per-version template.
+
+## Secrets discipline (matches `/docker-dev`)
+
+Nothing sensitive is committed. `LIGHTDASH_SECRET`, the postgres password, the EE license, Anthropic/E2B keys, and the GitHub App creds live only in k8s Secrets created at runtime. The EE license comes from the 1Password item **"Development Lightdash EE license key"** — **never** a customer-named item (confidentiality policy). S3 needs no keys at all (IRSA).
+
+## GitHub integration (dbt-over-GitHub + AI writeback)
+
+Required for connecting a dbt project from GitHub and for AI writeback (opening PRs). **Not**
+needed for data-app generation (that only needs the license + Anthropic + E2B).
+
+### ⚠️ Do NOT use the shared `lightdash-app-dev` App on a real host
+
+The shared dev App's OAuth callback is hardwired to a **proxy** (`github-proxy-dev.onrender.com`)
+that demultiplexes to *proxy-known* dev instances by parsing the `state` (`<redirectDomain>_<id>`).
+An arbitrary EKS host (sslip.io or your own domain) is unknown to that proxy, so after you
+install + authorize you land on the proxy with **"bad request missing parameter"** — the failure
+is the *proxy*, not your instance. You cannot fix this from the Lightdash side.
+
+### Use a dedicated GitHub App (the correct path for a hosted instance)
+
+1. GitHub → Settings → Developer settings → **New GitHub App**.
+2. **Callback URL:** `https://<SITE_HOST>/api/v1/github/oauth/callback` and check **"Request
+   user authorization (OAuth) during installation"**.
+3. Webhook: uncheck **Active** (not needed for testing).
+4. Permissions: Repository → **Contents** (R/W), **Pull requests** (R/W), **Metadata** (R).
+5. Create → generate a **private key** (.pem) → note **App ID**, **Client ID**, generate a
+   **Client secret** → **Install** it on the target repo(s).
+6. Put the creds in the `lightdash-app` secret (`GITHUB_APP_ID`, `GITHUB_APP_NAME`,
+   `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_PRIVATE_KEY` = `base64 -i key.pem`) and
+   `helm upgrade`. Point `GITHUB_OP_ITEM` at a 1Password item holding this App's `export GITHUB_*`
+   block so `up.sh` picks it up next time.
+
+Overlay env (set regardless of App): `GITHUB_REDIRECT_DOMAIN` = the **full** `SITE_HOST`
+(Lightdash's `siteUrl.split('.')[0]` derivation collapses a multi-label sslip.io host to just
+`lightdash`), and `GITHUB_OAUTH_REDIRECT_URI` = `https://<SITE_HOST>/api/v1/github/oauth/callback`.
+
+### Quick alternative — DB-reconcile (test writeback without the OAuth UI)
+
+`/docker-dev` never uses the browser flow; it writes the installation straight into
+`github_app_installations` (AES-256-GCM `salt[64]|tag[16]|iv[12]|msg`, pbkdf2 sha512/2000/32,
+keyed by the running `LIGHTDASH_SECRET`). This skill ships a k8s-adapted version — once the App
+is installed (grab `installation_id` from the failed callback URL `?installation_id=...`):
+
+```bash
+./scripts/k8s-dev/reconcile-github.sh <installation_id>
+```
+
+It reads `LIGHTDASH_SECRET` + pg password from the cluster secrets, port-forwards postgres,
+encrypts the id, and UPSERTs the row using the **real first user** (not the seeded demo). Verify
+the App + installation are live by minting a token: App JWT (RS256, `iss=GITHUB_APP_ID`, key =
+`Buffer.from(GITHUB_PRIVATE_KEY,'base64')`) → `POST /app/installations/<id>/access_tokens` → `201`.
+Note the secret stores `GITHUB_PRIVATE_KEY` as base64-of-PEM, so it's double-base64 under
+`kubectl get secret` (decode the storage layer, then `Buffer.from(...,'base64')` for the PEM).
+
+## Public access / TLS (no DNS access needed)
+
+Default **sslip mode** gives real Let's Encrypt HTTPS on `lightdash.<nlb-ip>.sslip.io` with zero DNS access. Because the dev domain's Route53 zone may live in another account, the optional **custom mode** (`SITE_HOST_MODE=custom`) uses HTTP-01, which only needs the hostname to resolve to the NLB — add one CNAME → NLB hostname in whichever account hosts the zone; no cross-account Route53 automation. Caveat: an NLB IP can change; if sslip breaks, re-run `up`. For sustained GitHub/writeback testing, prefer the custom-domain path (stable hostname).
+
+## Cost
+
+EKS control plane (~$0.10/hr) + 2× `m6i.large` (100 GiB) + NLB + single NAT. Not free — **always `down` when done**. `status` and `up`'s final line remind you the cluster is up.
+
+## Phase B: sandbox experiments (later)
+
+Once Lightdash is up and EE features work, the Kubernetes `SandboxProvider` (running agent sandboxes as pods/Jobs in *this* cluster instead of E2B) is tracked in `SandboxRuntime/DESIGN.md` and is a separate backend change — build this branch's image via `/k8s-dev deploy`. This skill exists to give it a place to run.
+
+## GKE (future)
+
+Structured so a sibling `gke-dev` is a drop-in later: the Helm overlay and TLS/issuer flow are portable; only `terraform/` and the IRSA→Workload-Identity annotation change.

--- a/scripts/k8s-dev/.gitignore
+++ b/scripts/k8s-dev/.gitignore
@@ -1,0 +1,10 @@
+# Local config (contains profile, hostnames) and any rendered runtime files
+config.env
+
+# Terraform state + provider/module downloads
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/*.tfvars
+terraform/crash.log

--- a/scripts/k8s-dev/TODO.md
+++ b/scripts/k8s-dev/TODO.md
@@ -1,0 +1,76 @@
+# /k8s-dev — TODO & handoff
+
+Status as of 2026-06-26. The `/k8s-dev` skill is built and a live testbed is **running**, but the
+end-to-end feature tests aren't finished and the work is **uncommitted**. This file is the
+pick-up list.
+
+## Current live state
+
+- **Cluster:** `lightdash-k8s-dev` · EKS · region **eu-west-2** · account **329599630187**
+- **Nodes:** 2× `m6i.large`, **100 GiB** disk (after the disk-size fix)
+- **App:** Lightdash **v0.3246.0** (`lightdash/lightdash:latest`), healthy, real Let's Encrypt HTTPS
+  at `https://lightdash.16.61.53.63.sslip.io` (sslip.io host — ephemeral, changes if the NLB IP changes)
+- **Wired & verified:** EE license valid · `enable-data-apps` + `ai-writeback` flags = true ·
+  admin has `create:DataApp` · Anthropic + E2B env set · S3 via IRSA · GitHub App **installation
+  reconciled** in the DB (writeback path)
+- **E2B confirmed working:** a generation run launched an E2B sandbox, ran Claude Code inside it,
+  and read the dbt schema — but that run was **interrupted by the backend rollout** (kicked off
+  mid-upgrade). Left a stale `appGeneratePipeline` graphile job (locked, attempts=1/2);
+  `sweepStaleAppLocks` should clear it, else just regenerate.
+
+## TO TEST (the actual point of the testbed)
+
+- [ ] **Data-app generation, clean end-to-end.** On the now-stable backend: create an app
+      (`+ → App`), confirm it finishes (E2B sandbox → Claude builds → `vite build` → `dist`
+      uploaded to S3 → preview loads in the browser). The earlier run only proved the front half.
+- [ ] **App preview/serving.** Confirm the generated app's assets serve from S3 and the preview
+      renders (check `VITE_ASSET_BASE_URL`/preview-origin behaviour on a real host, not localhost).
+- [ ] **AI writeback → PR.** Point a project's dbt connection at a repo in the **`lightdash` GitHub
+      org** (the installation covers all its repos), run a writeback, confirm it clones, edits YAML,
+      `lightdash compile`s, and **opens a PR**. (OAuth UI stays broken — shared dev App proxy — but
+      writeback uses the installation token, which is wired.)
+- [ ] **Sandbox-provider experiment (the eventual goal).** Build THIS branch's image
+      (`/k8s-dev deploy` → ECR) to get the unreleased `SANDBOX_PROVIDER` code, then experiment with
+      a Kubernetes sandbox provider running agent sandboxes as pods instead of E2B
+      (see `packages/backend/src/ee/services/SandboxRuntime/DESIGN.md`).
+
+## KNOWN ISSUES / FOLLOW-UPS
+
+- [ ] **Inline scheduler kills in-flight generations on backend restart.** `scheduler.enabled=false`
+      runs the worker inside the backend, so any `helm upgrade`/rollout aborts active app/writeback
+      jobs. Consider `scheduler.enabled=true` (dedicated worker) for the testbed to isolate jobs.
+- [ ] **`aws login` creds are short-lived (~10–15 min)** and expired mid-op several times (cluster
+      create, node-group update). All scripts are idempotent (re-run after re-login), but for long
+      ops prefer **static IAM keys** (`aws configure`) — set `AWS_PROFILE` in `config.env`.
+- [ ] **GitHub OAuth UI** can't work on this host (shared `lightdash-app-dev` App routes through
+      `github-proxy-dev.onrender.com`). For a clean UI flow, create a **dedicated GitHub App** with
+      the callback pointed at the host (documented in the skill). Writeback already works via reconcile.
+- [ ] Pin `IMAGE_TAG` to a specific release instead of `latest` once a known-good version is chosen
+      (reproducibility).
+
+## DESTROY THE STACK (stop billing)
+
+It's billing now (EKS control plane + 2 nodes + NLB + NAT). When done testing:
+
+```bash
+/k8s-dev down            # helm uninstall + terraform destroy
+# or:  ./scripts/k8s-dev/down.sh
+```
+
+- [ ] Run `down`. Re-login first if `aws login` creds expired (the destroy is a long op too).
+- [ ] **Verify in the AWS console** afterwards: no orphan **ELB/NLB**, **EBS volumes** (the postgres
+      PVC), **NAT gateway**, or **Elastic IPs** left behind. `down` deletes PVCs + the ingress LB
+      before `terraform destroy` to avoid stranded LBs, but confirm.
+
+## PUSH TO THE REPO
+
+The whole skill is uncommitted on `sandbox-runtime-docker-provider`.
+
+- [ ] Commit on its **own branch** (one-change-per-branch): `.claude/commands/k8s-dev.md` +
+      `scripts/k8s-dev/**`. **Do NOT commit `config.env`** (gitignored — local profile/host).
+      Also exclude `terraform/.terraform/`, state files, `TODO.md` if you'd rather keep it local.
+- [ ] Open a PR. The skill encodes a lot of hard-won fixes this session — call them out in the body:
+      AWS-CLI (official installer, not brew), empty `AWS_PROFILE`, `aws login`→Terraform cred bridge,
+      VPC limit, tainted-cluster untaint, NLB DNS retry, cert-manager `orderNotReady` auto-reissue,
+      ingress `proxy-buffer-size`, `IMAGE_TAG` (0.2248 was too old), node disk via
+      `block_device_mappings` (100 GiB), PDB disabled (node-drain deadlock), migration-job `S3_ENDPOINT`.

--- a/scripts/k8s-dev/config.example.env
+++ b/scripts/k8s-dev/config.example.env
@@ -1,0 +1,37 @@
+# Copy to config.env (gitignored) and adjust. Sourced by all k8s-dev scripts.
+
+# --- AWS auth ---
+# SSO/CLI profile with admin on the dev account. Leave UNSET (commented) to use the default
+# credential chain (e.g. after `aws login`). Do NOT export it empty — an empty AWS_PROFILE
+# makes the CLI fail with "config profile () could not be found".
+# export AWS_PROFILE="my-sso-profile"
+export AWS_REGION="eu-west-2"
+
+# --- Cluster ---
+export CLUSTER_NAME="lightdash-k8s-dev"
+
+# --- Helm chart location (the lightdash chart repo checkout) ---
+export HELM_CHART_PATH="$HOME/code/helm-charts/charts/lightdash"
+export HELM_RELEASE="lightdash"
+export K8S_NAMESPACE="lightdash"
+
+# --- App image (official first; deploy.sh overrides to the ECR branch image) ---
+# Do NOT use the chart's appVersion (0.2248.0) — too old for data-apps / env feature flags.
+# Use a recent release tag, or `/k8s-dev deploy` for this branch (needed for sandbox work).
+export IMAGE_REPO="lightdash/lightdash"
+export IMAGE_TAG="latest"
+
+# --- Public hostname / TLS ---
+# SITE_HOST_MODE:
+#   sslip   -> auto: lightdash.<nlb-ip>.sslip.io  (no DNS access needed; recommended)
+#   custom  -> use SITE_HOST below; you add a CNAME -> NLB hostname yourself
+export SITE_HOST_MODE="sslip"
+export SITE_HOST=""                       # only used when SITE_HOST_MODE=custom
+export LETSENCRYPT_EMAIL="oliver@lightdash.com"
+
+# --- Secrets pulled from 1Password by up.sh (item names overridable) ---
+export EE_LICENSE_OP_ITEM="Development Lightdash EE license key"
+export ANTHROPIC_OP_ITEM="(dev) ANTHROPIC_API_KEY"
+export E2B_OP_ITEM="(dev) E2B_API_KEY"
+# GitHub App (dbt-over-GitHub + AI writeback). Its notesPlain holds an `export GITHUB_*=...` block.
+export GITHUB_OP_ITEM="lightdash-app-dev Github integration for Lightdash"

--- a/scripts/k8s-dev/deploy.sh
+++ b/scripts/k8s-dev/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# "Code reload", production-style: build this repo's image -> push to ECR -> roll the
+# deployment onto the new tag. NOT hot reload — a fresh immutable image each time.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+load_config
+require_tools
+require_aws_identity
+configure_kubectl
+
+REPO_ROOT="$(cd "$K8S_DEV_DIR/../.." && pwd)"
+ECR_URL="$(tf_output ecr_repository_url)"
+[ -n "$ECR_URL" ] || fail "ecr -- no ECR repo output; run '/k8s-dev up' first"
+REGISTRY="${ECR_URL%/*}"
+TAG="$(cd "$REPO_ROOT" && git rev-parse --short HEAD)"
+
+step "ecr login"
+aws ecr get-login-password --region "$AWS_REGION" ${AWS_PROFILE:+--profile "$AWS_PROFILE"} \
+  | docker login --username AWS --password-stdin "$REGISTRY" >/dev/null
+ok "logged in to $REGISTRY"
+
+step "build image ($TAG) for linux/amd64"
+# Nodes are x86_64; build amd64 explicitly so it runs regardless of laptop arch.
+docker buildx build --platform linux/amd64 -t "${ECR_URL}:${TAG}" -f "$REPO_ROOT/Dockerfile" "$REPO_ROOT" --push
+ok "pushed ${ECR_URL}:${TAG}"
+
+step "helm upgrade onto new image"
+helm upgrade "$HELM_RELEASE" "$HELM_CHART_PATH" \
+  --namespace "$K8S_NAMESPACE" \
+  --reuse-values \
+  --set image.repository="$ECR_URL" \
+  --set image.tag="$TAG" \
+  --wait --timeout 15m
+ok "rolled out ${ECR_URL}:${TAG}"
+
+kubectl -n "$K8S_NAMESPACE" rollout status deploy/"${HELM_RELEASE}-backend" --timeout 5m
+echo "READY: deployed image tag $TAG"

--- a/scripts/k8s-dev/down.sh
+++ b/scripts/k8s-dev/down.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Tear everything down to stop all spend: helm uninstall -> terraform destroy.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+load_config
+require_tools
+require_aws_identity
+
+# Best-effort: uninstall in-cluster releases first so LBs/PVCs are released before destroy.
+if configure_kubectl 2>/dev/null && kubectl get nodes >/dev/null 2>&1; then
+  step "uninstall helm releases"
+  helm -n "$K8S_NAMESPACE" uninstall "$HELM_RELEASE" 2>/dev/null || skip "$HELM_RELEASE not installed"
+  # Drop the ingress-nginx Service (NLB) so terraform doesn't trip on a dangling ELB.
+  helm -n ingress-nginx uninstall ingress-nginx 2>/dev/null || skip "ingress-nginx not installed"
+  # Release postgres PVC so the EBS volume is deleted with the cluster.
+  kubectl -n "$K8S_NAMESPACE" delete pvc --all 2>/dev/null || true
+  ok "in-cluster resources removed"
+  sleep 20  # let the cloud-controller delete the NLB before destroy
+else
+  skip "cluster unreachable — going straight to terraform destroy"
+fi
+
+step "terraform destroy"
+terraform -chdir="$TF_DIR" init -input=false >/dev/null
+# shellcheck disable=SC2046
+terraform -chdir="$TF_DIR" destroy -input=false -auto-approve $(tf_vars)
+ok "terraform destroyed"
+echo "DOWN: all k8s-dev resources removed. Verify no orphan ELB/EBS in the AWS console."

--- a/scripts/k8s-dev/lib.sh
+++ b/scripts/k8s-dev/lib.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Shared helpers for k8s-dev scripts. Source this; don't execute it.
+# Contract (mirrors dev-fast-start.sh): emit STEP:/OK:/SKIP:/FAIL: markers; idempotent.
+
+set -euo pipefail
+
+K8S_DEV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$K8S_DEV_DIR/terraform"
+
+step() { echo "STEP: $*"; }
+ok()   { echo "OK: $*"; }
+skip() { echo "SKIP: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+load_config() {
+  if [ -f "$K8S_DEV_DIR/config.env" ]; then
+    # shellcheck disable=SC1091
+    source "$K8S_DEV_DIR/config.env"
+  else
+    fail "config -- $K8S_DEV_DIR/config.env not found. Copy config.example.env to config.env and edit it."
+  fi
+  : "${AWS_REGION:?AWS_REGION not set}"
+  : "${CLUSTER_NAME:?CLUSTER_NAME not set}"
+  : "${HELM_CHART_PATH:?HELM_CHART_PATH not set}"
+  : "${HELM_RELEASE:=lightdash}"
+  : "${K8S_NAMESPACE:=lightdash}"
+  # An exported but EMPTY AWS_PROFILE makes the CLI fail with "config profile () could not be
+  # found". Only export when non-empty; otherwise unset so the default credential chain is used.
+  if [ -n "${AWS_PROFILE:-}" ]; then export AWS_PROFILE; else unset AWS_PROFILE; fi
+  export AWS_REGION
+}
+
+# Args passed to terraform so CLI config matches the chart/IRSA expectations.
+tf_vars() {
+  echo "-var=region=$AWS_REGION -var=cluster_name=$CLUSTER_NAME -var=namespace=$K8S_NAMESPACE -var=service_account_name=lightdash ${AWS_PROFILE:+-var=profile=$AWS_PROFILE}"
+}
+
+require_tools() {
+  local missing=()
+  for t in terraform kubectl helm aws; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    fail "prereqs -- missing tools: ${missing[*]} (install: brew install ${missing[*]})"
+  fi
+}
+
+# Bridge `aws login` / SSO credentials into standard AWS_* env vars. The Terraform AWS
+# provider's SDK does NOT read the `aws login` cache (~/.aws/login) or SSO token cache the way
+# the CLI does, so without this it falls back to EC2 IMDS and fails with "No valid credential
+# sources found". `export-credentials` resolves whatever the CLI is using into env creds.
+export_aws_creds() {
+  local creds
+  creds="$(aws configure export-credentials --format env 2>/dev/null)" || true
+  [ -n "$creds" ] || fail "aws-creds -- could not export credentials. Run 'aws login' (or set AWS_PROFILE) and retry."
+  eval "$creds"
+}
+
+require_aws_identity() {
+  export_aws_creds
+  aws sts get-caller-identity >/dev/null 2>&1 \
+    || fail "aws-auth -- 'aws sts get-caller-identity' failed. Run 'aws login' (or your SSO login) and retry."
+}
+
+tf_output() {
+  terraform -chdir="$TF_DIR" output -raw "$1" 2>/dev/null
+}
+
+# Idempotent kubeconfig refresh for the cluster.
+configure_kubectl() {
+  aws eks update-kubeconfig --region "$AWS_REGION" --name "$CLUSTER_NAME" ${AWS_PROFILE:+--profile "$AWS_PROFILE"} >/dev/null
+}
+
+# Create a k8s secret only if it doesn't already exist (stable across upgrades).
+ensure_secret() {
+  local name="$1"; shift
+  if kubectl -n "$K8S_NAMESPACE" get secret "$name" >/dev/null 2>&1; then
+    skip "secret/$name already exists"
+  else
+    kubectl -n "$K8S_NAMESPACE" create secret generic "$name" "$@"
+    ok "secret/$name created"
+  fi
+}
+
+rand_hex() { openssl rand -hex 16; }

--- a/scripts/k8s-dev/manifests/cluster-issuer.yaml.tpl
+++ b/scripts/k8s-dev/manifests/cluster-issuer.yaml.tpl
@@ -1,0 +1,18 @@
+# Let's Encrypt production issuer using the HTTP-01 solver via ingress-nginx.
+# HTTP-01 only needs the hostname to resolve to the NLB — works for sslip.io AND for a
+# CNAME in a zone hosted in another AWS account (no Route53 API access required).
+# Rendered by up.sh (envsubst) to fill ${LETSENCRYPT_EMAIL}.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ${LETSENCRYPT_EMAIL}
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/scripts/k8s-dev/manifests/gp3-storageclass.yaml
+++ b/scripts/k8s-dev/manifests/gp3-storageclass.yaml
@@ -1,0 +1,14 @@
+# gp3 StorageClass set as cluster default, so the bundled postgres PVC binds without the
+# in-tree gp2 class. Applied (idempotently) by up.sh after the EBS CSI addon is ready.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: gp3
+  encrypted: "true"

--- a/scripts/k8s-dev/reconcile-github.cjs
+++ b/scripts/k8s-dev/reconcile-github.cjs
@@ -1,0 +1,82 @@
+// Write a GitHub App installation straight into github_app_installations for the k8s
+// deployment, encrypted with the running LIGHTDASH_SECRET. Mirrors the backend EncryptionUtil
+// EXACTLY (aes-256-gcm, pbkdf2 sha512/2000/32, layout salt[64]|tag[16]|iv[12]|msg) — same as
+// scripts/dev-github-reconcile.cjs — but uses the real first user (no seeded demo).
+const crypto = require('crypto');
+const { Client } = require('pg');
+
+const SALT = 64, TAG = 16, IV = 12, ITER = 2000, KEYLEN = 32, DIGEST = 'sha512';
+
+function encrypt(message, secret) {
+  const iv = crypto.randomBytes(IV);
+  const salt = crypto.randomBytes(SALT);
+  const key = crypto.pbkdf2Sync(secret, salt, ITER, KEYLEN, DIGEST);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, { authTagLength: TAG });
+  const enc = Buffer.concat([cipher.update(String(message), 'utf8'), cipher.final()]);
+  return Buffer.concat([salt, cipher.getAuthTag(), iv, enc]);
+}
+function decrypt(buf, secret) {
+  const salt = buf.subarray(0, SALT);
+  const tag = buf.subarray(SALT, SALT + TAG);
+  const iv = buf.subarray(SALT + TAG, SALT + TAG + IV);
+  const msg = buf.subarray(SALT + TAG + IV);
+  const key = crypto.pbkdf2Sync(secret, salt, ITER, KEYLEN, DIGEST);
+  const d = crypto.createDecipheriv('aes-256-gcm', key, iv, { authTagLength: TAG });
+  d.setAuthTag(tag);
+  return Buffer.concat([d.update(msg), d.final()]).toString('utf8');
+}
+
+(async () => {
+  const secret = process.env.RUNNING_SECRET;
+  const instId = process.env.INSTALLATION_ID;
+  if (!secret || !instId) throw new Error('need RUNNING_SECRET + INSTALLATION_ID');
+
+  const client = new Client({
+    host: process.env.PGHOST || 'localhost',
+    port: parseInt(process.env.PGPORT || '5433', 10),
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE,
+  });
+  await client.connect();
+
+  // Show NOT NULL columns so a schema drift is visible rather than a cryptic insert error.
+  const cols = await client.query(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_name='github_app_installations' AND is_nullable='NO' ORDER BY ordinal_position`);
+  console.log('NOT NULL cols:', cols.rows.map((r) => r.column_name).join(', '));
+
+  const org = (await client.query(
+    'SELECT organization_uuid FROM organizations ORDER BY organization_id LIMIT 1')).rows[0]?.organization_uuid;
+  if (!org) throw new Error('no organizations in DB');
+  const user = (await client.query(
+    'SELECT u.user_uuid FROM users u JOIN emails e ON e.user_id=u.user_id ORDER BY u.user_id LIMIT 1')).rows[0]?.user_uuid;
+  if (!user) throw new Error('no users in DB');
+
+  const enc = encrypt(instId, secret);
+  if (decrypt(enc, secret) !== String(instId)) throw new Error('encrypt/decrypt roundtrip failed');
+
+  const exists = (await client.query(
+    'SELECT 1 FROM github_app_installations WHERE organization_uuid=$1', [org])).rows.length;
+  if (exists) {
+    await client.query(
+      'UPDATE github_app_installations SET encrypted_installation_id=$1, updated_at=now(), updated_by_user_uuid=$3 WHERE organization_uuid=$2',
+      [enc, org, user]);
+    console.log('UPDATED installation row');
+  } else {
+    await client.query(
+      `INSERT INTO github_app_installations
+         (organization_uuid, encrypted_installation_id, auth_token, refresh_token,
+          created_by_user_uuid, updated_by_user_uuid, created_at, updated_at)
+       VALUES ($1,$2,'placeholder','placeholder',$3,$3,now(),now())`,
+      [org, enc, user]);
+    console.log('INSERTED installation row');
+  }
+
+  // Verify it reads back + decrypts.
+  const back = (await client.query(
+    "SELECT encrypted_installation_id AS e FROM github_app_installations WHERE organization_uuid=$1", [org])).rows[0].e;
+  console.log('verify decrypt ->', decrypt(back, secret), '(org=' + org + ', user=' + user + ')');
+  await client.end();
+  console.log('DONE');
+})().catch((e) => { console.error('ERR', e.message); process.exit(1); });

--- a/scripts/k8s-dev/reconcile-github.sh
+++ b/scripts/k8s-dev/reconcile-github.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Write a GitHub App installation straight into github_app_installations, bypassing the broken
+# shared-dev-App proxy OAuth flow (see the GitHub section in .claude/commands/k8s-dev.md).
+#
+# Usage: ./scripts/k8s-dev/reconcile-github.sh <installation_id>
+#   <installation_id> comes from the failed OAuth callback URL (?installation_id=...) or from
+#   the GitHub App's "Install App" settings. The App must already be installed on your org/repo
+#   and its creds must be in the lightdash-app secret (GITHUB_APP_ID / GITHUB_PRIVATE_KEY).
+#
+# Encrypts the id with the RUNNING LIGHTDASH_SECRET (read from the cluster secret) so the
+# backend decrypts it; uses the real first user (not the seeded demo). Idempotent.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+INSTALLATION_ID="${1:?usage: reconcile-github.sh <installation_id>}"
+load_config
+require_tools
+require_aws_identity
+configure_kubectl
+
+export RUNNING_SECRET="$(kubectl -n "$K8S_NAMESPACE" get secret lightdash-app -o jsonpath='{.data.LIGHTDASH_SECRET}' | base64 -d)"
+export PGPASSWORD="$(kubectl -n "$K8S_NAMESPACE" get secret lightdash-pg -o jsonpath='{.data.password}' | base64 -d)"
+export PGUSER=lightdash PGDATABASE=lightdash PGHOST=localhost PGPORT=5433 INSTALLATION_ID
+export NODE_PATH="$(cd "$K8S_DEV_DIR/../.." && pwd)/packages/backend/node_modules"   # for `pg`
+
+step "port-forward postgres :5433"
+kubectl -n "$K8S_NAMESPACE" port-forward svc/lightdash-postgresql 5433:5432 >/tmp/k8s-dev-pf.log 2>&1 &
+PF=$!
+trap 'kill $PF 2>/dev/null || true' EXIT
+for _ in $(seq 1 30); do nc -z localhost 5433 2>/dev/null && break; sleep 0.5; done
+nc -z localhost 5433 2>/dev/null || fail "pg -- port-forward to lightdash-postgresql never came up ($(cat /tmp/k8s-dev-pf.log))"
+
+step "reconcile github_app_installations (installation $INSTALLATION_ID)"
+node "$K8S_DEV_DIR/reconcile-github.cjs"
+ok "github installation reconciled — writeback can now mint installation tokens"

--- a/scripts/k8s-dev/status.sh
+++ b/scripts/k8s-dev/status.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Read-only status of the testbed. Safe to run anytime.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+load_config
+
+echo "=== AWS identity ==="
+aws sts get-caller-identity --query '{Account:Account,Arn:Arn}' --output table 2>/dev/null \
+  || echo "NEED: aws auth (run your SSO login)"
+
+echo "=== Terraform ==="
+if terraform -chdir="$TF_DIR" output >/dev/null 2>&1; then
+  echo "cluster:  $(tf_output cluster_name)"
+  echo "s3:       $(tf_output s3_bucket)"
+  echo "ecr:      $(tf_output ecr_repository_url)"
+  echo "OK: infra provisioned"
+else
+  echo "NEED: terraform not applied yet (run '/k8s-dev up')"
+  exit 0
+fi
+
+if ! configure_kubectl 2>/dev/null; then
+  echo "NEED: cannot configure kubectl (cluster may be down)"
+  exit 0
+fi
+
+echo "=== Helm release ==="
+helm -n "$K8S_NAMESPACE" status "$HELM_RELEASE" 2>/dev/null | sed -n '1,6p' || echo "NEED: helm release not installed"
+
+echo "=== Pods ==="
+kubectl -n "$K8S_NAMESPACE" get pods 2>/dev/null || true
+
+echo "=== Public URL ==="
+HOST="$(kubectl -n "$K8S_NAMESPACE" get ingress -o jsonpath='{.items[0].spec.rules[0].host}' 2>/dev/null || true)"
+if [ -n "$HOST" ]; then
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://${HOST}/api/v1/health" || true)"
+  echo "https://${HOST}  (health HTTP ${CODE:-000})"
+  echo "Cluster is UP and billing — '/k8s-dev down' to stop spend."
+else
+  echo "no ingress host yet"
+fi

--- a/scripts/k8s-dev/terraform/addons.tf
+++ b/scripts/k8s-dev/terraform/addons.tf
@@ -1,0 +1,13 @@
+# EBS CSI driver addon — provisions EBS volumes for the bundled postgres PVC.
+# Standalone (not in the eks module's cluster_addons) to break the addon→role→module cycle.
+
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name             = module.eks.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = aws_iam_role.ebs_csi.arn
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  depends_on = [module.eks]
+}

--- a/scripts/k8s-dev/terraform/ecr.tf
+++ b/scripts/k8s-dev/terraform/ecr.tf
@@ -1,0 +1,29 @@
+# ECR repo for the build-local-branch path (`/k8s-dev deploy`). Empty until you push.
+
+resource "aws_ecr_repository" "lightdash" {
+  name                 = var.cluster_name
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+# Keep only the most recent images so the repo doesn't grow unbounded.
+resource "aws_ecr_lifecycle_policy" "lightdash" {
+  repository = aws_ecr_repository.lightdash.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last 10 images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/scripts/k8s-dev/terraform/eks.tf
+++ b/scripts/k8s-dev/terraform/eks.tf
@@ -1,0 +1,59 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.24"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.kubernetes_version
+
+  # Public endpoint so we can run kubectl/helm from a laptop. Private also enabled for
+  # in-VPC traffic.
+  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = true
+
+  enable_irsa = true
+
+  # Grant the Terraform caller cluster-admin so up.sh can apply manifests right after apply.
+  enable_cluster_creator_admin_permissions = true
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # aws-ebs-csi-driver is created as a standalone aws_eks_addon in addons.tf to avoid a
+  # dependency cycle (addon needs an IRSA role that needs this module's OIDC output).
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni    = {}
+  }
+
+  eks_managed_node_groups = {
+    default = {
+      ami_type       = "AL2023_x86_64_STANDARD"
+      instance_types = [var.node_instance_type]
+      capacity_type  = "ON_DEMAND"
+
+      min_size     = var.node_min_size
+      desired_size = var.node_desired_size
+      max_size     = var.node_max_size
+
+      # `disk_size` is IGNORED for managed node groups that use a launch template (the module
+      # default), so AL2023 falls back to a 20GiB root and large images (Lightdash ~2.4GiB each)
+      # cause ephemeral-storage eviction. Set the root volume via block_device_mappings instead.
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = var.node_disk_size
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+
+      labels = {
+        "lightdash.com/pool" = "system"
+      }
+    }
+  }
+}

--- a/scripts/k8s-dev/terraform/irsa.tf
+++ b/scripts/k8s-dev/terraform/irsa.tf
@@ -1,0 +1,92 @@
+# IAM Roles for Service Accounts (IRSA). Two roles:
+#   1. ebs_csi  — lets the EBS CSI controller provision volumes (kube-system/ebs-csi-controller-sa)
+#   2. lightdash_app — lets the Lightdash backend/worker pods read+write the S3 bucket with no
+#                      static keys (the AWS SDK picks up the projected OIDC token).
+
+# ---------- EBS CSI controller role ----------
+
+data "aws_iam_policy_document" "ebs_csi_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi" {
+  name               = "${var.cluster_name}-ebs-csi"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi" {
+  role       = aws_iam_role.ebs_csi.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# ---------- Lightdash app role (S3 access) ----------
+
+data "aws_iam_policy_document" "lightdash_app_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:sub"
+      values   = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_issuer}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lightdash_s3" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = [
+      aws_s3_bucket.lightdash.arn,
+      "${aws_s3_bucket.lightdash.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "lightdash_app" {
+  name               = "${var.cluster_name}-app"
+  assume_role_policy = data.aws_iam_policy_document.lightdash_app_assume.json
+}
+
+resource "aws_iam_role_policy" "lightdash_s3" {
+  name   = "s3-access"
+  role   = aws_iam_role.lightdash_app.id
+  policy = data.aws_iam_policy_document.lightdash_s3.json
+}

--- a/scripts/k8s-dev/terraform/main.tf
+++ b/scripts/k8s-dev/terraform/main.tf
@@ -1,0 +1,46 @@
+# k8s-dev: AWS infra underneath the Lightdash Helm chart.
+# Cloud-only concerns live here (VPC, EKS, S3, IRSA, ECR). Everything Kubernetes-level
+# (ingress-nginx, cert-manager, the chart itself, secrets) is applied by up.sh so this
+# stack never needs cluster credentials at plan time.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # Local state to start — simplest for a single-user testbed. To share this cluster,
+  # move state to S3 + DynamoDB (see scripts/k8s-dev/README in the skill doc).
+  backend "local" {}
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.profile != "" ? var.profile : null
+
+  default_tags {
+    tags = {
+      Project   = "lightdash-k8s-dev"
+      ManagedBy = "terraform"
+      Owner     = var.owner
+    }
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+  # OIDC issuer host/path with the https:// stripped — used to build IRSA trust conditions.
+  oidc_issuer = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+}

--- a/scripts/k8s-dev/terraform/outputs.tf
+++ b/scripts/k8s-dev/terraform/outputs.tf
@@ -1,0 +1,37 @@
+output "region" {
+  value = var.region
+}
+
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "service_account_name" {
+  value = var.service_account_name
+}
+
+output "s3_bucket" {
+  value = aws_s3_bucket.lightdash.bucket
+}
+
+output "app_role_arn" {
+  description = "IRSA role ARN to annotate onto the Lightdash service account."
+  value       = aws_iam_role.lightdash_app.arn
+}
+
+output "ecr_repository_url" {
+  value = aws_ecr_repository.lightdash.repository_url
+}
+
+output "configure_kubectl" {
+  description = "Command to point kubectl at this cluster."
+  value       = "aws eks update-kubeconfig --region ${var.region} --name ${module.eks.cluster_name}${var.profile != "" ? " --profile ${var.profile}" : ""}"
+}

--- a/scripts/k8s-dev/terraform/s3.tf
+++ b/scripts/k8s-dev/terraform/s3.tf
@@ -1,0 +1,37 @@
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+locals {
+  bucket_name = var.bucket_name != "" ? var.bucket_name : "${var.cluster_name}-${random_id.bucket_suffix.hex}"
+}
+
+resource "aws_s3_bucket" "lightdash" {
+  bucket = local.bucket_name
+
+  # Testbed bucket — allow destroy even when non-empty so `down` is clean.
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_public_access_block" "lightdash" {
+  bucket = aws_s3_bucket.lightdash.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Expire objects so a forgotten testbed bucket doesn't accumulate cost.
+resource "aws_s3_bucket_lifecycle_configuration" "lightdash" {
+  bucket = aws_s3_bucket.lightdash.id
+
+  rule {
+    id     = "expire-temp-objects"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = 30
+    }
+  }
+}

--- a/scripts/k8s-dev/terraform/variables.tf
+++ b/scripts/k8s-dev/terraform/variables.tf
@@ -1,0 +1,74 @@
+variable "region" {
+  description = "AWS region for the testbed"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "profile" {
+  description = "AWS CLI profile / SSO profile to authenticate with. Empty = default credential chain."
+  type        = string
+  default     = ""
+}
+
+variable "owner" {
+  description = "Tag value identifying who spun this up (for cost attribution / cleanup)."
+  type        = string
+  default     = "k8s-dev"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "lightdash-k8s-dev"
+}
+
+variable "kubernetes_version" {
+  description = "EKS Kubernetes version"
+  type        = string
+  default     = "1.30"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for the managed node group. EC2 (not Fargate) so the future Kubernetes sandbox provider can run DaemonSets / privileged / gVisor pods."
+  type        = string
+  default     = "m6i.large"
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "node_desired_size" {
+  type    = number
+  default = 2
+}
+
+variable "node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "node_disk_size" {
+  description = "Node root EBS volume size (GiB). Applied via block_device_mappings (see eks.tf). Lightdash images are ~2.4GiB each, plus browserless ~1.1GiB and migration ephemeral, so keep headroom."
+  type        = number
+  default     = 100
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace the Lightdash release lives in (used for IRSA trust)."
+  type        = string
+  default     = "lightdash"
+}
+
+variable "service_account_name" {
+  description = "Service account name the chart creates (must match values.aws.yaml serviceAccount.name) — used for IRSA trust."
+  type        = string
+  default     = "lightdash"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name for Lightdash storage. Empty = auto-generate a unique name."
+  type        = string
+  default     = ""
+}

--- a/scripts/k8s-dev/terraform/vpc.tf
+++ b/scripts/k8s-dev/terraform/vpc.tf
@@ -1,0 +1,24 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.8"
+
+  name = "${var.cluster_name}-vpc"
+  cidr = "10.42.0.0/16"
+
+  azs             = local.azs
+  private_subnets = ["10.42.1.0/24", "10.42.2.0/24"]
+  public_subnets  = ["10.42.101.0/24", "10.42.102.0/24"]
+
+  # Single NAT gateway keeps the testbed cheap (no cross-AZ HA needed here).
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  # Tags the AWS Load Balancer / ingress-nginx use to discover subnets.
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}

--- a/scripts/k8s-dev/up.sh
+++ b/scripts/k8s-dev/up.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Idempotent bring-up of the Lightdash EKS testbed. Re-runnable; reconciles drift.
+# Exits with `READY: <url>` on success or `FAIL: <step> -- <reason>`.
+set -euo pipefail
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+load_config
+require_tools
+require_aws_identity
+
+# ---------------------------------------------------------------------------
+step "terraform apply (VPC, EKS, nodes, S3, IRSA, ECR)"
+terraform -chdir="$TF_DIR" init -input=false >/dev/null
+# shellcheck disable=SC2046
+terraform -chdir="$TF_DIR" apply -input=false -auto-approve $(tf_vars)
+ok "terraform applied"
+
+APP_ROLE_ARN="$(tf_output app_role_arn)"
+S3_BUCKET="$(tf_output s3_bucket)"
+ECR_URL="$(tf_output ecr_repository_url)"
+[ -n "$APP_ROLE_ARN" ] && [ -n "$S3_BUCKET" ] || fail "terraform -- missing outputs (app_role_arn/s3_bucket)"
+
+# ---------------------------------------------------------------------------
+step "configure kubectl"
+configure_kubectl
+kubectl get nodes >/dev/null || fail "kubectl -- cannot reach cluster API"
+kubectl get ns "$K8S_NAMESPACE" >/dev/null 2>&1 || kubectl create ns "$K8S_NAMESPACE"
+ok "kubectl configured (namespace $K8S_NAMESPACE)"
+
+# ---------------------------------------------------------------------------
+step "default gp3 StorageClass"
+kubectl apply -f "$K8S_DEV_DIR/manifests/gp3-storageclass.yaml" >/dev/null
+ok "gp3 storageclass applied"
+
+# ---------------------------------------------------------------------------
+step "ingress-nginx (NLB)"
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx >/dev/null 2>&1 || true
+helm repo update ingress-nginx >/dev/null 2>&1 || true
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-cross-zone-load-balancing-enabled"=true \
+  --wait --timeout 10m >/dev/null
+ok "ingress-nginx installed"
+
+step "wait for NLB hostname"
+LB_HOST=""
+for _ in $(seq 1 40); do
+  LB_HOST="$(kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
+  [ -n "$LB_HOST" ] && break
+  sleep 15
+done
+[ -n "$LB_HOST" ] || fail "nlb -- ingress-nginx LoadBalancer has no hostname yet (retry 'up')"
+ok "NLB hostname: $LB_HOST"
+
+# ---------------------------------------------------------------------------
+step "resolve public hostname"
+if [ "${SITE_HOST_MODE:-sslip}" = "custom" ]; then
+  : "${SITE_HOST:?SITE_HOST must be set when SITE_HOST_MODE=custom}"
+  echo "NOTE: add a DNS CNAME  $SITE_HOST  ->  $LB_HOST  (in whichever account hosts the zone)"
+else
+  # A freshly-created NLB hostname takes a minute or two to start resolving — retry, don't bail.
+  LB_IP=""
+  for _ in $(seq 1 24); do
+    LB_IP="$(dig +short "$LB_HOST" | grep -Eo '^[0-9.]+$' | head -1 || true)"
+    [ -n "$LB_IP" ] && break
+    sleep 15
+  done
+  [ -n "$LB_IP" ] || fail "dns -- $LB_HOST still not resolving after ~6m (NLB DNS propagation slow; re-run 'up')"
+  SITE_HOST="lightdash.${LB_IP}.sslip.io"
+fi
+export SITE_HOST
+ok "SITE_HOST=$SITE_HOST"
+
+# ---------------------------------------------------------------------------
+step "cert-manager + ClusterIssuer"
+helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
+helm repo update jetstack >/dev/null 2>&1 || true
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true \
+  --wait --timeout 10m >/dev/null
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-admin@example.com}" \
+  envsubst < "$K8S_DEV_DIR/manifests/cluster-issuer.yaml.tpl" | kubectl apply -f - >/dev/null
+ok "cert-manager + letsencrypt issuer ready"
+
+# ---------------------------------------------------------------------------
+step "k8s secrets (postgres + app + EE license)"
+ensure_secret lightdash-pg \
+  --from-literal=password="$(rand_hex)" \
+  --from-literal=postgres-password="$(rand_hex)"
+
+# EE license + AI/E2B keys from 1Password (never echoed). Skipped if the secret exists.
+# Item names default to the same ones /docker-dev confirmed in ~/.lightdash/dev-secrets.local.json.
+if kubectl -n "$K8S_NAMESPACE" get secret lightdash-app >/dev/null 2>&1; then
+  skip "secret/lightdash-app already exists"
+else
+  LICENSE="$(op item get "${EE_LICENSE_OP_ITEM}" --fields label=password --reveal 2>/dev/null || true)"
+  [ -n "$LICENSE" ] || fail "ee-license -- could not read '${EE_LICENSE_OP_ITEM}' from 1Password (run 'op signin' and retry)"
+  ANTHROPIC_KEY="$(op item get "${ANTHROPIC_OP_ITEM:-(dev) ANTHROPIC_API_KEY}" --fields label=credential --reveal 2>/dev/null || true)"
+  [ -n "$ANTHROPIC_KEY" ] || ANTHROPIC_KEY="$(op item get "${ANTHROPIC_OP_ITEM:-(dev) ANTHROPIC_API_KEY}" --fields label=password --reveal 2>/dev/null || true)"
+  [ -n "$ANTHROPIC_KEY" ] || fail "anthropic -- could not read '${ANTHROPIC_OP_ITEM:-(dev) ANTHROPIC_API_KEY}' from 1Password"
+  E2B_KEY="$(op item get "${E2B_OP_ITEM:-(dev) E2B_API_KEY}" --fields label=credential --reveal 2>/dev/null || true)"
+  [ -n "$E2B_KEY" ] || E2B_KEY="$(op item get "${E2B_OP_ITEM:-(dev) E2B_API_KEY}" --fields label=password --reveal 2>/dev/null || true)"
+  [ -n "$E2B_KEY" ] || fail "e2b -- could not read '${E2B_OP_ITEM:-(dev) E2B_API_KEY}' from 1Password"
+  # GitHub App (dbt-over-GitHub + AI writeback). The item's notesPlain is an `export KEY="val"`
+  # block; eval it to populate GITHUB_*. GITHUB_PRIVATE_KEY is base64-encoded PEM.
+  # op renders notesPlain with literal \n escapes — decode with printf '%b' (portable; macOS
+  # sed won't expand \n) before eval, or the multi-line export block collapses to one line.
+  GH_RAW="$(op item get "${GITHUB_OP_ITEM:-lightdash-app-dev Github integration for Lightdash}" --fields label=notesPlain --reveal 2>/dev/null || true)"
+  [ -n "$GH_RAW" ] || fail "github -- could not read GitHub App env-block from '${GITHUB_OP_ITEM:-lightdash-app-dev Github integration for Lightdash}'"
+  eval "$(printf '%b' "$GH_RAW")"
+  [ -n "${GITHUB_APP_ID:-}" ] && [ -n "${GITHUB_PRIVATE_KEY:-}" ] || fail "github -- env-block missing GITHUB_APP_ID / GITHUB_PRIVATE_KEY"
+  kubectl -n "$K8S_NAMESPACE" create secret generic lightdash-app \
+    --from-literal=LIGHTDASH_SECRET="$(rand_hex)" \
+    --from-literal=LIGHTDASH_LICENSE_KEY="$LICENSE" \
+    --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_KEY" \
+    --from-literal=E2B_API_KEY="$E2B_KEY" \
+    --from-literal=GITHUB_APP_ID="$GITHUB_APP_ID" \
+    --from-literal=GITHUB_APP_NAME="${GITHUB_APP_NAME:-lightdash-app-dev}" \
+    --from-literal=GITHUB_CLIENT_ID="$GITHUB_CLIENT_ID" \
+    --from-literal=GITHUB_CLIENT_SECRET="$GITHUB_CLIENT_SECRET" \
+    --from-literal=GITHUB_PRIVATE_KEY="$GITHUB_PRIVATE_KEY"
+  ok "secret/lightdash-app created (EE license + Anthropic + E2B + GitHub App wired)"
+fi
+
+# ---------------------------------------------------------------------------
+step "render helm values"
+RENDERED="$(mktemp -t k8s-dev-values.XXXXXX).yaml"
+IMAGE_REPO="${IMAGE_REPO:-lightdash/lightdash}" \
+IMAGE_TAG="${IMAGE_TAG:-latest}" \
+APP_ROLE_ARN="$APP_ROLE_ARN" \
+S3_BUCKET="$S3_BUCKET" \
+S3_REGION="$AWS_REGION" \
+SITE_HOST="$SITE_HOST" \
+  envsubst < "$K8S_DEV_DIR/values.aws.yaml.tpl" > "$RENDERED"
+ok "values rendered -> $RENDERED"
+
+# ---------------------------------------------------------------------------
+step "helm upgrade --install $HELM_RELEASE"
+helm dependency build "$HELM_CHART_PATH" >/dev/null 2>&1 || true
+helm upgrade --install "$HELM_RELEASE" "$HELM_CHART_PATH" \
+  --namespace "$K8S_NAMESPACE" \
+  -f "$RENDERED" \
+  --wait --timeout 15m
+ok "helm release deployed"
+
+# ---------------------------------------------------------------------------
+step "wait for TLS certificate"
+# cert-manager can hit a transient "Failed to finalize Order: orderNotReady" race on first
+# issue even though the HTTP-01 challenge validated. Deleting the Certificate forces a clean
+# re-issue (which succeeds immediately). Auto-heal it here instead of failing.
+CERT_READY=""
+for _ in $(seq 1 10); do
+  CERT_READY="$(kubectl -n "$K8S_NAMESPACE" get certificate lightdash-tls -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+  [ "$CERT_READY" = "True" ] && break
+  if kubectl -n "$K8S_NAMESPACE" get order -o jsonpath='{.items[*].status.state}' 2>/dev/null | grep -q errored; then
+    kubectl -n "$K8S_NAMESPACE" delete certificate lightdash-tls --ignore-not-found >/dev/null 2>&1 || true
+    kubectl -n "$K8S_NAMESPACE" delete certificaterequest,order --all >/dev/null 2>&1 || true
+  fi
+  sleep 15
+done
+[ "$CERT_READY" = "True" ] && ok "TLS certificate issued" \
+  || echo "WARN: TLS cert not Ready yet — app still serves HTTP. Check 'kubectl describe certificate -n $K8S_NAMESPACE lightdash-tls'"
+
+# ---------------------------------------------------------------------------
+step "verify health"
+for _ in $(seq 1 20); do
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://${SITE_HOST}/api/v1/health" || true)"
+  [ "$CODE" = "200" ] && break
+  sleep 15
+done
+echo "health HTTP ${CODE:-000} (TLS may take a few min on first issue)"
+
+echo "READY: https://${SITE_HOST}"
+echo "ECR: ${ECR_URL}  |  S3: ${S3_BUCKET}"
+echo "Cluster is UP and billing — run '/k8s-dev down' when finished."

--- a/scripts/k8s-dev/values.aws.yaml.tpl
+++ b/scripts/k8s-dev/values.aws.yaml.tpl
@@ -1,0 +1,181 @@
+# Helm overlay for the AWS EKS testbed. Rendered by up.sh via envsubst (${...} filled from
+# terraform outputs + config), then passed to `helm upgrade --install`.
+#
+# Secrets are NOT in this file. up.sh creates two k8s Secrets idempotently:
+#   - lightdash-pg   (keys: password, postgres-password)   -> bundled postgres + PGPASSWORD
+#   - lightdash-app  (keys: LIGHTDASH_SECRET, LIGHTDASH_LICENSE_KEY, ANTHROPIC_API_KEY,
+#                     E2B_API_KEY, GITHUB_*) -> backend + migration job
+# We deliberately leave the chart-managed `secrets:` map empty so nothing sensitive is
+# templated from values; everything sensitive comes from those Secrets via valueFrom.
+
+image:
+  repository: ${IMAGE_REPO}
+  tag: "${IMAGE_TAG}"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# Single-replica testbed: a PDB with minAvailable:1 means 0 allowed disruptions, which DEADLOCKS
+# node drains / managed-node-group rolling updates (the backend pod can't be evicted). Disable it.
+podDisruptionBudget:
+  enabled: false
+
+# Disable the chart-managed Secret; we inject sensitive env via extraEnv/valueFrom below.
+secrets: {}
+
+configMap:
+  SITE_URL: "https://${SITE_HOST}"
+  SECURE_COOKIES: "true"
+  TRUST_PROXY: "true"   # behind ingress-nginx TLS termination
+  # Feature gates: enable-data-apps (AppGenerateService) + ai-writeback (AiWritebackService —
+  # throws ForbiddenError without it). Both resolved from this env via FeatureFlagModel.
+  LIGHTDASH_ENABLE_FEATURE_FLAGS: "enable-data-apps,ai-writeback"
+  # GitHub integration (dbt-over-GitHub + AI writeback). The redirect domain must be the FULL
+  # host — Lightdash's auto-derivation (siteUrl.split('.')[0]) breaks on a multi-label sslip.io
+  # name. GITHUB_OAUTH_REDIRECT_URI is the single shared install+user-auth callback; it MUST be
+  # registered as a Callback URL on the GitHub App (see the skill doc — manual one-time step).
+  GITHUB_REDIRECT_DOMAIN: "${SITE_HOST}"
+  GITHUB_OAUTH_REDIRECT_URI: "https://${SITE_HOST}/api/v1/github/oauth/callback"
+
+# --- Bundled, ephemeral postgres (our "temporary" DB) ---
+postgresql:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: pgvector/pgvector
+    tag: pg16
+  auth:
+    username: lightdash
+    database: lightdash
+    existingSecret: lightdash-pg
+    secretKeys:
+      userPasswordKey: password
+  primary:
+    persistence:
+      enabled: true
+      storageClass: gp3
+      size: 8Gi
+
+# Inline scheduler: scheduler.enabled=false makes the BACKEND run the graphile scheduler
+# inline (the chart inverts SCHEDULER_ENABLED). One fewer deployment; jobs still process.
+# Flip to true + give it resources when the testbed needs a dedicated worker.
+scheduler:
+  enabled: false
+
+# Bundled headless browser stays on (default) for exports/screenshots.
+browserless-chrome:
+  enabled: true
+
+# NATS not needed for the testbed.
+nats:
+  enabled: false
+
+# Run migrations (core + EE) as a pre-install/upgrade hook. EE migration dirs are included
+# automatically because LIGHTDASH_LICENSE_KEY is in scope via migrationJob.extraEnv.
+migrationJob:
+  enabled: true
+  extraEnv:
+    - name: LIGHTDASH_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: lightdash-app
+          key: LIGHTDASH_SECRET
+    - name: LIGHTDASH_LICENSE_KEY
+      valueFrom:
+        secretKeyRef:
+          name: lightdash-app
+          key: LIGHTDASH_LICENSE_KEY
+    # The migration job loads the FULL config at startup (lightdashConfig), and recent versions
+    # ENFORCE S3 (parseBaseS3Config requires S3_ENDPOINT+BUCKET+REGION). The job doesn't inherit
+    # the main extraEnv/configMap, so set S3 here too or `knex migrate` dies on a ParseError.
+    - { name: S3_ENDPOINT, value: "https://s3.${S3_REGION}.amazonaws.com" }
+    - { name: S3_BUCKET, value: "${S3_BUCKET}" }
+    - { name: S3_REGION, value: "${S3_REGION}" }
+
+# Service account annotated for IRSA -> S3 access with no static keys.
+serviceAccount:
+  create: true
+  name: lightdash
+  annotations:
+    eks.amazonaws.com/role-arn: "${APP_ROLE_ARN}"
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    # Lightdash sends a large Content-Security-Policy header; the default 4k nginx proxy
+    # buffer overflows → 502 on asset routes ("upstream sent too big header"). Bump it.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+  hosts:
+    - host: "${SITE_HOST}"
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: lightdash-tls
+      hosts:
+        - "${SITE_HOST}"
+
+# Backend env: secret + S3. IRSA supplies AWS credentials, so no keys here — just bucket+region.
+extraEnv:
+  - name: LIGHTDASH_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: lightdash-app
+        key: LIGHTDASH_SECRET
+  - name: LIGHTDASH_LICENSE_KEY
+    valueFrom:
+      secretKeyRef:
+        name: lightdash-app
+        key: LIGHTDASH_LICENSE_KEY
+  # Recent versions enforce S3_ENDPOINT (parseBaseS3Config). Real AWS S3 regional endpoint;
+  # IRSA still supplies the credentials. Virtual-hosted-style works with this endpoint.
+  - name: S3_ENDPOINT
+    value: "https://s3.${S3_REGION}.amazonaws.com"
+  - name: S3_REGION
+    value: "${S3_REGION}"
+  - name: S3_BUCKET
+    value: "${S3_BUCKET}"
+  - name: S3_EXPIRATION_TIME
+    value: "259200"
+  # --- Data-app generation via E2B (the baseline before swapping in a k8s SandboxProvider) ---
+  - name: AI_COPILOT_ENABLED
+    value: "true"
+  - name: AI_DEFAULT_PROVIDER
+    value: "anthropic"
+  - name: ANTHROPIC_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: lightdash-app
+        key: ANTHROPIC_API_KEY
+  # E2B runs the agent sandbox in E2B's cloud (cluster egress via NAT). Swap to
+  # SANDBOX_PROVIDER=kubernetes later — see SandboxRuntime/DESIGN.md.
+  - name: SANDBOX_PROVIDER
+    value: "e2b"
+  - name: E2B_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: lightdash-app
+        key: E2B_API_KEY
+  # Template tag defaults to the running version; pin to the rolling :latest so a missing
+  # per-version template doesn't fail sandbox creation on this pinned image.
+  - name: E2B_TEMPLATE_TAG
+    value: "latest"
+  # --- GitHub App (dbt-over-GitHub + AI writeback). Creds from the lightdash-app secret. ---
+  - name: GITHUB_APP_ID
+    valueFrom: { secretKeyRef: { name: lightdash-app, key: GITHUB_APP_ID } }
+  - name: GITHUB_APP_NAME
+    valueFrom: { secretKeyRef: { name: lightdash-app, key: GITHUB_APP_NAME } }
+  - name: GITHUB_CLIENT_ID
+    valueFrom: { secretKeyRef: { name: lightdash-app, key: GITHUB_CLIENT_ID } }
+  - name: GITHUB_CLIENT_SECRET
+    valueFrom: { secretKeyRef: { name: lightdash-app, key: GITHUB_CLIENT_SECRET } }
+  - name: GITHUB_PRIVATE_KEY
+    valueFrom: { secretKeyRef: { name: lightdash-app, key: GITHUB_PRIVATE_KEY } }
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 1Gi


### PR DESCRIPTION
## What

A new `/k8s-dev` skill (slash command + `scripts/k8s-dev/`) that idempotently stands up a public, HTTPS, EE-enabled Lightdash on **AWS EKS** — the testbed for later running agent/data-app sandboxes in AWS instead of E2B (the Kubernetes `SandboxProvider` in `SandboxRuntime/DESIGN.md`). Mirrors `/docker-dev`: idempotent `up.sh` + agentic self-repair.

## How it works

- **Terraform** (`scripts/k8s-dev/terraform/`): VPC, EKS + EC2 managed node group, S3, IRSA roles, ECR, EBS-CSI addon.
- Deploys the **unmodified** `~/code/helm-charts` lightdash chart via `values.aws.yaml.tpl` (bundled ephemeral postgres + browserless).
- **ingress-nginx (NLB) + cert-manager + sslip.io** → real Let's Encrypt HTTPS with zero DNS access (custom-domain path documented).
- EE license + Anthropic + E2B + GitHub App pulled from 1Password into k8s Secrets at runtime (nothing sensitive committed; `config.env` gitignored).
- `up` / `down` / `deploy` (build branch → ECR) / `status` + a `reconcile-github` helper for writeback.

## Validated

`terraform validate` ✓ · `helm template` against the chart ✓ · scripts `bash -n` ✓. Stood up a live cluster end-to-end (Lightdash 0.3246.0, data-app generation via E2B confirmed running).

## Notes

- Single-user testbed (local TF state, ephemeral postgres, sslip.io) — **not** a prod deployment; that's what `lightdash-cloud` is for.
- The command doc captures a long list of hard-won AWS/EKS/chart gotchas in its self-repair section.