### PR TITLE
fix(coder): enforce SQL chart save permissions on content-as-code path

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1570,6 +1570,28 @@ export class CoderService extends BaseService {
         });
         const existingSqlChart = sqlChartRows[0];
 
+        // Saving a SQL chart via content-as-code requires the same permissions
+        // as the UI path (SavedSqlService): manage:CustomSql plus space-level
+        // create/update on SavedChart. ContentAsCode alone is not sufficient.
+        // manage:CustomSql is project-level, so check it before resolving the
+        // space so a forbidden save can't orphan a newly created space.
+        const isUpdate = existingSqlChart !== undefined;
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('CustomSql', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid: project.projectUuid,
+                    metadata:
+                        existingSqlChart !== undefined
+                            ? { savedSqlUuid: existingSqlChart.saved_sql_uuid }
+                            : {},
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
         const { space, created: spaceCreated } = await this.getOrCreateSpace(
             projectUuid,
             sqlChartAsCode.spaceSlug,
@@ -1578,6 +1600,37 @@ export class CoderService extends BaseService {
             publicSpaceCreate,
             spaceNames,
         );
+
+        // Space-level create/update on SavedChart. On a move (update with a
+        // different target space) require access to both the current and the
+        // target space, mirroring SavedSqlService.hasAccess.
+        const savedChartAction = isUpdate ? 'update' : 'create';
+        const spaceUuidsToCheck =
+            existingSqlChart !== undefined &&
+            existingSqlChart.space_uuid !== space.uuid
+                ? [space.uuid, existingSqlChart.space_uuid]
+                : [space.uuid];
+        const spaceAccessContexts =
+            await this.spacePermissionService.getSpacesAccessContext(
+                user.userUuid,
+                spaceUuidsToCheck,
+            );
+        const lacksSavedChartAccess = spaceUuidsToCheck.some((spaceUuid) =>
+            auditedAbility.cannot(
+                savedChartAction,
+                subject('SavedChart', {
+                    ...spaceAccessContexts[spaceUuid],
+                    metadata: {
+                        savedSqlUuid: existingSqlChart?.saved_sql_uuid ?? null,
+                    },
+                }),
+            ),
+        );
+        if (lacksSavedChartAccess) {
+            throw new ForbiddenError(
+                `You don't have access to ${savedChartAction} this Saved SQL chart`,
+            );
+        }
 
         if (existingSqlChart === undefined) {
             // Create new SQL chart

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -1,0 +1,251 @@
+import { Ability, type RawRuleOf } from '@casl/ability';
+import {
+    AnyType,
+    ForbiddenError,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    SessionUser,
+    SqlChartAsCode,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ContentVerificationModel } from '../../models/ContentVerificationModel';
+import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { PromoteService } from '../PromoteService/PromoteService';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { CoderService } from './CoderService';
+
+const PROJECT_UUID = 'project-uuid';
+const ORG_UUID = 'org-uuid';
+const SPACE_UUID = 'space-uuid';
+const OTHER_SPACE_UUID = 'other-space-uuid';
+
+const makeUser = (
+    rules: RawRuleOf<Ability<PossibleAbilities>>[],
+): SessionUser =>
+    ({
+        userUuid: 'user-uuid',
+        email: 'user@test.com',
+        firstName: 'Test',
+        lastName: 'User',
+        organizationUuid: ORG_UUID,
+        role: OrganizationMemberRole.MEMBER,
+        ability: new Ability<PossibleAbilities>(rules),
+        abilityRules: [],
+    }) as unknown as SessionUser;
+
+const sqlChartAsCode = {
+    name: 'My SQL chart',
+    description: 'desc',
+    slug: 'my-sql-chart',
+    sql: 'SELECT 1',
+    limit: 500,
+    config: {},
+    version: 1,
+    spaceSlug: 'my-space',
+} as unknown as SqlChartAsCode;
+
+const accessContext = (projectUuid: string = PROJECT_UUID) => ({
+    organizationUuid: ORG_UUID,
+    projectUuid,
+    inheritsFromOrgOrProject: true,
+    access: [],
+    admins: [],
+});
+
+const buildService = (
+    savedSqlModel: AnyType,
+    getSpacesAccessContext: AnyType = jest.fn(
+        async (_userUuid: string, spaceUuids: string[]) =>
+            Object.fromEntries(
+                spaceUuids.map((uuid) => [uuid, accessContext()]),
+            ),
+    ),
+) =>
+    new CoderService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: {
+            get: jest.fn(async () => ({
+                projectUuid: PROJECT_UUID,
+                organizationUuid: ORG_UUID,
+            })),
+        } as unknown as ProjectModel,
+        savedChartModel: {} as unknown as SavedChartModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
+        dashboardModel: {} as unknown as DashboardModel,
+        spaceModel: {} as unknown as SpaceModel,
+        schedulerClient: {} as unknown as SchedulerClient,
+        promoteService: {} as unknown as PromoteService,
+        spacePermissionService: {
+            getSpacesAccessContext,
+        } as unknown as SpacePermissionService,
+        contentVerificationModel: {} as unknown as ContentVerificationModel,
+    });
+
+const stubSpace = (service: CoderService, uuid: string = SPACE_UUID) =>
+    jest.spyOn(service, 'getOrCreateSpace').mockResolvedValue({
+        space: { uuid } as AnyType,
+        created: false,
+    });
+
+const existingRow = (spaceUuid: string = SPACE_UUID) => ({
+    saved_sql_uuid: 'existing-uuid',
+    space_uuid: spaceUuid,
+    slug: sqlChartAsCode.slug,
+});
+
+const upsert = (service: CoderService, user: SessionUser) =>
+    service.upsertSqlChart(
+        user,
+        PROJECT_UUID,
+        sqlChartAsCode.slug,
+        sqlChartAsCode,
+    );
+
+describe('CoderService.upsertSqlChart - permissions', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    describe('create (chart does not exist yet)', () => {
+        it('throws ForbiddenError with ContentAsCode but not CustomSql', async () => {
+            const savedSqlModel = {
+                find: jest.fn(async () => []),
+                create: jest.fn(),
+            };
+            const service = buildService(savedSqlModel);
+            stubSpace(service);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+            ]);
+
+            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            expect(savedSqlModel.create).not.toHaveBeenCalled();
+        });
+
+        it('throws ForbiddenError with CustomSql but no space create:SavedChart', async () => {
+            const savedSqlModel = {
+                find: jest.fn(async () => []),
+                create: jest.fn(),
+            };
+            const service = buildService(savedSqlModel);
+            stubSpace(service);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+                { subject: 'CustomSql', action: 'manage' },
+            ]);
+
+            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            expect(savedSqlModel.create).not.toHaveBeenCalled();
+        });
+
+        it('creates the chart with ContentAsCode + CustomSql + create:SavedChart', async () => {
+            const savedSqlModel = {
+                find: jest.fn(async () => []),
+                create: jest.fn(async () => ({ savedSqlUuid: 'new-uuid' })),
+            };
+            const service = buildService(savedSqlModel);
+            stubSpace(service);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+                { subject: 'CustomSql', action: 'manage' },
+                {
+                    subject: 'SavedChart',
+                    action: 'create',
+                    conditions: { projectUuid: PROJECT_UUID },
+                },
+            ]);
+
+            await upsert(service, user);
+            expect(savedSqlModel.create).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('update (chart already exists)', () => {
+        it('updates the chart with CustomSql + update:SavedChart in its space', async () => {
+            const savedSqlModel = {
+                find: jest.fn(async () => [existingRow(SPACE_UUID)]),
+                update: jest.fn(async () => ({
+                    savedSqlUuid: 'existing-uuid',
+                })),
+                create: jest.fn(),
+            };
+            const service = buildService(savedSqlModel);
+            stubSpace(service, SPACE_UUID);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+                { subject: 'CustomSql', action: 'manage' },
+                {
+                    subject: 'SavedChart',
+                    action: 'update',
+                    conditions: { projectUuid: PROJECT_UUID },
+                },
+            ]);
+
+            await upsert(service, user);
+            expect(savedSqlModel.update).toHaveBeenCalledTimes(1);
+            expect(savedSqlModel.create).not.toHaveBeenCalled();
+        });
+
+        it('throws ForbiddenError on update without update:SavedChart', async () => {
+            const savedSqlModel = {
+                find: jest.fn(async () => [existingRow(SPACE_UUID)]),
+                update: jest.fn(),
+                create: jest.fn(),
+            };
+            const service = buildService(savedSqlModel);
+            stubSpace(service, SPACE_UUID);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+                { subject: 'CustomSql', action: 'manage' },
+            ]);
+
+            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            expect(savedSqlModel.update).not.toHaveBeenCalled();
+        });
+
+        it('blocks a move when the user lacks access to the chart current space', async () => {
+            // Chart currently lives in OTHER_SPACE_UUID; YAML moves it to SPACE_UUID.
+            // User can update in the target space but not the current one.
+            const savedSqlModel = {
+                find: jest.fn(async () => [existingRow(OTHER_SPACE_UUID)]),
+                update: jest.fn(),
+                create: jest.fn(),
+            };
+            const getSpacesAccessContext = jest.fn(
+                async (_userUuid: string, spaceUuids: string[]) =>
+                    Object.fromEntries(
+                        spaceUuids.map((uuid) => [
+                            uuid,
+                            uuid === SPACE_UUID
+                                ? accessContext(PROJECT_UUID)
+                                : accessContext('inaccessible-project'),
+                        ]),
+                    ),
+            );
+            const service = buildService(savedSqlModel, getSpacesAccessContext);
+            stubSpace(service, SPACE_UUID);
+            const user = makeUser([
+                { subject: 'ContentAsCode', action: 'manage' },
+                { subject: 'CustomSql', action: 'manage' },
+                {
+                    subject: 'SavedChart',
+                    action: 'update',
+                    conditions: { projectUuid: PROJECT_UUID },
+                },
+            ]);
+
+            await expect(upsert(service, user)).rejects.toThrow(ForbiddenError);
+            expect(savedSqlModel.update).not.toHaveBeenCalled();
+            // both the target and the current space were checked
+            expect(getSpacesAccessContext).toHaveBeenCalledWith('user-uuid', [
+                SPACE_UUID,
+                OTHER_SPACE_UUID,
+            ]);
+        });
+    });
+});

