### PR TITLE
feat: show saved chart preview in launcher

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css
@@ -111,6 +111,22 @@
     flex-direction: column;
 }
 
+.previewPanel {
+    --mantine-scale: 0.9;
+    position: absolute;
+    bottom: calc(100% + var(--mantine-spacing-xs));
+    right: calc(
+        min(rem(440px), calc(100vw - var(--mantine-spacing-md) * 2)) +
+            var(--mantine-spacing-xs)
+    );
+    width: min(
+        rem(620px),
+        calc(100vw - rem(440px) - var(--mantine-spacing-md) * 3)
+    );
+    height: rem(640px);
+    max-height: min(rem(640px), calc(100vh - rem(80px)));
+}
+
 .panelHeader {
     display: flex;
     align-items: center;

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx
@@ -1,4 +1,4 @@
-import { Transition } from '@mantine-8/core';
+import { Box, Transition } from '@mantine-8/core';
 import { useMediaQuery } from '@mantine-8/hooks';
 import { useEffect, useRef, type FC } from 'react';
 import { useMatches } from 'react-router';
@@ -9,6 +9,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { AiSavedChartPreviewPanel } from '../ChatElements/AiSavedChartPreviewPanel';
 import styles from './AiAgentsLauncher.module.css';
 import {
     getLauncherPanelAgent,
@@ -52,6 +53,9 @@ const AiAgentsLauncherInner: FC = () => {
     );
     const activeAgentUuid = useAiAgentStoreSelector(
         (state) => state.aiAgentLauncher.activeAgentUuid,
+    );
+    const savedChartPreview = useAiAgentStoreSelector(
+        (state) => state.aiArtifact.savedChart,
     );
     const { dock } = useLauncherDock(activeProjectUuid);
 
@@ -106,6 +110,16 @@ const AiAgentsLauncherInner: FC = () => {
     const isPanelOpenSafe =
         mode === 'panel-open' &&
         (safeActiveThreadId !== null || safeActiveAgentUuid !== null);
+    const activeSavedChartPreview =
+        savedChartPreview?.projectUuid === activeProjectUuid
+            ? savedChartPreview
+            : null;
+    const lastSavedChartPreviewRef = useRef(activeSavedChartPreview);
+    if (activeSavedChartPreview) {
+        lastSavedChartPreviewRef.current = activeSavedChartPreview;
+    }
+    const transitionSavedChartPreview =
+        activeSavedChartPreview ?? lastSavedChartPreviewRef.current;
 
     // The launcher has no persistent affordance: it appears only when the
     // user opens a panel (via AskAiAgentMenuItem) or has active dock items.
@@ -117,6 +131,27 @@ const AiAgentsLauncherInner: FC = () => {
     return (
         <div className={styles.root}>
             <LauncherDock projectUuid={activeProjectUuid} agents={agents} />
+            {transitionSavedChartPreview && (
+                <Transition
+                    mounted={
+                        isPanelOpenSafe && activeSavedChartPreview !== null
+                    }
+                    transition="slide-up"
+                    duration={180}
+                    timingFunction="ease"
+                >
+                    {(transitionStyle) => (
+                        <Box
+                            className={styles.previewPanel}
+                            style={transitionStyle}
+                        >
+                            <AiSavedChartPreviewPanel
+                                savedChartPreview={transitionSavedChartPreview}
+                            />
+                        </Box>
+                    )}
+                </Transition>
+            )}
             <Transition
                 mounted={isPanelOpenSafe}
                 transition="slide-up"


### PR DESCRIPTION
### Description
- Mounts the saved chart preview panel from the global AI launcher, so chart links clicked from launcher conversations open beside the chat instead of only working on full AI thread pages.
- Keeps the user on the current app page while showing the chart preview with title, description, verified badge, More options, and close controls.

### Verification
- `pnpm -F frontend run formatter src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css`
- `pnpm -F frontend run linter --fix src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.tsx src/ee/features/aiCopilot/components/Launcher/AiAgentsLauncher.module.css`
- `pnpm -F frontend run typecheck:fast` fails on existing jest-dom matcher type errors in unrelated test files; no errors from this change.
- Verified in browser on a dashboard route: launcher conversation chart link opens preview, chart loads, current URL stays on dashboard, More options and close controls show, verified badge shows for verified content.

Relates: ZAP-543
