### PR TITLE
fix(date-zoom): preserve date zoom tileTargets in dashboards as code

### DIFF
--- a/packages/api-tests/tests/contentAsCode.test.ts
+++ b/packages/api-tests/tests/contentAsCode.test.ts
@@ -201,6 +201,67 @@ describe('Dashboards as Code API', () => {
         const updatedDashboard = response.body.results.dashboards[0].data;
         expect(updatedDashboard.description).toBe(newDescription);
     });
+
+    it('should preserve date zoom controls and tileTargets through upload/download round-trip', async () => {
+        // The fixture tiles have no tileSlug, so date zoom tileTargets are keyed
+        // by chartSlug. On upload the slug is resolved to the tile's (regenerated)
+        // uuid, and on download it is converted back to the slug.
+        const controlUuid = '11111111-1111-4111-8111-111111111111';
+        const targetSlug = 'how-many-orders-we-have-over-time';
+        const dashboardWithDateZoom = {
+            ...dashboardAsCode,
+            config: {
+                isDateZoomDisabled: false,
+                dateZoomConfig: {
+                    controls: [
+                        {
+                            uuid: controlUuid,
+                            name: 'Orders zoom',
+                            granularity: 'Week',
+                        },
+                    ],
+                    tileTargets: {
+                        [targetSlug]: {
+                            controlUuid,
+                            fieldId: 'orders_order_date',
+                            tableName: 'orders',
+                        },
+                    },
+                },
+            },
+        };
+
+        const uploadResponse = await admin.post<any>(
+            `/api/v1/projects/${projectUuid}/dashboards/${dashboardAsCode.slug}/code`,
+            dashboardWithDateZoom,
+        );
+        expect(uploadResponse.status).toBe(200);
+        expect(uploadResponse.body.results.dashboards[0].action).toBe('update');
+
+        const downloadResponse = await admin.get<any>(
+            `/api/v1/projects/${projectUuid}/dashboards/code?ids=${dashboardAsCode.slug}`,
+        );
+        expect(downloadResponse.status).toBe(200);
+        const downloaded = downloadResponse.body.results.dashboards[0];
+
+        // Control definition survives, keyed by its own uuid
+        expect(downloaded.config.dateZoomConfig.controls).toEqual([
+            {
+                uuid: controlUuid,
+                name: 'Orders zoom',
+                granularity: 'Week',
+            },
+        ]);
+
+        // tileTargets survives the round-trip, re-keyed back to the tile slug
+        expect(downloaded.config.dateZoomConfig.tileTargets).toEqual({
+            [targetSlug]: {
+                controlUuid,
+                fieldId: 'orders_order_date',
+                tableName: 'orders',
+            },
+        });
+    });
 });
 
 describe('SQL Charts as Code API', () => {

--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -224,6 +224,269 @@ describe('CoderService', () => {
         });
     });
 
