### PR TITLE
fix(catalog): scope table-selection filter to non-allowlist searches

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -783,6 +783,19 @@ export class CatalogModel {
         hasTimeDimension?: boolean;
         tags?: string[];
     }): Promise<KnexPaginatedData<CatalogItem[]>> {
+        // filteredExplores enforces visibility through the type-specific allow-list
+        // filter below, which only runs for Table/Field. Without an explicit type that
+        // filter is skipped and nothing constrains the results, so fail loud instead.
+        if (
+            filteredExplores &&
+            type !== CatalogType.Table &&
+            type !== CatalogType.Field
+        ) {
+            throw new UnexpectedServerError(
+                'filteredExplores requires an explicit Table or Field catalog type',
+            );
+        }
+
         // Use websearch_to_tsquery for AI Agent queries for better natural language support
         const useWebSearch =
             context === CatalogSearchContext.AI_AGENT ||
@@ -849,6 +862,12 @@ export class CatalogModel {
             .where(`${CatalogTableName}.project_uuid`, projectUuid)
             // tables configuration filtering
             .andWhere(function tablesConfigurationFiltering() {
+                // An explicit explore allow-list is the authoritative visibility set,
+                // so the project table-selection config must not further restrict it.
+                if (filteredExplores) {
+                    return;
+                }
+
                 const {
                     tableSelection: { type: tableSelectionType, value },
                 } = tablesConfiguration;


### PR DESCRIPTION
Closes: #24829

### Description:
Catalog search applied the project table-selection config even when the caller passed an explicit explore allow-list. That allow-list is already the authoritative visibility set, so applying the table-selection on top of it hid fields the caller was entitled to see.

This skips the table-selection filter when an explore allow-list is provided; visibility is then governed solely by the allow-list and the existing user-attribute checks. Searches without an allow-list (catalog browse/search, metrics explorer) are unchanged.

Since the allow-list filter only runs for an explicit `Table`/`Field` catalog type, the method now asserts that an allow-list is paired with a type — turning a would-be silent visibility gap into a loud failure rather than relying on the convention implicitly.