### PR TITLE
feat: show verified badge in chart preview

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
@@ -1,3 +1,4 @@
+import { type ContentVerificationInfo } from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -9,7 +10,12 @@ import {
     Text,
     Tooltip,
 } from '@mantine-8/core';
-import { IconDots, IconExternalLink, IconX } from '@tabler/icons-react';
+import {
+    IconCircleCheckFilled,
+    IconDots,
+    IconExternalLink,
+    IconX,
+} from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import TruncatedText from '../../../../../components/common/TruncatedText';
@@ -24,6 +30,26 @@ import { AiSavedChartVisualization } from './AiSavedChartVisualization';
 
 type Props = {
     savedChartPreview: SavedChartPreviewData;
+};
+
+const VerifiedBadge: FC<{ verification: ContentVerificationInfo }> = ({
+    verification,
+}) => {
+    const verifiedDate = new Date(verification.verifiedAt).toLocaleDateString();
+
+    return (
+        <Tooltip
+            withinPortal
+            multiline
+            maw={300}
+            position="bottom"
+            label={`Verified by ${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName} on ${verifiedDate}`}
+        >
+            <Box component="span" lh={0} c="green.6">
+                <MantineIcon icon={IconCircleCheckFilled} size={16} />
+            </Box>
+        </Tooltip>
+    );
 };
 
 export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
@@ -100,6 +126,11 @@ export const AiSavedChartPreviewPanel: FC<Props> = ({ savedChartPreview }) => {
                     </Stack>
 
                     <Group gap={2} className={artifactStyles.headRight}>
+                        {savedChart.verification && (
+                            <VerifiedBadge
+                                verification={savedChart.verification}
+                            />
+                        )}
                         <Menu withinPortal position="bottom-end">
                             <Menu.Target>
                                 <Tooltip withinPortal label="More options">


### PR DESCRIPTION
### Summary
- Show a verified badge next to the saved chart preview actions menu when the saved chart is verified
- Reuse the existing verified icon/tooltip pattern with verifier and date details

### Verification
- pnpm -F frontend run formatter src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
- pnpm -F frontend run linter --fix src/ee/features/aiCopilot/components/ChatElements/AiSavedChartPreviewPanel.tsx
- Browser sanity check: saved chart preview still opens and header actions render

Relates: ZAP-543