--- a/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.upsertSqlChart.test.ts
@@ -160,8 +160,7 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 },
             ]);
 
-            await upsert(service, user);
-            expect(savedSqlModel.create).toHaveBeenCalledTimes(1);
+            await expect(upsert(service, user)).resolves.not.toThrow();
         });
     });
 
@@ -186,9 +185,7 @@ describe('CoderService.upsertSqlChart - permissions', () => {
                 },
             ]);
 
-            await upsert(service, user);
-            expect(savedSqlModel.update).toHaveBeenCalledTimes(1);
-            expect(savedSqlModel.create).not.toHaveBeenCalled();
+            await expect(upsert(service, user)).resolves.not.toThrow();
         });
 
         it('throws ForbiddenError on update without update:SavedChart', async () => {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -175,7 +175,16 @@ export const HeaderCreate: FC = () => {
           : canWriteBackToDbt
             ? 'writeBackToDbt'
             : 'save';
-    const ctaAction = userSelectedCtaAction ?? defaultCtaAction;
+    // Ignore a stale selection if the user no longer has permission for it
+    // (permissions can change after the spaces query resolves).
+    const isUserSelectedActionValid =
+        (userSelectedCtaAction === 'save' && canSaveChart) ||
+        (userSelectedCtaAction === 'createVirtualView' &&
+            canCreateVirtualView) ||
+        (userSelectedCtaAction === 'writeBackToDbt' && canWriteBackToDbt);
+    const ctaAction = isUserSelectedActionValid
+        ? (userSelectedCtaAction ?? defaultCtaAction)
+        : defaultCtaAction;
 
     const handleCtaClick = useCallback(() => {
         switch (ctaAction) {

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -26,6 +26,7 @@ import { useGitIntegration } from '../../../../hooks/gitIntegration/useGitIntegr
 import useHealth from '../../../../hooks/health/useHealth';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useProject } from '../../../../hooks/useProject';
+import useCreateInAnySpaceAccess from '../../../../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../../../../providers/App/useApp';
 import { CreateVirtualViewModal } from '../../../virtualView';
 import { useCreateSqlRunnerShareUrl } from '../../hooks/useSqlRunnerShareUrl';
@@ -52,10 +53,17 @@ export const HeaderCreate: FC = () => {
     const { user } = useApp();
     const organizationUuid = user.data?.organizationUuid;
 
-    const canSaveChart = !!user.data?.ability?.can(
+    // Saving a SQL chart needs both the project-level CustomSql permission and
+    // create access to at least one space (matches the backend SavedChart check).
+    const canManageCustomSql = !!user.data?.ability?.can(
         'manage',
         subject('CustomSql', { organizationUuid, projectUuid }),
     );
+    const canCreateChartInSpace = useCreateInAnySpaceAccess(
+        projectUuid,
+        'SavedChart',
+    );
+    const canSaveChart = canManageCustomSql && canCreateChartInSpace;
     const canCreateVirtualView = !!user.data?.ability?.can(
         'create',
         subject('VirtualView', { organizationUuid, projectUuid }),
@@ -155,14 +163,19 @@ export const HeaderCreate: FC = () => {
             !!cartesianChartSelectors.getErrors(state, selectedChartType),
     );
 
-    const initialCtaAction: CtaAction = canSaveChart
+    // The default depends on permissions that resolve asynchronously
+    // (canSaveChart waits on the spaces query), so derive it during render and
+    // only override it once the user explicitly picks an action.
+    const [userSelectedCtaAction, setUserSelectedCtaAction] =
+        useState<CtaAction | null>(null);
+    const defaultCtaAction: CtaAction = canSaveChart
         ? 'save'
         : canCreateVirtualView
           ? 'createVirtualView'
           : canWriteBackToDbt
             ? 'writeBackToDbt'
             : 'save';
-    const [ctaAction, setCtaAction] = useState<CtaAction>(initialCtaAction);
+    const ctaAction = userSelectedCtaAction ?? defaultCtaAction;
 
     const handleCtaClick = useCallback(() => {
         switch (ctaAction) {
@@ -325,7 +338,9 @@ export const HeaderCreate: FC = () => {
                                                 <Menu.Item
                                                     disabled={!canSaveChart}
                                                     onClick={() => {
-                                                        setCtaAction('save');
+                                                        setUserSelectedCtaAction(
+                                                            'save',
+                                                        );
                                                     }}
                                                 >
                                                     <Stack spacing="two">
@@ -380,7 +395,7 @@ export const HeaderCreate: FC = () => {
                                                         !canCreateVirtualView
                                                     }
                                                     onClick={() => {
-                                                        setCtaAction(
+                                                        setUserSelectedCtaAction(
                                                             'createVirtualView',
                                                         );
                                                     }}
@@ -448,7 +463,7 @@ export const HeaderCreate: FC = () => {
                                                         undefined
                                                     }
                                                     onClick={() => {
-                                                        setCtaAction(
+                                                        setUserSelectedCtaAction(
                                                             'writeBackToDbt',
                                                         );
                                                     }}

--- a/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/SaveSqlChartModal.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { ChartKind } from '@lightdash/common';
 import { Button, Stack, Textarea, TextInput } from '@mantine-8/core';
 import { useForm, zodResolver } from '@mantine/form';
@@ -14,6 +15,7 @@ import { selectCompleteConfigByKind } from '../../../components/DataViz/store/se
 import { useModalSteps } from '../../../hooks/useModalSteps';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
+import useApp from '../../../providers/App/useApp';
 import { DEFAULT_SQL_LIMIT } from '../constants';
 import { useCreateSqlChartMutation } from '../hooks/useSavedSqlCharts';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -41,6 +43,7 @@ const SAVE_CHART_FORM_ID = 'save-sql-chart-form';
 
 export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
     const dispatch = useAppDispatch();
+    const { user } = useApp();
     const projectUuid = useAppSelector((state) => state.sqlRunner.projectUuid);
     const hasUnrunChanges = useAppSelector(
         (state) => state.sqlRunner.hasUnrunChanges,
@@ -96,7 +99,19 @@ export const SaveSqlChartModal: FC<Props> = ({ opened, onClose }) => {
         data: spaces = [],
         isLoading: isLoadingSpace,
         isSuccess: isSuccessSpace,
-    } = useSpaceSummaries(projectUuid, true);
+    } = useSpaceSummaries(projectUuid, true, {
+        select: (data) =>
+            data.filter((space) =>
+                // Only show spaces the user can create SQL charts in
+                user.data?.ability.can(
+                    'create',
+                    subject('SavedChart', {
+                        ...space,
+                        access: space.userAccess ? [space.userAccess] : [],
+                    }),
+                ),
+            ),
+    });
 
     const spaceManagement = useSpaceManagement({
         projectUuid,


### PR DESCRIPTION
## Problem

Saving a SQL chart via **content-as-code / CLI** (`POST /projects/{uuid}/sqlCharts/{slug}/code`) only checked `manage:ContentAsCode`, skipping the `manage:CustomSql` + space-level `SavedChart` checks the **UI** path enforces.

A custom role with `ContentAsCode` but **not** `CustomSql` could create, update, or move SQL charts via `lightdash upload` while being blocked in the UI.

## Fix

`CoderService.upsertSqlChart` now mirrors `SavedSqlService`:

- Requires `manage:CustomSql` (checked before the space is resolved).
- Requires space-level `create`/`update` on `SavedChart`.
- On a move, checks **both** the current and target space.

Frontend (UX only — backend is the real gate):

- `HeaderCreate` — Save is gated on create-access to a space; the default CTA is derived reactively.
- `SaveSqlChartModal` — the space dropdown lists only spaces you can create in.

## Impact

Only affects principals with `ContentAsCode` **without** `CustomSql` — their `lightdash upload` of SQL charts now returns 403. Service accounts, system roles, and roles that already hold `CustomSql` are unchanged.

## Testing

- Unit: `CoderService.upsertSqlChart.test.ts` — create / update / move authorization (6 cases).
- Manual: restricted role → **403**; admin → **200**; UI save flow works.
