### PR TITLE
fix(timezone): honour convert_timezone false in filter where clause

### DIFF
--- a/docs/timezones/draft-user-documentation.md
+++ b/docs/timezones/draft-user-documentation.md
@@ -104,7 +104,7 @@ columns:
         convert_timezone: false
 ```
 
-Use cases: audit logs, system timestamps, pre-converted values. The column will render exactly what the warehouse stores.
+Use cases: audit logs, system timestamps, pre-converted values. The column will render exactly what the warehouse stores. Filtering on the column uses the same raw value, so a filter matches the day the row displays under.
 
 ### `wall_clock_timezone:` — declare a non-UTC source zone for one column
 

--- a/docs/timezones/timezone-handling.md
+++ b/docs/timezones/timezone-handling.md
@@ -162,9 +162,9 @@ A "Day of week" or "Month number" dimension grouped next to a DATE_TRUNC sibling
 
 **Files:** `packages/common/src/utils/timeFrames.ts`, `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts`
 
-### Per-dimension display opt-out (`convert_timezone: false`)
+### Per-dimension timezone opt-out (`convert_timezone: false`)
 
-By default every TIMESTAMP dimension follows the project timezone for display. Some columns (system timestamps, audit logs, pre-converted values) need to render in their raw warehouse value instead. Set `convert_timezone: false` on the dimension's YAML meta to opt that single column out:
+By default every TIMESTAMP dimension follows the project timezone. Some columns (system timestamps, audit logs, pre-converted values) need to use their raw warehouse value instead. Set `convert_timezone: false` on the dimension's YAML meta to opt that single column out:
 
 ```yaml
 - name: created_at_utc
