### PR TITLE
fix(test): stop duplicate ssh2 native addon crashing jest workers

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -46,6 +46,7 @@ jest.mock('e2b', () => ({
     TimeoutError: class TimeoutError extends Error {},
     ALL_TRAFFIC: 'all',
 }));
+jest.mock('dockerode', () => jest.fn());
 // The service talks to a SandboxProvider, never a concrete SDK. Keep the real
 // error classes (the service branches on them with instanceof) but stub the
 // factory so the run() tests inject a fake provider over the fake sandbox.


### PR DESCRIPTION
## Problem

The backend `Build & Test` job (`backend#test`) has been failing across most open PRs since the morning of 2026-06-26. A jest worker is killed by `SIGSEGV`/`SIGTRAP` — intermittently with the V8 fatal assertion `# Check failed: node->IsInUse().` — and a **different test suite fails each run** (`CsvService`, `EmbedService`, `ProjectModel`, `PreAggregation…`). `main` is mostly green, so it reads as flaky.

## Root cause

A **duplicate `ssh2` native crypto addon** corrupting a V8 global handle on load — not OOM, and not a bug in the suites that show red (they're random victims of whichever worker dies).

- The tree now carries **two** compiled `ssh2` copies: `1.14.0` (warehouse SSH tunnels) and `1.17.0` (via `dockerode → docker-modem → ssh2`, added with the Docker sandbox provider in #24743).
- `AiWritebackService.test.ts` is the **only** backend unit test that evaluates the real `SandboxRuntime` barrel (`jest.requireActual('../SandboxRuntime')`), which statically imports `DockerSandboxProvider` → eagerly `import Docker from 'dockerode'`. #24767 introduced that `requireActual` on the morning of 2026-06-26 — matching the onset exactly.
- When both `sshcrypto.node` addons `dlopen` into the jest worker pool in the wrong order, the second registration double-frees a V8 global handle and aborts the worker (`node->IsInUse()`).

Reproduced locally with the native stack: `DLOpen → ssh2 sshcrypto.node init() → ChaChaPolyCipher::Init → v8::GlobalHandles::NodeSpace::Release`. `--runInBand` masks it (safe load order); parallel mode crashes ~1-in-5 runs.

## This change (minimal / scoped)

Mock `dockerode` in `AiWritebackService.test.ts` so the `ssh2@1.17.0` native chain never enters a jest worker. Since this is the only test that loads the real barrel, the run is left with a single `ssh2` addon → no dual-load → no crash.

```ts
jest.mock('dockerode', () => jest.fn());
```

**Tradeoff:** this is the low-risk "stop the bleeding" fix — one line, test-only. It does **not** remove the underlying duplicate-`ssh2` hazard or the eager native import; any *future* test that loads the real `SandboxRuntime` barrel would need the same guard. The structural fix is in #24818.

## Verification

- ✅ Confirmed `AiWritebackService.test.ts` is the only backend `*.test.ts` importing `dockerode` / loading the real `SandboxRuntime` barrel — so this scoped mock covers the entire known crash path.
- ⏳ Local full-suite parallel runs in progress; CI on this PR is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
