### PR TITLE
fix: chart language map fallback

### DIFF
--- a/packages/common/src/utils/i18n/chartAsCode.test.ts
+++ b/packages/common/src/utils/i18n/chartAsCode.test.ts
@@ -60,7 +60,7 @@ describe('ChartAsCodeInternalization', () => {
             );
         });
 
-        it('should throw error for chart with missing eChartsConfig for cartesian type', () => {
+        it('should handle chart with missing eChartsConfig for cartesian type', () => {
             // Create a chart with cartesian type but missing eChartsConfig
             const chartAsCode: ChartAsCode = {
                 dashboardSlug: undefined,
@@ -72,10 +72,8 @@ describe('ChartAsCodeInternalization', () => {
                 spaceSlug: 'test-space',
                 chartConfig: {
                     type: ChartType.CARTESIAN,
-                    config: {
-                        // Missing eChartsConfig
-                    },
-                } as ChartConfig,
+                    config: {},
+                } as unknown as ChartConfig,
                 metricQuery: {
                     exploreName: 'test_explore',
                     dimensions: [],
@@ -95,10 +93,16 @@ describe('ChartAsCodeInternalization', () => {
             };
 
             const chartAsCodeInternalization = new ChartAsCodeInternalization();
-
-            expect(() => {
+            const languageMap =
                 chartAsCodeInternalization.getLanguageMap(chartAsCode);
-            }).toThrow();
+
+            expect(languageMap.chart[chartAsCode.slug]).toMatchObject({
+                name: 'Test Chart',
+                description: '',
+            });
+            expect(
+                languageMap.chart[chartAsCode.slug].chartConfig,
+            ).toBeUndefined();
         });
 
         it('should handle valid pie chart', () => {

--- a/packages/common/src/utils/i18n/chartAsCode.ts
+++ b/packages/common/src/utils/i18n/chartAsCode.ts
@@ -139,19 +139,21 @@ export class ChartAsCodeInternalization extends AsCodeInternalization<
     }
 
     public getLanguageMap(chartAsCode: ChartAsCode) {
-        const parsedChartAsCode = this.schema
-            .deepPartial()
-            .strip()
-            .safeParse(chartAsCode);
+        const languageMapSchema = this.schema.deepPartial().strip();
+        type ChartAsCodeLanguageMapEntry = z.infer<typeof languageMapSchema>;
+
+        const parsedChartAsCode = languageMapSchema.safeParse(chartAsCode);
+        const languageMapEntry: ChartAsCodeLanguageMapEntry =
+            parsedChartAsCode.success
+                ? parsedChartAsCode.data
+                : chartAsCodeSchema
+                      .pick({ name: true, description: true })
+                      .strip()
+                      .parse(chartAsCode);
 
         return {
             chart: {
-                [chartAsCode.slug]: parsedChartAsCode.success
-                    ? parsedChartAsCode.data
-                    : chartAsCodeSchema
-                          .pick({ name: true, description: true })
-                          .strip()
-                          .parse(chartAsCode),
+                [chartAsCode.slug]: languageMapEntry,
             },
         };
     }

--- a/packages/common/src/utils/i18n/chartAsCode.ts
+++ b/packages/common/src/utils/i18n/chartAsCode.ts
@@ -139,12 +139,19 @@ export class ChartAsCodeInternalization extends AsCodeInternalization<
     }
 
     public getLanguageMap(chartAsCode: ChartAsCode) {
+        const parsedChartAsCode = this.schema
+            .deepPartial()
+            .strip()
+            .safeParse(chartAsCode);
+
         return {
             chart: {
-                [chartAsCode.slug]: this.schema
-                    .deepPartial()
-                    .strip()
-                    .parse(chartAsCode),
+                [chartAsCode.slug]: parsedChartAsCode.success
+                    ? parsedChartAsCode.data
+                    : chartAsCodeSchema
+                          .pick({ name: true, description: true })
+                          .strip()
+                          .parse(chartAsCode),
             },
         };
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-8477
Closes: #24689

### Description:
This updates chart-as-code language map generation so full schema extraction can fail without causing the chart language map entry to be skipped. When full extraction fails, the chart still returns a minimal language map with the always-translatable `name` and `description` fields. The regression test now covers cartesian runtime data missing `eChartsConfig` while keeping the Zod cartesian schema aligned with the TypeScript chart config type.