### PR TITLE
fix: custom dimension 'Remove' in results column menu should deselect, not delete

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.test.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * Component-level tests for the custom-dimension branch of ColumnHeaderContextMenu.
+ *
+ * Specifically verifies the `hideRemove` guard: when the user cannot author custom
+ * SQL on a saved chart, no removal options should appear at all (regression from the
+ * original fix which left the generic "Remove" unconditional).
+ */
+import { CustomDimensionType, DimensionType } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import ColumnHeaderContextMenu from './ColumnHeaderContextMenu';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../features/explorer/store', () => ({
+    useExplorerDispatch: () => vi.fn(),
+    useExplorerSelector: vi.fn((selector: (s: unknown) => unknown) =>
+        selector({
+            explorer: {
+                unsavedChartVersion: {
+                    tableName: 'my_table',
+                    metricQuery: {
+                        additionalMetrics: [],
+                        tableCalculations: [],
+                        customDimensions: [],
+                    },
+                },
+                // savedChart is set per test via the selector mock
+            },
+        }),
+    ),
+    selectAdditionalMetrics: (s: {
+        explorer: {
+            unsavedChartVersion: {
+                metricQuery: { additionalMetrics: unknown[] };
+            };
+        };
+    }) => s.explorer.unsavedChartVersion.metricQuery.additionalMetrics,
+    selectTableCalculations: (s: {
+        explorer: {
+            unsavedChartVersion: {
+                metricQuery: { tableCalculations: unknown[] };
+            };
+        };
+    }) => s.explorer.unsavedChartVersion.metricQuery.tableCalculations,
+    selectTableName: (s: {
+        explorer: { unsavedChartVersion: { tableName: string } };
+    }) => s.explorer.unsavedChartVersion.tableName,
+    selectSavedChart: vi.fn(),
+    explorerActions: {
+        setSortFields: vi.fn(),
+        toggleDimension: vi.fn((id: string) => ({
+            type: 'toggleDimension',
+            id,
+        })),
+        removeCustomDimension: vi.fn((id: string) => ({
+            type: 'removeCustomDimension',
+            id,
+        })),
+        toggleCustomDimensionModal: vi.fn(),
+        toggleAdditionalMetricModal: vi.fn(),
+        togglePeriodOverPeriodComparisonModal: vi.fn(),
+        removeField: vi.fn((id: string) => ({ type: 'removeField', id })),
+    },
+}));
+
+vi.mock('../../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined }),
+}));
+
+vi.mock('../../../hooks/useFilters', () => ({
+    useFilters: () => ({ addFilter: vi.fn() }),
+}));
+
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'test-project-uuid',
+}));
+
+vi.mock('../../../providers/Tracking/useTracking', () => ({
+    default: () => ({ track: vi.fn() }),
+}));
+
+vi.mock('./ColumnHeaderSortMenuOptions', () => ({
+    default: () => null,
+}));
+
+vi.mock('./FormatMenuOptions', () => ({
+    default: () => null,
+}));
+
+vi.mock('./QuickCalculations', () => ({
+    default: () => null,
+}));
+
+vi.mock('../../../features/tableCalculation', () => ({
+    DeleteTableCalculationModal: () => null,
+    UpdateTableCalculationModal: () => null,
+}));
+
+import { selectSavedChart } from '../../../features/explorer/store';
+// ---------------------------------------------------------------------------
+// Hook that drives hideRemove
+// ---------------------------------------------------------------------------
+import * as CannotAuthorModule from '../../../hooks/user/useCannotAuthorCustomSql';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CUSTOM_SQL_DIM = {
+    id: 'my_table_sql_dim',
+    name: 'sql_dim',
+    table: 'my_table',
+    type: CustomDimensionType.SQL,
+    sql: 'FLOOR(${my_table.amount} / 100)',
+    dimensionType: DimensionType.NUMBER,
+} as const;
+
+const CUSTOM_BIN_DIM = {
+    id: 'my_table_bin_dim',
+    name: 'bin_dim',
+    table: 'my_table',
+    type: CustomDimensionType.BIN,
+    dimensionId: 'my_table_amount',
+    binType: 'fixed_number' as const,
+    binNumber: 5,
+} as const;
+
+function makeHeader(item: typeof CUSTOM_SQL_DIM | typeof CUSTOM_BIN_DIM) {
+    return {
+        column: {
+            id: item.id,
+            columnDef: { meta: { item } },
+        },
+    } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+function openMenu() {
+    // The test env also mounts a React Query DevTools button, so we can't use
+    // getByRole('button') alone. Find the column-header chevron button by
+    // aria-label="Open React Query Devtools" exclusion, or by picking the
+    // first button that is NOT the devtools toggle.
+    const buttons = screen.getAllByRole('button');
+    const trigger = buttons.find(
+        (b) => b.getAttribute('aria-label') !== 'Open React Query Devtools',
+    )!;
+    fireEvent.click(trigger);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ColumnHeaderContextMenu — custom dimension removal options', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('regular BIN custom dimension (hideRemove always false)', () => {
+        beforeEach(() => {
+            vi.spyOn(
+                CannotAuthorModule,
+                'useCannotAuthorCustomSql',
+            ).mockReturnValue(false);
+            vi.mocked(selectSavedChart).mockReturnValue(undefined as any);
+        });
+
+        it('shows "Remove" (deselect) and "Remove custom dimension" (delete)', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_BIN_DIM)} />,
+            );
+            openMenu();
+
+            // Mantine Menu renders items via portal — use findByText to wait for async render
+            expect(await screen.findByText('Remove')).toBeInTheDocument();
+            expect(
+                await screen.findByText('Remove custom dimension'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('custom SQL dimension — user CAN author (hideRemove = false)', () => {
+        beforeEach(() => {
+            vi.spyOn(
+                CannotAuthorModule,
+                'useCannotAuthorCustomSql',
+            ).mockReturnValue(false);
+            vi.mocked(selectSavedChart).mockReturnValue({
+                uuid: 'chart-123',
+            } as any);
+        });
+
+        it('shows both removal options', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_SQL_DIM)} />,
+            );
+            openMenu();
+
+            // Mantine Menu renders items via portal — use findByText to wait for async render
+            expect(await screen.findByText('Remove')).toBeInTheDocument();
+            expect(
+                await screen.findByText('Remove custom dimension'),
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('custom SQL dimension — user CANNOT author + saved chart (hideRemove = true)', () => {
+        beforeEach(() => {
+            vi.spyOn(
+                CannotAuthorModule,
+                'useCannotAuthorCustomSql',
+            ).mockReturnValue(true);
+            vi.mocked(selectSavedChart).mockReturnValue({
+                uuid: 'chart-123',
+            } as any);
+        });
+
+        it('shows neither "Remove" nor "Remove custom dimension"', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_SQL_DIM)} />,
+            );
+            openMenu();
+
+            // Wait for the menu to actually open by confirming a known item IS present.
+            // isFilterableField returns true for CustomDimensionType.SQL, so "Filter by"
+            // will always appear in the dropdown — use it as the anchor.
+            await screen.findByRole('menuitem', { name: /Filter by/ });
+
+            // With hideRemove=true, neither removal option should be present
+            expect(screen.queryByText('Remove')).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Remove custom dimension'),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('custom SQL dimension — user CANNOT author but NO saved chart (hideRemove = false)', () => {
+        beforeEach(() => {
+            vi.spyOn(
+                CannotAuthorModule,
+                'useCannotAuthorCustomSql',
+            ).mockReturnValue(true);
+            vi.mocked(selectSavedChart).mockReturnValue(undefined as any);
+        });
+
+        it('shows both removal options (not on a saved chart, so hideRemove stays false)', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_SQL_DIM)} />,
+            );
+            openMenu();
+
+            // Mantine Menu renders items via portal — use findByText to wait for async render
+            expect(await screen.findByText('Remove')).toBeInTheDocument();
+            expect(
+                await screen.findByText('Remove custom dimension'),
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.test.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Component-level tests for the custom-dimension branch of ColumnHeaderContextMenu.
  *
- * Specifically verifies the `hideRemove` guard: when the user cannot author custom
- * SQL on a saved chart, no removal options should appear at all (regression from the
- * original fix which left the generic "Remove" unconditional).
+ * Two concerns:
+ * 1. Render guard — the `hideRemove` flag correctly shows/hides both removal items.
+ * 2. Dispatch wiring — clicking "Remove" dispatches toggleDimension (deselect, not
+ *    delete) and clicking "Remove custom dimension" dispatches removeCustomDimension.
  */
 import { CustomDimensionType, DimensionType } from '@lightdash/common';
 import { fireEvent, screen } from '@testing-library/react';
@@ -12,11 +13,16 @@ import { renderWithProviders } from '../../../testing/testUtils';
 import ColumnHeaderContextMenu from './ColumnHeaderContextMenu';
 
 // ---------------------------------------------------------------------------
+// vi.hoisted: mockDispatch must be created before vi.mock() is hoisted
+// ---------------------------------------------------------------------------
+const mockDispatch = vi.hoisted(() => vi.fn());
+
+// ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
 vi.mock('../../../features/explorer/store', () => ({
-    useExplorerDispatch: () => vi.fn(),
+    useExplorerDispatch: () => mockDispatch,
     useExplorerSelector: vi.fn((selector: (s: unknown) => unknown) =>
         selector({
             explorer: {
@@ -28,7 +34,6 @@ vi.mock('../../../features/explorer/store', () => ({
                         customDimensions: [],
                     },
                 },
-                // savedChart is set per test via the selector mock
             },
         }),
     ),
@@ -139,10 +144,6 @@ function makeHeader(item: typeof CUSTOM_SQL_DIM | typeof CUSTOM_BIN_DIM) {
 }
 
 function openMenu() {
-    // The test env also mounts a React Query DevTools button, so we can't use
-    // getByRole('button') alone. Find the column-header chevron button by
-    // aria-label="Open React Query Devtools" exclusion, or by picking the
-    // first button that is NOT the devtools toggle.
     const buttons = screen.getAllByRole('button');
     const trigger = buttons.find(
         (b) => b.getAttribute('aria-label') !== 'Open React Query Devtools',
@@ -158,6 +159,10 @@ describe('ColumnHeaderContextMenu — custom dimension removal options', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
+
+    // -------------------------------------------------------------------------
+    // Render-guard tests: verify correct items appear / are hidden
+    // -------------------------------------------------------------------------
 
     describe('regular BIN custom dimension (hideRemove always false)', () => {
         beforeEach(() => {
@@ -199,7 +204,6 @@ describe('ColumnHeaderContextMenu — custom dimension removal options', () => {
             );
             openMenu();
 
-            // Mantine Menu renders items via portal — use findByText to wait for async render
             expect(await screen.findByText('Remove')).toBeInTheDocument();
             expect(
                 await screen.findByText('Remove custom dimension'),
@@ -224,12 +228,9 @@ describe('ColumnHeaderContextMenu — custom dimension removal options', () => {
             );
             openMenu();
 
-            // Wait for the menu to actually open by confirming a known item IS present.
-            // isFilterableField returns true for CustomDimensionType.SQL, so "Filter by"
-            // will always appear in the dropdown — use it as the anchor.
+            // Confirm the menu IS open — isFilterableField returns true for SQL custom dims
             await screen.findByRole('menuitem', { name: /Filter by/ });
 
-            // With hideRemove=true, neither removal option should be present
             expect(screen.queryByText('Remove')).not.toBeInTheDocument();
             expect(
                 screen.queryByText('Remove custom dimension'),
@@ -252,11 +253,64 @@ describe('ColumnHeaderContextMenu — custom dimension removal options', () => {
             );
             openMenu();
 
-            // Mantine Menu renders items via portal — use findByText to wait for async render
             expect(await screen.findByText('Remove')).toBeInTheDocument();
             expect(
                 await screen.findByText('Remove custom dimension'),
             ).toBeInTheDocument();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Dispatch-wiring tests: verify the correct Redux action fires on click
+    // -------------------------------------------------------------------------
+
+    describe('dispatch wiring — "Remove" deselects, does not delete', () => {
+        beforeEach(() => {
+            vi.spyOn(
+                CannotAuthorModule,
+                'useCannotAuthorCustomSql',
+            ).mockReturnValue(false);
+            vi.mocked(selectSavedChart).mockReturnValue(undefined as any);
+        });
+
+        it('clicking "Remove" dispatches toggleDimension (deselect), not removeField (delete)', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_SQL_DIM)} />,
+            );
+            openMenu();
+
+            fireEvent.click(await screen.findByText('Remove'));
+
+            // Deselect action fired
+            expect(mockDispatch).toHaveBeenCalledWith({
+                type: 'toggleDimension',
+                id: CUSTOM_SQL_DIM.id,
+            });
+            // Destructive delete NOT fired
+            expect(mockDispatch).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'removeField' }),
+            );
+            expect(mockDispatch).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'removeCustomDimension' }),
+            );
+        });
+
+        it('clicking "Remove custom dimension" dispatches removeCustomDimension (delete)', async () => {
+            renderWithProviders(
+                <ColumnHeaderContextMenu header={makeHeader(CUSTOM_SQL_DIM)} />,
+            );
+            openMenu();
+
+            fireEvent.click(await screen.findByText('Remove custom dimension'));
+
+            expect(mockDispatch).toHaveBeenCalledWith({
+                type: 'removeCustomDimension',
+                id: CUSTOM_SQL_DIM.id,
+            });
+            // Deselect NOT fired
+            expect(mockDispatch).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'toggleDimension' }),
+            );
         });
     });
 });

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -304,24 +304,34 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     onSelect={onSortSelect}
                 />
 
-                {!hideRemove && (
-                    <>
-                        <Menu.Divider />
+                <Menu.Divider />
 
-                        <Menu.Item
-                            leftSection={<MantineIcon icon={IconTrash} />}
-                            color="red"
-                            onClick={() => {
-                                dispatch(
-                                    explorerActions.removeField(
-                                        getItemId(item),
-                                    ),
-                                );
-                            }}
-                        >
-                            Remove
-                        </Menu.Item>
-                    </>
+                <Menu.Item
+                    leftSection={<MantineIcon icon={IconTrash} />}
+                    color="red"
+                    onClick={() => {
+                        dispatch(
+                            explorerActions.toggleDimension(getItemId(item)),
+                        );
+                    }}
+                >
+                    Remove
+                </Menu.Item>
+
+                {!hideRemove && (
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        color="red"
+                        onClick={() => {
+                            dispatch(
+                                explorerActions.removeCustomDimension(
+                                    getItemId(item),
+                                ),
+                            );
+                        }}
+                    >
+                        Remove custom dimension
+                    </Menu.Item>
                 )}
             </>
         );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -304,34 +304,38 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     onSelect={onSortSelect}
                 />
 
-                <Menu.Divider />
-
-                <Menu.Item
-                    leftSection={<MantineIcon icon={IconTrash} />}
-                    color="red"
-                    onClick={() => {
-                        dispatch(
-                            explorerActions.toggleDimension(getItemId(item)),
-                        );
-                    }}
-                >
-                    Remove
-                </Menu.Item>
-
                 {!hideRemove && (
-                    <Menu.Item
-                        leftSection={<MantineIcon icon={IconTrash} />}
-                        color="red"
-                        onClick={() => {
-                            dispatch(
-                                explorerActions.removeCustomDimension(
-                                    getItemId(item),
-                                ),
-                            );
-                        }}
-                    >
-                        Remove custom dimension
-                    </Menu.Item>
+                    <>
+                        <Menu.Divider />
+
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.toggleDimension(
+                                        getItemId(item),
+                                    ),
+                                );
+                            }}
+                        >
+                            Remove
+                        </Menu.Item>
+
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                            color="red"
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.removeCustomDimension(
+                                        getItemId(item),
+                                    ),
+                                );
+                            }}
+                        >
+                            Remove custom dimension
+                        </Menu.Item>
+                    </>
                 )}
             </>
         );

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -1,0 +1,102 @@
+import { CustomDimensionType } from '@lightdash/common';
+import { createExplorerStore, explorerActions } from './index';
+
+const CUSTOM_DIM_ID = 'my_table_my_custom_dim';
+
+function makeStoreWithCustomDimension() {
+    return createExplorerStore({
+        explorer: {
+            isVisualizationConfigOpen: false,
+            isEditMode: true,
+            isMinimal: false,
+            parameterReferences: [],
+            parameterDefinitions: {},
+            previouslyFetchedState: undefined,
+            cachedChartConfigs: {},
+            expandedSections: [],
+            unsavedChartVersion: {
+                tableName: 'my_table',
+                metricQuery: {
+                    exploreName: 'my_table',
+                    dimensions: [CUSTOM_DIM_ID, 'my_table_regular_dim'],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: [],
+                    customDimensions: [
+                        {
+                            id: CUSTOM_DIM_ID,
+                            name: 'my_custom_dim',
+                            dimensionType: CustomDimensionType.BIN,
+                            table: 'my_table',
+                            binType: 'fixed_count',
+                            binCount: 5,
+                        },
+                    ],
+                },
+                pivotConfig: undefined,
+                tableConfig: {
+                    columnOrder: [CUSTOM_DIM_ID, 'my_table_regular_dim'],
+                },
+                chartConfig: {
+                    type: 'cartesian' as const,
+                    config: undefined,
+                },
+            },
+            modals: {
+                format: { isOpen: false },
+                additionalMetric: { isOpen: false },
+                customDimension: { isOpen: false },
+                writeBack: { isOpen: false },
+                itemDetail: { isOpen: false },
+                periodOverPeriodComparison: { isOpen: false },
+            },
+            unsavedColorPaletteUuid: null,
+            queryExecution: {
+                validQueryArgs: null,
+                unpivotedQueryArgs: null,
+                queryUuidHistory: [],
+                unpivotedQueryUuidHistory: [],
+                pendingFetch: false,
+            },
+            preAggregate: {
+                usePreAggregateCache: true,
+                check: { status: 'idle' },
+            },
+        },
+    });
+}
+
+describe('explorerSlice — custom dimension removal', () => {
+    it('removeField on a custom dimension id deletes the custom dimension definition (current broken behavior)', () => {
+        const store = makeStoreWithCustomDimension();
+        store.dispatch(explorerActions.removeField(CUSTOM_DIM_ID));
+        const { metricQuery } = store.getState().explorer.unsavedChartVersion;
+
+        // removeField strips the definition — this is the BUG
+        expect(metricQuery.customDimensions).toHaveLength(0);
+        expect(metricQuery.dimensions).not.toContain(CUSTOM_DIM_ID);
+    });
+
+    it('toggleDimension on a custom dimension id deselects it but preserves the definition', () => {
+        const store = makeStoreWithCustomDimension();
+        store.dispatch(explorerActions.toggleDimension(CUSTOM_DIM_ID));
+        const { metricQuery } = store.getState().explorer.unsavedChartVersion;
+
+        // toggleDimension should only affect dimensions[], not customDimensions[]
+        expect(metricQuery.customDimensions).toHaveLength(1);
+        expect(metricQuery.customDimensions?.[0].id).toBe(CUSTOM_DIM_ID);
+        expect(metricQuery.dimensions).not.toContain(CUSTOM_DIM_ID);
+    });
+
+    it('removeCustomDimension removes the definition AND deselects', () => {
+        const store = makeStoreWithCustomDimension();
+        store.dispatch(explorerActions.removeCustomDimension(CUSTOM_DIM_ID));
+        const { metricQuery } = store.getState().explorer.unsavedChartVersion;
+
+        expect(metricQuery.customDimensions).toHaveLength(0);
+        expect(metricQuery.dimensions).not.toContain(CUSTOM_DIM_ID);
+    });
+});

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -1,4 +1,4 @@
-import { CustomDimensionType } from '@lightdash/common';
+import { BinType, ChartType, CustomDimensionType } from '@lightdash/common';
 import { createExplorerStore, explorerActions } from './index';
 
 const CUSTOM_DIM_ID = 'my_table_my_custom_dim';
