### PR TITLE
fix: ai artifact grouped tables

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -84,6 +84,7 @@ export type VisualizationProviderProps = {
     containerHeight?: number;
     isDashboard?: boolean;
     isEditMode?: boolean;
+    hasExplorerStore?: boolean;
     dateZoom?: DateZoom;
 };
 
@@ -115,6 +116,7 @@ const VisualizationProvider: FC<
     containerHeight,
     isDashboard,
     isEditMode,
+    hasExplorerStore = true,
     dateZoom,
 }) => {
     const itemsMap = useMemo(() => {
@@ -359,6 +361,7 @@ const VisualizationProvider: FC<
         containerHeight,
         isDashboard,
         isEditMode,
+        hasExplorerStore,
         isTouchDevice,
         resolvedTimezone: lastValidResultsData?.resolvedTimezone,
     };

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -55,6 +55,7 @@ type VisualizationContext = {
     containerHeight?: number;
     isDashboard?: boolean;
     isEditMode?: boolean;
+    hasExplorerStore: boolean;
     // Touch device detection for tooltip positioning
     isTouchDevice: boolean;
     // Resolved timezone for formatting (undefined when EnableTimezoneSupport flag is off)

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -53,6 +53,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         isLoading,
         isEditMode,
         parameters,
+        hasExplorerStore,
     } = useVisualizationContext();
 
     const hasSignaledScreenshotReady = useRef(false);
@@ -303,10 +304,8 @@ const SimpleTable: FC<SimpleTableProps> = ({
             >
                 {pivotTableData.data && resultsData?.hasFetchedAllRows ? (
                     <>
-                        {/* Dashboard mode has no explorer store — use the plain
-                         * table; the explorer uses the sort-enabled variant. */}
-                        {isDashboard ? (
-                            <PivotTable
+                        {hasExplorerStore && !isDashboard ? (
+                            <ExplorerPivotTable
                                 className={className}
                                 data={pivotTableData.data}
                                 isMinimal={minimal}
@@ -328,7 +327,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
                                 {...rest}
                             />
                         ) : (
-                            <ExplorerPivotTable
+                            <PivotTable
                                 className={className}
                                 data={pivotTableData.data}
                                 isMinimal={minimal}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -216,6 +216,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
             resolvedTimezone={resolvedTimezone}
         >
             <VisualizationProvider
+                hasExplorerStore={false}
                 key={selectedChartType ?? 'default'}
                 resultsData={resultsData}
                 chartConfig={


### PR DESCRIPTION
## Description

AI-generated grouped table visualizations in agent artifacts could crash when rendered outside Explorer because the grouped table path used the Explorer-specific pivot table wrapper, which reads Explorer Redux state.

This adds an explicit visualization context flag for whether an Explorer store is available. Generated AI visualizations opt out, so grouped tables use the plain pivot table renderer while preserving normal non-minimal AI table interactions.

## Testing

- `./node_modules/.bin/oxfmt packages/frontend/src/components/LightdashVisualization/context.ts packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx packages/frontend/src/components/SimpleTable/index.tsx packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx --check`
- `PATH="$PWD/packages/frontend/node_modules/.bin:$PATH" ./packages/frontend/node_modules/.bin/oxlint -c packages/frontend/.oxlintrc.json --ignore-path .gitignore packages/frontend/src/components/LightdashVisualization/context.ts packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx packages/frontend/src/components/SimpleTable/index.tsx packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx`
- `./packages/frontend/node_modules/.bin/tsgo --project packages/frontend/tsconfig.fast.json --noEmit` fails on existing unrelated test matcher type errors
- sub-agent review: initial finding addressed; re-review no findings

Closes: PROD-8532