### PR TITLE
fix(gitlab): paginate branch list so previews show all branches

### DIFF
--- a/packages/backend/src/clients/gitlab/Gitlab.test.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.test.ts
@@ -1,5 +1,6 @@
 import fetchMock from 'jest-fetch-mock';
 import {
+    getBranches,
     getFileContent,
     getGitlabRepoTree,
     getMergeRequestComments,
@@ -165,6 +166,70 @@ describe('GitlabClient.getGitlabRepoTree', () => {
 
         const error = await getGitlabRepoTree(args).catch((e) => e);
         expect(isGitlabRateLimitError(error)).toBe(true);
+    });
+});
+
+describe('GitlabClient.getBranches', () => {
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    const args = {
+        owner: 'my-group',
+        repo: 'my-repo',
+        token: 'glpat-xxx',
+    };
+
+    // One GitLab branches API page plus the x-next-page header GitLab uses for
+    // pagination (empty string ⇒ last page).
+    const branchPage = (
+        branches: Array<{ name: string; protected?: boolean }>,
+        nextPage: string,
+    ) =>
+        [
+            JSON.stringify(branches),
+            { headers: { 'x-next-page': nextPage } },
+        ] as const;
+
+    it('follows x-next-page across pages and returns every branch', async () => {
+        fetchMock.mockResponseOnce(
+            ...branchPage([{ name: 'main', protected: true }], '2'),
+        );
+        fetchMock.mockResponseOnce(
+            ...branchPage([{ name: 'feature/a', protected: false }], ''),
+        );
+
+        const branches = await getBranches(args);
+
+        expect(fetchMock.mock.calls).toHaveLength(2);
+        expect(branches).toEqual([
+            { name: 'main', protected: true },
+            { name: 'feature/a', protected: false },
+        ]);
+        // requests the max page size and walks pages in order
+        expect(fetchMock.mock.calls[0][0]).toContain('per_page=100');
+        expect(fetchMock.mock.calls[0][0]).toContain('page=1');
+        expect(fetchMock.mock.calls[1][0]).toContain('page=2');
+    });
+
+    it('stops after a single page when x-next-page is empty', async () => {
+        fetchMock.mockResponseOnce(...branchPage([{ name: 'main' }], ''));
+
+        const branches = await getBranches(args);
+
+        expect(fetchMock.mock.calls).toHaveLength(1);
+        expect(branches).toEqual([{ name: 'main' }]);
+    });
+
+    it('requests branches on a self-hosted host when hostDomain is provided', async () => {
+        fetchMock.mockResponseOnce(...branchPage([], ''));
+
+        await getBranches({ ...args, hostDomain: 'gitlab.internal.acme.com' });
+
+        const [url] = fetchMock.mock.calls[0];
+        expect(url).toContain(
+            'https://gitlab.internal.acme.com/api/v4/projects/my-group%2Fmy-repo/repository/branches',
+        );
     });
 });
 

