### PR TITLE
fix(omnibar): use subtle dark shade for search group dividers in dark mode

### DIFF
--- a/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemGroups.module.css
@@ -4,13 +4,13 @@
     padding-right: var(--mantine-spacing-md);
     background-color: light-dark(
         var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-6)
+        var(--mantine-color-ldDark-2)
     );
 
     &:hover {
         background-color: light-dark(
             var(--mantine-color-ldGray-1),
-            var(--mantine-color-ldDark-5)
+            var(--mantine-color-ldDark-3)
         );
     }
 }


### PR DESCRIPTION
### Description:
The global search result group dividers used ldDark-6 (#7a7a7a, a glaring mid-gray) in dark mode, because in dark mode the ldDark scale runs darkest at index 0. Switch to ldDark-2/ldDark-3 so the divider band sits subtly lighter than the dropdown body, mirroring the light-mode look.


Before:
<img width="869" height="1358" alt="Screenshot 2026-06-26 at 12 07 07" src="https://github.com/user-attachments/assets/06325df5-d55e-4f19-9db4-c72e4dd73d5b" />


After:
<img width="869" height="1358" alt="after" src="https://github.com/user-attachments/assets/ac91725a-e034-481a-af69-58d42b23026d" />