+    describe('getConfigWithDateZoomTileSlugs', () => {
+        it('should convert date zoom tileTargets tile UUIDs to slugs', () => {
+            const mockDashboard = {
+                config: {
+                    isDateZoomDisabled: false,
+                    dateZoomConfig: {
+                        controls: [
+                            {
+                                uuid: 'control-1',
+                                name: 'Revenue zoom',
+                                granularity: 'WEEK',
+                            },
+                        ],
+                        tileTargets: {
+                            'uuid-1': {
+                                controlUuid: 'control-1',
+                                fieldId: 'orders_order_date',
+                                tableName: 'orders',
+                            },
+                        },
+                    },
+                },
+                tiles: [
+                    {
+                        uuid: 'uuid-1',
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: { chartSlug: 'slug-1' },
+                    },
+                ],
+            } as AnyType;
+
+            const result =
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard);
+
+            expect(result?.dateZoomConfig?.tileTargets).toEqual({
+                'slug-1': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+            });
+            // controls are untouched
+            expect(result?.dateZoomConfig?.controls).toEqual(
+                mockDashboard.config.dateZoomConfig.controls,
+            );
+        });
+
+        it('should drop tileTargets whose tile UUID no longer exists', () => {
+            const mockDashboard = {
+                config: {
+                    isDateZoomDisabled: false,
+                    dateZoomConfig: {
+                        controls: [
+                            {
+                                uuid: 'control-1',
+                                name: 'Revenue zoom',
+                                granularity: 'WEEK',
+                            },
+                        ],
+                        tileTargets: {
+                            'orphaned-uuid': {
+                                controlUuid: 'control-1',
+                                fieldId: 'orders_order_date',
+                                tableName: 'orders',
+                            },
+                        },
+                    },
+                },
+                tiles: [],
+            } as AnyType;
+
+            const result =
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard);
+
+            expect(result?.dateZoomConfig?.tileTargets).toEqual({});
+        });
+
+        it('should return config unchanged when there is no dateZoomConfig', () => {
+            const mockDashboard = {
+                config: { isDateZoomDisabled: false },
+                tiles: [],
+            } as AnyType;
+
+            const result =
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard);
+
+            expect(result).toEqual({ isDateZoomDisabled: false });
+        });
+
+        it('should return undefined when there is no config', () => {
+            const mockDashboard = { tiles: [] } as AnyType;
+
+            expect(
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('getConfigWithDateZoomTileUuids', () => {
+        const tilesWithUuids = [
+            {
+                uuid: 'uuid-1',
+                type: DashboardTileTypes.SAVED_CHART,
+                properties: { chartSlug: 'slug-1' },
+            },
+            {
+                uuid: 'uuid-2',
+                type: DashboardTileTypes.SAVED_CHART,
+                properties: { chartSlug: 'slug-2' },
+            },
+        ];
+
+        it('should convert date zoom tileTargets tile slugs to UUIDs', () => {
+            const config = {
+                isDateZoomDisabled: false,
+                dateZoomConfig: {
+                    controls: [
+                        {
+                            uuid: 'control-1',
+                            name: 'Revenue zoom',
+                            granularity: 'WEEK',
+                        },
+                    ],
+                    tileTargets: {
+                        'slug-1': {
+                            controlUuid: 'control-1',
+                            fieldId: 'orders_order_date',
+                            tableName: 'orders',
+                        },
+                    },
+                },
+            };
+
+            const result = CoderService.getConfigWithDateZoomTileUuids(
+                config as AnyType,
+                tilesWithUuids as AnyType,
+            );
+
+            expect(result.dateZoomConfig?.tileTargets).toEqual({
+                'uuid-1': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+            });
+        });
+
+        it('should log an error and skip a target whose slug does not match a tile', () => {
+            console.error = jest.fn();
+
+            const config = {
+                isDateZoomDisabled: false,
+                dateZoomConfig: {
+                    controls: [],
+                    tileTargets: {
+                        'slug-1': {
+                            controlUuid: 'control-1',
+                            fieldId: 'f1',
+                            tableName: 'orders',
+                        },
+                        'missing-slug': {
+                            controlUuid: 'control-1',
+                            fieldId: 'f2',
+                            tableName: 'orders',
+                        },
+                    },
+                },
+            };
+
+            const result = CoderService.getConfigWithDateZoomTileUuids(
+                config as AnyType,
+                tilesWithUuids as AnyType,
+            );
+
+            expect(console.error).toHaveBeenCalledWith(
+                'Tile with slug missing-slug not found for date zoom target',
+            );
+            expect(result.dateZoomConfig?.tileTargets).toEqual({
+                'uuid-1': {
+                    controlUuid: 'control-1',
+                    fieldId: 'f1',
+                    tableName: 'orders',
+                },
+            });
+        });
+
+        it('should return config unchanged when there is no dateZoomConfig', () => {
+            const config = { isDateZoomDisabled: false };
+
+            const result = CoderService.getConfigWithDateZoomTileUuids(
+                config as AnyType,
+                tilesWithUuids as AnyType,
+            );
+
+            expect(result).toEqual({ isDateZoomDisabled: false });
+        });
+    });
+
+    describe('date zoom config round-trip', () => {
+        it('should preserve tileTargets through download then upload', () => {
+            // Download: a saved dashboard keyed by the original tile UUID
+            const mockDashboard = {
+                config: {
+                    isDateZoomDisabled: false,
+                    dateZoomConfig: {
+                        controls: [
+                            {
+                                uuid: 'control-1',
+                                name: 'Revenue zoom',
+                                granularity: 'WEEK',
+                            },
+                        ],
+                        tileTargets: {
+                            'original-uuid': {
+                                controlUuid: 'control-1',
+                                fieldId: 'orders_order_date',
+                                tableName: 'orders',
+                            },
+                        },
+                    },
+                },
+                tiles: [
+                    {
+                        uuid: 'original-uuid',
+                        type: DashboardTileTypes.SAVED_CHART,
+                        properties: { chartSlug: 'revenue-over-time' },
+                    },
+                ],
+            } as AnyType;
+
+            const asCodeConfig =
+                CoderService.getConfigWithDateZoomTileSlugs(mockDashboard);
+
+            // As-code is keyed by slug, not the ephemeral tile UUID
+            expect(
+                Object.keys(asCodeConfig?.dateZoomConfig?.tileTargets ?? {}),
+            ).toEqual(['revenue-over-time']);
+
+            // Upload: the tile is re-created with a brand new UUID
+            const tilesWithNewUuids = [
+                {
+                    uuid: 'regenerated-uuid',
+                    type: DashboardTileTypes.SAVED_CHART,
+                    properties: { chartSlug: 'revenue-over-time' },
+                },
+            ];
+
+            const restoredConfig = CoderService.getConfigWithDateZoomTileUuids(
+                asCodeConfig as AnyType,
+                tilesWithNewUuids as AnyType,
+            );
+
+            // The target is re-attached to the new tile UUID, not lost
+            expect(restoredConfig.dateZoomConfig?.tileTargets).toEqual({
+                'regenerated-uuid': {
+                    controlUuid: 'control-1',
+                    fieldId: 'orders_order_date',
+                    tableName: 'orders',
+                },
+            });
+        });
+    });
+
     describe('convertTileWithSlugsToUuids', () => {
         it('should allow chart tiles with null chartSlug', async () => {
             const service = new CoderService({

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -395,7 +395,7 @@ export class CoderService extends BaseService {
         if (!config?.dateZoomConfig) return config;
 
         const tileTargets = Object.entries(
-            config.dateZoomConfig.tileTargets,
+            config.dateZoomConfig.tileTargets ?? {},
         ).reduce<Record<string, DateZoomTileTarget>>(
             (acc, [tileUuid, target]) => {
                 const tileSlug = CoderService.getChartSlugForTileUuid(
@@ -424,24 +424,27 @@ export class CoderService extends BaseService {
         const { dateZoomConfig } = config;
         if (!dateZoomConfig) return config;
 
-        const tileTargets = Object.entries(dateZoomConfig.tileTargets).reduce<
-            Record<string, DateZoomTileTarget>
-        >((acc, [tileSlug, target]) => {
-            const tileUuid = tilesWithUuids.find(
-                (t) =>
-                    isAnyChartTile(t) &&
-                    // Match first by tileSlug, then by chartSlug (for the case of tile not having a slug)
-                    (t.tileSlug === tileSlug ||
-                        t.properties.chartSlug === tileSlug),
-            )?.uuid;
-            if (!tileUuid) {
-                console.error(
-                    `Tile with slug ${tileSlug} not found for date zoom target`,
-                );
-                return acc;
-            }
-            return { ...acc, [tileUuid]: target };
-        }, {});
+        const tileTargets = Object.entries(
+            dateZoomConfig.tileTargets ?? {},
+        ).reduce<Record<string, DateZoomTileTarget>>(
+            (acc, [tileSlug, target]) => {
+                const tileUuid = tilesWithUuids.find(
+                    (t) =>
+                        isAnyChartTile(t) &&
+                        // Match first by tileSlug, then by chartSlug (for the case of tile not having a slug)
+                        (t.tileSlug === tileSlug ||
+                            t.properties.chartSlug === tileSlug),
+                )?.uuid;
+                if (!tileUuid) {
+                    console.error(
+                        `Tile with slug ${tileSlug} not found for date zoom target`,
+                    );
+                    return acc;
+                }
+                return { ...acc, [tileUuid]: target };
+            },
+            {},
+        );
 
         return {
             ...config,

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -40,7 +40,10 @@ import {
     SqlChartAsCode,
     UpdatedByUser,
     type ContentVerificationInfo,
+    type DashboardConfig,
     type DashboardTileWithSlug,
+    type DateZoomConfig,
+    type DateZoomTileTarget,
     type FilterGroup,
     type FilterGroupInput,
     type FilterGroupItem,
@@ -382,6 +385,70 @@ export class CoderService extends BaseService {
         };
     }
 
+    /* Convert date zoom control tileTargets from tile uuids to tile slugs
+     * DashboardDAO to DashboardAsCode
+     */
+    static getConfigWithDateZoomTileSlugs(
+        dashboard: DashboardDAO,
+    ): DashboardConfig | undefined {
+        const { config } = dashboard;
+        if (!config?.dateZoomConfig) return config;
+
+        const tileTargets = Object.entries(
+            config.dateZoomConfig.tileTargets,
+        ).reduce<Record<string, DateZoomTileTarget>>(
+            (acc, [tileUuid, target]) => {
+                const tileSlug = CoderService.getChartSlugForTileUuid(
+                    dashboard,
+                    tileUuid,
+                );
+                if (!tileSlug) return acc;
+                return { ...acc, [tileSlug]: target };
+            },
+            {},
+        );
+
+        return {
+            ...config,
+            dateZoomConfig: { ...config.dateZoomConfig, tileTargets },
+        };
+    }
+
+    /* Convert date zoom control tileTargets from tile slugs to tile uuids
+     * DashboardAsCode to DashboardDAO
+     */
+    static getConfigWithDateZoomTileUuids(
+        config: DashboardConfig,
+        tilesWithUuids: DashboardTileWithSlug[],
+    ): DashboardConfig {
+        const { dateZoomConfig } = config;
+        if (!dateZoomConfig) return config;
+
+        const tileTargets = Object.entries(dateZoomConfig.tileTargets).reduce<
+            Record<string, DateZoomTileTarget>
+        >((acc, [tileSlug, target]) => {
+            const tileUuid = tilesWithUuids.find(
+                (t) =>
+                    isAnyChartTile(t) &&
+                    // Match first by tileSlug, then by chartSlug (for the case of tile not having a slug)
+                    (t.tileSlug === tileSlug ||
+                        t.properties.chartSlug === tileSlug),
+            )?.uuid;
+            if (!tileUuid) {
+                console.error(
+                    `Tile with slug ${tileSlug} not found for date zoom target`,
+                );
+                return acc;
+            }
+            return { ...acc, [tileUuid]: target };
+        }, {});
+
+        return {
+            ...config,
+            dateZoomConfig: { ...dateZoomConfig, tileTargets },
+        };
+    }
+
     private static transformDashboard(
         dashboard: DashboardDAO,
         spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
@@ -471,7 +538,13 @@ export class CoderService extends BaseService {
             filters: CoderService.getFiltersWithTileSlugs(dashboard),
             tabs: dashboard.tabs,
             slug: dashboard.slug,
-            ...(dashboard.config ? { config: dashboard.config } : {}),
+            ...(dashboard.config
+                ? {
+                      config: CoderService.getConfigWithDateZoomTileSlugs(
+                          dashboard,
+                      ),
+                  }
+                : {}),
             ...(dashboard.parameters
                 ? { parameters: dashboard.parameters }
                 : {}),
@@ -1812,6 +1885,12 @@ export class CoderService extends BaseService {
             dashboardWithDefaults,
             tilesWithUuids,
         );
+        const dashboardConfig = dashboardWithDefaults.config
+            ? CoderService.getConfigWithDateZoomTileUuids(
+                  dashboardWithDefaults.config,
+                  tilesWithUuids,
+              )
+            : dashboardWithDefaults.config;
         // If chart does not exist, we can't use promoteService,
         // since it relies on information that's not available in ChartAsCode, and other uuids
         if (dashboardSummary === undefined) {
@@ -1832,6 +1911,7 @@ export class CoderService extends BaseService {
                     tiles: tilesWithUuids,
                     forceSlug: shouldUseExactSlug,
                     filters: dashboardFilters,
+                    config: dashboardConfig,
                 },
                 user,
                 projectUuid,
@@ -1878,6 +1958,7 @@ export class CoderService extends BaseService {
         const dashboardWithUuids = {
             ...dashboardWithDefaults,
             tiles: tilesWithUuids,
+            config: dashboardConfig,
         };
         const { promotedDashboard, upstreamDashboard } =
             await this.promoteService.getPromotedDashboard(


### PR DESCRIPTION
## What

Date zoom controls store their chart attachments (`tileTargets`) keyed by tile UUID. Dashboards as code regenerates tile UUIDs on every upload, so those attachments were silently dropped on a download/upload round trip, leaving controls orphaned (a pill attached to no charts).

This remaps `tileTargets` keys to tile slugs on download and back to UUIDs on upload, mirroring how dashboard filter `tileTargets` are already handled. Control definitions were unaffected (they are keyed by their own UUID); only the chart attachments were lost.

## Tests

- `CoderService` unit tests for slug/uuid conversion in both directions, plus a download then upload round-trip.
- An API round-trip test in the content-as-code suite that uploads a date zoom config and asserts the `tileTargets` survive download.

Closes https://linear.app/lightdash/issue/GLITCH-530/preserve-date-zoom-tiletargets-in-dashboards-as-code
