### PR TITLE
fix: deduplicate distinct metrics within selected dimension groups

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -47,6 +47,7 @@ import {
     INTRINSIC_USER_ATTRIBUTES,
     METRIC_QUERY,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
+    METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_CROSS_TABLE,
@@ -68,6 +69,7 @@ import {
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
     METRIC_QUERY_SAME_MODEL_NUMBER_WITH_SUM_DISTINCT,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
+    METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
     METRIC_QUERY_TWO_TABLES,
     METRIC_QUERY_WITH_CUSTOM_DIMENSION,
     METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
@@ -2317,6 +2319,28 @@ LIMIT 10`;
             expect(result.query).not.toContain('INNER JOIN dd_');
         });
 
+        test('sum_distinct should deduplicate within selected dimension groups', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(replaceWhitespace(result.query)).toContain(
+                replaceWhitespace(
+                    'PARTITION BY "orders".line_item_id, "orders".payment_method, "orders".status ORDER BY',
+                ),
+            );
+            expect(result.query).toContain(
+                'INNER JOIN dd_orders_total_revenue',
+            );
+            expect(result.query).not.toContain(
+                'CROSS JOIN dd_orders_total_revenue',
+            );
+        });
+
         test('average_distinct should generate CTE with FLOAT division', () => {
             const result = buildQuery({
                 explore: EXPLORE_WITH_AVERAGE_DISTINCT,
@@ -2340,6 +2364,28 @@ LIMIT 10`;
             );
             // Neither distinct metric type should use COALESCE
             expect(result.query).not.toContain('COALESCE');
+        });
+
+        test('average_distinct should deduplicate within selected dimension groups', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_AVERAGE_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            expect(replaceWhitespace(result.query)).toContain(
+                replaceWhitespace(
+                    'PARTITION BY "orders".line_item_id, "orders".payment_method ORDER BY',
+                ),
+            );
+            expect(result.query).toContain(
+                'INNER JOIN dd_orders_avg_shipping_cost',
+            );
+            expect(result.query).not.toContain(
+                'CROSS JOIN dd_orders_avg_shipping_cost',
+            );
         });
 
         test('type:number metric referencing cross-model sum_distinct should use CTE', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -3009,14 +3009,12 @@ export class MetricQueryBuilder {
     /**
      * Builds CTE(s) for distinct metrics (sum_distinct, average_distinct) using ROW_NUMBER deduplication.
      *
-     * Semantics (SPK-450):
-     *   1. Inner subquery picks one row per distinct_keys combination (PARTITION BY distinct_keys).
-     *   2. Outer CTE aggregates up to the grain of (distinct_keys ∩ selected dimensions).
-     *   3. JOIN to dd_base on the overlapping keys (INNER JOIN), or CROSS JOIN when there is no
-     *      overlap so a single scalar is repeated across every output row.
-     *
-     * Selected dimensions that are NOT part of distinct_keys never affect the dedup or the
-     * partitioning — they ride along on dd_base and receive the same value across all of their rows.
+     * Semantics:
+     *   1. Inner subquery picks one row per selected dimension + distinct_keys
+     *      combination.
+     *   2. Outer CTE aggregates up to the selected dimension grain.
+     *   3. JOIN to dd_base on selected dimensions (INNER JOIN), or CROSS JOIN when
+     *      there are no selected dimensions.
      */
     private buildDistinctMetricCtes({
         dimensionSelects,
@@ -3050,8 +3048,6 @@ export class MetricQueryBuilder {
             },
         );
 
-        // Build a map: normalized dimension SQL expression -> dimension id.
-        // Used to detect which distinct_keys overlap with the selected dimensions.
         const normalizeSql = (sql: string): string => {
             let s = sql.trim();
             while (s.startsWith('(') && s.endsWith(')')) {
@@ -3059,16 +3055,18 @@ export class MetricQueryBuilder {
             }
             return s;
         };
-        const dimensionSqlToId = new Map<string, string>();
-        for (const [id, selectStr] of Object.entries(dimensionSelects)) {
-            const suffix = ` AS ${fieldQuoteChar}${id}${fieldQuoteChar}`;
-            const idx = selectStr.lastIndexOf(suffix);
-            const sqlExpr =
-                idx > -1
+        const dimensionAlias = Object.keys(dimensionSelects).map(
+            (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
+        );
+        const dimensionExprs = Object.entries(dimensionSelects).map(
+            ([id, selectStr]) => {
+                const suffix = ` AS ${fieldQuoteChar}${id}${fieldQuoteChar}`;
+                const idx = selectStr.lastIndexOf(suffix);
+                return idx > -1
                     ? selectStr.substring(0, idx).trim()
                     : selectStr.trim();
-            dimensionSqlToId.set(normalizeSql(sqlExpr), id);
-        }
+            },
+        );
 
         const ctes: string[] = [];
         const ddJoins: string[] = [];
@@ -3088,32 +3086,25 @@ export class MetricQueryBuilder {
                     metric.compiledValueSql,
                 );
 
-                // For each distinct_key, find the matching selected dimension (if any).
-                // Joinable keys = distinct_keys that the user is also grouping by, and so
-                // need to flow through to the output as join columns.
-                const joinableKeys: Array<{
-                    keySql: string;
-                    dimId: string;
-                }> = [];
-                for (const keySql of metric.compiledDistinctKeys) {
-                    const matchedDimId = dimensionSqlToId.get(
-                        normalizeSql(keySql),
-                    );
-                    if (matchedDimId) {
-                        joinableKeys.push({ keySql, dimId: matchedDimId });
+                const partitionExprs = [...metric.compiledDistinctKeys];
+                for (const dimensionExpr of dimensionExprs) {
+                    if (
+                        !partitionExprs.some(
+                            (keySql) =>
+                                normalizeSql(keySql) ===
+                                normalizeSql(dimensionExpr),
+                        )
+                    ) {
+                        partitionExprs.push(dimensionExpr);
                     }
                 }
 
-                // Inner subquery: project joinable keys (so the outer can group by them)
+                // Inner subquery: project dimensions (so the outer can group by them)
                 // plus the row-numbered metric value.
-                const innerKeySelects = joinableKeys.map(
-                    ({ keySql, dimId }) =>
-                        `  ${keySql} AS ${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
-                );
                 const innerSelects = [
-                    ...innerKeySelects,
+                    ...Object.values(dimensionSelects),
                     `  ${valueSql} AS __dd_val`,
-                    `  ROW_NUMBER() OVER (PARTITION BY ${metric.compiledDistinctKeys.join(', ')} ORDER BY ${valueSql}) AS __dd_rn`,
+                    `  ROW_NUMBER() OVER (PARTITION BY ${partitionExprs.join(', ')} ORDER BY ${valueSql}) AS __dd_rn`,
                 ];
 
                 const innerSubquery = MetricQueryBuilder.assembleSqlParts([
@@ -3132,17 +3123,14 @@ export class MetricQueryBuilder {
                     outerAgg = `SUM(CASE WHEN __dd_rn = 1 THEN __dd_val ELSE NULL END)`;
                 }
 
-                // Outer CTE: group by the joinable keys (or no group by for a scalar).
-                const outerKeyAliases = joinableKeys.map(
-                    ({ dimId }) => `${fieldQuoteChar}${dimId}${fieldQuoteChar}`,
-                );
+                // Outer CTE: group by selected dimensions (or no group by for a scalar).
                 const outerSelects = [
-                    ...outerKeyAliases.map((alias) => `  ${alias}`),
+                    ...dimensionAlias.map((alias) => `  ${alias}`),
                     `  ${outerAgg} AS ${fieldQuoteChar}${metricId}${fieldQuoteChar}`,
                 ];
                 const outerGroupBy =
-                    joinableKeys.length > 0
-                        ? `GROUP BY ${joinableKeys.map((_, i) => i + 1).join(', ')}`
+                    dimensionAlias.length > 0
+                        ? `GROUP BY ${dimensionAlias.map((_, i) => i + 1).join(', ')}`
                         : undefined;
 
                 const cteParts = [
@@ -3153,11 +3141,11 @@ export class MetricQueryBuilder {
                 const cteSql = `${ddCteName} AS (\n${MetricQueryBuilder.assembleSqlParts(cteParts)}\n)`;
                 ctes.push(cteSql);
 
-                if (joinableKeys.length === 0) {
+                if (dimensionAlias.length === 0) {
                     ddJoins.push(`CROSS JOIN ${ddCteName}`);
                 } else {
                     ddJoins.push(
-                        `INNER JOIN ${ddCteName} ON ${outerKeyAliases
+                        `INNER JOIN ${ddCteName} ON ${dimensionAlias
                             .map((alias) =>
                                 warehouseSqlBuilder.getNullSafeEqualJoinSql(
                                     `${baseCteName}.${alias}`,

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -180,6 +180,8 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a su
 "WITH
   dd_orders_total_revenue AS (
     SELECT
+      "orders_payment_method",
+      "orders_status",
       SUM(
         CASE
           WHEN __dd_rn = 1 THEN __dd_val
@@ -189,16 +191,23 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a su
     FROM
       (
         SELECT
+          "orders".payment_method AS "orders_payment_method",
+          "orders".status AS "orders_status",
           "orders".amount AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "orders".line_item_id
+              "orders".line_item_id,
+              "orders".payment_method,
+              "orders".status
             ORDER BY
               "orders".amount
           ) AS __dd_rn
         FROM
           "db"."schema"."orders" AS "orders"
       ) __dd_sub
+    GROUP BY
+      1,
+      2
   ),
   dd_base AS (
     SELECT
@@ -215,7 +224,20 @@ SELECT
   dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
 FROM
   dd_base
-  CROSS JOIN dd_orders_total_revenue
+  INNER JOIN dd_orders_total_revenue ON (
+    dd_base."orders_payment_method" = dd_orders_total_revenue."orders_payment_method"
+    OR (
+      dd_base."orders_payment_method" IS NULL
+      AND dd_orders_total_revenue."orders_payment_method" IS NULL
+    )
+  )
+  AND (
+    dd_base."orders_status" = dd_orders_total_revenue."orders_status"
+    OR (
+      dd_base."orders_status" IS NULL
+      AND dd_orders_total_revenue."orders_status" IS NULL
+    )
+  )
 ORDER BY
   "orders_total_revenue" DESC
 LIMIT
@@ -287,6 +309,7 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a ty
   ),
   dd_transfers_total_residual_transfers AS (
     SELECT
+      "transfers_date",
       SUM(
         CASE
           WHEN __dd_rn = 1 THEN __dd_val
@@ -296,16 +319,20 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a ty
     FROM
       (
         SELECT
+          "transfers".date AS "transfers_date",
           "transfers".total_daily_residual_transfers AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "transfers".client_id
+              "transfers".client_id,
+              "transfers".date
             ORDER BY
               "transfers".total_daily_residual_transfers
           ) AS __dd_rn
         FROM
           "db"."schema"."transfers" AS "transfers"
       ) __dd_sub
+    GROUP BY
+      1
   ),
   dd_base AS (
     SELECT
@@ -336,7 +363,13 @@ FROM
       AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
     )
   )
-  CROSS JOIN dd_transfers_total_residual_transfers
+  INNER JOIN dd_transfers_total_residual_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_residual_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_residual_transfers."transfers_date" IS NULL
+    )
+  )
 ORDER BY
   "transfers_date"
 LIMIT
@@ -374,6 +407,7 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a ty
   ),
   dd_transfers_total_residual_transfers AS (
     SELECT
+      "transfers_date",
       SUM(
         CASE
           WHEN __dd_rn = 1 THEN __dd_val
@@ -383,16 +417,20 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a ty
     FROM
       (
         SELECT
+          "transfers".date AS "transfers_date",
           "transfers".total_daily_residual_transfers AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "transfers".client_id
+              "transfers".client_id,
+              "transfers".date
             ORDER BY
               "transfers".total_daily_residual_transfers
           ) AS __dd_rn
         FROM
           "db"."schema"."transfers" AS "transfers"
       ) __dd_sub
+    GROUP BY
+      1
   ),
   dd_base AS (
     SELECT
@@ -416,7 +454,13 @@ FROM
       AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
     )
   )
-  CROSS JOIN dd_transfers_total_residual_transfers
+  INNER JOIN dd_transfers_total_residual_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_residual_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_residual_transfers."transfers_date" IS NULL
+    )
+  )
 ORDER BY
   "transfers_date"
 LIMIT
@@ -427,6 +471,7 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an a
 "WITH
   dd_orders_avg_shipping_cost AS (
     SELECT
+      "orders_payment_method",
       CAST(
         SUM(
           CASE
@@ -447,16 +492,20 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an a
     FROM
       (
         SELECT
+          "orders".payment_method AS "orders_payment_method",
           "orders".shipping_cost AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "orders".line_item_id
+              "orders".line_item_id,
+              "orders".payment_method
             ORDER BY
               "orders".shipping_cost
           ) AS __dd_rn
         FROM
           "db"."schema"."orders" AS "orders"
       ) __dd_sub
+    GROUP BY
+      1
   ),
   dd_base AS (
     SELECT
@@ -471,7 +520,13 @@ SELECT
   dd_orders_avg_shipping_cost."orders_avg_shipping_cost" AS "orders_avg_shipping_cost"
 FROM
   dd_base
-  CROSS JOIN dd_orders_avg_shipping_cost
+  INNER JOIN dd_orders_avg_shipping_cost ON (
+    dd_base."orders_payment_method" = dd_orders_avg_shipping_cost."orders_payment_method"
+    OR (
+      dd_base."orders_payment_method" IS NULL
+      AND dd_orders_avg_shipping_cost."orders_payment_method" IS NULL
+    )
+  )
 ORDER BY
   "orders_avg_shipping_cost" DESC
 LIMIT
@@ -554,6 +609,7 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for both
   ),
   dd_transfers_total_residual_transfers AS (
     SELECT
+      "transfers_date",
       SUM(
         CASE
           WHEN __dd_rn = 1 THEN __dd_val
@@ -563,16 +619,20 @@ exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for both
     FROM
       (
         SELECT
+          "transfers".date AS "transfers_date",
           "transfers".total_daily_residual_transfers AS __dd_val,
           ROW_NUMBER() OVER (
             PARTITION BY
-              "transfers".client_id
+              "transfers".client_id,
+              "transfers".date
             ORDER BY
               "transfers".total_daily_residual_transfers
           ) AS __dd_rn
         FROM
           "db"."schema"."transfers" AS "transfers"
       ) __dd_sub
+    GROUP BY
+      1
   ),
   dd_base AS (
     SELECT
@@ -603,7 +663,13 @@ FROM
       AND dd_transfers_total_corridor_transfers."transfers_date" IS NULL
     )
   )
-  CROSS JOIN dd_transfers_total_residual_transfers
+  INNER JOIN dd_transfers_total_residual_transfers ON (
+    dd_base."transfers_date" = dd_transfers_total_residual_transfers."transfers_date"
+    OR (
+      dd_base."transfers_date" IS NULL
+      AND dd_transfers_total_residual_transfers."transfers_date" IS NULL
+    )
+  )
 ORDER BY
   "transfers_date"
 LIMIT

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
@@ -16,9 +16,8 @@ import {
 import { buildQuery } from './helpers';
 
 describe('MetricQueryBuilder snapshot: distinct queries', () => {
-    // Selected dimensions are orthogonal to the distinct key, so the dedup CTE collapses to a
-    // scalar and is CROSS JOINed onto dd_base. Every output row sees the same global total
-    // (SPK-450 Wise case).
+    // Selected dimensions are orthogonal to the distinct key, but deduplication still happens
+    // within each selected dimension group so each output row gets its own grouped total.
     test('matches snapshot for a sum-distinct query with dimensions not in distinct_keys', () => {
         expect(
             buildQuery({
@@ -86,8 +85,8 @@ describe('MetricQueryBuilder snapshot: distinct queries', () => {
         ).toMatchSnapshot();
     });
 
-    // average_distinct with a selected dimension that is not in distinct_keys — same global value
-    // attached to every dimension row via CROSS JOIN.
+    // average_distinct also deduplicates within the selected dimension group, even when that
+    // dimension is not part of distinct_keys.
     test('matches snapshot for an average-distinct query with dimensions not in distinct_keys', () => {
         expect(
             buildQuery({

--- a/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
+++ b/packages/e2e/cypress/e2e/api/sumDistinctWithFanout.cy.ts
@@ -2,14 +2,16 @@ import { SEED_PROJECT } from '@lightdash/common';
 
 const apiUrl = '/api/v2';
 
+type ResultRow = Record<string, { value: { raw: unknown; formatted: string } }>;
+
 /**
  * Executes an async metric query and returns the result rows.
  */
 const runMetricQuery = (
     projectUuid: string,
     query: Record<string, unknown>,
-): Cypress.Chainable<Record<string, unknown>[]> => {
-    const checkResults = (queryUuid: string): Cypress.Chainable<unknown> =>
+): Cypress.Chainable<ResultRow[]> => {
+    const checkResults = (queryUuid: string): Cypress.Chainable<ResultRow[]> =>
         cy
             .request({
                 url: `${apiUrl}/projects/${projectUuid}/query/${queryUuid}`,
@@ -20,11 +22,11 @@ const runMetricQuery = (
                     resp: Cypress.Response<{
                         results: {
                             status: string;
-                            rows: Record<string, unknown>[];
+                            rows: ResultRow[];
                             error?: string;
                         };
                     }>,
-                ) => {
+                ): ResultRow[] | Cypress.Chainable<ResultRow[]> => {
                     if (resp.body.results.error) {
                         throw new Error(
                             `Query failed: ${resp.body.results.error}`,
@@ -36,7 +38,7 @@ const runMetricQuery = (
                     }
                     return resp.body.results.rows;
                 },
-            );
+            ) as Cypress.Chainable<ResultRow[]>;
 
     return cy
         .request({
@@ -51,8 +53,11 @@ const runMetricQuery = (
             expect(resp.status).to.eq(200);
             const { queryUuid } = resp.body.results;
             return checkResults(queryUuid);
-        });
+        }) as unknown as Cypress.Chainable<ResultRow[]>;
 };
+
+const getRawValue = (row: ResultRow, fieldId: string): unknown =>
+    row[fieldId].value.raw;
 
 describe('SQL fanout deduplication', () => {
     const projectUuid = SEED_PROJECT.project_uuid;
@@ -102,7 +107,7 @@ describe('SQL fanout deduplication', () => {
             expect(ordersRows).to.have.length(1);
 
             const ordersTotalAmount = Number(
-                ordersRows[0].orders_total_order_amount,
+                getRawValue(ordersRows[0], 'orders_total_order_amount'),
             );
             expect(ordersTotalAmount).to.be.greaterThan(0);
 
@@ -111,7 +116,10 @@ describe('SQL fanout deduplication', () => {
                     expect(customersRows).to.have.length(1);
 
                     const customersDedupedAmount = Number(
-                        customersRows[0].customers_total_order_amount_deduped,
+                        getRawValue(
+                            customersRows[0],
+                            'customers_total_order_amount_deduped',
+                        ),
                     );
 
                     expect(customersDedupedAmount).to.eq(ordersTotalAmount);
@@ -120,19 +128,18 @@ describe('SQL fanout deduplication', () => {
         });
     });
 
-    it('sum_distinct should INNER JOIN on distinct_keys when the user selects them as dimensions (SPK-450)', () => {
+    it('sum_distinct should return grouped values when the user selects distinct keys as dimensions', () => {
         // Multi-key sum_distinct: distinct_keys = [order_id, payment_method].
         // Selecting both keys as dimensions should produce one (correct) value per
         // (order_id, payment_method), via INNER JOIN on the dedup CTE.
-        const groundTruthQuery = {
-            exploreName: 'payments',
-            dimensions: ['payments_order_id', 'payments_payment_method'],
-            metrics: ['payments_total_revenue'],
-            filters: {},
-            sorts: [
-                { fieldId: 'payments_order_id', descending: false },
-                { fieldId: 'payments_payment_method', descending: false },
+        const totalQuery = {
+            exploreName: 'customer_order_payments',
+            dimensions: [],
+            metrics: [
+                'customer_order_payments_total_payment_by_method_per_order',
             ],
+            filters: {},
+            sorts: [],
             limit: 500,
             tableCalculations: [],
             additionalMetrics: [],
@@ -165,57 +172,57 @@ describe('SQL fanout deduplication', () => {
             metricOverrides: {},
         };
 
-        runMetricQuery(projectUuid, groundTruthQuery).then(
-            (groundTruthRows) => {
-                expect(groundTruthRows.length).to.be.greaterThan(1);
+        runMetricQuery(projectUuid, totalQuery).then((totalRows) => {
+            expect(totalRows).to.have.length(1);
+            const total = Number(
+                getRawValue(
+                    totalRows[0],
+                    'customer_order_payments_total_payment_by_method_per_order',
+                ),
+            );
+            expect(total).to.be.greaterThan(0);
 
-                const expected: Record<string, number> = {};
-                groundTruthRows.forEach((row) => {
-                    const key = `${String(row.payments_order_id)}|${String(
-                        row.payments_payment_method,
-                    )}`;
-                    expected[key] = Number(row.payments_total_revenue);
-                });
+            runMetricQuery(projectUuid, dedupedQuery).then((dedupedRows) => {
+                expect(dedupedRows.length).to.be.greaterThan(1);
 
-                runMetricQuery(projectUuid, dedupedQuery).then(
-                    (dedupedRows) => {
-                        expect(dedupedRows.length).to.eq(
-                            groundTruthRows.length,
-                        );
-
-                        // Distinct values across rows confirms it's NOT a global scalar CROSS JOIN.
-                        const distinctValues = new Set(
-                            dedupedRows.map((r) =>
-                                Number(
-                                    r.customer_order_payments_total_payment_by_method_per_order,
-                                ),
-                            ),
-                        );
-                        expect(distinctValues.size).to.be.greaterThan(1);
-
-                        dedupedRows.forEach((row) => {
-                            const key = `${String(
-                                row.customer_order_payments_order_id,
-                            )}|${String(
-                                row.customer_order_payments_payment_method,
-                            )}`;
-                            const deduped = Number(
-                                row.customer_order_payments_total_payment_by_method_per_order,
-                            );
-                            expect(deduped, `key=${key}`).to.eq(expected[key]);
-                        });
-                    },
+                const groupedValues = dedupedRows.map((row) =>
+                    Number(
+                        getRawValue(
+                            row,
+                            'customer_order_payments_total_payment_by_method_per_order',
+                        ),
+                    ),
                 );
-            },
-        );
+                const groupedSum = Number(
+                    groupedValues
+                        .reduce((sum, value) => sum + value, 0)
+                        .toFixed(2),
+                );
+
+                // Distinct values across rows confirms it's NOT a global scalar CROSS JOIN.
+                expect(new Set(groupedValues).size).to.be.greaterThan(1);
+                expect(groupedSum).to.eq(total);
+
+                dedupedRows.forEach((row) => {
+                    expect(
+                        getRawValue(row, 'customer_order_payments_order_id'),
+                    ).to.not.eq(null);
+                    expect(
+                        getRawValue(
+                            row,
+                            'customer_order_payments_payment_method',
+                        ),
+                    ).to.not.eq(null);
+                });
+            });
+        });
     });
 
-    it('sum_distinct should return the same global deduplicated total when the selected dimension is not a distinct_key (SPK-450)', () => {
-        // Ground truth: direct SUM on payments table without grouping (no fan-out)
-        const paymentsTotalQuery = {
-            exploreName: 'payments',
+    it('sum_distinct grouped by dimension outside distinct_keys should return per-group values', () => {
+        const totalQuery = {
+            exploreName: 'customer_order_payments',
             dimensions: [],
-            metrics: ['payments_total_revenue'],
+            metrics: ['customer_order_payments_total_payment_amount_deduped'],
             filters: {},
             sorts: [],
             limit: 500,
@@ -224,9 +231,7 @@ describe('SQL fanout deduplication', () => {
             metricOverrides: {},
         };
 
-        // sum_distinct on the wide (fanned-out) table grouped by a non-distinct-key dimension.
-        // Selected dimensions must NOT participate in the dedup PARTITION BY — every row should
-        // show the same global total, since payment_method isn't part of distinct_keys.
+        // sum_distinct on the wide table grouped by payment_method.
         const wideTableQuery = {
             exploreName: 'customer_order_payments',
             dimensions: ['customer_order_payments_payment_method'],
@@ -244,27 +249,36 @@ describe('SQL fanout deduplication', () => {
             metricOverrides: {},
         };
 
-        runMetricQuery(projectUuid, paymentsTotalQuery).then((totalRows) => {
+        runMetricQuery(projectUuid, totalQuery).then((totalRows) => {
             expect(totalRows).to.have.length(1);
-            const expectedTotal = Number(totalRows[0].payments_total_revenue);
-            expect(expectedTotal).to.be.greaterThan(0);
+            const total = Number(
+                getRawValue(
+                    totalRows[0],
+                    'customer_order_payments_total_payment_amount_deduped',
+                ),
+            );
+            expect(total).to.be.greaterThan(0);
 
             runMetricQuery(projectUuid, wideTableQuery).then(
                 (wideTableRows) => {
                     expect(wideTableRows.length).to.be.greaterThan(1);
 
-                    wideTableRows.forEach((row) => {
-                        const method = String(
-                            row.customer_order_payments_payment_method,
-                        );
-                        const deduped = Number(
-                            row.customer_order_payments_total_payment_amount_deduped,
-                        );
+                    const groupedValues = wideTableRows.map((row) =>
+                        Number(
+                            getRawValue(
+                                row,
+                                'customer_order_payments_total_payment_amount_deduped',
+                            ),
+                        ),
+                    );
+                    const groupedSum = Number(
+                        groupedValues
+                            .reduce((sum, value) => sum + value, 0)
+                            .toFixed(2),
+                    );
 
-                        expect(deduped, `payment_method=${method}`).to.eq(
-                            expectedTotal,
-                        );
-                    });
+                    expect(new Set(groupedValues).size).to.be.greaterThan(1);
+                    expect(groupedSum).to.eq(total);
                 },
             );
         });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8531/sum-distinct-wrong-values-when-grouping-by-dimensions-not-in-distinct

<img width="1053" height="300" alt="CleanShot 2026-06-29 at 11 24 00" src="https://github.com/user-attachments/assets/ea4a88f2-59ab-48a5-8f54-bcc197d284b9" />

Before the fix, the deduped column would have behaved like a scalar CROSS JOIN, so every row would show the same grand total:
bank_transfer  $299.00
coupon         $299.00
credit_card    $299.00
gift_card      $299.00
After the fix, it partitions the distinct calculation by the selected dimension too, so you get the correct per-group values:
bank_transfer  $67.50
coupon         $51.00
credit_card    $135.00
gift_card      $45.50

### Description:

Previously, when a `sum_distinct` or `average_distinct` metric was queried alongside dimensions that were not part of the metric's `distinct_keys`, the deduplication CTE would collapse to a scalar value and be `CROSS JOIN`ed onto the base CTE. This meant every output row received the same global deduplicated total, regardless of the selected dimension grouping.

This changes the deduplication semantics so that selected dimensions are always included in the `PARTITION BY` clause of the inner `ROW_NUMBER()` subquery, and the outer CTE groups by all selected dimensions. The CTE is then `INNER JOIN`ed to the base CTE on those dimensions rather than `CROSS JOIN`ed. As a result, each output row receives a correctly deduplicated value scoped to its own dimension group, rather than a single global total repeated across all rows.

The `CROSS JOIN` path is now only used when there are no selected dimensions at all.

New unit tests verify that `sum_distinct` and `average_distinct` both produce `INNER JOIN` (not `CROSS JOIN`) and include the selected dimensions in the `PARTITION BY` when dimensions are present. Snapshot tests and the E2E fanout deduplication test have been updated to reflect the corrected per-group behavior.