### PR TITLE
fix: remove MCP auth warnings from agent thread UI

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7577,16 +7577,8 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
                 keepaliveInterval = undefined;
             }
         };
-        const streamWithMcpNotices = createUIMessageStream({
+        const uiMessageStream = createUIMessageStream({
             execute: ({ writer }) => {
-                for (const unavailableMcpServer of mcpToolSetup.unavailableMcpServers) {
-                    writer.write({
-                        type: 'data-mcp-unavailable',
-                        data: unavailableMcpServer,
-                        transient: true,
-                    });
-                }
-
                 // Keep the connection warm during long, output-silent tool
                 // calls so an idle-timeout proxy can't cut the stream (see
                 // STREAM_KEEPALIVE_INTERVAL_MS). `transient: true` → never
@@ -7651,7 +7643,7 @@ Use your existing tools to inspect them when relevant to the user's question. Wh
             pipeUIMessageStreamToResponse: (response) => {
                 pipeUIMessageStreamToResponse({
                     response,
-                    stream: streamWithMcpNotices,
+                    stream: uiMessageStream,
                 });
             },
             consumeStream: result.consumeStream.bind(result),

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.module.css
@@ -97,60 +97,6 @@
     flex-shrink: 0;
 }
 
-.mcpUnavailableNotice {
-    width: fit-content;
-    max-width: 100%;
-    border-radius: 999px;
-    padding: 5px 8px;
-    animation: cardSlideIn 280ms cubic-bezier(0.16, 1, 0.3, 1);
-    font-family: var(--mantine-font-family);
-
-    @mixin light {
-        background-color: var(--mantine-color-ldGray-0);
-    }
-
-    @mixin dark {
-        background-color: var(--mantine-color-dark-7);
-    }
-}
-
-.mcpUnavailableNoticeHeader {
-    min-width: 0;
-}
-
-.mcpUnavailableNoticeIconChip {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 20px;
-    border-radius: 999px;
-}
-
-.mcpUnavailableNoticeIcon {
-    flex-shrink: 0;
-    color: var(--mantine-color-ldGray-7);
-}
-
-.mcpUnavailableNoticeBody {
-    min-width: 0;
-}
-
-.mcpUnavailableNoticeLabel {
-    line-height: 1.1;
-    letter-spacing: 0;
-    color: var(--mantine-color-ldGray-8);
-}
-
-.mcpUnavailableNoticeMessage {
-    color: var(--mantine-color-ldGray-6);
-    letter-spacing: 0;
-}
-
-.mcpUnavailableNoticeAction {
-    align-self: center;
-}
-
 .sqlMarkdownCodeBlock {
     overflow: hidden;
     border: 1px solid var(--mantine-color-ldGray-2);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -31,7 +31,6 @@ import {
     IconCopy,
     IconExclamationCircle,
     IconMessageX,
-    IconPlug,
     IconRefresh,
     IconTerminal2,
     IconTestPipe,
@@ -45,7 +44,6 @@ import { Link } from 'react-router';
 import { type CustomRendererProps } from 'streamdown';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import MantineIcon from '../../../../../components/common/MantineIcon';
-import { useAiAgentPermission } from '../../hooks/useAiAgentPermission';
 import {
     useRetryAiAgentThreadMessageMutation,
     useUpdatePromptFeedbackMutation,
@@ -325,10 +323,6 @@ const AssistantBubbleContent: FC<{
     mcpServers,
     onDashboardLinkClick,
 }) => {
-    const canManageAgents = useAiAgentPermission({
-        action: 'manage',
-        projectUuid,
-    });
     const threadStreamingState = useAiAgentThreadStreamQuery(
         message.threadUuid,
     );
@@ -478,8 +472,6 @@ const AssistantBubbleContent: FC<{
         };
     })();
 
-    const mcpUnavailableNotices = streamingState?.mcpUnavailableNotices ?? [];
-
     return (
         <>
             {shouldShowRetry && (
@@ -538,68 +530,6 @@ const AssistantBubbleContent: FC<{
                     </Group>
                 </Paper>
             )}
-
-            {mcpUnavailableNotices.map((notice) => (
-                <Box
-                    key={notice.serverUuid}
-                    className={styles.mcpUnavailableNotice}
-                >
-                    <Group
-                        gap={8}
-                        align="flex-start"
-                        wrap="nowrap"
-                        className={styles.mcpUnavailableNoticeHeader}
-                    >
-                        <Box className={styles.mcpUnavailableNoticeIconChip}>
-                            <MantineIcon
-                                icon={IconPlug}
-                                size={12}
-                                stroke={1.7}
-                                className={styles.mcpUnavailableNoticeIcon}
-                            />
-                        </Box>
-                        <Stack
-                            gap={2}
-                            className={styles.mcpUnavailableNoticeBody}
-                        >
-                            <Text
-                                size="xs"
-                                fw={500}
-                                className={styles.mcpUnavailableNoticeLabel}
-                            >
-                                Couldn&apos;t connect to {notice.serverName}
-                            </Text>
-                            <Group gap={8} align="center" wrap="wrap">
-                                <Text
-                                    size="xs"
-                                    className={
-                                        styles.mcpUnavailableNoticeMessage
-                                    }
-                                >
-                                    {canManageAgents
-                                        ? 'Check connection settings.'
-                                        : 'Reach out to an agent administrator to update this MCP connection.'}
-                                </Text>
-                                {canManageAgents && (
-                                    <Button
-                                        component={Link}
-                                        to={`/projects/${projectUuid}/ai-agents/${agentUuid}/edit`}
-                                        variant="subtle"
-                                        color="gray"
-                                        size="compact-xs"
-                                        px={0}
-                                        className={
-                                            styles.mcpUnavailableNoticeAction
-                                        }
-                                    >
-                                        Open settings
-                                    </Button>
-                                )}
-                            </Group>
-                        </Stack>
-                    </Group>
-                </Box>
-            ))}
 
             {/* Reasoning lives inside the LiveActivityCard at all times, so
              *  there is one unified bento for the agent's process. */}

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.test.ts
@@ -2,7 +2,6 @@ import { SHOULD_AUTOBATCH } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 import {
     addReasoning,
-    addMcpUnavailableNotice,
     addToolCall,
     aiAgentThreadStreamSlice,
     appendStepProgress,
@@ -12,51 +11,6 @@ import {
 } from './aiAgentThreadStreamSlice';
 
 describe('aiAgentThreadStreamSlice', () => {
-    it('stores MCP unavailable notices once per server for the active stream', () => {
-        const startedState = aiAgentThreadStreamSlice.reducer(
-            undefined,
-            startStreaming({
-                threadUuid: 'thread-1',
-                messageUuid: 'message-1',
-            }),
-        );
-
-        const stateWithNotice = aiAgentThreadStreamSlice.reducer(
-            startedState,
-            addMcpUnavailableNotice({
-                threadUuid: 'thread-1',
-                notice: {
-                    serverUuid: 'server-1',
-                    serverName: 'Docs MCP',
-                    message: 'Connection refused',
-                    status: 'error',
-                },
-            }),
-        );
-
-        const dedupedState = aiAgentThreadStreamSlice.reducer(
-            stateWithNotice,
-            addMcpUnavailableNotice({
-                threadUuid: 'thread-1',
-                notice: {
-                    serverUuid: 'server-1',
-                    serverName: 'Docs MCP',
-                    message: 'Connection refused',
-                    status: 'error',
-                },
-            }),
-        );
-
-        expect(dedupedState['thread-1']?.mcpUnavailableNotices ?? []).toEqual([
-            {
-                serverUuid: 'server-1',
-                serverName: 'Docs MCP',
-                message: 'Connection refused',
-                status: 'error',
-            },
-        ]);
-    });
-
     it('marks high-frequency stream updates for Redux auto-batching', () => {
         const expectedMeta = { [SHOULD_AUTOBATCH]: true };
 
@@ -86,17 +40,6 @@ describe('aiAgentThreadStreamSlice', () => {
                 threadUuid: 'thread-1',
                 reasoningId: 'reasoning-1',
                 text: 'thinking',
-            }).meta,
-        ).toEqual(expectedMeta);
-        expect(
-            addMcpUnavailableNotice({
-                threadUuid: 'thread-1',
-                notice: {
-                    serverUuid: 'server-1',
-                    serverName: 'Docs MCP',
-                    message: 'Connection refused',
-                    status: 'error',
-                },
             }).meta,
         ).toEqual(expectedMeta);
         expect(

--- a/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/aiAgentThreadStreamSlice.ts
@@ -1,4 +1,3 @@
-import { type AiMcpServerConnectionStatus } from '@lightdash/common';
 import {
     createSlice,
     prepareAutoBatched,
@@ -14,13 +13,6 @@ type ToolCall = AiAgentToolCall & {
 type Reasoning = {
     reasoningId: string;
     parts: string[];
-};
-
-export type McpUnavailableNotice = {
-    serverUuid: string;
-    serverName: string;
-    message: string;
-    status: AiMcpServerConnectionStatus;
 };
 
 export type StepProgressMessage = {
@@ -68,7 +60,6 @@ export interface AiAgentThreadStreamingState {
     toolCalls: ToolCall[];
     reasoning: Reasoning[];
     decidedToolCallIds: string[];
-    mcpUnavailableNotices: McpUnavailableNotice[];
     /**
      * Ordered history of step-progress events emitted by the agent's
      * tools (e.g. "Starting sandbox…", "Cloning project…", "Editing
@@ -103,7 +94,6 @@ const initialThread: Omit<
     toolCalls: [],
     reasoning: [],
     decidedToolCallIds: [],
-    mcpUnavailableNotices: [],
     stepProgressMessages: [],
 };
 
@@ -355,31 +345,6 @@ export const aiAgentThreadStreamSlice = createSlice({
                 toolName: string | null;
             }>(),
         },
-        addMcpUnavailableNotice: {
-            reducer: (
-                state,
-                action: PayloadAction<{
-                    threadUuid: string;
-                    notice: McpUnavailableNotice;
-                }>,
-            ) => {
-                const { threadUuid, notice } = action.payload;
-                const streamingThread = state[threadUuid];
-                if (
-                    streamingThread &&
-                    !streamingThread.mcpUnavailableNotices.some(
-                        (existingNotice) =>
-                            existingNotice.serverUuid === notice.serverUuid,
-                    )
-                ) {
-                    streamingThread.mcpUnavailableNotices.push(notice);
-                }
-            },
-            prepare: prepareAutoBatched<{
-                threadUuid: string;
-                notice: McpUnavailableNotice;
-            }>(),
-        },
     },
 });
 
@@ -392,7 +357,6 @@ export const {
     setError,
     addToolCall,
     addReasoning,
-    addMcpUnavailableNotice,
     setImproveContextNotification,
     clearImproveContextNotification,
     appendStepProgress,

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
     getStreamToolCallPart,
-    getMcpUnavailableNoticeFromChunk,
     getStepProgressFromChunk,
 } from './useAiAgentThreadStreamMutation';
 
@@ -60,37 +59,6 @@ describe('getStreamToolCallPart', () => {
             toolResult: output,
             isPreliminary: false,
         });
-    });
-});
-
-describe('getMcpUnavailableNoticeFromChunk', () => {
-    it('parses MCP unavailable data chunks', () => {
-        expect(
-            getMcpUnavailableNoticeFromChunk({
-                type: 'data-mcp-unavailable',
-                data: {
-                    serverUuid: 'server-1',
-                    serverName: 'Docs MCP',
-                    message: 'Connection refused',
-                    status: 'error',
-                },
-                transient: true,
-            }),
-        ).toEqual({
-            serverUuid: 'server-1',
-            serverName: 'Docs MCP',
-            message: 'Connection refused',
-            status: 'error',
-        });
-    });
-
-    it('ignores unrelated chunks', () => {
-        expect(
-            getMcpUnavailableNoticeFromChunk({
-                type: 'text-start',
-                id: 'text-1',
-            }),
-        ).toBeNull();
     });
 });
 

--- a/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/streaming/useAiAgentThreadStreamMutation.ts
@@ -16,7 +16,6 @@ import { lightdashApiStream } from '../../../../api';
 import { getAiAgentApiBase } from '../hooks/aiAgentRouting';
 import {
     addReasoning,
-    addMcpUnavailableNotice,
     addToolCall,
     appendStepProgress,
     markToolCallDecided,
@@ -61,17 +60,6 @@ type StreamToolPart = {
     output?: unknown;
     preliminary?: boolean;
     state: string;
-};
-
-type McpUnavailableNoticeChunk = UIMessageChunk & {
-    type: 'data-mcp-unavailable';
-    data: {
-        serverUuid: string;
-        serverName: string;
-        message: string;
-        status: 'not_connected' | 'connecting' | 'connected' | 'error';
-    };
-    transient?: boolean;
 };
 
 type StepProgressChunk = UIMessageChunk & {
@@ -209,29 +197,6 @@ export const getStreamToolCallPart = (
     } as StreamToolCallPart;
 };
 
-export const getMcpUnavailableNoticeFromChunk = (
-    chunk: UIMessageChunk,
-): McpUnavailableNoticeChunk['data'] | null => {
-    if (
-        chunk.type === 'data-mcp-unavailable' &&
-        'data' in chunk &&
-        chunk.data &&
-        typeof chunk.data === 'object'
-    ) {
-        const data = chunk.data as McpUnavailableNoticeChunk['data'];
-        if (
-            typeof data.serverUuid === 'string' &&
-            typeof data.serverName === 'string' &&
-            typeof data.message === 'string' &&
-            typeof data.status === 'string'
-        ) {
-            return data;
-        }
-    }
-
-    return null;
-};
-
 export const getStepProgressFromChunk = (
     chunk: UIMessageChunk,
 ): { message: string; toolName: string | null } | null => {
@@ -312,17 +277,6 @@ export function useAiAgentThreadStreamMutation() {
                         const { done, value } = await rawChunkReader.read();
                         if (done) {
                             break;
-                        }
-
-                        const notice = getMcpUnavailableNoticeFromChunk(value);
-                        if (notice) {
-                            dispatch(
-                                addMcpUnavailableNotice({
-                                    threadUuid,
-                                    notice,
-                                }),
-                            );
-                            continue;
                         }
 
                         const stepProgress = getStepProgressFromChunk(value);


### PR DESCRIPTION
Connection warnings like "Couldn't connect to Linear MCP" / "Couldn't connect to Notion" were showing in the thread even when irrelevant to the request. Since users are already prompted to log in before sending a message, these notices are dropped from the thread UI.

This removes the `data-mcp-unavailable` stream write on the backend and the full frontend pipeline that parsed, stored (Redux), and rendered the notices.

The backend still resolves `unavailableMcpServers` internally — it's unchanged and continues to drive Slack OAuth login prompts and to inform the agent which servers are unauthenticated.