### PR TITLE
feat(sandbox): reaper cron for idle sandboxes + snapshot GC

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -104,6 +104,14 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                     maxAttempts: 1,
                 },
             },
+            {
+                task: EE_SCHEDULER_TASKS.REAP_SANDBOXES,
+                pattern: '*/5 * * * *', // Every 5 minutes
+                options: {
+                    backfillPeriod: 5 * 60 * 1000, // 5 min
+                    maxAttempts: 1,
+                },
+            },
         ];
     }
 
@@ -414,6 +422,9 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
             },
             [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
                 await this.appGenerateService.sweepStaleLocks();
+            },
+            [EE_SCHEDULER_TASKS.REAP_SANDBOXES]: async () => {
+                await this.appGenerateService.reapSandboxes();
             },
             [EE_SCHEDULER_TASKS.SEND_REVIEW_NOTIFICATION]: async (payload) => {
                 await sendReviewNotification({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -409,6 +409,18 @@ export class AppGenerateService extends BaseService {
      * and to the returned {@link SandboxHandle} for the data plane.
      * See SandboxRuntime/DESIGN.md.
      */
+    /**
+     * Whether a sandbox runtime is actually configured. Mirrors the precondition
+     * in `createSandboxProvider`: Docker needs no credentials, E2B requires an
+     * API key. Used to no-op the reaper cron on installs with no runtime
+     * configured (the default `SANDBOX_PROVIDER=e2b` with no `E2B_API_KEY`),
+     * instead of throwing `MissingConfigError` on every scheduled run.
+     */
+    private isSandboxRuntimeConfigured(): boolean {
+        const { sandboxProvider, e2bApiKey } = this.lightdashConfig.appRuntime;
+        return sandboxProvider === 'docker' || e2bApiKey !== null;
+    }
+
     private getSandboxManager(): SandboxManager {
         if (!this.sandboxManager) {
             this.sandboxManager = createSandboxManager({
@@ -1148,6 +1160,13 @@ export class AppGenerateService extends BaseService {
                 `Released ${rowCount} stale appGeneratePipeline job(s) (no progress in ${STALE_THRESHOLD})`,
             );
         }
+    }
+
+    async reapSandboxes(): Promise<void> {
+        if (!this.isSandboxRuntimeConfigured()) {
+            return;
+        }
+        await this.getSandboxManager().reapIdle();
     }
 
     private async createSandbox(

--- a/packages/backend/src/ee/services/AppGenerateService/reapSandboxes.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/reapSandboxes.test.ts
@@ -1,0 +1,91 @@
+// e2b and ai are ESM-only packages that cannot be required by Jest/CJS.
+// Mock them before importing AppGenerateService.
+import { AppGenerateService } from './AppGenerateService';
+
+vi.mock('e2b', () => ({
+    Sandbox: class {},
+    CommandExitError: class extends Error {},
+    ALL_TRAFFIC: '*',
+}));
+vi.mock('ai', () => ({
+    generateObject: vi.fn(),
+}));
+
+type AppRuntimeOverrides = {
+    sandboxProvider: 'e2b' | 'docker';
+    e2bApiKey: string | null;
+};
+
+const buildService = (appRuntime: AppRuntimeOverrides) => {
+    const sandboxRegistryModel = {
+        findIdleRunning: vi.fn().mockResolvedValue([]),
+        findExpiredSuspended: vi.fn().mockResolvedValue([]),
+    };
+    const lightdashConfig = {
+        appRuntime: {
+            ...appRuntime,
+            sandboxDockerImage: 'img',
+            sandboxIdleTimeoutMs: 1000,
+            sandboxSnapshotRetentionMs: 5000,
+        },
+        s3: {},
+    };
+    const service = new AppGenerateService({
+        lightdashConfig: lightdashConfig as never,
+        analytics: {} as never,
+        analyticsModel: {} as never,
+        catalogModel: {} as never,
+        appModel: {} as never,
+        featureFlagModel: {} as never,
+        organizationDesignModel: {} as never,
+        pinnedListModel: {} as never,
+        projectModel: {} as never,
+        projectParametersModel: {} as never,
+        spaceModel: {} as never,
+        schedulerClient: {} as never,
+        savedChartService: {} as never,
+        spacePermissionService: {} as never,
+        dashboardService: {} as never,
+        projectService: {} as never,
+        promoteService: {} as never,
+        externalConnectionModel: {} as never,
+        sandboxRegistryModel: sandboxRegistryModel as never,
+    });
+    return { service, sandboxRegistryModel };
+};
+
+describe('AppGenerateService.reapSandboxes', () => {
+    it('no-ops when the default e2b provider has no API key configured', async () => {
+        const { service, sandboxRegistryModel } = buildService({
+            sandboxProvider: 'e2b',
+            e2bApiKey: null,
+        });
+
+        // Must resolve (not throw MissingConfigError) and never touch the
+        // registry — the provider is never constructed.
+        await expect(service.reapSandboxes()).resolves.toBeUndefined();
+        expect(sandboxRegistryModel.findIdleRunning).not.toHaveBeenCalled();
+    });
+
+    it('runs the sweep when e2b is configured with an API key', async () => {
+        const { service, sandboxRegistryModel } = buildService({
+            sandboxProvider: 'e2b',
+            e2bApiKey: 'e2b-key',
+        });
+
+        await service.reapSandboxes();
+
+        expect(sandboxRegistryModel.findIdleRunning).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs the sweep for docker, which needs no credentials', async () => {
+        const { service, sandboxRegistryModel } = buildService({
+            sandboxProvider: 'docker',
+            e2bApiKey: null,
+        });
+
+        await service.reapSandboxes();
+
+        expect(sandboxRegistryModel.findIdleRunning).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -250,6 +250,7 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
+    [SCHEDULER_TASKS.REAP_SANDBOXES]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
     [SCHEDULER_TASKS.INGEST_PROJECT_CONTEXT]: (payload) => ({
         'organization.uuid': payload.organizationUuid,

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -77,6 +77,7 @@ export const EE_SCHEDULER_TASKS = {
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
     APP_GENERATE_PIPELINE: 'appGeneratePipeline',
     SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
+    REAP_SANDBOXES: 'reapSandboxes',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -170,6 +171,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [SCHEDULER_TASKS.REAP_SANDBOXES]: TraceTaskBase;
 }
 
 export interface EETaskPayloadMap {
@@ -185,6 +187,7 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [EE_SCHEDULER_TASKS.REAP_SANDBOXES]: TraceTaskBase;
 }
 
 export type SchedulerTaskName =


### PR DESCRIPTION
## What & why

Final piece of Phase 1 of the sandbox runtime work (stacked on #24794). Wires the **sandbox reaper cron** so `SandboxManager.reapIdle()` runs on a schedule.

`reapIdle()` already exists and is unit-tested — this PR is **only the scheduling**, no new logic, no migration, no env gating. It does two things:

1. **Suspends orphaned `status=running` registry rows** idle past `sandboxIdleTimeoutMs` (30m) — the safety net for a worker that crashed before its end-of-turn `finally { suspend() }` ran, which would otherwise leak a container.
2. **GCs suspended snapshots** past `sandboxSnapshotRetentionMs` (7d) so object storage doesn't grow unboundedly.

In steady state on a healthy worker it returns `{ suspended: 0, gced: 0 }`.

## Changes

Mirrors the existing `SWEEP_STALE_APP_LOCKS` task at every site:

- `schedulerTaskList.ts` — `REAP_SANDBOXES: 'reapSandboxes'` in `EE_SCHEDULER_TASKS` + `TraceTaskBase` payload-map entries.
- `SchedulerTaskTracer.ts` — `() => ({})` trace entry.
- `ee/scheduler/SchedulerWorker.ts` — cron item (`*/5 * * * *`, less urgent than SWEEP's `*/2`) + handler calling `appGenerateService.reapSandboxes()`.
- `AppGenerateService.ts` — one-line `reapSandboxes()` delegating to `getSandboxManager().reapIdle()`. One `reapIdle()` sweeps the whole registry regardless of feature/image, so a single entrypoint suffices.

## Validation

Throwaway driver against **real Postgres + Docker + MinIO**: seeded (a) a `status=running` row backed by a live container, idle 31m, and (b) a `suspended` row with a real MinIO snapshot, idle 8d, then called `reapIdle()`. **11/11 checks** — orphan became suspended (snapshot written, provider id nulled, container destroyed); expired snapshot was GC'd (row dropped, object deleted). `typecheck:fast` + lint clean.
