### PR TITLE
feat(filters): support null as a selectable value in the 'is' filter

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3022,6 +3022,7 @@ const models: TsoaRoute.Models = {
     'FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_': {
         dataType: 'refObject',
         properties: {
+            includeNull: { dataType: 'boolean' },
             values: {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
@@ -4002,6 +4003,7 @@ const models: TsoaRoute.Models = {
     MetricFilterRule: {
         dataType: 'refObject',
         properties: {
+            includeNull: { dataType: 'boolean' },
             values: {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
@@ -4216,6 +4218,7 @@ const models: TsoaRoute.Models = {
     FilterRule: {
         dataType: 'refObject',
         properties: {
+            includeNull: { dataType: 'boolean' },
             values: {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
@@ -5057,6 +5060,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                includeNull: { dataType: 'boolean' },
                 values: {
                     dataType: 'array',
                     array: {
@@ -6897,6 +6901,7 @@ const models: TsoaRoute.Models = {
     JoinModelRequiredFilterRule: {
         dataType: 'refObject',
         properties: {
+            includeNull: { dataType: 'boolean' },
             values: {
                 dataType: 'array',
                 array: { dataType: 'refAlias', ref: 'AnyType' },
@@ -14217,17 +14222,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -14256,7 +14261,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                requiredFilters:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14264,68 +14269,14 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'nestedObjectLiteral',
-                                                                                                                        nestedProperties:
-                                                                                                                            {
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                settings:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'any',
-                                                                                                                                    },
-                                                                                                                                values: {
-                                                                                                                                    dataType:
-                                                                                                                                        'union',
-                                                                                                                                    subSchemas:
-                                                                                                                                        [
-                                                                                                                                            {
-                                                                                                                                                dataType:
-                                                                                                                                                    'array',
-                                                                                                                                                array: {
-                                                                                                                                                    dataType:
-                                                                                                                                                        'any',
-                                                                                                                                                },
-                                                                                                                                            },
-                                                                                                                                            {
-                                                                                                                                                dataType:
-                                                                                                                                                    'undefined',
-                                                                                                                                            },
-                                                                                                                                        ],
-                                                                                                                                },
-                                                                                                                                operator:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                tableName:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                fieldRef:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                                fieldId:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'string',
-                                                                                                                                        required: true,
-                                                                                                                                    },
-                                                                                                                            },
-                                                                                                                    },
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -14360,7 +14311,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                requiredFilters:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14368,14 +14319,68 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'nestedObjectLiteral',
+                                                                                                                        nestedProperties:
+                                                                                                                            {
+                                                                                                                                settings:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'any',
+                                                                                                                                    },
+                                                                                                                                values: {
+                                                                                                                                    dataType:
+                                                                                                                                        'union',
+                                                                                                                                    subSchemas:
+                                                                                                                                        [
+                                                                                                                                            {
+                                                                                                                                                dataType:
+                                                                                                                                                    'array',
+                                                                                                                                                array: {
+                                                                                                                                                    dataType:
+                                                                                                                                                        'any',
+                                                                                                                                                },
+                                                                                                                                            },
+                                                                                                                                            {
+                                                                                                                                                dataType:
+                                                                                                                                                    'undefined',
+                                                                                                                                            },
+                                                                                                                                        ],
+                                                                                                                                },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                tableName:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                fieldRef:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                fieldId:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                                operator:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'string',
+                                                                                                                                        required: true,
+                                                                                                                                    },
+                                                                                                                            },
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -14772,26 +14777,6 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -14808,6 +14793,13 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
                                                                                                         'false',
                                                                                                     ],
                                                                                                 },
@@ -14818,23 +14810,16 @@ const models: TsoaRoute.Models = {
                                                                                                         'not_applicable',
                                                                                                     ],
                                                                                                 },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
-                                                                                                    ],
-                                                                                                },
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -14863,17 +14848,7 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
@@ -14884,6 +14859,36 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             },
                                                                     },
                                                                     required: true,
@@ -14907,12 +14912,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'nestedObjectLiteral',
                                                                                                     nestedProperties:
                                                                                                         {
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             settings:
                                                                                                                 {
                                                                                                                     dataType:
@@ -14937,10 +14936,10 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
-                                                                                                            operator:
+                                                                                                            required:
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'string',
+                                                                                                                        'boolean',
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                             tableName:
@@ -14956,6 +14955,12 @@ const models: TsoaRoute.Models = {
                                                                                                                     required: true,
                                                                                                                 },
                                                                                                             fieldId:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
                                                                                                                 {
                                                                                                                     dataType:
                                                                                                                         'string',
@@ -30723,6 +30728,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                includeNull: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -31452,6 +31464,13 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'array', array: { dataType: 'any' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                includeNull: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
                         { dataType: 'undefined' },
                     ],
                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3096,6 +3096,10 @@
             },
             "FilterRule_FilterOperator.DashboardFieldTarget.AnyType.AnyType_": {
                 "properties": {
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
                     "values": {
                         "items": {
                             "$ref": "#/components/schemas/AnyType"
@@ -4260,6 +4264,10 @@
             "MetricFilterRule": {
                 "description": "Filter rule for metrics, targeting fields by reference",
                 "properties": {
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
                     "values": {
                         "items": {
                             "$ref": "#/components/schemas/AnyType"
@@ -4603,6 +4611,10 @@
             },
             "FilterRule": {
                 "properties": {
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
                     "values": {
                         "items": {
                             "$ref": "#/components/schemas/AnyType"
@@ -5702,6 +5714,10 @@
             },
             "BaseFilterRule_FilterOperator.number-or-string_": {
                 "properties": {
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
                     "values": {
                         "items": {
                             "anyOf": [
@@ -7936,6 +7952,10 @@
             },
             "JoinModelRequiredFilterRule": {
                 "properties": {
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
+                    },
                     "values": {
                         "items": {
                             "$ref": "#/components/schemas/AnyType"
@@ -15699,10 +15719,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -15711,8 +15731,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -15722,19 +15742,28 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "nullable": true
+                                                                        },
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
                                                                                     "settings": {},
                                                                                     "values": {
                                                                                         "items": {},
                                                                                         "type": "array"
                                                                                     },
-                                                                                    "operator": {
-                                                                                        "type": "string"
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -15744,30 +15773,21 @@
                                                                                     },
                                                                                     "fieldId": {
                                                                                         "type": "string"
+                                                                                    },
+                                                                                    "operator": {
+                                                                                        "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "required",
-                                                                                    "operator",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "fieldId"
+                                                                                    "fieldId",
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
-                                                                        },
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
@@ -15970,25 +15990,21 @@
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "isFromJoinedTable": {
                                                                                     "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
+                                                                                        "true",
                                                                                         "false",
-                                                                                        "not_applicable",
-                                                                                        "true"
+                                                                                        "not_applicable"
                                                                                     ]
                                                                                 },
-                                                                                "fieldFilterType": {
+                                                                                "fieldValueType": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldValueType": {
+                                                                                "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -15998,30 +16014,34 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldId": {
                                                                                     "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
-                                                                                "fieldFilterType",
                                                                                 "fieldValueType",
+                                                                                "fieldFilterType",
                                                                                 "fieldType",
-                                                                                "table",
                                                                                 "label",
-                                                                                "name",
-                                                                                "fieldId"
+                                                                                "fieldId",
+                                                                                "table",
+                                                                                "description",
+                                                                                "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -16032,16 +16052,13 @@
                                                                             "requiredFilters": {
                                                                                 "items": {
                                                                                     "properties": {
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
                                                                                         "settings": {},
                                                                                         "values": {
                                                                                             "items": {},
                                                                                             "type": "array"
                                                                                         },
-                                                                                        "operator": {
-                                                                                            "type": "string"
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         },
                                                                                         "tableName": {
                                                                                             "type": "string"
@@ -16051,14 +16068,17 @@
                                                                                         },
                                                                                         "fieldId": {
                                                                                             "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
                                                                                         }
                                                                                     },
                                                                                     "required": [
                                                                                         "required",
-                                                                                        "operator",
                                                                                         "tableName",
                                                                                         "fieldRef",
-                                                                                        "fieldId"
+                                                                                        "fieldId",
+                                                                                        "operator"
                                                                                     ],
                                                                                     "type": "object"
                                                                                 },
@@ -31401,6 +31421,10 @@
                         "items": {},
                         "type": "array",
                         "description": "Values to filter by"
+                    },
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
                     }
                 },
                 "required": ["target", "operator"],
@@ -32024,6 +32048,10 @@
                         "items": {},
                         "type": "array",
                         "description": "Values to filter by"
+                    },
+                    "includeNull": {
+                        "type": "boolean",
+                        "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule."
                     },
                     "tileTargets": {
                         "$ref": "#/components/schemas/Record_string.DashboardTileTarget_"
@@ -41461,7 +41489,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3253.1",
+        "version": "0.3254.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/cli/src/handlers/lint.ts
+++ b/packages/cli/src/handlers/lint.ts
@@ -73,6 +73,7 @@ export function findMalformedDashboardFilters(data: unknown): ErrorObject[] {
                 operator?: FilterOperator;
                 values?: unknown[] | null;
                 disabled?: boolean;
+                includeNull?: boolean;
                 label?: string;
                 target?: { fieldId?: string };
             };
@@ -82,6 +83,7 @@ export function findMalformedDashboardFilters(data: unknown): ErrorObject[] {
                     operator: f.operator,
                     values: f.values,
                     disabled: f.disabled,
+                    includeNull: f.includeNull,
                 })
             ) {
                 return;

--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -536,6 +536,26 @@ export const stringFilterRuleMocks = {
         operator: FilterOperator.EQUALS,
     },
 
+    equalsFilterWithMultiValAndNull: {
+        ...stringMultiValueFilter,
+        operator: FilterOperator.EQUALS,
+        includeNull: true,
+    },
+    equalsFilterWithMultiValAndNullSQL: `((${stringFilterDimension}) IN ('Tom','Jerry') OR (${stringFilterDimension}) IS NULL)`,
+
+    equalsFilterWithOnlyNull: {
+        ...noValueFilter,
+        operator: FilterOperator.EQUALS,
+        includeNull: true,
+    },
+    equalsFilterWithOnlyNullSQL: `(${stringFilterDimension}) IS NULL`,
+
+    equalsFilterWithNoValAndNoNull: {
+        ...noValueFilter,
+        operator: FilterOperator.EQUALS,
+    },
+    equalsFilterWithNoValAndNoNullSQL: 'true',
+
     includeFilterWithEmptyString: {
         ...emptyStringFilter,
         operator: FilterOperator.INCLUDE,

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1302,6 +1302,36 @@ describe('Filter SQL', () => {
         ).toBe(stringFilterRuleMocks.startsWithFilterWithEmptyStringSQL);
     });
 
+    test('should add OR IS NULL when equals filter includes null with values', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.equalsFilterWithMultiValAndNull,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.equalsFilterWithMultiValAndNullSQL);
+    });
+
+    test('should return IS NULL when equals filter includes null with no values', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.equalsFilterWithOnlyNull,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.equalsFilterWithOnlyNullSQL);
+    });
+
+    test('should return true when equals filter has no values and does not include null', () => {
+        expect(
+            renderStringFilterSql(
+                stringFilterDimension,
+                stringFilterRuleMocks.equalsFilterWithNoValAndNoNull,
+                "'",
+            ),
+        ).toBe(stringFilterRuleMocks.equalsFilterWithNoValAndNoNullSQL);
+    });
+
     test('should return true when ends with filter has empty string value', () => {
         expect(
             renderStringFilterSql(

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -131,15 +131,22 @@ export const renderStringFilterSql = (
         !caseSensitive ? String(value).toUpperCase() : value;
 
     switch (filter.operator) {
-        case FilterOperator.EQUALS:
-            return filter.values && filter.values.length > 0
-                ? `(${wrapDimension(dimensionSql)}) IN (${filter.values
-                      .map(
-                          (v) =>
-                              `${stringQuoteChar}${wrapValue(v)}${stringQuoteChar}`,
-                      )
-                      .join(',')})`
-                : 'true';
+        case FilterOperator.EQUALS: {
+            const inClause =
+                filter.values && filter.values.length > 0
+                    ? `(${wrapDimension(dimensionSql)}) IN (${filter.values
+                          .map(
+                              (v) =>
+                                  `${stringQuoteChar}${wrapValue(v)}${stringQuoteChar}`,
+                          )
+                          .join(',')})`
+                    : undefined;
+            if (filter.includeNull) {
+                const nullClause = `(${dimensionSql}) IS NULL`;
+                return inClause ? `(${inClause} OR ${nullClause})` : nullClause;
+            }
+            return inClause ?? 'true';
+        }
         case FilterOperator.NOT_EQUALS:
             return filter.values && filter.values.length > 0
                 ? `((${wrapDimension(dimensionSql)}) NOT IN (${filter.values

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -179,6 +179,10 @@
                     "description": "Unique identifier for the filter rule",
                     "type": "string"
                 },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
+                    "type": "boolean"
+                },
                 "operator": {
                     "$ref": "#/$defs/FilterOperator",
                     "description": "Filter operator"
@@ -1938,6 +1942,10 @@
                     "description": "Unique identifier for the filter",
                     "type": "string"
                 },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
+                    "type": "boolean"
+                },
                 "operator": {
                     "$ref": "#/$defs/FilterOperator",
                     "description": "Filter operator"
@@ -2227,6 +2235,10 @@
                 },
                 "disabled": {
                     "description": "Whether this filter is disabled",
+                    "type": "boolean"
+                },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
                     "type": "boolean"
                 },
                 "operator": {

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -736,6 +736,10 @@
                     "description": "Unique identifier for the filter",
                     "type": "string"
                 },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
+                    "type": "boolean"
+                },
                 "operator": {
                     "$ref": "#/$defs/FilterOperator",
                     "description": "Filter operator"
@@ -815,6 +819,10 @@
                 },
                 "disabled": {
                     "description": "Whether this filter is disabled",
+                    "type": "boolean"
+                },
+                "includeNull": {
+                    "description": "For the `equals` operator on string fields, also match rows where the\nfield is null (compiles to `field IN (...) OR field IS NULL`). Lets users\ncombine null with selected values in a single \"is\" rule.",
                     "type": "boolean"
                 },
                 "label": {

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -55,6 +55,12 @@ export type BaseFilterRule<O = FilterOperator, V = unknown> = {
     operator: O;
     /** Values to filter by */
     values?: V[];
+    /**
+     * For the `equals` operator on string fields, also match rows where the
+     * field is null (compiles to `field IN (...) OR field IS NULL`). Lets users
+     * combine null with selected values in a single "is" rule.
+     */
+    includeNull?: boolean;
 };
 
 export enum UnitOfTime {

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -223,9 +223,11 @@ export const isMalformedEmptyDashboardFilter = (filter: {
     operator: FilterOperator;
     values?: unknown[] | null;
     disabled?: boolean;
+    includeNull?: boolean;
 }): boolean =>
     filter.disabled !== true &&
     isWithValueFilter(filter.operator) &&
+    filter.includeNull !== true &&
     (!Array.isArray(filter.values) || filter.values.length === 0);
 
 export const getFilterRuleWithDefaultValue = <T extends FilterRule>(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -87,6 +87,16 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             onDropdownClose={popoverProps?.onClose}
                             values={(rule.values || []).filter(isString)}
                             singleValue={isSingleValue}
+                            showNullOption={
+                                rule.operator === FilterOperator.EQUALS
+                            }
+                            includeNull={rule.includeNull}
+                            onIncludeNullChange={(includeNull) =>
+                                onChange({
+                                    ...rule,
+                                    includeNull,
+                                })
+                            }
                             onChange={(values) =>
                                 onChange({
                                     ...rule,

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -45,6 +45,8 @@ import {
     isValueSelected,
     mergeWithHiddenValues,
     MORE_VALUES_TOKEN,
+    NULL_VALUE_LABEL,
+    NULL_VALUE_TOKEN,
     SUMMARY_MODE_THRESHOLD,
     wasTokenRemoved,
 } from './FilterStringAutoComplete.utils';
@@ -59,6 +61,10 @@ type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     suggestions: string[];
     onChange: (values: string[]) => void;
     singleValue?: boolean;
+    /** Show a static "(null)" option that toggles the rule's includeNull flag. */
+    showNullOption?: boolean;
+    includeNull?: boolean;
+    onIncludeNullChange?: (includeNull: boolean) => void;
 };
 
 // Single value component that mimics a single select behavior - maxSelectedValues={1} behaves weirdly so we don't use it.
@@ -133,8 +139,13 @@ const FilterStringAutoComplete: FC<Props> = ({
     onFocus: onInputFocus,
     onBlur: onInputBlur,
     singleValue,
+    showNullOption,
+    includeNull,
+    onIncludeNullChange,
     ...rest
 }) => {
+    // The "(null)" option is only meaningful for multi-value filters.
+    const showNull = !!showNullOption && !singleValue;
     const multiSelectRef = useRef<HTMLInputElement>(null);
     const { projectUuid, getAutocompleteFilterGroup, parameterValues } =
         useFiltersContext();
@@ -273,11 +284,17 @@ const FilterStringAutoComplete: FC<Props> = ({
         // Mantine does not show value tag if value is not found in data
         // so we need to add it manually here
         // also we are merging status indicator as a first item
-        return uniq([...results, ...values]).map((value) => ({
+        const valueData = uniq([...results, ...values]).map((value) => ({
             value,
             label: formatDisplayValue(value),
         }));
-    }, [results, values]);
+        return showNull
+            ? [
+                  ...valueData,
+                  { value: NULL_VALUE_TOKEN, label: NULL_VALUE_LABEL },
+              ]
+            : valueData;
+    }, [results, values, showNull]);
 
     const isSummaryMode =
         !singleValue && values.length > SUMMARY_MODE_THRESHOLD;
@@ -526,10 +543,10 @@ const FilterStringAutoComplete: FC<Props> = ({
                             // Override selection state to check against full values array
                             // This fixes the bug where hidden values (beyond display limit) appear
                             // unselected in dropdown even though they're actually selected
-                            const isSelected = isValueSelected(
-                                itemValue,
-                                values,
-                            );
+                            const isSelected =
+                                itemValue === NULL_VALUE_TOKEN
+                                    ? !!includeNull
+                                    : isValueSelected(itemValue, values);
                             const itemClassName = [
                                 className,
                                 isSelected
@@ -568,18 +585,41 @@ const FilterStringAutoComplete: FC<Props> = ({
                                   ]
                                 : data
                         }
-                        value={displayValues}
+                        value={
+                            showNull && includeNull
+                                ? [...displayValues, NULL_VALUE_TOKEN]
+                                : displayValues
+                        }
                         onDropdownOpen={onDropdownOpen}
                         onDropdownClose={() => {
                             handleResetSearch();
                             onDropdownClose?.();
                         }}
                         onChange={(updatedValues) => {
+                            const valuesWithoutNull = updatedValues.filter(
+                                (v) => v !== NULL_VALUE_TOKEN,
+                            );
+
+                            // The "(null)" option toggles includeNull on the rule
+                            // rather than becoming a real value. A single MultiSelect
+                            // change only ever toggles the null token OR edits real
+                            // values, so when the token's presence flips we update the
+                            // flag and stop — calling handleChange too would overwrite
+                            // includeNull from a stale rule and drop the flag.
+                            if (showNull) {
+                                const nextIncludeNull =
+                                    updatedValues.includes(NULL_VALUE_TOKEN);
+                                if (nextIncludeNull !== !!includeNull) {
+                                    onIncludeNullChange?.(nextIncludeNull);
+                                    return;
+                                }
+                            }
+
                             // If token was removed (backspace on truncated list), open modal instead
                             if (
                                 wasTokenRemoved(
                                     displayValues,
-                                    updatedValues,
+                                    valuesWithoutNull,
                                     hiddenCount,
                                 )
                             ) {
@@ -589,7 +629,7 @@ const FilterStringAutoComplete: FC<Props> = ({
 
                             // Merge with hidden values to prevent data loss in truncated mode
                             const finalValues = mergeWithHiddenValues(
-                                updatedValues,
+                                valuesWithoutNull,
                                 displayValues,
                                 values,
                             );

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.ts
@@ -3,6 +3,13 @@ export const SUMMARY_MODE_THRESHOLD = 500;
 export const MORE_VALUES_TOKEN = '__lightdash_more_values__';
 
 /**
+ * UI-only sentinel for the static "(null)" option. It never reaches the filter
+ * rule's `values`; selecting it toggles the rule's `includeNull` flag instead.
+ */
+export const NULL_VALUE_TOKEN = '__lightdash_null_value__';
+export const NULL_VALUE_LABEL = '(null)';
+
+/**
  * Computes display values for the MultiSelect component.
  * When there are more than INLINE_RENDER_LIMIT values, truncates to first N items
  * and appends a token representing the hidden items.

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.test.ts
@@ -34,6 +34,57 @@ describe('getConditionalRuleLabel', () => {
         });
     });
 
+    it('should append (null) for an equals string filter with includeNull', () => {
+        const rule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.EQUALS,
+            values: ['a', 'b'],
+            includeNull: true,
+        };
+
+        const result = getConditionalRuleLabel(
+            rule,
+            FilterType.STRING,
+            'Status',
+        );
+
+        expect(result.value).toBe('a, b, (null)');
+    });
+
+    it('should show only (null) when an equals string filter has no values but includeNull', () => {
+        const rule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.EQUALS,
+            values: [],
+            includeNull: true,
+        };
+
+        const result = getConditionalRuleLabel(
+            rule,
+            FilterType.STRING,
+            'Status',
+        );
+
+        expect(result.value).toBe('(null)');
+    });
+
+    it('should not append (null) for a non-equals string filter even if includeNull is set', () => {
+        const rule: BaseFilterRule = {
+            id: 'test-rule-id',
+            operator: FilterOperator.NOT_EQUALS,
+            values: ['a'],
+            includeNull: true,
+        };
+
+        const result = getConditionalRuleLabel(
+            rule,
+            FilterType.STRING,
+            'Status',
+        );
+
+        expect(result.value).toBe('a');
+    });
+
     it('should return correct labels for a number filter', () => {
         // Arrange
         const rule: BaseFilterRule = {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/utils.ts
@@ -30,6 +30,7 @@ import isEmpty from 'lodash/isEmpty';
 import uniq from 'lodash/uniq';
 import { type MomentInput } from 'moment';
 import { filterOperatorLabel } from './constants';
+import { NULL_VALUE_LABEL } from './FilterStringAutoComplete.utils';
 
 export const getFilterOptions = <T extends FilterOperator>(
     operators: Array<T>,
@@ -152,8 +153,19 @@ const getValueAsString = (
                 case FilterOperator.IN_BETWEEN:
                 case FilterOperator.NOT_IN_BETWEEN:
                     return `${firstValue || 0}, ${secondValue || 0}`;
-                default:
-                    return values?.join(', ');
+                default: {
+                    const joined = values?.join(', ');
+                    if (
+                        filterType === FilterType.STRING &&
+                        operator === FilterOperator.EQUALS &&
+                        rule.includeNull
+                    ) {
+                        return joined
+                            ? `${joined}, ${NULL_VALUE_LABEL}`
+                            : NULL_VALUE_LABEL;
+                    }
+                    return joined;
+                }
             }
         case FilterType.BOOLEAN:
             return values?.map(formatBoolean).join(', ');


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8193


## Before

<img width="2400" height="1726" alt="before-1-dropdown" src="https://github.com/user-attachments/assets/8e7e8995-cf2c-4158-a245-baf9224c5f57" />

## After

<img width="2400" height="1726" alt="after-1-dropdown" src="https://github.com/user-attachments/assets/3e09721b-34dc-4a45-9fa8-44ff949367f8" />

## Summary

String `is` filters can now include null rows alongside selected values. A
static `(null)` option appears in the value dropdown for the `equals` operator;
selecting it compiles to `field IN (...) OR field IS NULL`.

Previously null was deliberately excluded from filter autocomplete (#15640), so
users could only approximate this with `is not [...]` or an OR-mode `is null`
rule. This adds an explicit, first-class option without reintroducing null into
autocomplete suggestions.

## How it works

A new optional `includeNull` flag on the filter rule carries the intent —
`values` stays a clean `string[]`, and autocomplete still never returns null.

    Rule:     { operator: 'equals', values: ['SWITCH_OUT', 'MOVE_OUT'], includeNull: true }
    Compiles: (field IN ('SWITCH_OUT', 'MOVE_OUT') OR field IS NULL)

    Rule:     { operator: 'equals', values: [], includeNull: true }
    Compiles: field IS NULL

- **Type** (`common/types/filter.ts`): `includeNull?: boolean` on `BaseFilterRule`.
- **Compiler** (`common/compiler/filtersCompiler.ts`): the string `EQUALS` branch
  appends `OR (field) IS NULL` when `includeNull` is set; with no values it
  emits a bare `IS NULL`. All other operators/types are untouched.
- **UI** (`FilterStringAutoComplete.tsx`): a static `(null)` item is injected
  into the Mantine `MultiSelect` via a UI-only sentinel token. Toggling it flips
  `includeNull`; the token is stripped before values ever reach the rule, so it
  can never be persisted as a real value. Shown only for `equals`, multi-value
  string filters.
- **Label** (`FilterInputs/utils.ts`): the rule summary appends `(null)` for
  `equals` string rules with `includeNull`.
- **Validation** (`common/utils/filters.ts`, `cli/handlers/lint.ts`):
  `isMalformedEmptyDashboardFilter` treats `includeNull` as a value, so an
  `is (null)` rule with no other values is not flagged as empty.

## Out of scope

- Number/date/boolean filters and the `is not` operator — string `is` only,
  matching the request. The flag is ignored elsewhere.

## Test plan

- **Unit**: 3 compiler cases (`IN (...) OR IS NULL`, bare `IS NULL`, unchanged
  `IN (...)`) and 3 rule-label cases. `pnpm -F common test filtersCompiler` →
  273 passed; frontend `utils.test.ts` → green.
- **Backend SQL** (jaffle-shop, via compileQuery): `equals + values + includeNull`
  → `(... IN ('gold') OR ... IS NULL)`; `equals + [] + includeNull` → `... IS NULL`;
  `equals + values` (no flag) → `... IN ('gold')`.
- **UI e2e** (Explore, string dimension): `(null)` appears in the dropdown for
  `is`, renders as a removable chip alongside real values, and `includeNull: true`
  reaches the `metric-query` request. Removing the chip clears the flag. The
  option does not appear for `is not`.

## Notes

`pnpm generate-api` regenerated `swagger.json` / `routes.ts` /
`chart-as-code-1.0.json` / `dashboard-as-code-1.0.json`. Output is deterministic
(two consecutive runs identical); some unrelated re-ordering is the committed
spec catching up to the pinned toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)