### PR TITLE
feat: honor granularity_labels override in chart-axis labels

### DIFF
--- a/packages/common/src/utils/bigNumber.test.ts
+++ b/packages/common/src/utils/bigNumber.test.ts
@@ -90,6 +90,14 @@ describe('resolveGranularityInLabel', () => {
         map.d = DateGranularity.YEAR;
         expect(resolveGranularityInLabel('${d.granularity}', map)).toBe('year');
     });
+
+    it('renders a standard-grain override verbatim (not lowercased)', () => {
+        expect(
+            resolveGranularityInLabel('Revenue by ${events_date.granularity}', {
+                events_date: { verbatim: 'Week starting Monday' },
+            }),
+        ).toBe('Revenue by Week starting Monday');
+    });
 });
 
 describe('getGranularityMapFromItems', () => {
@@ -126,6 +134,25 @@ describe('getGranularityMapFromItems', () => {
 
         expect(getGranularityMapFromItems(itemsMap)).toEqual({
             orders_order_date: 'Fiscal quarter',
+        });
+    });
+
+    it('uses the verbatim override label for a standard grain with timeIntervalLabel', () => {
+        const itemsMap = {
+            orders_order_date_week: {
+                fieldType: FieldType.DIMENSION,
+                type: DimensionType.DATE,
+                table: 'orders',
+                name: 'order_date_week',
+                label: 'Order date week starting monday',
+                timeInterval: TimeFrames.WEEK,
+                timeIntervalLabel: 'Week starting Monday',
+                timeIntervalBaseDimensionName: 'order_date',
+            },
+        } as unknown as ItemsMap;
+
+        expect(getGranularityMapFromItems(itemsMap)).toEqual({
+            orders_order_date: { verbatim: 'Week starting Monday' },
         });
     });
 });

--- a/packages/common/src/utils/bigNumber.ts
+++ b/packages/common/src/utils/bigNumber.ts
@@ -7,7 +7,15 @@ import {
 
 const GRANULARITY_PATTERN = /\$\{([^}]+)\.granularity\}/g;
 
-export type GranularityMap = Record<string, DateGranularity | string>;
+/** A standard grain whose label was overridden via project `granularity_labels`
+ *  (GLITCH-264). Carried verbatim so chart labels show it as-authored, unlike
+ *  standard/custom grains which are lowercased for the label. */
+type VerbatimGranularity = { verbatim: string };
+
+export type GranularityMap = Record<
+    string,
+    DateGranularity | string | VerbatimGranularity
+>;
 
 // Builds a base-field-id → active-granularity map from the query's items. The
 // fields already reflect the effective grain (date zoom is applied server-side
@@ -33,7 +41,11 @@ export const getGranularityMapFromItems = (
                 const granularity =
                     timeFrameToDateGranularityMap[field.timeInterval];
                 if (granularity) {
-                    map[baseId] = granularity;
+                    // A project `granularity_labels` override is baked onto the
+                    // dimension as `timeIntervalLabel`; render it verbatim.
+                    map[baseId] = field.timeIntervalLabel
+                        ? { verbatim: field.timeIntervalLabel }
+                        : granularity;
                 }
             }
         }
@@ -51,9 +63,11 @@ export const resolveGranularityInLabel = (
         GRANULARITY_PATTERN,
         (match, fieldBaseId: string) => {
             const granularity = granularityMap[fieldBaseId];
-            return granularity
-                ? getGranularityReferenceValue(granularity)
-                : match;
+            if (!granularity) return match;
+            // Overridden standard grains carry a verbatim label; everything
+            // else (DateGranularity, custom label) is lowercased as before.
+            if (typeof granularity === 'object') return granularity.verbatim;
+            return getGranularityReferenceValue(granularity);
         },
     );
 };

--- a/packages/common/src/utils/bigNumber.ts
+++ b/packages/common/src/utils/bigNumber.ts
@@ -7,8 +7,8 @@ import {
 
 const GRANULARITY_PATTERN = /\$\{([^}]+)\.granularity\}/g;
 
-/** A standard grain whose label was overridden via project `granularity_labels`
- *  (GLITCH-264). Carried verbatim so chart labels show it as-authored, unlike
+/** A standard grain whose label was overridden via project `granularity_labels`.
+ *  Carried verbatim so chart labels show it as-authored, unlike
  *  standard/custom grains which are lowercased for the label. */
 type VerbatimGranularity = { verbatim: string };
 


### PR DESCRIPTION
## Summary

Stacked on **#24831 (GLITCH-264)**. Chart-axis/title `${field.granularity}` interpolation now renders a standard grain's project `granularity_labels` override **verbatim** (e.g. "Revenue by Week starting Monday"), so charts match the Explorer and date zoom.

## Change (one file)

`packages/common/src/utils/bigNumber.ts`:
- `getGranularityMapFromItems` reads the `timeIntervalLabel` baked onto the dimension by GLITCH-264. When a standard grain has an override, it's tagged `{ verbatim }`; otherwise unchanged.
- `resolveGranularityInLabel` renders a `{ verbatim }` value as-is. Non-overridden standard grains and custom granularities keep their existing lowercase rendering.

No threading to the 5 chart hooks (they consume `GranularityMap` opaquely), and the custom-SQL `date_zoom` value path (`getGranularityReferenceValue` → `reservedParameters.ts`) is **untouched**. Period-over-period is out of scope.

## Testing

- Unit: 2 new `bigNumber` tests — `getGranularityMapFromItems` tags an overridden grain `{ verbatim }`; `resolveGranularityInLabel` renders it verbatim (not lowercased). 12/12 green; common + frontend typecheck clean.
- Verified the override reaches chart data on the demo project: the compiled `order_date_week` dimension carries `timeIntervalLabel` set to the override, which is the field `itemsMap` feeds to the chart hooks.

Closes: GLITCH-528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
