### PR TITLE
fix(ai): stop blank Settings page when default AI provider isn't configured (#24802)

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -2003,6 +2003,7 @@ export class AiAgentService extends BaseService {
         return getAvailableModels(this.lightdashConfig.ai.copilot).map(
             (preset) => {
                 const isDefault =
+                    defaultModel !== null &&
                     preset.provider === defaultModel.provider &&
                     matchesPreset(preset, defaultModel.name);
 

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -82,6 +82,7 @@ export class AiOrganizationSettingsService extends BaseService {
                 description: preset.description,
                 provider: preset.provider,
                 default:
+                    defaultModel !== null &&
                     preset.provider === defaultModel.provider &&
                     matchesPreset(preset, defaultModel.name),
                 supportsReasoning: preset.supportsReasoning,

--- a/packages/backend/src/ee/services/ai/models/index.test.ts
+++ b/packages/backend/src/ee/services/ai/models/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { MockLanguageModelV3 } from 'ai/test';
 import { z } from 'zod';
 import { lightdashConfigMock } from '../../../../config/lightdashConfig.mock';
-import { applyStreamingCapability, getModel } from './index';
+import { applyStreamingCapability, getDefaultModel, getModel } from './index';
 
 jest.mock('ai', () => {
     const actual = jest.requireActual('ai');
@@ -29,6 +29,38 @@ const copilotConfigWithStreaming = (supportsStreaming: boolean) => ({
             supportsStreaming,
         },
     },
+});
+
+describe('getDefaultModel', () => {
+    it('returns the default model when the configured provider is present', () => {
+        expect(getDefaultModel(baseCopilotConfig)).toEqual({
+            name: baseCopilotConfig.providers.openai!.modelName,
+            provider: 'openai',
+        });
+    });
+
+    it('returns null when the configured default provider is not set up', () => {
+        // Reproduces the blank-Settings-page bug: defaultProvider `openai`
+        // with no OPENAI_API_KEY (providers.openai absent) must degrade to
+        // null rather than throw, so /aiAgents/admin/settings stays 2xx.
+        const configWithoutProvider = {
+            ...baseCopilotConfig,
+            defaultProvider: 'openai' as const,
+            providers: {},
+        };
+
+        expect(getDefaultModel(configWithoutProvider)).toBeNull();
+    });
+
+    it('returns null when the default azure provider is not configured', () => {
+        const configWithoutAzure = {
+            ...baseCopilotConfig,
+            defaultProvider: 'azure' as const,
+            providers: {},
+        };
+
+        expect(getDefaultModel(configWithoutAzure)).toBeNull();
+    });
 });
 
 describe('getModel', () => {

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -40,6 +40,10 @@ export const getDefaultModel = (
         case 'azure': {
             const azureConfig = config.providers.azure;
             if (!azureConfig) {
+                Logger.warn(
+                    'getDefaultModel: default AI provider is not configured',
+                    { defaultProvider: 'azure' },
+                );
                 return null;
             }
 
@@ -51,6 +55,10 @@ export const getDefaultModel = (
         default: {
             const defaultProvider = config.providers[config.defaultProvider];
             if (!defaultProvider) {
+                Logger.warn(
+                    'getDefaultModel: default AI provider is not configured',
+                    { defaultProvider: config.defaultProvider },
+                );
                 return null;
             }
             return {

--- a/packages/backend/src/ee/services/ai/models/index.ts
+++ b/packages/backend/src/ee/services/ai/models/index.ts
@@ -25,17 +25,22 @@ const FAST_MODELS: Record<ModelPresetProvider, string> = {
     bedrock: 'claude-haiku-4-5',
 };
 
+// Returns null when the configured default provider isn't set up (e.g. the
+// default `openai` provider with no OPENAI_API_KEY). Callers use this only to
+// flag which preset is the default, so a missing provider should degrade to
+// "no default" rather than throw — otherwise endpoints that list models (and
+// the whole Settings page that depends on them) break for that config.
 export const getDefaultModel = (
     config: LightdashConfig['ai']['copilot'],
 ): {
     name: string;
     provider: typeof config.defaultProvider;
-} => {
+} | null => {
     switch (config.defaultProvider) {
         case 'azure': {
             const azureConfig = config.providers.azure;
             if (!azureConfig) {
-                throw new ParameterError('Azure configuration is required');
+                return null;
             }
 
             return {
@@ -46,9 +51,7 @@ export const getDefaultModel = (
         default: {
             const defaultProvider = config.providers[config.defaultProvider];
             if (!defaultProvider) {
-                throw new ParameterError(
-                    `Default provider ${config.defaultProvider} not found`,
-                );
+                return null;
             }
             return {
                 name: defaultProvider.modelName,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -751,15 +751,21 @@ const Settings: FC = () => {
         );
     }, [location.pathname]);
 
+    // Only block on AI org settings while actually navigating to an AI route, so
+    // its dynamic routes (e.g. /ai/reviews) register before the catch-all redirect
+    // fires on a hard refresh. Scoping it here means a failure of that query no
+    // longer blanks the entire Settings surface — every non-AI route still renders.
+    const isAwaitingAiSettingsRoute =
+        isAiOrganizationSettingsLoading &&
+        Boolean(matchPath('/generalSettings/ai/*', location.pathname));
+
     if (
         isHealthLoading ||
         isUserLoading ||
         isOrganizationLoading ||
         isActiveProjectUuidLoading ||
         isProjectLoading ||
-        // Wait for AI org settings so the /ai/reviews route is registered before
-        // routing — otherwise a hard refresh there falls through to the default.
-        isAiOrganizationSettingsLoading
+        isAwaitingAiSettingsRoute
     ) {
         return <PageSpinner />;
     }


### PR DESCRIPTION
Fixes #24802 (PROD-8524).

## Problem

The **entire Settings surface** (integrations, members, org settings, …) rendered as a permanent blank full-page spinner for org admins on any instance where the AI copilot default provider is `openai` but no OpenAI key is configured — i.e. **every instance without OpenAI configured** on `>= 0.3231.0`.

Two independently-green changes combined:

1. **#24613** made `getDefaultModel()` **throw** when the configured default provider isn't set up. `defaultProvider` defaults to `openai`, and `providers.openai` only exists when `OPENAI_API_KEY` is set — so `GET /aiAgents/admin/settings` returned **HTTP 400** (`ParameterError: Default provider openai not found`).
2. **#24596** added that query to the top-level render gate in `Settings.tsx`, so the 400 turned the whole page into a dead spinner (with no error/timeout fallback).

## Fix

- **Backend (root cause):** `getDefaultModel()` now returns `null` instead of throwing when the provider isn't configured (both the `azure` and default branches). Its two callers (`AiOrganizationSettingsService`, `AiAgentService`) only use it to flag which preset is the "default" in a model list, so "no default" degrades gracefully and `/aiAgents/admin/settings` stays 2xx.
- **Frontend (defense-in-depth):** the Settings render gate now only waits on the AI org settings query **while actually navigating to an `/ai/*` route** — preserving the route-registration need from #24596 (so a hard refresh to `/ai/reviews` still registers before the catch-all redirect) — so a failure of that query no longer blanks the whole Settings page.

Either fix resolves the blank page; both are done for defence in depth, as the issue recommends.

## Verification

Reproduced locally on an EE instance with `openai` default and no key:

| Check | Before | After |
|---|---|---|
| `GET /aiAgents/admin/settings` | **400** `ParameterError` | **200** (`defaultAiAgentModelOptions: []`) |
| Settings → Integrations with backend forced to 400 | blank spinner | **renders fully** |
| Requests on that load | — | **1** request, no retry loop |

- Added regression tests for `getDefaultModel` returning `null` when the default (and azure) provider isn't configured.
- `getSettings` return type is unchanged → no OpenAPI regen needed.

## Affected code

- `packages/backend/src/ee/services/ai/models/index.ts` (+ `index.test.ts`)
- `packages/backend/src/ee/services/AiOrganizationSettingsService.ts`
- `packages/backend/src/ee/services/AiAgentService/AiAgentService.ts`
- `packages/frontend/src/pages/Settings.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)