### PR TITLE
fix: cap notifications popover scroll height

### DIFF
--- a/packages/frontend/src/components/NavBar/NotificationsMenu/NotificationsMenu.module.css
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/NotificationsMenu.module.css
@@ -2,3 +2,8 @@
     /* Revert overflow so badge doesn't get cropped off */
     overflow: revert;
 }
+
+.dropdown {
+    max-height: 400px;
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
+++ b/packages/frontend/src/components/NavBar/NotificationsMenu/index.tsx
@@ -130,7 +130,7 @@ export const NotificationsMenu: FC<{ projectUuid: string }> = ({
                     </Indicator>
                 </Button>
             </Menu.Target>
-            <Menu.Dropdown maw="400px">
+            <Menu.Dropdown maw="400px" className={classes.dropdown}>
                 {hasValidationNotifications && (
                     <ValidationErrorNotification
                         projectUuid={projectUuid}


### PR DESCRIPTION
The notifications popover grew unbounded when many AI context notifications were present, producing a very long scrollable list.

This caps the dropdown's `max-height` at 400px and makes it scroll internally, so the popover stays usable regardless of how many notifications are flowing in.