### PR TITLE
fix(ai-agent): rename 'App' source label to 'Web' in Ask AI threads table

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminThreadsTable.tsx
@@ -333,7 +333,7 @@ const AiAgentAdminThreadsTable = ({
                 if (label === 'slack') {
                     label = 'Slack';
                 } else if (label === 'web_app') {
-                    label = 'App';
+                    label = 'Web';
                 }
 
                 const slackUrl =


### PR DESCRIPTION
The **Source** column in the Ask AI > Threads admin table labelled web-UI threads as `App`, which is ambiguous now that Data Apps is a distinct feature. Renamed the label to `Web` so it's clear where a thread originated.

Single string change in `AiAgentAdminThreadsTable.tsx` — the `web_app` source now renders as `Web` instead of `App`.