### PR TITLE
feat: preview saved charts from ai chat

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentPageLayout/AiAgentPageLayout.tsx
@@ -21,12 +21,13 @@ import {
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { NAVBAR_HEIGHT } from '../../../../../components/common/Page/constants';
 import ErrorBoundary from '../../../../../features/errorBoundary/ErrorBoundary';
-import { clearArtifact } from '../../store/aiArtifactSlice';
+import { clearPreview } from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
 import { AiArtifactPanel } from '../ChatElements/AiArtifactPanel';
+import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './aiAgentPageLayout.module.css';
 import { SidebarButton } from './SidebarButton';
 
@@ -52,6 +53,10 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     const artifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,
     );
+    const savedChart = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.savedChart,
+    );
+    const preview = artifact || savedChart;
     const isMobile = useMediaQuery('(max-width: 768px)');
 
     const toggleSidebar = useCallback(() => {
@@ -64,11 +69,15 @@ export const AiAgentPageLayout: React.FC<Props> = ({
     }, [setIsAgentSidebarCollapsed, isAgentSidebarCollapsed]);
 
     useLayoutEffect(() => {
-        if (artifact) {
+        if (!preview) return;
+
+        const frame = requestAnimationFrame(() => {
             sidebarPanelRef.current?.collapse();
             setIsAgentSidebarCollapsed?.(true);
-        }
-    }, [artifact, setIsAgentSidebarCollapsed]);
+        });
+
+        return () => cancelAnimationFrame(frame);
+    }, [preview, setIsAgentSidebarCollapsed]);
 
     return (
         <div
@@ -160,7 +169,7 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                     </Panel>
                 </ErrorBoundary>
 
-                {!isMobile && artifact && (
+                {!isMobile && preview && (
                     <Fragment>
                         <PanelResizeHandle
                             aria-label="Resize artifact panel"
@@ -181,7 +190,13 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                                 order={3}
                             >
                                 <Box className={styles.floatingArtifactWrap}>
-                                    <AiArtifactPanel artifact={artifact} />
+                                    {artifact ? (
+                                        <AiArtifactPanel artifact={artifact} />
+                                    ) : savedChart ? (
+                                        <AiSavedChartPreviewPanel
+                                            savedChartPreview={savedChart}
+                                        />
+                                    ) : null}
                                 </Box>
                             </Panel>
                         </ErrorBoundary>
@@ -191,8 +206,8 @@ export const AiAgentPageLayout: React.FC<Props> = ({
 
             {isMobile && (
                 <Drawer
-                    opened={!!artifact}
-                    onClose={() => dispatch(clearArtifact())}
+                    opened={!!preview}
+                    onClose={() => dispatch(clearPreview())}
                     size="75%"
                     position="bottom"
                     h="75%"
@@ -210,7 +225,13 @@ export const AiAgentPageLayout: React.FC<Props> = ({
                         },
                     }}
                 >
-                    {artifact && <AiArtifactPanel artifact={artifact} />}
+                    {artifact ? (
+                        <AiArtifactPanel artifact={artifact} />
+                    ) : savedChart ? (
+                        <AiSavedChartPreviewPanel
+                            savedChartPreview={savedChart}
+                        />
+                    ) : null}
                 </Drawer>
             )}
         </div>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
@@ -1,0 +1,146 @@
+import {
+    ActionIcon,
+    Box,
+    Center,
+    Group,
+    Loader,
+    Menu,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import { IconDots, IconExternalLink, IconX } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import TruncatedText from '../../../../../components/common/TruncatedText';
+import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
+import {
+    clearSavedChartPreview,
+    type SavedChartPreviewData,
+} from '../../store/aiArtifactSlice';
+import { useAiAgentStoreDispatch } from '../../store/hooks';
+import artifactStyles from './AiArtifactPanel.module.css';
+import { AiSavedChartVisualization } from './AiSavedChartVisualization';
+
+type Props = {
+    savedChartPreview: SavedChartPreviewData;
+};
+
+export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
+    const dispatch = useAiAgentStoreDispatch();
+
+    const {
+        data: savedChart,
+        isInitialLoading,
+        isError,
+    } = useSavedQuery({
+        uuidOrSlug: savedChartPreview.savedChartUuid,
+        projectUuid: savedChartPreview.projectUuid,
+    });
+
+    const chartUrl = `/projects/${savedChartPreview.projectUuid}/saved/${savedChartPreview.savedChartUuid}/view`;
+
+    const closeButton = (
+        <ActionIcon
+            size="sm"
+            variant="subtle"
+            color="ldGray.6"
+            onClick={() => dispatch(clearSavedChartPreview())}
+            aria-label="Close"
+        >
+            <MantineIcon icon={IconX} />
+        </ActionIcon>
+    );
+
+    if (isError) {
+        return (
+            <div className={artifactStyles.floatingPanel}>
+                <Center className={artifactStyles.loading}>
+                    <Stack gap="xs" align="center">
+                        <Text size="xs" c="dimmed" ta="center">
+                            Failed to load chart. Please try again.
+                        </Text>
+                        {closeButton}
+                    </Stack>
+                </Center>
+            </div>
+        );
+    }
+
+    if (isInitialLoading || !savedChart) {
+        return (
+            <div className={artifactStyles.floatingPanel}>
+                <Center className={artifactStyles.loading}>
+                    <Stack gap="xs" align="center">
+                        <Loader
+                            type="dots"
+                            color="gray"
+                            delayedMessage="Loading chart..."
+                        />
+                        {closeButton}
+                    </Stack>
+                </Center>
+            </div>
+        );
+    }
+
+    return (
+        <div className={artifactStyles.floatingPanel}>
+            <div className={artifactStyles.floatingContent}>
+                <div className={artifactStyles.head}>
+                    <Stack gap={0} flex={1} miw={0}>
+                        <TruncatedText fz="sm" fw={600} maxWidth="100%">
+                            {savedChart.name}
+                        </TruncatedText>
+                        {savedChart.description && (
+                            <TruncatedText fz="xs" c="dimmed" maxWidth="100%">
+                                {savedChart.description}
+                            </TruncatedText>
+                        )}
+                    </Stack>
+
+                    <Group gap={2} className={artifactStyles.headRight}>
+                        <Menu withinPortal position="bottom-end">
+                            <Menu.Target>
+                                <Tooltip withinPortal label="More options">
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="ldGray.6"
+                                        aria-label="More options"
+                                    >
+                                        <MantineIcon icon={IconDots} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            </Menu.Target>
+                            <Menu.Dropdown>
+                                <Menu.Item
+                                    component="a"
+                                    href={chartUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconExternalLink}
+                                            size="sm"
+                                        />
+                                    }
+                                >
+                                    Explore from here
+                                </Menu.Item>
+                            </Menu.Dropdown>
+                        </Menu>
+                        {closeButton}
+                    </Group>
+                </div>
+
+                <Box flex={1} mih={0}>
+                    <AiSavedChartVisualization
+                        projectUuid={savedChartPreview.projectUuid}
+                        savedChart={savedChart}
+                    />
+                </Box>
+            </div>
+        </div>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartVisualization.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartVisualization.tsx
@@ -1,0 +1,127 @@
+import { type SavedChart } from '@lightdash/common';
+import { Box, Center, Loader } from '@mantine-8/core';
+import { useEffect, useMemo, useState, type FC } from 'react';
+import { Provider } from 'react-redux';
+import LightdashVisualization from '../../../../../components/LightdashVisualization';
+import VisualizationProvider from '../../../../../components/LightdashVisualization/VisualizationProvider';
+import MetricQueryDataProvider from '../../../../../components/MetricQueryData/MetricQueryDataProvider';
+import {
+    buildInitialExplorerState,
+    createExplorerStore,
+    explorerActions,
+} from '../../../../../features/explorer/store';
+import { useExplorerQueryEffects } from '../../../../../hooks/useExplorerQueryEffects';
+import { useExplorerQueryManager } from '../../../../../hooks/useExplorerQueryManager';
+import { useResizeObserver } from '../../../../../hooks/useResizeObserver';
+import { ExplorerSection } from '../../../../../providers/Explorer/types';
+
+type Props = {
+    projectUuid: string;
+    savedChart: SavedChart;
+};
+
+const AiSavedChartVisualizationContent: FC<Props> = ({
+    projectUuid,
+    savedChart,
+}) => {
+    useExplorerQueryEffects({
+        minimal: true,
+        projectUuid,
+        savedQueryUuid: savedChart.uuid,
+    });
+
+    const [measureRef, { width: containerWidth, height: containerHeight }] =
+        useResizeObserver<HTMLDivElement>();
+
+    const { query, queryResults, explore } = useExplorerQueryManager({
+        projectUuid,
+        savedQueryUuid: savedChart.uuid,
+    });
+
+    const resultsData = useMemo(
+        () => ({
+            ...queryResults,
+            metricQuery: query.data?.metricQuery,
+            fields: query.data?.fields,
+            resolvedTimezone: query.data?.resolvedTimezone ?? undefined,
+        }),
+        [queryResults, query.data],
+    );
+
+    const isLoading =
+        query.isFetching ||
+        queryResults.isFetchingRows ||
+        !query.data?.queryUuid ||
+        queryResults.queryUuid !== query.data.queryUuid;
+
+    return (
+        <MetricQueryDataProvider
+            metricQuery={query.data?.metricQuery}
+            tableName={savedChart.tableName ?? ''}
+            explore={explore}
+            queryUuid={query.data?.queryUuid}
+            parameters={query.data?.usedParametersValues}
+            resolvedTimezone={query.data?.resolvedTimezone}
+        >
+            <VisualizationProvider
+                minimal
+                chartConfig={savedChart.chartConfig}
+                initialPivotDimensions={savedChart.pivotConfig?.columns}
+                resultsData={resultsData}
+                isLoading={isLoading}
+                columnOrder={savedChart.tableConfig.columnOrder}
+                savedChartUuid={savedChart.uuid}
+                colorPalette={savedChart.colorPalette}
+                parameters={query.data?.usedParametersValues}
+                containerWidth={containerWidth}
+                containerHeight={containerHeight}
+            >
+                <Box h="100%" mih="inherit">
+                    <LightdashVisualization
+                        ref={measureRef}
+                        className="sentry-block ph-no-capture"
+                        data-testid="ai-saved-chart-visualization"
+                    />
+                </Box>
+            </VisualizationProvider>
+        </MetricQueryDataProvider>
+    );
+};
+
+export const AiSavedChartVisualization: FC<Props> = ({
+    projectUuid,
+    savedChart,
+}) => {
+    const [store] = useState(() => createExplorerStore());
+
+    useEffect(() => {
+        const initialState = buildInitialExplorerState({
+            savedChart,
+            minimal: true,
+            expandedSections: [ExplorerSection.VISUALIZATION],
+        });
+
+        store.dispatch(explorerActions.reset(initialState));
+    }, [savedChart, store]);
+
+    if (!savedChart) {
+        return (
+            <Center h="100%">
+                <Loader
+                    type="dots"
+                    color="gray"
+                    delayedMessage="Loading chart..."
+                />
+            </Center>
+        );
+    }
+
+    return (
+        <Provider store={store} key={`ai-saved-chart-${savedChart.uuid}`}>
+            <AiSavedChartVisualizationContent
+                projectUuid={projectUuid}
+                savedChart={savedChart}
+            />
+        </Provider>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.module.css
@@ -64,6 +64,25 @@
     );
 }
 
+.contentLink[data-chart-active='true'] {
+    background-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-blue-6) 3.5%,
+            var(--mantine-color-white)
+        ),
+        var(--mantine-color-dark-6)
+    ) !important;
+    border-color: light-dark(
+        color-mix(
+            in srgb,
+            var(--mantine-color-blue-6) 18%,
+            var(--mantine-color-ldGray-2)
+        ),
+        var(--mantine-color-ldGray-3)
+    );
+}
+
 .sqlRunnerLinkButton {
     --button-bg: light-dark(
         var(--mantine-color-white),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentLink.tsx
@@ -8,7 +8,7 @@ import {
 import { type FC, type MouseEvent, type ReactNode } from 'react';
 import { Link, createPath, useLocation, useNavigate } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { setArtifact } from '../../store/aiArtifactSlice';
+import { setArtifact, setSavedChartPreview } from '../../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -49,6 +49,9 @@ export const ContentLink: FC<ContentLinkProps> = ({
     const dispatch = useAiAgentStoreDispatch();
     const currentArtifact = useAiAgentStoreSelector(
         (state) => state.aiArtifact.artifact,
+    );
+    const currentSavedChart = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.savedChart,
     );
 
     const handleDashboardClick = (e: MouseEvent<HTMLAnchorElement>) => {
@@ -97,6 +100,16 @@ export const ContentLink: FC<ContentLinkProps> = ({
             );
 
         case 'chart-link': {
+            const chartUuid =
+                'data-chart-uuid' in props &&
+                typeof props['data-chart-uuid'] === 'string'
+                    ? props['data-chart-uuid']
+                    : undefined;
+            const chartSource =
+                'data-chart-source' in props &&
+                typeof props['data-chart-source'] === 'string'
+                    ? props['data-chart-source']
+                    : undefined;
             const chartType =
                 'data-chart-type' in props &&
                 typeof props['data-chart-type'] === 'string'
@@ -108,12 +121,44 @@ export const ContentLink: FC<ContentLinkProps> = ({
                 Object.values(ChartKind).includes(chartType as ChartKind)
                     ? (chartType as ChartKind)
                     : ChartKind.VERTICAL_BAR;
+            const href = typeof props.href === 'string' ? props.href : '';
+            const isSavedChart = chartSource !== 'sql-runner' && !!chartUuid;
+            const isActive =
+                isSavedChart && currentSavedChart?.savedChartUuid === chartUuid;
+
+            const handleChartClick = (e: MouseEvent<HTMLAnchorElement>) => {
+                if (
+                    !isSavedChart ||
+                    !chartUuid ||
+                    e.defaultPrevented ||
+                    e.button !== 0 ||
+                    e.metaKey ||
+                    e.altKey ||
+                    e.ctrlKey ||
+                    e.shiftKey
+                ) {
+                    return;
+                }
+
+                e.preventDefault();
+                dispatch(
+                    setSavedChartPreview({
+                        savedChartUuid: chartUuid,
+                        messageUuid: message.uuid,
+                        threadUuid: message.threadUuid,
+                        projectUuid,
+                        agentUuid,
+                    }),
+                );
+            };
 
             return (
                 <ContentReferenceLink
                     chartKind={chartTypeKind}
-                    to={typeof props.href === 'string' ? props.href : undefined}
+                    to={href || undefined}
                     kind="chart"
+                    data-chart-active={isActive || undefined}
+                    onClick={handleChartClick}
                     rel="noreferrer"
                     target="_blank"
                     title={title}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts
@@ -39,6 +39,21 @@ describe('rehypeAiAgentContentLinks', () => {
         ).toMatchObject({
             href: '/projects/project-uuid/saved/chart-slug/view#section',
             'data-content-type': 'chart-link',
+            'data-chart-source': 'saved-chart',
+            'data-chart-uuid': 'chart-slug',
+        });
+    });
+
+    it('marks explicit saved chart reference links', () => {
+        expect(
+            processHref(
+                '/projects/project-uuid/saved/chart-slug/view#chart-link#chart-type-line',
+            ),
+        ).toMatchObject({
+            href: '/projects/project-uuid/saved/chart-slug/view',
+            'data-content-type': 'chart-link',
+            'data-chart-source': 'saved-chart',
+            'data-chart-type': 'line',
             'data-chart-uuid': 'chart-slug',
         });
     });
@@ -49,6 +64,7 @@ describe('rehypeAiAgentContentLinks', () => {
         ).toMatchObject({
             href: '/projects/project-uuid/sql-runner/sql-chart-slug',
             'data-content-type': 'chart-link',
+            'data-chart-source': 'sql-runner',
             'data-chart-uuid': 'sql-chart-slug',
         });
     });

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.ts
@@ -35,6 +35,7 @@ const LINK_PROCESSORS: LinkProcessor[] = [
             const typeMatch = href.match(/#chart-type-(.+?)($|#)/);
 
             if (chartMatch) data['data-chart-uuid'] = chartMatch[1];
+            if (chartMatch) data['data-chart-source'] = 'saved-chart';
             if (typeMatch) data['data-chart-type'] = typeMatch[1];
 
             return data;
@@ -97,6 +98,7 @@ const processLink = (node: Element, href: string): void => {
                 ...node.properties,
                 'data-content-type': 'chart-link',
                 'data-chart-uuid': chartMatch[1],
+                'data-chart-source': 'saved-chart',
                 href,
             };
         } else if (sqlRunnerMatch) {
@@ -104,6 +106,7 @@ const processLink = (node: Element, href: string): void => {
                 ...node.properties,
                 'data-content-type': 'chart-link',
                 'data-chart-uuid': sqlRunnerMatch[1],
+                'data-chart-source': 'sql-runner',
                 href,
             };
         } else if (settingsMatch) {

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentThreadArtifact.ts
@@ -1,6 +1,6 @@
 import { type AiAgentThread } from '@lightdash/common';
 import { useEffect, useMemo, useRef } from 'react';
-import { clearArtifact, setArtifact } from '../store/aiArtifactSlice';
+import { clearPreview, setArtifact } from '../store/aiArtifactSlice';
 import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
@@ -29,7 +29,7 @@ export const useAiAgentThreadArtifact = ({
 
     useEffect(() => {
         return () => {
-            dispatch(clearArtifact());
+            dispatch(clearPreview());
             lastHandledMessageUuidRef.current = null;
             prevArtifactRef.current = null;
         };

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiArtifactSlice.ts
@@ -11,11 +11,21 @@ export interface ArtifactData {
 
 export interface AiArtifactState {
     artifact: ArtifactData | null;
+    savedChart: SavedChartPreviewData | null;
 }
 
 const initialState: AiArtifactState = {
     artifact: null,
+    savedChart: null,
 };
+
+export interface SavedChartPreviewData {
+    savedChartUuid: string;
+    messageUuid: string;
+    threadUuid: string;
+    projectUuid: string;
+    agentUuid: string;
+}
 
 export const aiArtifactSlice = createSlice({
     name: 'aiArtifact',
@@ -48,11 +58,32 @@ export const aiArtifactSlice = createSlice({
                 projectUuid,
                 agentUuid,
             };
+            state.savedChart = null;
+        },
+        setSavedChartPreview: (
+            state,
+            action: PayloadAction<SavedChartPreviewData>,
+        ) => {
+            state.savedChart = action.payload;
+            state.artifact = null;
         },
         clearArtifact: (state) => {
             state.artifact = null;
         },
+        clearSavedChartPreview: (state) => {
+            state.savedChart = null;
+        },
+        clearPreview: (state) => {
+            state.artifact = null;
+            state.savedChart = null;
+        },
     },
 });
 
-export const { setArtifact, clearArtifact } = aiArtifactSlice.actions;
+export const {
+    setArtifact,
+    setSavedChartPreview,
+    clearArtifact,
+    clearSavedChartPreview,
+    clearPreview,
+} = aiArtifactSlice.actions;


### PR DESCRIPTION
## Summary

- add saved-chart preview state alongside artifact previews
- open saved chart links in the AI thread side panel on plain click
- render saved chart title, description, visualization, close, and `Explore from here`
- keep SQL runner chart links as normal links and tag saved-vs-sql chart sources

## Verification

- `pnpm -F frontend exec vitest run src/ee/features/aiCopilot/components/ChatElements/rehypeContentLinks.test.ts`
- `pnpm --filter frontend typecheck:fast` *(fails on existing test matcher typings in unrelated test files)*
- Browser: plain-click saved chart link opens side panel without leaving thread URL
- Browser: panel shows title, visualization, close button, and `Explore from here` target blank link
- Browser: sidebar collapses when panel opens
- Sub-agent code review: initial P1 fixed, re-review no findings

Closes: ZAP-543