### PR TITLE
feat(backend): add org and project ids to warehouse query completion log

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2806,6 +2806,7 @@ export class AsyncQueryService extends ProjectService {
                 : '';
             this.logger.info(
                 `Query ${queryUuid} completed: source=${executionSource} s3_stream_create=${s3StreamCreatedMs}ms query_exec=${queryExecMs}ms s3_upload_close=${s3UploadCloseMs}ms db_update=${dbUpdateMs}ms total=${totalMs}ms rows=${pivotDetails?.totalRows ?? totalRows}${streamMetricsStr}`,
+                { organizationUuid, projectUuid, queryUuid },
             );
 
             // Track successful query in Prometheus


### PR DESCRIPTION
### Description:

The async warehouse query completion log

```
Query <uuid> completed: source=warehouse s3_stream_create=…ms query_exec=…ms … total=…ms rows=…
```

is the only log line that records warehouse execution time (`query_exec`), but it carries no tenant identity. In multi-tenant deployments, organizations share a kubernetes namespace, so the namespace alone cannot attribute a slow query to a specific organization.

This adds `organizationUuid`, `projectUuid` and `queryUuid` as structured log metadata on that `logger.info` call, so the completion log can be filtered/attributed per organization in Cloud Logging (`jsonPayload.organizationUuid`). All three values are already in scope as parameters of `runAsyncWarehouseQuery`, so it's a one-line addition with no behavior change.

Motivation: enables support/observability tooling to analyse per-tenant warehouse query performance on shared instances. Follows the existing `logger.info('msg', { ... })` metadata convention used elsewhere in `AsyncQueryService`.
