### PR TITLE
fix(charts): correct row_total() table calc in big number tiles

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2,6 +2,7 @@ import { Ability } from '@casl/ability';
 import {
     Account,
     AnyType,
+    ChartType,
     CreateWarehouseCredentials,
     DimensionType,
     DownloadFileType,
@@ -3572,6 +3573,102 @@ describe('AsyncQueryService', () => {
             expect(runSpy).toHaveBeenCalledTimes(1);
             expect(runSpy.mock.calls[0][0]).toEqual(
                 expect.objectContaining({ dateZoom }),
+            );
+        });
+    });
+
+    describe('executeAsyncSavedChartQuery pivotDimensions wiring', () => {
+        const pivotColumn = 'a_dim1';
+
+        const authorizedAccount = {
+            ...sessionAccount,
+            user: {
+                ...sessionAccount.user,
+                ability: new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['view'] },
+                    { subject: 'SavedChart', action: ['view'] },
+                ]),
+            },
+        } as unknown as Account;
+
+        const bigNumberChart = {
+            uuid: 'savedChartUuid',
+            name: 'Big number chart',
+            organizationUuid: projectSummary.organizationUuid,
+            projectUuid,
+            spaceUuid: 'spaceUuid',
+            tableName: validExplore.name,
+            metricQuery: metricQueryMock,
+            parameters: undefined,
+            pivotConfig: { columns: [pivotColumn] },
+            chartConfig: { type: ChartType.BIG_NUMBER },
+        };
+
+        test('passes savedChart.pivotConfig.columns as pivotDimensions to prepareMetricQueryAsyncQueryArgs', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock, {
+                savedChartModel: {
+                    get: jest.fn(async () => bigNumberChart),
+                } as unknown as SavedChartModel,
+                analyticsModel: {
+                    addChartViewEvent: jest.fn(async () => {}),
+                } as unknown as AnalyticsModel,
+            });
+
+            service.getExploreWithUserAccessControls = jest
+                .fn()
+                .mockResolvedValue({
+                    explore: validExplore,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                });
+            (service as AnyType).getWarehouseCredentials = jest
+                .fn()
+                .mockResolvedValue(warehouseClientMock.credentials);
+            service.combineParameters = jest.fn().mockResolvedValue(undefined);
+            (service as AnyType).getMetricQueryFields = jest
+                .fn()
+                .mockResolvedValue({ fields: {} });
+
+            const prepareSpy = jest.fn().mockResolvedValue({
+                sql: 'SELECT 1',
+                fields: {},
+                warnings: [],
+                parameterReferences: [],
+                missingParameterReferences: [],
+                usedParameters: {},
+                responseMetricQuery: metricQueryMock,
+                userAccessControls: {
+                    userAttributes: {},
+                    intrinsicUserAttributes: {},
+                },
+                availableParameterDefinitions: {},
+            });
+            (service as AnyType).prepareMetricQueryAsyncQueryArgs = prepareSpy;
+
+            service['executeAsyncQuery'] = jest.fn().mockResolvedValue({
+                queryUuid: 'queryUuid',
+                cacheMetadata: { cacheHit: false },
+            });
+
+            await service.executeAsyncSavedChartQuery({
+                account: authorizedAccount,
+                projectUuid,
+                chartUuid: bigNumberChart.uuid,
+                versionUuid: undefined,
+                context: QueryExecutionContext.CHART,
+                invalidateCache: false,
+                limit: undefined,
+                parameters: undefined,
+                pivotResults: false,
+                filterOverrides: undefined,
+            });
+
+            expect(prepareSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    pivotDimensions: [pivotColumn],
+                }),
             );
         });
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3303,6 +3303,7 @@ export class AsyncQueryService extends ProjectService {
         parameters,
         projectUuid,
         pivotConfiguration,
+        pivotDimensions,
         userAttributeOverrides,
         materializationRole,
         columnTimezone,
@@ -3324,6 +3325,13 @@ export class AsyncQueryService extends ProjectService {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
         pivotConfiguration?: PivotConfiguration;
+        /**
+         * Chart's pivotConfig.columns, for chart types that build no
+         * pivotConfiguration (big number, map, sankey) but still need row_total()
+         * to resolve — see BuildQueryProps.pivotDimensions. Defaults to the
+         * metricQuery's own pivotDimensions (the explorer path).
+         */
+        pivotDimensions?: string[];
         columnTimezone?: string;
         sessionTimezone?: string | null;
         /**
@@ -3387,7 +3395,7 @@ export class AsyncQueryService extends ProjectService {
             parameters,
             availableParameterDefinitions,
             pivotConfiguration,
-            pivotDimensions: metricQuery.pivotDimensions,
+            pivotDimensions: pivotDimensions ?? metricQuery.pivotDimensions,
             useTimezoneAwareDateTrunc,
             columnTimezone,
             applyDateZoomToFilters,
@@ -4771,6 +4779,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            pivotDimensions: savedChart.pivotConfig?.columns,
             columnTimezone: getColumnTimezone(warehouseCredentials),
             preloadedUserAccessControls,
         });
@@ -5231,6 +5240,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            pivotDimensions: savedChart.pivotConfig?.columns,
             columnTimezone: getColumnTimezone(warehouseCredentials),
             sessionTimezone,
             preloadedUserAccessControls: userAccessControls,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8523

## Summary

A big number chart whose selected field is a table calculation using `row_total()` over a pivoted metric (e.g. `count / NULLIF(row_total(count), 0)`) rendered `1` (100%) on dashboards and in the saved-chart view, while the explorer/edit path showed the correct ratio (e.g. `0.309`).

Affects big number charts (and any chart type that builds no pivot configuration — map, sankey, etc.). Table and cartesian charts are unaffected.

## Root cause

`row_total()` is not computed client-side — it compiles to a `row_totals` CTE that `SUM`s the metric across pivot columns. That CTE is only emitted when the query carries pivot context. Big number charts return `undefined` from `derivePivotConfigurationFromChart`, and the stored chart's `metricQuery` has no `pivotDimensions` (the pivot lives in `pivotConfig.columns`). So on the saved-chart and dashboard async paths the builder saw no pivot at all:

```ts
// MetricQueryBuilder.replaceTotalReferences — no pivot → row_total(count) becomes count
const hasPivot =
    !!this.args.pivotConfiguration ||
    (this.args.pivotDimensions && this.args.pivotDimensions.length > 0);
result = result.replace(rowTotalRegex, hasPivot ? `${q}$1__row_total${q}` : `${q}$1${q}`);
```

The denominator collapsed to the bare metric, so `count / count = 1`. The explorer path works because its `metricQuery.pivotDimensions` is populated and flows to the builder — `pivotDimensions` is the documented lightweight signal that lets `row_total()` resolve without a full pivot configuration.

## Fix

Pass the chart's `pivotConfig.columns` as `pivotDimensions` on the saved-chart and dashboard-chart async paths, matching what the explorer already sends. This emits the `row_totals` CTE without pivoting the result rows (result spreading is driven by `pivotConfiguration`, which big number still doesn't get).

- `AsyncQueryService.ts` — `prepareMetricQueryAsyncQueryArgs` gains an optional `pivotDimensions` arg (defaults to `metricQuery.pivotDimensions`); `executeAsyncSavedChartQuery` and `executeAsyncDashboardChartQuery` pass `savedChart.pivotConfig?.columns`.
- No change for table/cartesian charts: `getNonPivotDimensionIds()` prefers `pivotConfiguration.indexColumn`, so the extra arg is a no-op when a pivot configuration exists.

## Before / After

Same saved chart, `count / NULLIF(row_total(count), 0)` as the big number:

```
Surface              Before     After
Explorer / edit      0.309      0.309   (always correct)
Saved-chart view     1          0.309
Dashboard tile       1          0.309
```

## Test plan

- [x] `pnpm -F backend typecheck:fast && pnpm -F backend lint`
- [x] `pnpm -F backend test -- AsyncQueryService.test` — 49 pass, added regression `executeAsyncSavedChartQuery pivotDimensions wiring` (verified it fails when the fix is reverted)
- [x] Manual: dashboard tile + saved-chart view now show `0.309`, matching explorer
- [x] Manual: confirmed reproducible without any dashboard filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)