@@ -29,10 +29,11 @@ function makeStoreWithCustomDimension() {
                         {
                             id: CUSTOM_DIM_ID,
                             name: 'my_custom_dim',
-                            dimensionType: CustomDimensionType.BIN,
+                            type: CustomDimensionType.BIN,
                             table: 'my_table',
-                            binType: 'fixed_count',
-                            binCount: 5,
+                            dimensionId: 'my_table_some_field',
+                            binType: BinType.FIXED_NUMBER,
+                            binNumber: 5,
                         },
                     ],
                 },
@@ -41,7 +42,7 @@ function makeStoreWithCustomDimension() {
                     columnOrder: [CUSTOM_DIM_ID, 'my_table_regular_dim'],
                 },
                 chartConfig: {
-                    type: 'cartesian' as const,
+                    type: ChartType.CARTESIAN,
                     config: undefined,
                 },
             },
@@ -70,17 +71,17 @@ function makeStoreWithCustomDimension() {
 }
 
 describe('explorerSlice — custom dimension removal', () => {
-    it('removeField on a custom dimension id deletes the custom dimension definition (current broken behavior)', () => {
+    it('removeField on a custom dimension deletes the definition (not used by column header)', () => {
         const store = makeStoreWithCustomDimension();
         store.dispatch(explorerActions.removeField(CUSTOM_DIM_ID));
         const { metricQuery } = store.getState().explorer.unsavedChartVersion;
 
-        // removeField strips the definition — this is the BUG
+        // removeField strips the definition — only used for table calculations / invalid items, not custom dimensions
         expect(metricQuery.customDimensions).toHaveLength(0);
         expect(metricQuery.dimensions).not.toContain(CUSTOM_DIM_ID);
     });
 
-    it('toggleDimension on a custom dimension id deselects it but preserves the definition', () => {
+    it('toggleDimension on a custom dimension deselects it but preserves the definition (column header Remove behavior)', () => {
         const store = makeStoreWithCustomDimension();
         store.dispatch(explorerActions.toggleDimension(CUSTOM_DIM_ID));
         const { metricQuery } = store.getState().explorer.unsavedChartVersion;


### PR DESCRIPTION
## What & why

Fixes #24555 (PROD-8411). In the results-table column-header menu, **"Remove" on a custom dimension permanently deleted it from the explore** instead of just deselecting it — inconsistent with regular dimensions/metrics, where "Remove" only deselects.

## Change

`ColumnHeaderContextMenu.tsx`:
- The generic **"Remove"** action now dispatches `toggleDimension(itemId)` (deselect from results, keep it available in the explore) instead of `removeField(...)` (destructive delete) — matching the behaviour for regular fields.
- Adds a **separate, explicitly-labelled "Remove custom dimension"** destructive item (gated on `!hideRemove`) so the destructive path is still available but clearly distinguished, mirroring the sidebar tree's wording.

## Tests

`explorerSlice.test.ts`: adds coverage asserting custom-dimension "Remove" deselects (and the explicit destructive action deletes). 3 tests pass.

## Evidence (after)

- **Test file**: `packages/frontend/src/features/explorer/store/explorerSlice.test.ts`
- **Test results**: ✅ 828 tests pass (101 test files) — no regressions
- typecheck / lint / test: ✅

| Test | Asserts |
|---|---|
| `removeField on a custom dimension deletes the definition` | `removeField` wipes `customDimensions[]` entry — confirms old (broken) behavior is isolated |
| `toggleDimension on a custom dimension deselects but preserves the definition` | `toggleDimension` removes from `dimensions[]` but keeps `customDimensions[]` entry — the new "Remove" behavior |
| `removeCustomDimension removes the definition AND deselects` | Destructive delete still works via the new "Remove custom dimension" action |

### Visual evidence

Captured via headless Chrome (chrome-devtools) driving the live dev app — confirming the corrected column-header menu behaviour on demo (Jaffle shop) data:

**Custom dimension selected** — `remove_test_dim` is added to the results table and listed under **Custom dimensions** in the sidebar:

![custom dimension selected](https://raw.githubusercontent.com/charliedowler/jarvis-evidence/main/repro-fix/custom-dim-remove/custom-dimension-selected.png)

**Corrected column menu** — the menu now offers **"Remove"** (deselect — keeps the definition) as a distinct option from **"Remove custom dimension"** (destructive delete), instead of a single "Remove" that destructively deleted the dimension:

![column menu: Remove vs Remove custom dimension](https://raw.githubusercontent.com/charliedowler/jarvis-evidence/main/repro-fix/custom-dim-remove/column-menu-remove-vs-delete.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

