### PR TITLE
fix(slack): stop link unfurls toggle reverting to on after refresh

### DIFF
--- a/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
+++ b/packages/backend/src/ee/services/CommercialSlackIntegrationService.ts
@@ -71,6 +71,7 @@ export class CommercialSlackIntegrationService extends SlackIntegrationService<C
             aiRequireOAuth: installation.aiRequireOAuth,
             aiMultiAgentChannelId: installation.aiMultiAgentChannelId,
             aiMultiAgentProjectUuids: installation.aiMultiAgentProjectUuids,
+            unfurlsEnabled: installation.unfurlsEnabled,
         };
 
         return response;

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -100,6 +100,7 @@ export class SlackIntegrationService<
             hasRequiredScopes: this.slackClient.hasRequiredScopes(
                 installation.scopes,
             ),
+            unfurlsEnabled: installation.unfurlsEnabled,
         };
 
         return response;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8514

## Summary

In Settings → Integrations → Slack, toggling "Enable link unfurls" off shows a success toast but the toggle springs back to on after a refresh. The setting appears to never persist.

## Root cause

The setting *does* persist — the write path is correct and stores `unfurls_enabled = false` in `slack_auth_tokens`. The bug is on the read path: both builders of the `GET /api/v1/slack/` response rebuild the `SlackSettings` object field by field and never copy `unfurlsEnabled`, so the field is absent from the response entirely.

```ts
// CommercialSlackIntegrationService.getInstallationFromOrganizationUuid
const response: SlackSettings = {
    ...
    aiMultiAgentProjectUuids: installation.aiMultiAgentProjectUuids,
    // unfurlsEnabled never copied → dropped from the response
};
```

The frontend form then re-initialises from a missing field:

```ts
unfurlsEnabled: slackInstallation.unfurlsEnabled ?? true  // undefined ?? true → true
```

So the toggle always reads back as on, regardless of the stored value. `SlackSettings` already declared `unfurlsEnabled?`, and the models already returned it (`row.unfurls_enabled ?? true`) — only the two service response builders dropped it.

Round-trip, before vs after the fix:

```
write  PUT /custom-settings {unfurlsEnabled:false}  → DB: unfurls_enabled = false   (both)
read   GET /slack/                                   → response.unfurlsEnabled:
          Before:  (absent)  → form: undefined ?? true  → toggle ON   ✗
          After:   false     → form: false              → toggle OFF  ✓
```

## Fix

Copy `unfurlsEnabled` from the model result into the `SlackSettings` response in both code paths, so the GET reflects the stored value.

- `services/SlackIntegrationService/SlackIntegrationService.ts` — add `unfurlsEnabled: installation.unfurlsEnabled` to the response (serves OSS orgs).
- `ee/services/CommercialSlackIntegrationService.ts` — same, in the override that serves AI/EE orgs (it rebuilds the response without calling `super`, so it needs its own line).
- Write path, type, and models left untouched — they were already correct.

## Test plan

- [x] `pnpm -F backend typecheck:fast && pnpm -F backend lint`
- [x] Manual: seed a `slack_auth_tokens` row, `GET /api/v1/slack/` now returns `unfurlsEnabled` matching the DB (`false`→`false`, `true`→`true`); previously the field was absent. Full round-trip via `PUT /custom-settings` then `GET` confirmed.
- [ ] Manual (UI): toggle "Enable link unfurls" off → Save → refresh → stays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)