### PR TITLE
fix(data-apps): honor data-screenshot-bounds for delivery screenshot height

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1800,6 +1800,18 @@ export class UnfurlService extends BaseService {
                                 // of overflow.
                                 const contentHeight = await appFrame.evaluate(
                                     () => {
+                                        // Opt-in: honor an element flagged with
+                                        // `data-screenshot-bounds` as the content extent.
+                                        const explicit = document.querySelector(
+                                            '[data-screenshot-bounds]',
+                                        );
+                                        if (explicit) {
+                                            const r =
+                                                explicit.getBoundingClientRect();
+                                            if (r.width > 0 && r.height > 0) {
+                                                return Math.ceil(r.bottom);
+                                            }
+                                        }
                                         let maxBottom = 0;
                                         const root =
                                             document.querySelector('#root') ??


### PR DESCRIPTION
### Description:
After the CDP viewport fix, data-app delivery screenshots render at the right
width but are often too tall — apps using `min-h-screen`/full-viewport
backgrounds expand to the 4000px iframe, so the content-height measurement
reports ~4000px and the image is mostly empty space.

The APP content-height `evaluate` now uses an element flagged with
`data-screenshot-bounds` (its `rect.bottom`) when present, otherwise falls
through to the existing leaf-walk unchanged. APP-only, inside the existing
try/catch; height only.