### PR TITLE
fix(content-table): debounce search and stop per-keystroke table re-renders

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -109,12 +109,19 @@ const DebouncedSearchInput = memo(
         const [value, setValue] = useState('');
         const debouncedOnSearch = useDebouncedCallback(onSearch, 300);
 
-        // Calling the debounced callback again (incl. on clear) cancels any
-        // pending call, so a stale keystroke can't resurrect the search.
-        const handleChange = (newValue: string) => {
-            setValue(newValue);
-            debouncedOnSearch(newValue);
-        };
+        // Debounce typing. Clearing (empty value) flushes immediately; re-invoking
+        // the debounced fn cancels any pending call so a stale keystroke can't
+        // resurrect a just-cleared search.
+        const handleChange = useCallback(
+            (newValue: string) => {
+                setValue(newValue);
+                debouncedOnSearch(newValue);
+                if (newValue === '') {
+                    debouncedOnSearch.flush();
+                }
+            },
+            [debouncedOnSearch],
+        );
 
         return (
             <Tooltip withinPortal variant="xs" label="Search by name">

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -13,6 +13,7 @@ import {
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
+import { useDebouncedCallback } from '@mantine-8/hooks';
 import {
     ActionIcon,
     Anchor,
@@ -39,8 +40,8 @@ import {
     IconX,
 } from '@tabler/icons-react';
 import {
+    memo,
     useCallback,
-    useDeferredValue,
     useEffect,
     useMemo,
     useRef,
@@ -100,6 +101,77 @@ type ResourceView2Props = Partial<ContentTableOptions<ResourceViewItem>> & {
 };
 
 const defaultSpaces: SpaceSummary[] = [];
+
+// Self-contained search input: holds the typed value locally and only lifts the
+// debounced value to the parent, so keystrokes don't re-render the whole table.
+const DebouncedSearchInput = memo(
+    ({ onSearch }: { onSearch: (value: string) => void }) => {
+        const [value, setValue] = useState('');
+        const debouncedOnSearch = useDebouncedCallback(onSearch, 300);
+
+        // Calling the debounced callback again (incl. on clear) cancels any
+        // pending call, so a stale keystroke can't resurrect the search.
+        const handleChange = (newValue: string) => {
+            setValue(newValue);
+            debouncedOnSearch(newValue);
+        };
+
+        return (
+            <Tooltip withinPortal variant="xs" label="Search by name">
+                <TextInput
+                    size="xs"
+                    radius="md"
+                    styles={(inputTheme) => ({
+                        input: {
+                            height: 32,
+                            width: 309,
+                            padding: `${inputTheme.spacing.xs} ${inputTheme.spacing.sm}`,
+                            textOverflow: 'ellipsis',
+                            fontSize: inputTheme.fontSizes.sm,
+                            fontWeight: 400,
+                            color: value
+                                ? inputTheme.colors.ldGray[8]
+                                : inputTheme.colors.ldGray[5],
+                            boxShadow: inputTheme.shadows.subtle,
+                            border: `1px solid ${inputTheme.colors.ldGray[3]}`,
+                            '&:hover': {
+                                border: `1px solid ${inputTheme.colors.ldGray[4]}`,
+                            },
+                            '&:focus': {
+                                border: `1px solid ${inputTheme.colors.blue[5]}`,
+                            },
+                        },
+                    })}
+                    type="search"
+                    variant="default"
+                    placeholder="Search by name"
+                    value={value}
+                    icon={
+                        <MantineIcon
+                            size="md"
+                            color="ldGray.6"
+                            icon={IconSearch}
+                        />
+                    }
+                    onChange={(e) => handleChange(e.target.value)}
+                    rightSection={
+                        value && (
+                            <ActionIcon
+                                onClick={() => handleChange('')}
+                                variant="transparent"
+                                size="xs"
+                                color="ldGray.5"
+                            >
+                                <MantineIcon icon={IconX} />
+                            </ActionIcon>
+                        )
+                    }
+                />
+            </Tooltip>
+        );
+    },
+);
+DebouncedSearchInput.displayName = 'DebouncedSearchInput';
 
 const InfiniteResourceTable = ({
     filters,
@@ -294,12 +366,11 @@ const InfiniteResourceTable = ({
     ];
     const [sorting, setSorting] =
         useState<ContentTableSortingState>(initialSorting);
-    const [search, setSearch] = useState<string | undefined>(undefined);
+    // Holds the debounced search value lifted from DebouncedSearchInput.
+    const [search, setSearch] = useState('');
     const [selectedContentType, setSelectedContentType] = useState<
         ContentType | undefined
     >(contentTypeFilter?.defaultValue);
-    const clearSearch = useCallback(() => setSearch(''), [setSearch]);
-    const deferredSearch = useDeferredValue(search);
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const rowVirtualizerInstanceRef =
         useRef<ContentTableVirtualizer<HTMLDivElement, HTMLTableRowElement>>(
@@ -343,7 +414,7 @@ const InfiniteResourceTable = ({
                 projectUuids: [filters.projectUuid],
                 page: 1,
                 pageSize: 25,
-                search: deferredSearch,
+                search,
                 sortBy: sortBy?.sortBy,
                 sortDirection: sortBy?.sortDirection,
                 includePersonalDataApps: filters.includePersonalDataApps,
@@ -595,63 +666,7 @@ const InfiniteResourceTable = ({
                 <Box>
                     <Group p={`${theme.spacing.lg} ${theme.spacing.xl}`}>
                         <Group spacing="xs">
-                            <Tooltip
-                                withinPortal
-                                variant="xs"
-                                label="Search by name"
-                            >
-                                {/* Search input */}
-                                <TextInput
-                                    size="xs"
-                                    radius="md"
-                                    styles={(inputTheme) => ({
-                                        input: {
-                                            height: 32,
-                                            width: 309,
-                                            padding: `${inputTheme.spacing.xs} ${inputTheme.spacing.sm}`,
-                                            textOverflow: 'ellipsis',
-                                            fontSize: inputTheme.fontSizes.sm,
-                                            fontWeight: 400,
-                                            color: search
-                                                ? inputTheme.colors.ldGray[8]
-                                                : inputTheme.colors.ldGray[5],
-                                            boxShadow:
-                                                inputTheme.shadows.subtle,
-                                            border: `1px solid ${inputTheme.colors.ldGray[3]}`,
-                                            '&:hover': {
-                                                border: `1px solid ${inputTheme.colors.ldGray[4]}`,
-                                            },
-                                            '&:focus': {
-                                                border: `1px solid ${inputTheme.colors.blue[5]}`,
-                                            },
-                                        },
-                                    })}
-                                    type="search"
-                                    variant="default"
-                                    placeholder="Search by name"
-                                    value={search ?? ''}
-                                    icon={
-                                        <MantineIcon
-                                            size="md"
-                                            color="ldGray.6"
-                                            icon={IconSearch}
-                                        />
-                                    }
-                                    onChange={(e) => setSearch(e.target.value)}
-                                    rightSection={
-                                        search && (
-                                            <ActionIcon
-                                                onClick={clearSearch}
-                                                variant="transparent"
-                                                size="xs"
-                                                color="ldGray.5"
-                                            >
-                                                <MantineIcon icon={IconX} />
-                                            </ActionIcon>
-                                        )
-                                    }
-                                />
-                            </Tooltip>
+                            <DebouncedSearchInput onSearch={setSearch} />
 
                             {contentTypeFilter &&
                             contentTypeFilter.options.length > 1 ? (
@@ -774,7 +789,7 @@ const InfiniteResourceTable = ({
             showProgressBars: false,
             showSkeletons: isInitialLoading, // loading for the first time with no data
             density: 'md',
-            globalFilter: search ?? '',
+            globalFilter: search,
         },
         mantineLoadingOverlayProps: {
             loaderProps: {


### PR DESCRIPTION
### Description:

The "All spaces/dashboards/charts/data apps" search fired a /api/v2/content request on every keystroke and re-rendered the entire InfiniteResourceTable on each keypress (rebuilding the columns and the useContentTable config), making the input laggy and tripping React's "Maximum update depth exceeded" limit when typing fast.

Extract the input into a memoised DebouncedSearchInput that holds the typed text locally and debounces (300ms) internally, lifting only the debounced value to the parent. Keystrokes now re-render just the input, and the table re-renders at most once per typing pause. useDeferredValue (which is not a debounce) is removed.

Before (watch the after for speed comparison):

https://github.com/user-attachments/assets/3442c3ef-8971-4424-8b92-f3b538ae976f



After:


https://github.com/user-attachments/assets/623d6d45-68f7-4798-83e9-ca901b3aa355