--- a/packages/backend/src/clients/gitlab/Gitlab.ts
+++ b/packages/backend/src/clients/gitlab/Gitlab.ts
@@ -81,11 +81,11 @@ export class GitlabRateLimitError extends LightdashError {
 export const isGitlabRateLimitError = (error: unknown): boolean =>
     error instanceof GitlabRateLimitError;
 
-const makeGitlabRequest = async (
+const makeGitlabResponse = async (
     url: string,
     token: string,
     options: RequestInit = {},
-) => {
+): Promise<Response> => {
     const response = await fetch(url, {
         ...options,
         headers: {
@@ -123,6 +123,15 @@ const makeGitlabRequest = async (
         );
     }
 
+    return response;
+};
+
+const makeGitlabRequest = async (
+    url: string,
+    token: string,
+    options: RequestInit = {},
+) => {
+    const response = await makeGitlabResponse(url, token, options);
     return response.json();
 };
 
@@ -485,19 +494,45 @@ export const updateMergeRequest = async ({
     });
 };
 
+// GitLab paginates the branches endpoint and defaults to 20 per page, so a
+// single request silently truncates repos with more branches. Request the max
+// page size and follow `x-next-page` (empty on the last page) to collect them
+// all — matching the GitHub client's `octokit.paginate` behaviour.
+const GITLAB_BRANCHES_PER_PAGE = 100;
+// Safety cap (100 pages × 100 = 10000 branches) so a malformed/looping
+// `x-next-page` from a misbehaving (e.g. self-hosted) GitLab can't spin
+// forever. Real repos are well under this; same defensive pattern as the tree.
+const MAX_BRANCH_PAGES = 100;
+
 export const getBranches = async ({
     owner,
     repo,
     token,
     hostDomain = DEFAULT_GITLAB_HOST_DOMAIN,
-}: GitlabApiParams) => {
+}: GitlabApiParams): Promise<Array<{ name: string; protected?: boolean }>> => {
     const projectId = getProjectId(owner, repo);
-    const url = getApiUrl(
-        hostDomain,
-        `/projects/${projectId}/repository/branches`,
-    );
+    const branches: Array<{ name: string; protected?: boolean }> = [];
+    let page = 1;
 
-    const branches = await makeGitlabRequest(url, token);
+    for (let i = 0; i < MAX_BRANCH_PAGES; i += 1) {
+        const url = getApiUrl(
+            hostDomain,
+            `/projects/${projectId}/repository/branches?per_page=${GITLAB_BRANCHES_PER_PAGE}&page=${page}`,
+        );
+        // eslint-disable-next-line no-await-in-loop
+        const response = await makeGitlabResponse(url, token);
+        // eslint-disable-next-line no-await-in-loop
+        const pageBranches = (await response.json()) as Array<{
+            name: string;
+            protected?: boolean;
+        }>;
+        branches.push(...pageBranches);
+
+        const nextPage = Number(response.headers.get('x-next-page'));
+        if (!nextPage || Number.isNaN(nextPage)) break;
+        page = nextPage;
+    }
+
     return branches;
 };
 


### PR DESCRIPTION
## Summary

Creating a preview project against a GitLab-connected dbt project only listed the first 20 branches (alphabetically), and the branch search only matched within those 20. Any repository with more than 20 branches silently returned a partial list with no error.

Affects GitLab-connected projects only (direct PAT and OAuth). GitHub-connected projects were never affected.

## Root cause

`getBranches` issued a single request to GitLab's `/repository/branches` endpoint with no pagination parameters. GitLab paginates this endpoint and defaults to `per_page=20`, so the response was capped at the first page regardless of how many branches the repo had.

```ts
// Before — one request, no pagination → GitLab caps at 20
const url = getApiUrl(hostDomain, `/projects/${projectId}/repository/branches`);
const branches = await makeGitlabRequest(url, token);
return branches;
```

The GitHub client never had this problem because its `getBranches` uses `octokit.paginate`, which walks every page. The GitLab path simply never gained an equivalent.

## Fix

`getBranches` now requests the max page size (`per_page=100`) and follows GitLab's `x-next-page` response header until it's empty, collecting every branch — the same pagination idiom already used by `getGitlabRepoTree` in this file. The return shape is unchanged (`{ name, protected? }[]`), so both consumers in `GitIntegrationService` are unaffected.

- `packages/backend/src/clients/gitlab/Gitlab.ts` — paginate `getBranches` via `x-next-page`; extract `makeGitlabResponse` (returns the raw `Response`) so the loop can read pagination headers, with `makeGitlabRequest` now a thin `.json()` wrapper over it (behaviour-preserving for all other callers). Added a `MAX_BRANCH_PAGES` safety cap so a malformed/looping header from a misbehaving self-hosted GitLab can't spin forever.
- `packages/backend/src/clients/gitlab/Gitlab.test.ts` — regression tests for multi-page traversal, single-page termination, and self-hosted host.

## Behaviour

```
Repo with 45 branches, GET /repository/branches

Before:  page 1 (per_page=20) ─► 20 branches returned, rest dropped silently
                                  └─ search box only matches these 20

After:   page 1 (per_page=100, x-next-page: 2) ─► 45 branches
         page 2 (per_page=100, x-next-page: "") ─┘ all listed & searchable
```

## Test plan

- [x] `pnpm -F backend typecheck:fast` — clean
- [x] `pnpm -F backend exec eslint src/clients/gitlab/Gitlab.ts src/clients/gitlab/Gitlab.test.ts` — clean
- [x] `npx jest src/clients/gitlab/Gitlab.test.ts` — 11 tests pass (added regressions: follows `x-next-page` across pages; stops on empty `x-next-page`; self-hosted host)
- [ ] Manual: connect a GitLab repo with >20 branches, open Create Preview Project → all branches listed and searchable
- [ ] Manual: verify GitHub-connected preview creation still lists branches unchanged

Closes PROD-8329

🤖 Generated with [Claude Code](https://claude.com/claude-code)