### PR TITLE
docs(sandbox): default /docker-dev to the local Docker sandbox provider

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -276,6 +276,60 @@ Expect `Enterprise license for <site> is valid.` and no `no factory or provider`
 
 ---
 
+## Sandboxes (AI writeback & data-app generation)
+
+AI writeback and data-app generation run a Claude Code agent inside a **sandbox**. Locally,
+the **default is the Docker sandbox provider** (`SANDBOX_PROVIDER=docker`) — plain local
+containers, no E2B account needed. The `ee` profile sets `SANDBOX_PROVIDER=docker` for you
+(see `scripts/dev-profiles.json`); the dev E2B account is missing the `lightdash-ai-writeback`
+template, so Docker is the working local path anyway. Public docs:
+`mintlify-docs/self-host/customize-deployment/sandboxes.mdx`.
+
+**This is dev-only.** The Docker provider refuses to start when `NODE_ENV=production` (root
+-equivalent Docker-socket access, no isolation). Production uses `SANDBOX_PROVIDER=e2b`.
+
+### Setup (one-time per machine)
+
+1. **Build the two local images** (heavy — `lightdash-sandbox:local` ~2.3GB for data apps,
+   `lightdash-ai-writeback:local` ~5GB for writeback; rebuild only when the toolchain changes):
+   ```bash
+   ./sandboxes/data-apps/build-local-image.sh        # -> lightdash-sandbox:local
+   ./sandboxes/ai-writeback/build-local-image.sh     # -> lightdash-ai-writeback:local
+   ```
+2. **Env** (the `ee` profile writes `SANDBOX_PROVIDER=docker`; the image vars default, set only to override):
+   ```bash
+   SANDBOX_PROVIDER=docker
+   # SANDBOX_DOCKER_IMAGE=lightdash-sandbox:local
+   # SANDBOX_AI_WRITEBACK_DOCKER_IMAGE=lightdash-ai-writeback:local
+   ```
+   Requires `ANTHROPIC_API_KEY` (agent) and MinIO up (snapshots tar to object storage).
+
+### Critical gotchas
+
+- **Both api AND scheduler need the env.** Data-app generation runs in the **scheduler**
+  graphile task, so a stale `SANDBOX_PROVIDER` there silently keeps gen on E2B. PM2 caches
+  env across a plain `restart` — `pm2 delete ${LD_INSTANCE_ID}-api ${LD_INSTANCE_ID}-scheduler && pnpm pm2:start`
+  to reliably reload `.env.development.local`. Verify with `pm2 jlist` that BOTH processes
+  show `SANDBOX_PROVIDER=docker`.
+- **After an OrbStack/Docker restart**, MinIO + NATS may not come back (gen needs MinIO) and
+  the graphile worker can zombie — re-run shared compose up and restart the scheduler.
+
+### Verify
+
+```bash
+# One-shot writeback (synchronous, ~50s; destroys the container on exit):
+curl -s -X POST -H "Authorization: ApiKey $LDPAT" -H 'Content-Type: application/json' \
+  "$LIGHTDASH_API_URL/api/v1/ee/projects/<projectUuid>/ai-writeback" \
+  -d '{"prompt":"add a test metric"}'
+# Watch for: Docker sandbox created -> repo cloned -> lightdash compile -> opened PR.
+# A suspended data-app sandbox leaves a sandbox_registry row (provider=docker, status=suspended,
+# snapshot_ref kind=s3-tar) with the container destroyed.
+```
+
+To switch a local instance to E2B instead, add `E2B_API_KEY` and set `SANDBOX_PROVIDER=e2b`.
+
+---
+
 ## `start`: Auto-detect and Setup
 
 **ALWAYS try the deterministic fast path first.** Only fall back to the agentic steps when the script fails — this is what keeps worktree iteration fast.

--- a/scripts/dev-profiles.json
+++ b/scripts/dev-profiles.json
@@ -10,14 +10,15 @@
     },
     "ee": {
       "label": "Enterprise Edition — license + all AI (agents, writeback, reviews)",
-      "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey.",
+      "description": "EE license plus every AI feature: Copilot/agents, AI writeback (opens PRs via GitHub), and the reviews classifier. Bootstraps from the EE base snapshot. Requires the GitHub integration so writeback is turnkey. AI sandboxes default to the LOCAL Docker provider (SANDBOX_PROVIDER=docker) — no E2B account needed locally; build the images per the Sandboxes section of docker-dev.md.",
       "ee": true,
       "requires": ["github"],
-      "secrets": ["LIGHTDASH_LICENSE_KEY", "ANTHROPIC_API_KEY", "E2B_API_KEY"],
-      "env": { "AI_COPILOT_ENABLED": "true", "AI_DEFAULT_PROVIDER": "anthropic" },
+      "secrets": ["LIGHTDASH_LICENSE_KEY", "ANTHROPIC_API_KEY"],
+      "env": { "AI_COPILOT_ENABLED": "true", "AI_DEFAULT_PROVIDER": "anthropic", "SANDBOX_PROVIDER": "docker" },
       "flags": ["ai-writeback", "github-mcp-one-click", "ai-preview-deploy-setup"],
       "orgSettings": { "ai_agent_reviews_enabled": true },
-      "verify": ["agents-200", "writeback-token"]
+      "verify": ["agents-200", "writeback-token"],
+      "notes": "Sandboxes default to SANDBOX_PROVIDER=docker (local containers). Build the two local images (lightdash-sandbox:local, lightdash-ai-writeback:local) via sandboxes/*/build-local-image.sh before running writeback or data-app generation — see the Sandboxes section of docker-dev.md. To use E2B instead, add E2B_API_KEY and set SANDBOX_PROVIDER=e2b."
     },
     "slack": {
       "label": "Slack bot (optional add-on)",


### PR DESCRIPTION
## Summary

Makes the local dev tooling default AI sandboxes (AI writeback + data-app generation) to the **local Docker sandbox provider** instead of E2B, and documents the setup. Dev-tooling/docs only — no product code changes.

- **`scripts/dev-profiles.json`** — the `ee` profile now sets `SANDBOX_PROVIDER=docker` in its env and no longer requires an `E2B_API_KEY` secret (the dev E2B account is missing the `lightdash-ai-writeback` template, so Docker is the working local path anyway). Switching back to E2B is documented in the profile `notes`.
- **`.claude/commands/docker-dev.md`** — adds a "Sandboxes" section: build the two local images, the env vars, the two gotchas (scheduler also needs the env / PM2 caches env across restarts; MinIO+NATS after a Docker restart), and a verify recipe. Cross-links the new public docs page.

The matching public documentation is in a separate `mintlify-docs` PR.

No Linear ticket — confirmed with the author (dev-tooling/docs only).