@@ -174,23 +174,23 @@ By default every TIMESTAMP dimension follows the project timezone for display. S
       convert_timezone: false
 ```
 
-The flag is asymmetric: it affects **display** only.
+The flag is symmetric: it applies everywhere the dimension is used, so the displayed value and the filter always agree.
 
 | Layer                                              | Honors `convert_timezone: false`? | Reason                                                              |
 | -------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------- |
 | SELECT — DATE_TRUNC                                | ✅                                | Whole TZ-aware path skipped — raw `DATE_TRUNC` emitted, no DATE cast |
 | SELECT — EXTRACT-based                             | ✅                                | Wrap is skipped, bare EXTRACT is emitted                            |
 | SELECT — base TIMESTAMP value                      | ✅                                | Result formatting renders the UTC instant as-is                     |
-| WHERE — filter rendering                           | ❌                                | Filters always convert into the project TZ (filter literals do too) |
+| WHERE — filter rendering                           | ✅                                | Filter LHS reuses the same unwrapped expression as the SELECT       |
 | Result formatting (table cells, exports)           | ✅                                | `formatItemValue` / `formatTemporalCellForSpreadsheet` short-circuit |
 
 The override propagates to all time-interval children of the base dim (`_day`, `_month`, `_day_of_week_index`, `_month_num`, …). Both Layer 2 SQL paths look up the **base** dim by `timeIntervalBaseDimensionName` and read `skipTimezoneConversion` from there, so child dims inherit the opt-out automatically.
 
 **In-memory shape.** YAML `convert_timezone: false` becomes `skipTimezoneConversion: true` on the compiled `Dimension`; absent means default. Call sites read it directly (`if (dim.skipTimezoneConversion)`).
 
-**Caveat.** Because filter SQL keeps converting while the displayed value does not, absolute date filters on a `convert_timezone: false` column may behave surprisingly: the user sees raw warehouse values but filters bound by project-TZ midnights. This is the documented trade-off — flag it in dimension descriptions when you opt out.
+**Filter parity.** The filter WHERE clause reuses the same unwrapped column expression as the SELECT, so a row is matched by the same day it displays under — no off-by-one between the table and the filter. Only the column expression is left unwrapped; the relative-window boundary ("today", "last 7 days") is still computed in the project timezone on the filter *value* side, so disabling the column conversion does not pull the relative window onto UTC.
 
-**Files:** `packages/common/src/compiler/translator.ts` (compile-time wiring), `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` (`getTimezoneAwareDimensionSql`'s `respectConvertTimezone` parameter), `packages/backend/src/utils/QueryBuilder/utils.ts` (`getDimensionFromId`), `packages/common/src/utils/formatting.ts` (`shouldShiftItemTimezone` + `formatItemValue`).
+**Files:** `packages/common/src/compiler/translator.ts` (compile-time wiring), `packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts` (`getTimezoneAwareDimensionSql` reads `skipTimezoneConversion` on the base dim for both SELECT and WHERE), `packages/backend/src/utils/QueryBuilder/utils.ts` (`getDimensionFromId`), `packages/common/src/utils/formatting.ts` (`shouldShiftItemTimezone` + `formatItemValue`).
 
 ### WHERE — Filter boundaries
 

--- a/docs/timezones/timezone-questions.md
+++ b/docs/timezones/timezone-questions.md
@@ -42,7 +42,7 @@ Companion to [`timezone-handling.md`](./timezone-handling.md) (what we do) and [
 
 **Not at the column level.** `dataTimezone` is per-warehouse (set on the connection — `projects.ts`), not per-column. Every NTZ column on that connection is assumed to be in `dataTimezone`. If you have one column in PT and another in ET on the same warehouse, you cannot express that today.
 
-The closest workaround is `convert_timezone: false` per-dimension (translator.ts:219), but that's a *display* opt-out, not a wall-clock-tz declaration. The filter SQL still converts as if the value were in `dataTimezone`.
+The closest workaround is `convert_timezone: false` per-dimension (translator.ts:219). It opts the column out of conversion entirely — display, grouping, *and* filtering all use the raw stored value — so a pre-converted, already-local column is never shifted. It is still not a wall-clock-tz *declaration*: you cannot say "interpret this column as zone X and convert from it," so a single NTZ column genuinely stored in a non-default zone that still needs conversion is not expressible.
 
 **This is a real gap** — flagged in [`timezone-review.md` section E](./timezone-review.md#e-the-datatimezone-is-an-unvalidated-user-assertion). Per the research synthesis, this is the single highest-leverage feature to differentiate the design.
 

--- a/packages/api-tests/tests/convertTimezoneFilter.test.ts
+++ b/packages/api-tests/tests/convertTimezoneFilter.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+import {
+    getTotalCount,
+    runTimezoneTestQuery,
+    updateDataTimezone,
+} from '../helpers/timezone-test';
+
+/**
+ * `convert_timezone: false` must be honoured by filters, not just display.
+ *
+ * The `event_timestamp_raw_utc` dimension opts out of timezone conversion, so
+ * its day bucket always reflects the raw warehouse value regardless of the
+ * query timezone. The filter on that dimension must compare against the same
+ * raw value — otherwise a row buckets to one day but matches a filter for a
+ * different day.
+ *
+ * Boundary row #11 is 2024-01-14 15:00Z:
+ *   - convert_timezone: false → raw day bucket is 2024-01-14 in every timezone.
+ *   - normal dimension in Asia/Tokyo (+9) → bucket shifts to 2024-01-15.
+ *
+ * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
+ */
+
+let admin: ApiClient;
+
+const RAW_UTC_DAY = 'timezone_test_event_timestamp_raw_utc_day';
+const DAY = 'timezone_test_event_timestamp_day';
+const COUNT = 'timezone_test_count';
+
+const dayEquals = (fieldId: string, value: string) => ({
+    dimensions: {
+        id: 'day-filter',
+        and: [
+            {
+                id: 'day-eq',
+                target: { fieldId },
+                operator: 'equals',
+                values: [value],
+            },
+        ],
+    },
+});
+
+const countFor = async (
+    dim: string,
+    filterDay: string,
+    timezone: string,
+): Promise<number> => {
+    const rows = await runTimezoneTestQuery(admin, {
+        dimensions: [dim],
+        metrics: [COUNT],
+        eventIds: [11],
+        timezone,
+        filters: dayEquals(dim, filterDay),
+    });
+    return getTotalCount(rows, COUNT);
+};
+
+describe('convert_timezone: false is honoured by filters', () => {
+    beforeAll(async () => {
+        admin = await login();
+        await updateDataTimezone(admin, undefined);
+    });
+
+    describe('opted-out dimension filters against the raw value (Asia/Tokyo)', () => {
+        it('matches the raw bucket day the row displays under', async () => {
+            expect(
+                await countFor(RAW_UTC_DAY, '2024-01-14', 'Asia/Tokyo'),
+            ).toBe(1);
+        });
+
+        it('does not match the timezone-shifted day', async () => {
+            expect(
+                await countFor(RAW_UTC_DAY, '2024-01-15', 'Asia/Tokyo'),
+            ).toBe(0);
+        });
+    });
+
+    describe('normal dimension still shifts with the query timezone (Asia/Tokyo)', () => {
+        it('matches the shifted bucket day', async () => {
+            expect(await countFor(DAY, '2024-01-15', 'Asia/Tokyo')).toBe(1);
+        });
+
+        it('does not match the raw UTC day', async () => {
+            expect(await countFor(DAY, '2024-01-14', 'Asia/Tokyo')).toBe(0);
+        });
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5921,9 +5921,9 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
         );
     });
 
-    test('convert_timezone: false on base dim — SELECT skips the wrap, WHERE keeps it', () => {
+    test('convert_timezone: false on base dim — SELECT and WHERE both skip the wrap', () => {
         const explore = buildExtractExplore(DimensionType.TIMESTAMP);
-        // Mark the base dim opted out of display conversion.
+        // Mark the base dim opted out of timezone conversion.
         explore.tables.events.dimensions.occurred_at.skipTimezoneConversion = true;
 
         const { query } = buildQuery({
@@ -5938,13 +5938,32 @@ describe('Timezone-aware EXTRACT-based time dimensions', () => {
         const wrapped = `DATE_PART('DOW', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York')`;
         const bare = `DATE_PART('DOW', "events".occurred_at)`;
 
-        // Asymmetry: SELECT renders the bare expression, WHERE keeps the
-        // project-tz wrap so the filter still bounds by project-tz days.
+        // The override applies on both sides: the filter compares against the
+        // stored value, matching what the SELECT renders.
         const selectClause = query.slice(0, query.indexOf('WHERE'));
         const whereClause = query.slice(query.indexOf('WHERE'));
 
         expect(selectClause).toContain(bare);
         expect(selectClause).not.toContain(wrapped);
+        expect(whereClause).toContain(bare);
+        expect(whereClause).not.toContain(wrapped);
+    });
+
+    test('dim without convert_timezone: false still wraps WHERE in project tz', () => {
+        const explore = buildExtractExplore(DimensionType.TIMESTAMP);
+
+        const { query } = buildQuery({
+            explore,
+            compiledMetricQuery: baseDowQuery([1]),
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: 'America/New_York',
+            useTimezoneAwareDateTrunc: true,
+        });
+
+        const wrapped = `DATE_PART('DOW', ("events".occurred_at)::timestamptz AT TIME ZONE 'America/New_York')`;
+        const whereClause = query.slice(query.indexOf('WHERE'));
+
         expect(whereClause).toContain(wrapped);
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -642,14 +642,13 @@ export class MetricQueryBuilder {
      * extractable intervals.
      *
      * Base dims with `convert_timezone: false` are skipped — the dim renders
-     * in its raw warehouse value. Pass `respectConvertTimezone: false` from
-     * filter rendering so WHERE clauses keep wrapping regardless.
+     * in its raw warehouse value, on both the SELECT and the WHERE side so
+     * filters compare against the stored value.
      */
     private getTimezoneAwareDimensionSql(
         dimension: CompiledDimension,
         adapterType: SupportedDbtAdapter,
         startOfWeek: WeekDay | null | undefined,
-        respectConvertTimezone: boolean = true,
     ): string {
         const { timezone, useTimezoneAwareDateTrunc } = this.args;
 
@@ -680,7 +679,7 @@ export class MetricQueryBuilder {
             return dimension.compiledSql;
         }
 
-        if (respectConvertTimezone && baseDimension.skipTimezoneConversion) {
+        if (baseDimension.skipTimezoneConversion) {
             return dimension.compiledSql;
         }
 
@@ -1724,8 +1723,9 @@ export class MetricQueryBuilder {
         }
 
         // Override filter dimension SQL to match the timezone-aware SELECT
-        // clause. Filters always wrap by project tz — even for dims with
-        // `convert_timezone: false` — so pass `respectConvertTimezone: false`.
+        // clause. This honours `convert_timezone: false` so the WHERE column
+        // expression stays unwrapped, exactly like the SELECT — the filter
+        // value side still resolves relative windows in the project timezone.
         const filterField = isDimension(field)
             ? {
                   ...field,
@@ -1733,7 +1733,6 @@ export class MetricQueryBuilder {
                       field,
                       adapterType,
                       startOfWeek,
-                      false,
                   ),
               }
             : field;


### PR DESCRIPTION
Closes https://github.com/lightdash/lightdash/issues/24840

## Problem

A timestamp dimension with `convert_timezone: false` renders its raw warehouse value on the SELECT side (display + grouping skip the project-timezone conversion), but the filter WHERE clause still wrapped the column in the project timezone. On a time-interval (truncated/extracted) dimension this made the displayed bucket and the filter window use different frames of reference, so a row shown under one day could be matched by a filter for an adjacent day.

## Root cause

`MetricQueryBuilder.getFilterRuleSQL` called `getTimezoneAwareDimensionSql` with `respectConvertTimezone: false`, explicitly bypassing the `skipTimezoneConversion` flag that the SELECT/grouping path already honours.

## Fix

The filter path now reuses the same unwrapped column expression as the SELECT. Only the column expression changes; the filter value side is untouched, so relative date windows ("today", "this week", "in the last N days") still resolve in the project timezone. With no caller overriding it anymore, the now-constant `respectConvertTimezone` parameter is removed.

## Behaviour change (warehouse data, project tz `America/Chicago`)

Seed row stored `2024-01-15 00:00:00`, which displays/groups as `2024-01-15` under `convert_timezone: false`:

| filter | before | after |
| --- | --- | --- |
| `is 2024-01-15` (the displayed day) | no match | **matches** |
| `is 2024-01-14` (adjacent day) | **matches** (bug) | no match |

After the fix, the filter agrees with what the row displays as.

## Manual verification

Ran against the `timezone_test` seed model with `EnableTimezoneSupport` on, project timezone `America/Chicago`, isolated to the row above (`event_id = 12`).

**Absolute filter** on `event_timestamp_raw_utc_day` (the `convert_timezone: false` dimension):

```sql
-- is 2024-01-15  (the displayed day)
WHERE (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) = ('2024-01-15')
-- -> 1 row

-- is 2024-01-14  (adjacent day)
WHERE (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) = ('2024-01-14')
-- -> 0 rows
```

**Relative filter** (large window needed because the seed data is from 2024; "today" is 2026-06-29):

```sql
-- in the last 1000 days
WHERE (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) >= ('2023-10-03')
  AND (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) <= ('2026-06-29')
-- -> 1 row

-- in the last 100 days
WHERE (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) >= ('2026-03-21')
  AND (DATE_TRUNC('DAY', "timezone_test".event_timestamp_raw_utc)) <= ('2026-06-29')
-- -> 0 rows
```

Note the column expression is bare (no `AT TIME ZONE`) on both SELECT and WHERE, and the relative window boundaries are real calendar dates computed in the project timezone, not UTC.

## Tests

- `MetricQueryBuilder.test.ts`: a `convert_timezone: false` dimension now renders the bare expression on both SELECT and WHERE; a dimension without the flag still wraps the WHERE in the project timezone.
- `api-tests/convertTimezoneFilter.test.ts`: end-to-end filter on the opted-out dimension matches the raw bucket day, and a normal dimension still shifts with the query timezone.
