### PR TITLE
refactor: allow explorer queries with explicit ids

### DIFF
--- a/packages/frontend/src/hooks/useExplore.tsx
+++ b/packages/frontend/src/hooks/useExplore.tsx
@@ -21,6 +21,19 @@ export const useExplore = (
     useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
 ) => {
     const projectUuid = useProjectUuid();
+
+    return useExploreByProjectUuid(
+        activeTableName,
+        projectUuid,
+        useQueryOptions,
+    );
+};
+
+export const useExploreByProjectUuid = (
+    activeTableName: string | undefined,
+    projectUuid: string | undefined,
+    useQueryOptions?: UseQueryOptions<ApiExploreResults, ApiError>,
+) => {
     const setErrorResponse = useQueryError();
 
     const queryKey = ['tables', activeTableName, projectUuid];

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -27,7 +27,12 @@ import useHealth from './health/useHealth';
 import { useExplorerQueryManager } from './useExplorerQueryManager';
 import { usePreAggregateCacheEnabled } from './usePreAggregateCacheEnabled';
 import { usePreAggregateCheck } from './usePreAggregateCheck';
-import { useProjectUuid } from './useProjectUuid';
+
+type ExplorerQueryEffectsArgs = {
+    minimal?: boolean;
+    projectUuid?: string;
+    savedQueryUuid?: string;
+};
 
 /**
  * Effects layer for Explorer query orchestration
@@ -45,7 +50,9 @@ import { useProjectUuid } from './useProjectUuid';
  */
 export const useExplorerQueryEffects = ({
     minimal = false,
-}: { minimal?: boolean } = {}) => {
+    projectUuid: explicitProjectUuid,
+    savedQueryUuid,
+}: ExplorerQueryEffectsArgs = {}) => {
     const dispatch = useExplorerDispatch();
 
     useEffect(() => {
@@ -53,8 +60,16 @@ export const useExplorerQueryEffects = ({
     }, [minimal, dispatch]);
 
     // Get all state and runQuery from manager (single source of truth)
-    const { runQuery, query, validQueryArgs, explore } =
-        useExplorerQueryManager();
+    const {
+        runQuery,
+        query,
+        validQueryArgs,
+        explore,
+        projectUuid: resolvedProjectUuid,
+    } = useExplorerQueryManager({
+        projectUuid: explicitProjectUuid,
+        savedQueryUuid,
+    });
 
     const isEditMode = useExplorerSelector(selectIsEditMode);
     const isResultsOpen = useExplorerSelector(selectIsResultsExpanded);
@@ -77,7 +92,6 @@ export const useExplorerQueryEffects = ({
     const isPreAggregateFeatureEnabled = health?.preAggregates?.enabled;
     const tableName = useExplorerSelector(selectTableName);
     const metricQuery = useExplorerSelector(selectMetricQuery);
-    const projectUuid = useProjectUuid();
     const [preAggCacheEnabled] = usePreAggregateCacheEnabled();
 
     const hasSelectedFields =
@@ -109,7 +123,7 @@ export const useExplorerQueryEffects = ({
     }, [hasConfiguredPreAggregates, explore, isPreAggregateFeatureEnabled]);
 
     const preAggregateCheckQuery = usePreAggregateCheck({
-        projectUuid,
+        projectUuid: resolvedProjectUuid,
         exploreName: tableName,
         metricQuery,
         usePreAggregateCache: preAggCacheEnabled,

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -21,9 +21,14 @@ import {
 } from '../features/explorer/store';
 import { useQueryExecutor } from '../providers/Explorer/useQueryExecutor';
 import { buildQueryArgs } from './explorer/buildQueryArgs';
-import { useExplore } from './useExplore';
+import { useExploreByProjectUuid } from './useExplore';
 import { useDateZoomGranularitySearch } from './useExplorerRoute';
 import { usePreAggregateCacheEnabled } from './usePreAggregateCacheEnabled';
+
+type ExplorerQueryManagerArgs = {
+    projectUuid?: string;
+    savedQueryUuid?: string;
+};
 
 /**
  * Manager hook for Explorer query state
@@ -38,7 +43,10 @@ import { usePreAggregateCacheEnabled } from './usePreAggregateCacheEnabled';
  *
  * Child components should use useExplorerQuery() for the full public API.
  */
-export const useExplorerQueryManager = () => {
+export const useExplorerQueryManager = ({
+    projectUuid: explicitProjectUuid,
+    savedQueryUuid: explicitSavedQueryUuid,
+}: ExplorerQueryManagerArgs = {}) => {
     // Get state from Redux selectors
     const dispatch = useExplorerDispatch();
     const metricQuery = useExplorerSelector(selectMetricQuery);
@@ -64,8 +72,12 @@ export const useExplorerQueryManager = () => {
         savedQueryUuid: string;
         projectUuid: string;
     }>();
-    const savedQueryUuid = embed?.savedQueryUuid || params.savedQueryUuid;
-    const projectUuid = embed?.projectUuid || params.projectUuid!;
+    const savedQueryUuid =
+        explicitSavedQueryUuid ||
+        embed?.savedQueryUuid ||
+        params.savedQueryUuid;
+    const projectUuid =
+        explicitProjectUuid || embed?.projectUuid || params.projectUuid!;
     const viewModeQueryArgs = useMemo(() => {
         return savedQueryUuid ? { chartUuid: savedQueryUuid } : undefined;
     }, [savedQueryUuid]);
@@ -83,7 +95,7 @@ export const useExplorerQueryManager = () => {
     );
 
     // Get explore data and pivot configuration
-    const { data: explore } = useExplore(tableName, {
+    const { data: explore } = useExploreByProjectUuid(tableName, projectUuid, {
         refetchOnMount: false,
         refetchOnWindowFocus: false,
     });


### PR DESCRIPTION
## Summary

- add `useExploreByProjectUuid` for callers that already have a project id
- let explorer query manager/effects accept explicit `projectUuid` and `savedQueryUuid`
- preserve existing route/embed fallback behavior and keep `useExplorerQuery` unchanged

## Verification

- `corepack pnpm --filter frontend typecheck:fast` *(fails on existing test matcher typings in unrelated test files)*
- Browser: minimal saved chart route renders the saved chart
- Browser: full saved chart route renders the saved chart with no visible error alert
- Sub-agent code review: no findings

Relates: ZAP-543