### PR TITLE
fix(athena): forward aws_session_token for temporary credentials

### DIFF
--- a/packages/cli/src/dbt/targets/athena.test.ts
+++ b/packages/cli/src/dbt/targets/athena.test.ts
@@ -58,6 +58,26 @@ describe('convertAthenaSchema', () => {
         });
     });
 
+    test('should forward aws_session_token as sessionToken for temporary STS credentials', () => {
+        const target = {
+            type: 'athena',
+            region_name: 'us-east-1',
+            database: 'AwsDataCatalog',
+            schema: 'default',
+            s3_staging_dir: 's3://test-results/',
+            aws_access_key_id: 'ASIATEST',
+            aws_secret_access_key: 'SECRETTEST',
+            aws_session_token: 'SESSIONTOKENTEST',
+        };
+
+        expect(convertAthenaSchema(target)).toMatchObject({
+            authenticationType: AthenaAuthenticationType.ACCESS_KEY,
+            accessKeyId: 'ASIATEST',
+            secretAccessKey: 'SECRETTEST',
+            sessionToken: 'SESSIONTOKENTEST',
+        });
+    });
+
     test('should throw parse error for invalid Athena target', () => {
         expect(() =>
             convertAthenaSchema({

--- a/packages/cli/src/dbt/targets/athena.ts
+++ b/packages/cli/src/dbt/targets/athena.ts
@@ -18,6 +18,7 @@ export type AthenaTarget = {
     s3_data_dir?: string;
     aws_access_key_id?: string;
     aws_secret_access_key?: string;
+    aws_session_token?: string;
     aws_assume_role_arn?: string;
     aws_assume_role_external_id?: string;
     work_group?: string;
@@ -53,6 +54,10 @@ export const athenaSchema: JSONSchemaType<AthenaTarget> = {
             nullable: true,
         },
         aws_secret_access_key: {
+            type: 'string',
+            nullable: true,
+        },
+        aws_session_token: {
             type: 'string',
             nullable: true,
         },
@@ -104,6 +109,7 @@ export const convertAthenaSchema = (
                 : AthenaAuthenticationType.IAM_ROLE,
             accessKeyId: target.aws_access_key_id,
             secretAccessKey: target.aws_secret_access_key,
+            sessionToken: target.aws_session_token,
             assumeRoleArn: target.aws_assume_role_arn,
             assumeRoleExternalId: target.aws_assume_role_external_id,
             workGroup: target.work_group,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -208,6 +208,7 @@ export type CreateAthenaCredentials = {
     authenticationType?: AthenaAuthenticationType;
     accessKeyId?: string;
     secretAccessKey?: string;
+    sessionToken?: string;
     assumeRoleArn?: string;
     assumeRoleExternalId?: string;
     workGroup?: string;

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -69,6 +69,26 @@ describe('AthenaWarehouseClient', () => {
             });
         });
 
+        test('should forward sessionToken for temporary STS credentials', () => {
+            const creds: CreateAthenaCredentials = {
+                ...baseCredentials,
+                accessKeyId: 'ASIATEST',
+                secretAccessKey: 'SECRET',
+                sessionToken: 'SESSIONTOKEN',
+            };
+            // eslint-disable-next-line no-new
+            new AthenaWarehouseClient(creds);
+
+            expect(mockAthenaClient).toHaveBeenCalledWith({
+                region: 'us-east-1',
+                credentials: {
+                    accessKeyId: 'ASIATEST',
+                    secretAccessKey: 'SECRET',
+                    sessionToken: 'SESSIONTOKEN',
+                },
+            });
+        });
+
         test('should not set credentials for IAM_ROLE auth', () => {
             const creds: CreateAthenaCredentials = {
                 ...baseCredentials,
@@ -107,6 +127,31 @@ describe('AthenaWarehouseClient', () => {
             expect(mockAthenaClient).toHaveBeenCalledWith({
                 region: 'us-east-1',
                 credentials: 'sts-credentials',
+            });
+        });
+
+        test('should chain assume role using temporary credentials (sessionToken in masterCredentials)', () => {
+            const creds: CreateAthenaCredentials = {
+                ...baseCredentials,
+                accessKeyId: 'ASIATEST',
+                secretAccessKey: 'SECRET',
+                sessionToken: 'SESSIONTOKEN',
+                assumeRoleArn: 'arn:aws:iam::123456789012:role/my-role',
+            };
+            // eslint-disable-next-line no-new
+            new AthenaWarehouseClient(creds);
+
+            expect(mockFromTemporaryCredentials).toHaveBeenCalledWith({
+                masterCredentials: {
+                    accessKeyId: 'ASIATEST',
+                    secretAccessKey: 'SECRET',
+                    sessionToken: 'SESSIONTOKEN',
+                },
+                params: {
+                    RoleArn: 'arn:aws:iam::123456789012:role/my-role',
+                    RoleSessionName: 'lightdash-athena-session',
+                    ExternalId: undefined,
+                },
             });
         });
 

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -284,6 +284,7 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                 clientConfig.credentials = {
                     accessKeyId: credentials.accessKeyId!,
                     secretAccessKey: credentials.secretAccessKey!,
+                    sessionToken: credentials.sessionToken || undefined,
                 };
             }
 


### PR DESCRIPTION
Closes #24838

## Summary

`lightdash preview` and `lightdash deploy` silently dropped `aws_session_token` from a dbt Athena profile, so temporary AWS STS credentials (the `ASIA…` keys) reached AWS without their session token and were rejected with `[UnrecognizedClientException 400] The security token included in the request is invalid`. Athena users could not run preview/deploy with temporary credentials at all. Static long-lived IAM keys and the `aws_assume_role_arn` flow were unaffected.

## Root cause

Temporary STS credentials are only valid when the access key, secret, and session token are sent together. The Athena credential path had no concept of a session token, so it was dropped on the way from the dbt profile to the AWS SDK:

```
dbt profiles.yml          CLI parse            credentials type          warehouse client
(3 values present)   ->   athena.ts        -> CreateAthenaCredentials -> AthenaWarehouseClient
                          no session token     no sessionToken field     sends key+secret only  --> AWS 400
```

`convertAthenaSchema` mapped only `aws_access_key_id` / `aws_secret_access_key`, the credentials type carried no `sessionToken`, and `AthenaWarehouseClient` built `clientConfig.credentials` from key + secret alone. Sending a temporary key pair without its session token makes AWS treat the key ID as invalid. This affected all versions since Athena support was added (#19752); the assume-role-ARN feature (#20315) added STS role assumption but never pass-through of a session token already present in the profile.

## Fix

Thread the session token through the same three layers, mirroring the existing Redshift `sessionToken` field.

- `packages/cli/src/dbt/targets/athena.ts` — add `aws_session_token` to `AthenaTarget` and the AJV schema, map it to `sessionToken` in `convertAthenaSchema`.
- `packages/common/src/types/projects.ts` — add `sessionToken?: string` to `CreateAthenaCredentials`. It is already in `sensitiveCredentialsFieldNames`, so it is stripped from API responses and re-merged on update automatically — no extra wiring.
- `packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts` — set `sessionToken: credentials.sessionToken || undefined` on the ACCESS_KEY SDK credentials. When both a token and `assumeRoleArn` are set, the token flows into `masterCredentials` so the role is assumed using the temporary base credentials (role chaining).
- Out of scope: server-side dbt profile generation (`backend/src/dbt/profiles.ts`), the per-user warehouse-credentials form, and the Athena connection UI form have no session-token field — separate paths, and temporary tokens are short-lived (the assume-role-ARN flow is the durable option).

## Before / After (ACCESS_KEY SDK credentials for `ASIA…` temp keys)

```
Before:  { accessKeyId: "ASIA…", secretAccessKey: "…" }                      --> AWS 400 UnrecognizedClientException
After:   { accessKeyId: "ASIA…", secretAccessKey: "…", sessionToken: "…" }   --> connects
```

## Test plan

- [x] `pnpm -F common typecheck:fast`, `pnpm -F warehouses typecheck:fast`, `pnpm -F @lightdash/cli typecheck` — clean
- [x] lint on `athena.ts`, `AthenaWarehouseClient.ts`, `projects.ts` (+ tests) — clean
- [x] `jest src/warehouseClients/AthenaWarehouseClient.test.ts` — 20 pass (regression: forwards `sessionToken`; role-chaining: token in `masterCredentials`; static-key + IAM_ROLE unchanged)
- [x] `jest src/dbt/targets` — 15 pass (regression: `convertAthenaSchema` maps `aws_session_token`)
- [ ] Manual (needs real Athena STS creds): set all three creds in `profiles.yml`, `lightdash preview` — connects instead of `UnrecognizedClientException`
- [ ] Manual: static long-lived IAM keys (no token) still connect unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)