### PR TITLE
fix(sql-runner): restore warehouse type when MCP share link clears it

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.test.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.test.ts
@@ -1,0 +1,49 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    initialState,
+    setState,
+    setWarehouseConnectionType,
+    sqlRunnerSlice,
+} from './sqlRunnerSlice';
+
+const { reducer } = sqlRunnerSlice;
+
+describe('sqlRunnerSlice warehouseConnectionType', () => {
+    it('setState replaces the slice and clears warehouseConnectionType when the payload omits it', () => {
+        // Simulates a share link (e.g. from the MCP `run_sql` tool) whose payload
+        // has no warehouseConnectionType: useSqlRunnerShareUrl spreads it over
+        // initialState, so the value arrives as undefined.
+        const withWarehouse = reducer(
+            undefined,
+            setWarehouseConnectionType(WarehouseTypes.SNOWFLAKE),
+        );
+        expect(withWarehouse.warehouseConnectionType).toBe(
+            WarehouseTypes.SNOWFLAKE,
+        );
+
+        const sharePayload = {
+            ...initialState,
+            sql: 'SELECT 1',
+            fetchResultsOnLoad: true,
+        };
+        const afterSetState = reducer(withWarehouse, setState(sharePayload));
+
+        expect(afterSetState.warehouseConnectionType).toBeUndefined();
+    });
+
+    it('setWarehouseConnectionType restores the value after it was clobbered (not permanently lost)', () => {
+        const clobbered = reducer(
+            undefined,
+            setState({ ...initialState, sql: 'SELECT 1' }),
+        );
+        expect(clobbered.warehouseConnectionType).toBeUndefined();
+
+        const restored = reducer(
+            clobbered,
+            setWarehouseConnectionType(WarehouseTypes.POSTGRES),
+        );
+
+        expect(restored.warehouseConnectionType).toBe(WarehouseTypes.POSTGRES);
+    });
+});

--- a/packages/frontend/src/pages/SqlRunner.tsx
+++ b/packages/frontend/src/pages/SqlRunner.tsx
@@ -52,6 +52,9 @@ const SqlRunner = ({
     const dispatch = useAppDispatch();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const mode = useAppSelector((state) => state.sqlRunner.mode);
+    const warehouseConnectionType = useAppSelector(
+        (state) => state.sqlRunner.warehouseConnectionType,
+    );
 
     const params = useParams<{ projectUuid: string; slug?: string }>();
     const share = useSearchParams('share');
@@ -148,18 +151,15 @@ const SqlRunner = ({
         }
     }, [dispatch, data]);
 
+    // Share links replace the whole slice via `setState`, dropping this
+    // project-derived field; re-restore it whenever the store value is missing.
+    const warehouseType = project?.warehouseConnection?.type;
     useEffect(() => {
-        if (project?.warehouseConnection?.type) {
-            dispatch(
-                setWarehouseConnectionType(project.warehouseConnection.type),
-            );
-            dispatch(
-                setQuoteChar(
-                    getFieldQuoteChar(project?.warehouseConnection?.type),
-                ),
-            );
+        if (warehouseType && !warehouseConnectionType) {
+            dispatch(setWarehouseConnectionType(warehouseType));
+            dispatch(setQuoteChar(getFieldQuoteChar(warehouseType)));
         }
-    }, [dispatch, project?.warehouseConnection?.type]);
+    }, [dispatch, warehouseType, warehouseConnectionType]);
 
     const handleSetSidebarOpen = (isOpen: boolean) => {
         dispatch(setSidebarOpen(isOpen));


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8506

## Summary

SQL Runner share links produced by the MCP `run_sql` tool (`/projects/{uuid}/sql-runner?share={nanoid}`) render a blank SQL editor for the recipient — the editor pane shows the "Warehouse connection not available" suboptimal state instead of the shared SQL, so the query can't be read, copied, or run. Links created from the SQL Runner UI's own Share button are unaffected.

It reproduces most consistently when the project is already cache-warm for the viewer (e.g. they were browsing the project, or open the link in a session where the project query is cached).

## Root cause

`warehouseConnectionType` is project-derived state that lives in the SQL Runner Redux slice. Opening a share link fully replaces the slice via `setState`, and MCP-generated payloads omit `warehouseConnectionType` (they carry only `sql` + optional `limit`), so it lands as `undefined`. The only code that restored it was an effect keyed solely on the project's warehouse type:

```ts
useEffect(() => {
    if (project?.warehouseConnection?.type) {
        dispatch(setWarehouseConnectionType(project.warehouseConnection.type));
        dispatch(setQuoteChar(getFieldQuoteChar(project.warehouseConnection.type)));
    }
}, [dispatch, project?.warehouseConnection?.type]);
```

When the project is already cached, this effect fires once on mount (setting the type), then the share `setState` resolves a moment later and clears it. The effect's dependency (the project's type string) never changes, so it doesn't re-fire — and `SqlEditor` renders `if (!warehouseConnectionType) → "Warehouse connection not available"`. It's a race: the restore effect must win *and* never need to run again, which only holds when the project resolves after the share.

The MCP share feature (#23358) introduced these links; this field was simply never part of the share payload, and the UI-Share path happens to serialize it.

## Fix

Make the restore self-healing: depend on the current store value and re-restore whenever it's missing but the project has a warehouse type. This is order-independent — it no longer matters whether the share `setState` lands before or after the project resolves.

- `packages/frontend/src/pages/SqlRunner.tsx` — restore effect now keys on the current `warehouseConnectionType` and re-applies it (and the derived `quoteChar`) when it's cleared. The `warehouseType && !warehouseConnectionType` guard makes it idempotent (no dispatch loop) and leaves projects with no warehouse connection untouched.
- `packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.test.ts` — regression test documenting the `setState` clobber and that the value is recoverable.
- Kept frontend-only: the fix covers any share link missing the field, not just MCP ones, so the backend payload was left unchanged.

## Before / After

```
Recipient opens an MCP share link (project cache-warm):

Before                                  After
┌───────────── SQL ─────────────┐       ┌───────────── SQL ─────────────┐
│                               │       │ 1  SELECT 42 AS blank_repro,  │
│            (!)                │       │      7 AS another_col         │
│  Warehouse connection         │       │                               │
│      not available            │       │                               │
└───────────────────────────────┘       └───────────────────────────────┘
  results visible but SQL              SQL editor populated, editable,
  unreadable / uncopyable              runnable
```

Verified live against the dev instance: dispatching the exact share-load `setState` that previously left the editor blank now self-heals — `warehouseConnectionType` goes `postgres → undefined → postgres` and the editor renders the SQL.

## Test plan

- [x] `pnpm -F frontend lint` — clean (0 errors); `typecheck:fast` adds no new errors (13 pre-existing jest-dom errors in unrelated test files)
- [x] `pnpm -F frontend test -- src/features/sqlRunner` — 2 tests pass (added regression in `sqlRunnerSlice.test.ts`)
- [x] Manual: open an MCP-style share link with the project cache-warm → editor renders the SQL instead of "Warehouse connection not available"
- [x] Manual: UI-generated share links and projects with no warehouse connection still behave the same