### PR TITLE
feat(sandbox): AWS Lambda MicroVMs SandboxProvider (native pause/resume, ships dark)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -56,6 +56,7 @@
         "@ai-sdk/mcp": "1.0.41",
         "@ai-sdk/openai": "3.0.68",
         "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-lambda-microvms": "3.1075.0",
         "@aws-sdk/client-s3": "3.992.0",
         "@aws-sdk/credential-providers": "3.995.0",
         "@aws-sdk/lib-storage": "3.995.0",

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -377,6 +377,18 @@ export const lightdashConfigMock: LightdashConfig = {
         sandboxAiWritebackDockerImage: 'lightdash-ai-writeback:local',
         sandboxIdleTimeoutMs: 30 * 60 * 1000,
         sandboxSnapshotRetentionMs: 7 * 24 * 60 * 60 * 1000,
+        lambdaMicroVm: {
+            region: 'eu-west-1',
+            executionRoleArn: null,
+            ingressConnectorArn:
+                'arn:aws:lambda:eu-west-1:aws:network-connector:aws-network-connector:ALL_INGRESS',
+            egressConnectorArn:
+                'arn:aws:lambda:eu-west-1:aws:network-connector:aws-network-connector:INTERNET_EGRESS',
+            maxIdleDurationSeconds: 30 * 60,
+            suspendedDurationSeconds: 7 * 24 * 60 * 60,
+        },
+        lambdaMicroVmDataAppImageArn: null,
+        lambdaMicroVmAiWritebackImageArn: null,
     },
     enabledFeatureFlags: new Set<string>(),
     disabledFeatureFlags: new Set<string>(),

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1596,10 +1596,11 @@ export type AppRuntimeConfig = {
     /**
      * Which sandbox backend the data-app pipeline launches sandboxes on.
      * `e2b` keeps today's hosted path; `docker` runs a plain local container
-     * (dev / self-host testbed — see SandboxRuntime/DESIGN.md). Later:
-     * kubernetes | ecs | microsandbox.
+     * (dev / self-host testbed — see SandboxRuntime/DESIGN.md);
+     * `lambda-microvm` runs AWS Lambda MicroVMs (native suspend/resume).
+     * Later: kubernetes | ecs | microsandbox.
      */
-    sandboxProvider: 'e2b' | 'docker';
+    sandboxProvider: 'e2b' | 'docker' | 'lambda-microvm';
     /**
      * OCI image the `docker` sandbox provider launches data-app containers
      * from. Built locally from sandboxes/data-apps (e.g. `lightdash-sandbox:local`).
@@ -1624,6 +1625,35 @@ export type AppRuntimeConfig = {
      * reaper GCs it. Defaults to 7 days.
      */
     sandboxSnapshotRetentionMs: number;
+    /**
+     * Static config the `lambda-microvm` sandbox provider needs (region, IAM
+     * execution role, network connectors, idle policy). Idle/suspended durations
+     * are derived from `sandboxIdleTimeoutMs`/`sandboxSnapshotRetentionMs` so the
+     * AWS-side `idlePolicy` (auto-suspend / auto-terminate) mirrors the reaper's
+     * windows. Always populated (with defaults); only read when the provider is
+     * `lambda-microvm`.
+     */
+    lambdaMicroVm: {
+        region: string;
+        executionRoleArn: string | null;
+        ingressConnectorArn: string;
+        egressConnectorArn: string;
+        maxIdleDurationSeconds: number;
+        suspendedDurationSeconds: number;
+    };
+    /**
+     * Lambda MicroVM image ARN the data-app pipeline runs from (the
+     * `lambda-microvm` analog of the Docker data-app image).
+     * Built out-of-band by the image pipeline (see sandboxes/). Required only
+     * when `sandboxProvider === 'lambda-microvm'`.
+     */
+    lambdaMicroVmDataAppImageArn: string | null;
+    /**
+     * Lambda MicroVM image ARN the AI writeback pipeline runs from (decoupled
+     * from the data-app image, mirroring the split Docker images).
+     * Required only when `sandboxProvider === 'lambda-microvm'`.
+     */
+    lambdaMicroVmAiWritebackImageArn: string | null;
 };
 
 export type IntercomConfig = {
@@ -1788,6 +1818,14 @@ export type SmtpConfig = {
 
 const DEFAULT_JOB_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 
+const parseSandboxProvider = (
+    value: string | undefined,
+): AppRuntimeConfig['sandboxProvider'] => {
+    if (value === 'docker') return 'docker';
+    if (value === 'lambda-microvm') return 'lambda-microvm';
+    return 'e2b';
+};
+
 const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
     const enabled = process.env.APPS_RUNTIME_ENABLED === 'true';
     const appsBucket = process.env.APPS_S3_BUCKET;
@@ -1825,6 +1863,16 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         };
     }
 
+    const sandboxIdleTimeoutMs = process.env.SANDBOX_IDLE_TIMEOUT_MS
+        ? parseInt(process.env.SANDBOX_IDLE_TIMEOUT_MS, 10)
+        : 30 * 60 * 1000;
+    const sandboxSnapshotRetentionMs = process.env.SANDBOX_SNAPSHOT_RETENTION_MS
+        ? parseInt(process.env.SANDBOX_SNAPSHOT_RETENTION_MS, 10)
+        : 7 * 24 * 60 * 60 * 1000;
+    // Lambda MicroVMs run in eu-west-1 (Ireland) — the EU launch region.
+    const lambdaMicroVmRegion =
+        process.env.LAMBDA_MICROVM_REGION || 'eu-west-1';
+
     return {
         enabled,
         lightdashOrigin: process.env.APP_RUNTIME_LIGHTDASH_ORIGIN || siteUrl,
@@ -1848,19 +1896,36 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
             'lightdash-ai-writeback',
         e2bAiWritebackTemplateTag:
             process.env.E2B_AI_WRITEBACK_TEMPLATE_TAG ?? (VERSION as string),
-        sandboxProvider:
-            process.env.SANDBOX_PROVIDER === 'docker' ? 'docker' : 'e2b',
+        sandboxProvider: parseSandboxProvider(process.env.SANDBOX_PROVIDER),
         sandboxDockerImage:
             process.env.SANDBOX_DOCKER_IMAGE || 'lightdash-sandbox:local',
         sandboxAiWritebackDockerImage:
             process.env.SANDBOX_AI_WRITEBACK_DOCKER_IMAGE ||
             'lightdash-ai-writeback:local',
-        sandboxIdleTimeoutMs: process.env.SANDBOX_IDLE_TIMEOUT_MS
-            ? parseInt(process.env.SANDBOX_IDLE_TIMEOUT_MS, 10)
-            : 30 * 60 * 1000,
-        sandboxSnapshotRetentionMs: process.env.SANDBOX_SNAPSHOT_RETENTION_MS
-            ? parseInt(process.env.SANDBOX_SNAPSHOT_RETENTION_MS, 10)
-            : 7 * 24 * 60 * 60 * 1000,
+        sandboxIdleTimeoutMs,
+        sandboxSnapshotRetentionMs,
+        lambdaMicroVm: {
+            region: lambdaMicroVmRegion,
+            executionRoleArn:
+                process.env.LAMBDA_MICROVM_EXECUTION_ROLE_ARN || null,
+            // Managed connectors are fixed, region-scoped ARNs (no list op). The
+            // open `INTERNET_EGRESS` connector is the MVP egress; a custom VPC
+            // connector (egress allowlist) is a later hardening.
+            ingressConnectorArn:
+                process.env.LAMBDA_MICROVM_INGRESS_CONNECTOR_ARN ||
+                `arn:aws:lambda:${lambdaMicroVmRegion}:aws:network-connector:aws-network-connector:ALL_INGRESS`,
+            egressConnectorArn:
+                process.env.LAMBDA_MICROVM_EGRESS_CONNECTOR_ARN ||
+                `arn:aws:lambda:${lambdaMicroVmRegion}:aws:network-connector:aws-network-connector:INTERNET_EGRESS`,
+            maxIdleDurationSeconds: Math.floor(sandboxIdleTimeoutMs / 1000),
+            suspendedDurationSeconds: Math.floor(
+                sandboxSnapshotRetentionMs / 1000,
+            ),
+        },
+        lambdaMicroVmDataAppImageArn:
+            process.env.LAMBDA_MICROVM_DATA_APP_IMAGE_ARN || null,
+        lambdaMicroVmAiWritebackImageArn:
+            process.env.LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN || null,
     };
 };
 

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -934,6 +934,7 @@ export class AiWritebackService extends BaseService {
                 dockerImage:
                     this.lightdashConfig.appRuntime
                         .sandboxAiWritebackDockerImage,
+                lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
                 snapshotStore: new S3SnapshotStore({
                     lightdashConfig: this.lightdashConfig,
                 }),
@@ -968,6 +969,17 @@ export class AiWritebackService extends BaseService {
         if (sandboxProvider === 'docker') {
             return this.lightdashConfig.appRuntime
                 .sandboxAiWritebackDockerImage;
+        }
+        if (sandboxProvider === 'lambda-microvm') {
+            const imageArn =
+                this.lightdashConfig.appRuntime
+                    .lambdaMicroVmAiWritebackImageArn;
+            if (!imageArn) {
+                throw new MissingConfigError(
+                    'Lambda MicroVM AI writeback image ARN is not configured (LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN)',
+                );
+            }
+            return imageArn;
         }
         return resolveSandboxTemplateRef({
             name: this.lightdashConfig.appRuntime.e2bAiWritebackTemplateName,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -389,6 +389,7 @@ export class AppGenerateService extends BaseService {
                 provider: this.lightdashConfig.appRuntime.sandboxProvider,
                 e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
                 dockerImage: this.lightdashConfig.appRuntime.sandboxDockerImage,
+                lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
                 snapshotStore: new S3SnapshotStore({
                     lightdashConfig: this.lightdashConfig,
                 }),
@@ -407,6 +408,16 @@ export class AppGenerateService extends BaseService {
             this.lightdashConfig.appRuntime;
         if (sandboxProvider === 'docker') {
             return this.lightdashConfig.appRuntime.sandboxDockerImage;
+        }
+        if (sandboxProvider === 'lambda-microvm') {
+            const imageArn =
+                this.lightdashConfig.appRuntime.lambdaMicroVmDataAppImageArn;
+            if (!imageArn) {
+                throw new MissingConfigError(
+                    'Lambda MicroVM data-app image ARN is not configured (LAMBDA_MICROVM_DATA_APP_IMAGE_ARN)',
+                );
+            }
+            return imageArn;
         }
         // E2B treats `name` and `name:default` interchangeably, so an empty
         // tag is fine — it just resolves to the implicit `default` build.

--- a/packages/backend/src/ee/services/SandboxRuntime/LambdaExecChannel.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/LambdaExecChannel.ts
@@ -1,0 +1,313 @@
+import { SandboxCommandError, SandboxTimeoutError } from './errors';
+import {
+    type CommandResult,
+    type RunOptions,
+    type SandboxCommands,
+    type SandboxFiles,
+} from './types';
+
+/**
+ * Data plane for a Lambda MicroVM: an HTTP client to the in-microVM exec agent
+ * (the sandbox-image agent — Workstream 2). Lambda ships no native exec SDK, so
+ * `commands`/`files` run over the microVM's HTTPS proxy `endpoint`, authenticated
+ * with the JWE bearer minted by `CreateMicrovmAuthToken` and sent as the
+ * `X-aws-proxy-auth` header (the AWS connector terminates it; the agent trusts
+ * inbound). `git` is layered on top of `commands.run` by {@link createGitOverCommands}.
+ *
+ * **The agent contract** (kept in lock-step with the agent in Workstream 2):
+ * - `POST /exec` JSON `{cmd, cwd?, envs?, timeoutMs?}` → a stream of
+ *   newline-delimited JSON events: `{"stream":"stdout"|"stderr","data":<base64>}`
+ *   chunks then a terminal `{"exitCode":<n>}` or `{"timeout":true}`.
+ * - `GET /files?path=` → raw bytes (200) / 404; `POST /files?path=` raw body →
+ *   write (creates parent dirs); `DELETE /files?path=` → idempotent remove.
+ */
+const AGENT_PORT_HEADER = 'X-aws-proxy-port';
+const AGENT_PORT = '8080';
+const AUTH_HEADER = 'X-aws-proxy-auth';
+
+type ExecEvent =
+    | { stream: 'stdout' | 'stderr'; data: string }
+    | { exitCode: number }
+    | { timeout: true };
+
+const isExecEvent = (value: unknown): value is ExecEvent => {
+    if (typeof value !== 'object' || value === null) return false;
+    const record = value as Record<string, unknown>;
+    if (record.timeout === true) return true;
+    if (typeof record.exitCode === 'number') return true;
+    return (
+        (record.stream === 'stdout' || record.stream === 'stderr') &&
+        typeof record.data === 'string'
+    );
+};
+
+/**
+ * Drain the newline-delimited JSON event stream, firing `onStdout`/`onStderr`
+ * as chunks arrive and resolving on the terminal event. Like the other
+ * providers, a non-zero exit throws {@link SandboxCommandError}; a timeout throws
+ * {@link SandboxTimeoutError}.
+ */
+const consumeExecStream = async (
+    body: ReadableStream<Uint8Array>,
+    command: string,
+    options: RunOptions | undefined,
+): Promise<CommandResult> => {
+    // Iterate the response body as an async stream of byte chunks. This works
+    // for both the native undici `ReadableStream` (production, Node 22) and
+    // node-fetch's Node `Readable` (test env) without branching.
+    const chunks = body as unknown as AsyncIterable<Uint8Array>;
+    const decoder = new TextDecoder();
+    let buffered = '';
+    let stdout = '';
+    let stderr = '';
+
+    const handleEvent = (event: ExecEvent): CommandResult | null => {
+        if ('timeout' in event) {
+            throw new SandboxTimeoutError(
+                `Command timed out after ${options?.timeoutMs}ms`,
+            );
+        }
+        if ('exitCode' in event) {
+            if (event.exitCode !== 0) {
+                throw new SandboxCommandError(event.exitCode, stderr, stdout);
+            }
+            return { stdout, stderr, exitCode: event.exitCode };
+        }
+        const text = Buffer.from(event.data, 'base64').toString('utf8');
+        if (event.stream === 'stdout') {
+            stdout += text;
+            options?.onStdout?.(text);
+        } else {
+            stderr += text;
+            options?.onStderr?.(text);
+        }
+        return null;
+    };
+
+    const drainLine = (line: string): CommandResult | null => {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) return null;
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(trimmed);
+        } catch {
+            // A non-JSON line means a corrupt frame — surface it rather than
+            // silently dropping output.
+            throw new SandboxCommandError(
+                -1,
+                `exec agent emitted a non-JSON frame: ${trimmed.slice(0, 200)}`,
+                stdout,
+            );
+        }
+        if (!isExecEvent(parsed)) {
+            throw new SandboxCommandError(
+                -1,
+                `exec agent emitted an unknown frame: ${trimmed.slice(0, 200)}`,
+                stdout,
+            );
+        }
+        return handleEvent(parsed);
+    };
+
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const value of chunks) {
+        buffered += decoder.decode(value, { stream: true });
+        let newlineIndex = buffered.indexOf('\n');
+        while (newlineIndex !== -1) {
+            const line = buffered.slice(0, newlineIndex);
+            buffered = buffered.slice(newlineIndex + 1);
+            const result = drainLine(line);
+            if (result) return result;
+            newlineIndex = buffered.indexOf('\n');
+        }
+    }
+    // Flush any final line without a trailing newline.
+    const result = drainLine(buffered);
+    if (result) return result;
+    throw new SandboxCommandError(
+        -1,
+        `exec agent stream ended without an exit code for: ${command}`,
+        stdout,
+    );
+};
+
+export class LambdaExecChannel {
+    private token: string | null = null;
+
+    private readonly baseUrl: string;
+
+    /**
+     * @param endpoint the microVM proxy endpoint from `RunMicrovm`/`GetMicrovm`.
+     *   AWS returns this as a bare hostname (no scheme), so we default it to
+     *   `https://` — it is an HTTPS endpoint. A scheme is honored if already present
+     *   (e.g. `http://` for a local test server).
+     * @param mintToken mints a fresh `X-aws-proxy-auth` bearer. Called lazily on
+     *   first use and again to refresh after an auth rejection, so a turn that
+     *   outlives its token (open item: long Claude runs > token TTL) self-heals.
+     */
+    constructor(
+        endpoint: string,
+        private readonly mintToken: () => Promise<string>,
+    ) {
+        this.baseUrl = /^https?:\/\//.test(endpoint)
+            ? endpoint
+            : `https://${endpoint}`;
+    }
+
+    private url(path: string): string {
+        return new URL(path, this.baseUrl).toString();
+    }
+
+    private async authToken(forceRefresh = false): Promise<string> {
+        if (forceRefresh || this.token === null) {
+            this.token = await this.mintToken();
+        }
+        return this.token;
+    }
+
+    /** Send a request, re-minting the bearer once on a 401/403 and retrying. */
+    private async send(
+        path: string,
+        init: RequestInit,
+        signal?: AbortSignal,
+    ): Promise<Response> {
+        const attempt = async (forceRefresh: boolean): Promise<Response> => {
+            const token = await this.authToken(forceRefresh);
+            return fetch(this.url(path), {
+                ...init,
+                signal: signal ?? null,
+                headers: {
+                    ...init.headers,
+                    [AUTH_HEADER]: token,
+                    [AGENT_PORT_HEADER]: AGENT_PORT,
+                },
+            });
+        };
+        const response = await attempt(false);
+        if (response.status === 401 || response.status === 403) {
+            return attempt(true);
+        }
+        return response;
+    }
+
+    readonly commands: SandboxCommands = {
+        run: async (
+            command: string,
+            options?: RunOptions,
+        ): Promise<CommandResult> => {
+            const controller = new AbortController();
+            const timer =
+                options?.timeoutMs && options.timeoutMs > 0
+                    ? setTimeout(
+                          () => controller.abort(),
+                          // Grace over the agent's own deadline so the agent's
+                          // `{"timeout":true}` event wins the race when it can.
+                          options.timeoutMs + 5_000,
+                      )
+                    : null;
+            try {
+                const response = await this.send(
+                    '/exec',
+                    {
+                        method: 'POST',
+                        headers: { 'content-type': 'application/json' },
+                        body: JSON.stringify({
+                            cmd: command,
+                            cwd: options?.cwd,
+                            envs: options?.envs,
+                            timeoutMs: options?.timeoutMs,
+                        }),
+                    },
+                    controller.signal,
+                );
+                if (!response.ok || response.body === null) {
+                    throw new SandboxCommandError(
+                        response.status,
+                        await response.text().catch(() => ''),
+                        '',
+                    );
+                }
+                return await consumeExecStream(response.body, command, options);
+            } catch (error) {
+                if (
+                    error instanceof DOMException &&
+                    error.name === 'AbortError'
+                ) {
+                    throw new SandboxTimeoutError(
+                        `Command timed out after ${options?.timeoutMs}ms`,
+                    );
+                }
+                throw error;
+            } finally {
+                if (timer) clearTimeout(timer);
+            }
+        },
+    };
+
+    readonly files: SandboxFiles = {
+        read: async (path: string): Promise<string> => {
+            const response = await this.send(
+                `/files?path=${encodeURIComponent(path)}`,
+                { method: 'GET' },
+            );
+            if (!response.ok) {
+                throw new SandboxCommandError(
+                    response.status,
+                    `failed to read ${path}: ${await response
+                        .text()
+                        .catch(() => '')}`,
+                    '',
+                );
+            }
+            return response.text();
+        },
+        readBytes: async (path: string): Promise<Buffer> => {
+            const response = await this.send(
+                `/files?path=${encodeURIComponent(path)}`,
+                { method: 'GET' },
+            );
+            if (!response.ok) {
+                throw new SandboxCommandError(
+                    response.status,
+                    `failed to read ${path}: ${await response
+                        .text()
+                        .catch(() => '')}`,
+                    '',
+                );
+            }
+            return Buffer.from(await response.arrayBuffer());
+        },
+        write: async (
+            path: string,
+            contents: string | Uint8Array,
+        ): Promise<void> => {
+            const body =
+                typeof contents === 'string'
+                    ? Buffer.from(contents, 'utf8')
+                    : Buffer.from(contents);
+            const response = await this.send(
+                `/files?path=${encodeURIComponent(path)}`,
+                {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/octet-stream' },
+                    body,
+                },
+            );
+            if (!response.ok) {
+                throw new SandboxCommandError(
+                    response.status,
+                    `failed to write ${path}: ${await response
+                        .text()
+                        .catch(() => '')}`,
+                    '',
+                );
+            }
+        },
+        remove: async (path: string): Promise<void> => {
+            // Idempotent: the agent returns 200/204 even when the path is gone.
+            await this.send(`/files?path=${encodeURIComponent(path)}`, {
+                method: 'DELETE',
+            });
+        },
+    };
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/LambdaMicroVmSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/LambdaMicroVmSandboxProvider.ts
@@ -1,0 +1,346 @@
+import {
+    LambdaMicrovms,
+    MicrovmState,
+    ResourceNotFoundException,
+} from '@aws-sdk/client-lambda-microvms';
+import { createGitOverCommands } from './gitOverCommands';
+import { LambdaExecChannel } from './LambdaExecChannel';
+import {
+    type PersistOptions,
+    type SandboxCapabilities,
+    type SandboxGit,
+    type SandboxHandle,
+    type SandboxLogger,
+    type SandboxProvider,
+    type SandboxSpec,
+    type SnapshotRef,
+} from './types';
+
+/** Token TTL for the data-plane bearer. AWS caps this at 60 minutes, which
+ * matches our per-turn sandbox ceiling; the channel re-mints on a 401/403. */
+const AUTH_TOKEN_TTL_MINUTES = 60;
+/** AWS hard cap on a microVM's total lifetime (8 hours). */
+const MAX_DURATION_SECONDS = 28_800;
+/** Poll cadence + ceiling while waiting for `PENDING`/`SUSPENDED` → `RUNNING`.
+ * Real timings are ~5s to RUNNING and ~1s to resume. */
+const POLL_INTERVAL_MS = 1_000;
+const POLL_TIMEOUT_MS = 120_000;
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+/** A microVM's lifecycle state + current HTTPS proxy endpoint. */
+export interface MicrovmDescription {
+    state: string;
+    endpoint: string;
+}
+
+/**
+ * The slice of the Lambda MicroVMs control plane the provider drives. A thin,
+ * typed seam over the AWS SDK so the provider stays vendor-neutral and unit
+ * tests inject a fake (mirroring how `AiWritebackService.test.ts` drives a fake
+ * `SandboxProvider`) without loading the SDK.
+ */
+export interface MicrovmControlPlane {
+    runMicrovm(input: {
+        imageIdentifier: string;
+        executionRoleArn: string | null;
+        ingressNetworkConnectors: string[];
+        egressNetworkConnectors: string[];
+        idlePolicy: {
+            maxIdleDurationSeconds: number;
+            suspendedDurationSeconds: number;
+            autoResumeEnabled: boolean;
+        };
+        maximumDurationInSeconds: number;
+        runHookPayload: string | null;
+    }): Promise<{ microVmId: string; endpoint: string; state: string }>;
+    getMicrovm(microVmId: string): Promise<MicrovmDescription>;
+    suspendMicrovm(microVmId: string): Promise<void>;
+    resumeMicrovm(microVmId: string): Promise<void>;
+    /** Idempotent: a no-op when the microVM is already gone. */
+    terminateMicrovm(microVmId: string): Promise<void>;
+    /** Mint the `X-aws-proxy-auth` bearer value for the data plane. */
+    createAuthToken(microVmId: string): Promise<string>;
+}
+
+/**
+ * The real control plane backed by `@aws-sdk/client-lambda-microvms`. Maps the
+ * SDK's request/response shapes onto {@link MicrovmControlPlane} and normalizes
+ * the one error we treat specially (terminate is idempotent).
+ */
+export class AwsMicrovmControlPlane implements MicrovmControlPlane {
+    constructor(private readonly client: LambdaMicrovms) {}
+
+    async runMicrovm(
+        input: Parameters<MicrovmControlPlane['runMicrovm']>[0],
+    ): Promise<{ microVmId: string; endpoint: string; state: string }> {
+        const response = await this.client.runMicrovm({
+            imageIdentifier: input.imageIdentifier,
+            ...(input.executionRoleArn
+                ? { executionRoleArn: input.executionRoleArn }
+                : {}),
+            ingressNetworkConnectors: input.ingressNetworkConnectors,
+            egressNetworkConnectors: input.egressNetworkConnectors,
+            idlePolicy: input.idlePolicy,
+            maximumDurationInSeconds: input.maximumDurationInSeconds,
+            ...(input.runHookPayload
+                ? { runHookPayload: input.runHookPayload }
+                : {}),
+        });
+        if (!response.microvmId || !response.endpoint || !response.state) {
+            throw new Error(
+                'RunMicrovm returned an incomplete response (missing id/endpoint/state)',
+            );
+        }
+        return {
+            microVmId: response.microvmId,
+            endpoint: response.endpoint,
+            state: response.state,
+        };
+    }
+
+    async getMicrovm(microVmId: string): Promise<MicrovmDescription> {
+        const response = await this.client.getMicrovm({
+            microvmIdentifier: microVmId,
+        });
+        if (!response.state || !response.endpoint) {
+            throw new Error(
+                `GetMicrovm for ${microVmId} returned an incomplete response (missing state/endpoint)`,
+            );
+        }
+        return { state: response.state, endpoint: response.endpoint };
+    }
+
+    async suspendMicrovm(microVmId: string): Promise<void> {
+        await this.client.suspendMicrovm({ microvmIdentifier: microVmId });
+    }
+
+    async resumeMicrovm(microVmId: string): Promise<void> {
+        await this.client.resumeMicrovm({ microvmIdentifier: microVmId });
+    }
+
+    async terminateMicrovm(microVmId: string): Promise<void> {
+        try {
+            await this.client.terminateMicrovm({
+                microvmIdentifier: microVmId,
+            });
+        } catch (error) {
+            if (error instanceof ResourceNotFoundException) {
+                return;
+            }
+            throw error;
+        }
+    }
+
+    async createAuthToken(microVmId: string): Promise<string> {
+        const response = await this.client.createMicrovmAuthToken({
+            microvmIdentifier: microVmId,
+            expirationInMinutes: AUTH_TOKEN_TTL_MINUTES,
+            allowedPorts: [{ allPorts: {} }],
+        });
+        const token = response.authToken?.['X-aws-proxy-auth'];
+        if (!token) {
+            throw new Error(
+                `CreateMicrovmAuthToken for ${microVmId} did not return an X-aws-proxy-auth token`,
+            );
+        }
+        return token;
+    }
+}
+
+/** Static config the provider needs that does not vary per sandbox. */
+export interface LambdaMicroVmConfig {
+    executionRoleArn: string | null;
+    ingressConnectorArn: string;
+    egressConnectorArn: string;
+    maxIdleDurationSeconds: number;
+    suspendedDurationSeconds: number;
+}
+
+class LambdaMicroVmSandboxHandle implements SandboxHandle {
+    readonly commands;
+
+    readonly files;
+
+    readonly git: SandboxGit;
+
+    constructor(
+        readonly sandboxId: string,
+        channel: LambdaExecChannel,
+        private readonly suspendSelf: () => Promise<void>,
+    ) {
+        this.commands = channel.commands;
+        this.files = channel.files;
+        this.git = createGitOverCommands(channel.commands, channel.files);
+    }
+
+    // Native suspend IS the snapshot (memory+disk+processes).
+    async pause(): Promise<void> {
+        await this.suspendSelf();
+    }
+}
+
+/**
+ * AWS Lambda MicroVMs provider — a native-pause backend. The
+ * control plane (`RunMicrovm`/`Suspend`/`Resume`/`Terminate`) maps 1:1 onto
+ * `create`/`persist`/`resume`/`destroy`; the genuinely new piece is the
+ * {@link LambdaExecChannel} data plane (HTTPS to an in-microVM agent), because
+ * Lambda ships no native exec SDK.
+ */
+export class LambdaMicroVmSandboxProvider implements SandboxProvider {
+    readonly capabilities: SandboxCapabilities = {
+        isolation: 'microvm',
+        pauseResume: true,
+        persistence: 'memory',
+        // MVP routes egress through the managed open `INTERNET_EGRESS` connector,
+        // so the provider cannot enforce `SandboxSpec.egress`. A custom VPC egress
+        // connector (later hardening) is what flips this to `true`.
+        egressAllowlist: false,
+        warmPool: false,
+    };
+
+    constructor(
+        private readonly controlPlane: MicrovmControlPlane,
+        private readonly config: LambdaMicroVmConfig,
+        private readonly logger: SandboxLogger,
+    ) {}
+
+    async create(spec: SandboxSpec): Promise<SandboxHandle> {
+        const { microVmId, state } = await this.controlPlane.runMicrovm({
+            imageIdentifier: spec.templateRef,
+            executionRoleArn: this.config.executionRoleArn,
+            ingressNetworkConnectors: [this.config.ingressConnectorArn],
+            egressNetworkConnectors: [this.config.egressConnectorArn],
+            idlePolicy: {
+                maxIdleDurationSeconds: this.config.maxIdleDurationSeconds,
+                suspendedDurationSeconds: this.config.suspendedDurationSeconds,
+                autoResumeEnabled: true,
+            },
+            maximumDurationInSeconds: Math.min(
+                Math.max(1, Math.floor(spec.timeoutMs / 1000)),
+                MAX_DURATION_SECONDS,
+            ),
+            runHookPayload: spec.envs
+                ? JSON.stringify({ envs: spec.envs })
+                : null,
+        });
+        this.logger.info(
+            `Lambda microVM created (id=${microVmId}, image=${spec.templateRef})`,
+        );
+        const endpoint = await this.waitForRunning(microVmId, state);
+        return this.buildHandle(microVmId, endpoint);
+    }
+
+    async connect(microVmId: string): Promise<SandboxHandle> {
+        const description = await this.controlPlane.getMicrovm(microVmId);
+        const endpoint = await this.ensureRunning(microVmId, description);
+        return this.buildHandle(microVmId, endpoint);
+    }
+
+    async destroy(microVmId: string): Promise<void> {
+        await this.controlPlane.terminateMicrovm(microVmId);
+        this.logger.info(`Lambda microVM terminated (id=${microVmId})`);
+    }
+
+    async pause(microVmId: string): Promise<void> {
+        await this.controlPlane.suspendMicrovm(microVmId);
+    }
+
+    // Native in-memory suspend IS the snapshot: the suspended microVM keeps RAM,
+    // disk and live processes, so the declared workspace is irrelevant here. The
+    // ref is just the microVM id to resume.
+    async persist(
+        handle: SandboxHandle,
+        _options: PersistOptions,
+    ): Promise<SnapshotRef> {
+        await this.controlPlane.suspendMicrovm(handle.sandboxId);
+        return {
+            kind: 'lambda-microvm-suspended',
+            microVmId: handle.sandboxId,
+        };
+    }
+
+    async resume(ref: SnapshotRef, _spec: SandboxSpec): Promise<SandboxHandle> {
+        if (ref.kind !== 'lambda-microvm-suspended') {
+            throw new Error(
+                `LambdaMicroVmSandboxProvider cannot resume a snapshot of kind '${ref.kind}'`,
+            );
+        }
+        return this.connect(ref.microVmId);
+    }
+
+    /** Resume a suspended microVM (or accept a running one); reject terminal ones. */
+    private async ensureRunning(
+        microVmId: string,
+        description: MicrovmDescription,
+    ): Promise<string> {
+        if (
+            description.state === MicrovmState.TERMINATED ||
+            description.state === MicrovmState.TERMINATING
+        ) {
+            throw new Error(
+                `Lambda microVM ${microVmId} is ${description.state} and can no longer be resumed`,
+            );
+        }
+        if (description.state === MicrovmState.RUNNING) {
+            return description.endpoint;
+        }
+        if (
+            description.state === MicrovmState.SUSPENDED ||
+            description.state === MicrovmState.SUSPENDING
+        ) {
+            await this.controlPlane.resumeMicrovm(microVmId);
+        }
+        return this.waitForRunning(microVmId, description.state);
+    }
+
+    /**
+     * Poll `GetMicrovm` until `RUNNING`, re-reading the endpoint each time (it is
+     * a separate, stable hostname — see §0). Fails closed on a terminal state or
+     * timeout.
+     */
+    private async waitForRunning(
+        microVmId: string,
+        currentState: string,
+    ): Promise<string> {
+        const deadline = Date.now() + POLL_TIMEOUT_MS;
+        let state = currentState;
+        while (state !== MicrovmState.RUNNING) {
+            if (
+                state === MicrovmState.TERMINATED ||
+                state === MicrovmState.TERMINATING
+            ) {
+                throw new Error(
+                    `Lambda microVM ${microVmId} entered ${state} while waiting for RUNNING`,
+                );
+            }
+            if (Date.now() > deadline) {
+                throw new Error(
+                    `Lambda microVM ${microVmId} did not reach RUNNING within ${POLL_TIMEOUT_MS}ms (last state ${state})`,
+                );
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(POLL_INTERVAL_MS);
+            // eslint-disable-next-line no-await-in-loop
+            const description = await this.controlPlane.getMicrovm(microVmId);
+            state = description.state;
+            if (state === MicrovmState.RUNNING) {
+                return description.endpoint;
+            }
+        }
+        const description = await this.controlPlane.getMicrovm(microVmId);
+        return description.endpoint;
+    }
+
+    private buildHandle(microVmId: string, endpoint: string): SandboxHandle {
+        const channel = new LambdaExecChannel(endpoint, () =>
+            this.controlPlane.createAuthToken(microVmId),
+        );
+        return new LambdaMicroVmSandboxHandle(microVmId, channel, () =>
+            this.controlPlane.suspendMicrovm(microVmId),
+        );
+    }
+}

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
@@ -230,6 +230,14 @@ export class SandboxManager {
      * Safety-net sweep (cron): suspend running sandboxes left idle by a crashed
      * worker, then GC suspended snapshots past the retention window. In steady
      * state this finds nothing — every turn suspends its own sandbox.
+     *
+     * Native-pause providers that self-suspend on their own idle policy
+     * (Lambda MicroVMs via its AWS `idlePolicy`) may have already suspended an
+     * "idle running" row out-of-band. That is harmless here: `suspendOrphan`
+     * connects (auto-resuming the microVM) and re-suspends, converging the row
+     * to SUSPENDED. A future refinement is to make this a pure reconcile for such
+     * providers (GetMicrovm: TERMINATED/missing → mark expired) and let AWS own
+     * idle-suspend entirely.
      */
     async reapIdle(): Promise<{ suspended: number; gced: number }> {
         const now = Date.now();

--- a/packages/backend/src/ee/services/SandboxRuntime/gitOverCommands.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/gitOverCommands.ts
@@ -1,0 +1,111 @@
+import { randomBytes } from 'node:crypto';
+import {
+    type GitAddTarget,
+    type GitCloneOptions,
+    type GitCommitOptions,
+    type GitPushOptions,
+    type GitStatus,
+    type SandboxCommands,
+    type SandboxFiles,
+    type SandboxGit,
+} from './types';
+
+/** Single-quote a value for safe interpolation into a `/bin/sh -c` string. */
+export const shQuote = (value: string): string =>
+    `'${value.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Build a `git -c http.extraHeader=...` prefix carrying HTTPS basic-auth
+ * credentials. Passed per-invocation (never written to the repo's `.git/config`),
+ * so the cloned remote URL stays clean.
+ * The same pattern GitHub Actions uses for token-authenticated checkouts.
+ */
+const gitAuthPrefix = (username: string, password: string): string => {
+    const token = Buffer.from(`${username}:${password}`).toString('base64');
+    return `git -c ${shQuote(`http.extraHeader=AUTHORIZATION: basic ${token}`)}`;
+};
+
+/**
+ * Implement {@link SandboxGit} on top of a sandbox's `commands`/`files` data
+ * plane, using the system `git` binary inside the sandbox. Providers without a
+ * native git SDK (Docker, Lambda MicroVMs) share this — `commands.run` throws
+ * `SandboxCommandError` on a non-zero exit, so each operation fails loudly.
+ * Credentials are supplied per-invocation via an
+ * auth header and never persisted to the repo (see {@link gitAuthPrefix}).
+ */
+export const createGitOverCommands = (
+    commands: SandboxCommands,
+    files: SandboxFiles,
+): SandboxGit => ({
+    clone: async (url: string, options: GitCloneOptions): Promise<void> => {
+        const flags = [
+            options.depth !== undefined ? `--depth ${options.depth}` : '',
+            options.branch !== undefined
+                ? `--branch ${shQuote(options.branch)}`
+                : '',
+        ]
+            .filter(Boolean)
+            .join(' ');
+        await commands.run(
+            `${gitAuthPrefix(options.username, options.password)} clone ${flags} ${shQuote(url)} ${shQuote(options.path)}`,
+            options.timeoutMs !== undefined
+                ? { timeoutMs: options.timeoutMs }
+                : undefined,
+        );
+    },
+    status: async (path: string): Promise<GitStatus> => {
+        const branch = (
+            await commands.run(
+                `git -C ${shQuote(path)} rev-parse --abbrev-ref HEAD`,
+            )
+        ).stdout.trim();
+        const porcelain = (
+            await commands.run(`git -C ${shQuote(path)} status --porcelain`)
+        ).stdout;
+        return {
+            // `rev-parse --abbrev-ref HEAD` prints `HEAD` on a detached head.
+            currentBranch: branch && branch !== 'HEAD' ? branch : null,
+            hasChanges: porcelain.trim().length > 0,
+        };
+    },
+    createBranch: async (path: string, branch: string): Promise<void> => {
+        await commands.run(
+            `git -C ${shQuote(path)} checkout -b ${shQuote(branch)}`,
+        );
+    },
+    add: async (path: string, target: GitAddTarget): Promise<void> => {
+        const spec =
+            'all' in target
+                ? '-A'
+                : `-- ${target.files.map(shQuote).join(' ')}`;
+        await commands.run(`git -C ${shQuote(path)} add ${spec}`);
+    },
+    commit: async (
+        path: string,
+        message: string,
+        options: GitCommitOptions,
+    ): Promise<void> => {
+        // Pass the message through a temp file (-F) so arbitrary content —
+        // newlines, quotes, co-author trailers — survives without shell
+        // quoting. user.* is set per-invocation so author == committer.
+        const msgPath = `/tmp/.ld-commit-msg-${randomBytes(4).toString('hex')}`;
+        await files.write(msgPath, message);
+        try {
+            await commands.run(
+                `git -C ${shQuote(path)} ` +
+                    `-c user.name=${shQuote(options.authorName)} ` +
+                    `-c user.email=${shQuote(options.authorEmail)} ` +
+                    `commit -F ${shQuote(msgPath)}`,
+            );
+        } finally {
+            await files.remove(msgPath);
+        }
+    },
+    push: async (path: string, options: GitPushOptions): Promise<void> => {
+        const upstream = options.setUpstream ? '-u ' : '';
+        await commands.run(
+            `${gitAuthPrefix(options.username, options.password)} -C ${shQuote(path)} ` +
+                `push ${upstream}${shQuote(options.remote)} ${shQuote(options.branch)}`,
+        );
+    },
+});

--- a/packages/backend/src/ee/services/SandboxRuntime/index.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/index.ts
@@ -1,6 +1,12 @@
+import { LambdaMicrovms } from '@aws-sdk/client-lambda-microvms';
 import { MissingConfigError } from '@lightdash/common';
 import { DockerSandboxProvider } from './DockerSandboxProvider';
 import { E2bSandboxProvider } from './E2bSandboxProvider';
+import {
+    AwsMicrovmControlPlane,
+    LambdaMicroVmSandboxProvider,
+    type LambdaMicroVmConfig,
+} from './LambdaMicroVmSandboxProvider';
 import { SandboxManager, type SandboxRegistryStore } from './SandboxManager';
 import { type SnapshotStore } from './SnapshotStore';
 import { type SandboxLogger, type SandboxProvider } from './types';
@@ -10,12 +16,19 @@ export * from './SandboxManager';
 export * from './SnapshotStore';
 export * from './types';
 
-export type SandboxProviderKind = 'e2b' | 'docker';
+export type SandboxProviderKind = 'e2b' | 'docker' | 'lambda-microvm';
+
+/** Static, non-per-sandbox config the Lambda MicroVMs provider needs. */
+export interface LambdaMicroVmProviderConfig extends LambdaMicroVmConfig {
+    region: string;
+}
 
 export interface CreateSandboxProviderOptions {
     provider: SandboxProviderKind;
     e2bApiKey: string | null;
     dockerImage: string;
+    /** Required when `provider === 'lambda-microvm'`; ignored otherwise. */
+    lambdaMicroVm: LambdaMicroVmProviderConfig | null;
     /** Backing store for object-store snapshots (used by the Docker provider). */
     snapshotStore: SnapshotStore;
     logger: SandboxLogger;
@@ -42,6 +55,27 @@ export const createSandboxProvider = (
                 options.logger,
                 options.snapshotStore,
             );
+        case 'lambda-microvm': {
+            const config = options.lambdaMicroVm;
+            if (!config) {
+                throw new MissingConfigError(
+                    'Lambda MicroVMs is not configured (LAMBDA_MICROVM_*)',
+                );
+            }
+            if (!config.ingressConnectorArn || !config.egressConnectorArn) {
+                throw new MissingConfigError(
+                    'Lambda MicroVMs ingress/egress connector ARNs are not configured',
+                );
+            }
+            const controlPlane = new AwsMicrovmControlPlane(
+                new LambdaMicrovms({ region: config.region }),
+            );
+            return new LambdaMicroVmSandboxProvider(
+                controlPlane,
+                config,
+                options.logger,
+            );
+        }
         default:
             throw new MissingConfigError(
                 `Unknown SANDBOX_PROVIDER: ${options.provider as string}`,
@@ -53,6 +87,7 @@ export interface CreateSandboxManagerOptions {
     provider: SandboxProviderKind;
     e2bApiKey: string | null;
     dockerImage: string;
+    lambdaMicroVm: LambdaMicroVmProviderConfig | null;
     snapshotStore: SnapshotStore;
     registryModel: SandboxRegistryStore;
     logger: SandboxLogger;
@@ -71,6 +106,7 @@ export const createSandboxManager = (
         provider: options.provider,
         e2bApiKey: options.e2bApiKey,
         dockerImage: options.dockerImage,
+        lambdaMicroVm: options.lambdaMicroVm,
         snapshotStore: options.snapshotStore,
         logger: options.logger,
     });

--- a/packages/backend/src/ee/services/SandboxRuntime/types.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/types.ts
@@ -172,11 +172,15 @@ export interface PersistentWorkspace {
 
 /**
  * A pointer to a persisted sandbox. `e2b-paused` is E2B's native in-memory
- * snapshot (the paused sandbox itself); `s3-tar` is a portable tarball of the
- * declared workspace in object storage, used by providers without native pause.
+ * snapshot (the paused sandbox itself); `lambda-microvm-suspended` is the
+ * equivalent for AWS Lambda MicroVMs (the suspended microVM, a Firecracker
+ * memory+disk snapshot referenced by its opaque id); `s3-tar` is a portable
+ * tarball of the declared workspace in object storage, used by providers without
+ * native pause.
  */
 export type SnapshotRef =
     | { kind: 'e2b-paused'; sandboxId: string }
+    | { kind: 'lambda-microvm-suspended'; microVmId: string }
     | { kind: 's3-tar'; key: string };
 
 /** Inputs for {@link SandboxProvider.persist}. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: 0.91.1
         version: 0.91.1(zod@3.25.55)
+      '@aws-sdk/client-lambda-microvms':
+        specifier: 3.1075.0
+        version: 3.1075.0
       '@aws-sdk/client-s3':
         specifier: 3.992.0
         version: 3.992.0
@@ -1958,6 +1961,10 @@ packages:
     resolution: {integrity: sha512-CBGYQb6v6uIxvbID+ZzuYk/eGYGBVyXNUY8eu890WimzfahtyF/eLhvQTQJI0GrtKl8inSLKPqZOQ4tnrVAofQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-lambda-microvms@3.1075.0':
+    resolution: {integrity: sha512-aRqc4fT/qwwsbhiiaTsY/rNtsZjZMWuDEIYBaWNgQcsGJ8BPQvz3uNq+O08vl8rnRhNf6NotMqXfqyW+byaPeQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-redshift-serverless@3.1000.0':
     resolution: {integrity: sha512-DBi7mN1O7MBkgI/HaNRTL9c82yogwQ4M+RSPMCznuZ58cpmPRMjuDVy2ihej92tZrKLxouETX/1rp6DESIidqg==}
     engines: {node: '>=20.0.0'}
@@ -1978,6 +1985,10 @@ packages:
     resolution: {integrity: sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.0':
     resolution: {integrity: sha512-ThlLhTqX68jvoIVv+pryOdb5coP1cX1/MaTbB9xkGDCbWbsqQcLqzPxuSoW1DCnAAIacmXCWpzUNOB9pv+xXQw==}
     engines: {node: '>=20.0.0'}
@@ -1990,32 +2001,64 @@ packages:
     resolution: {integrity: sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.15':
     resolution: {integrity: sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.13':
     resolution: {integrity: sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.13':
     resolution: {integrity: sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.14':
     resolution: {integrity: sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.13':
     resolution: {integrity: sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.13':
     resolution: {integrity: sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.13':
     resolution: {integrity: sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.995.0':
@@ -2080,6 +2123,10 @@ packages:
     resolution: {integrity: sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.6':
     resolution: {integrity: sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==}
     engines: {node: '>=20.0.0'}
@@ -2096,8 +2143,20 @@ packages:
     resolution: {integrity: sha512-9Qx5JcAucnxnomREPb2D6L8K8GLG0rknt3+VK/BU3qTUynAcV4W21DQ04Z2RKDw+DYpW88lsZpXbVetWST2WUg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.999.0':
     resolution: {integrity: sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.13':
+    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.4':
@@ -2143,6 +2202,10 @@ packages:
     peerDependenciesMeta:
       aws-crt:
         optional: true
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.8':
     resolution: {integrity: sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==}
@@ -6137,8 +6200,16 @@ packages:
     resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.26.0':
+    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.10':
     resolution: {integrity: sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.2':
+    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.8':
@@ -6163,6 +6234,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.11':
     resolution: {integrity: sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.5.2':
+    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.9':
@@ -6221,6 +6296,10 @@ packages:
     resolution: {integrity: sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.8.2':
+    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.10':
     resolution: {integrity: sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==}
     engines: {node: '>=18.0.0'}
@@ -6247,6 +6326,10 @@ packages:
 
   '@smithy/signature-v4@5.3.10':
     resolution: {integrity: sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.5.2':
+    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.0':
@@ -17192,7 +17275,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -17208,7 +17291,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
@@ -17248,7 +17331,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.13
       '@smithy/util-utf8': 2.0.0
       tslib: 2.8.1
 
@@ -17312,7 +17395,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
+      '@smithy/core': 3.25.1
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
@@ -17325,7 +17408,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.12
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -17383,6 +17466,19 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/client-lambda-microvms@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
 
   '@aws-sdk/client-redshift-serverless@3.1000.0':
     dependencies:
@@ -17549,7 +17645,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
+      '@smithy/core': 3.25.1
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
@@ -17562,7 +17658,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.12
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -17593,9 +17689,20 @@ snapshots:
       '@smithy/util-utf8': 4.2.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/core': 3.25.1
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      bowser: 2.11.0
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.0':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.3':
@@ -17616,6 +17723,14 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.15':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -17627,6 +17742,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.0
       '@smithy/types': 4.13.0
       '@smithy/util-stream': 4.5.15
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.13':
@@ -17648,6 +17773,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.13':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -17660,6 +17801,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.14':
     dependencies:
@@ -17678,6 +17828,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/credential-provider-imds': 4.4.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.13':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -17685,6 +17849,14 @@ snapshots:
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
       '@smithy/types': 4.13.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.13':
@@ -17700,6 +17872,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.13':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -17711,6 +17893,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
 
   '@aws-sdk/credential-providers@3.995.0':
     dependencies:
@@ -17743,7 +17934,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.10
       '@smithy/node-http-handler': 4.4.12
       '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/util-stream': 4.5.15
       tslib: 2.8.1
 
@@ -17910,7 +18101,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.972.6
       '@aws-sdk/util-user-agent-node': 3.973.0
       '@smithy/config-resolver': 4.4.9
-      '@smithy/core': 3.23.6
+      '@smithy/core': 3.25.1
       '@smithy/fetch-http-handler': 5.3.11
       '@smithy/hash-node': 4.2.10
       '@smithy/invalid-dependency': 4.2.10
@@ -17923,7 +18114,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.12
       '@smithy/protocol-http': 5.3.10
       '@smithy/smithy-client': 4.12.0
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-base64': 4.3.1
       '@smithy/util-body-length-browser': 4.2.1
@@ -17937,6 +18128,19 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/fetch-http-handler': 5.5.2
+      '@smithy/node-http-handler': 4.8.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.6':
     dependencies:
@@ -17975,6 +18179,22 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.5.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.25.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.999.0':
     dependencies:
       '@aws-sdk/core': 3.973.15
@@ -17982,10 +18202,15 @@ snapshots:
       '@aws-sdk/types': 3.973.4
       '@smithy/property-provider': 4.2.10
       '@smithy/shared-ini-file-loader': 4.4.5
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/types@3.973.13':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
 
   '@aws-sdk/types@3.973.4':
     dependencies:
@@ -17999,7 +18224,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.980.0':
     dependencies:
       '@aws-sdk/types': 3.973.4
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
       tslib: 2.8.1
@@ -18015,7 +18240,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.995.0':
     dependencies:
       '@aws-sdk/types': 3.973.4
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
       tslib: 2.8.1
@@ -18023,7 +18248,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.996.3':
     dependencies:
       '@aws-sdk/types': 3.973.4
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/url-parser': 4.2.10
       '@smithy/util-endpoints': 3.3.1
       tslib: 2.8.1
@@ -18054,9 +18279,14 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.8':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       fast-xml-parser: 5.3.6
       tslib: 2.8.1
 
@@ -18209,7 +18439,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -18281,7 +18511,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -19042,7 +19272,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19066,7 +19296,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19603,7 +19833,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -19965,7 +20195,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -20360,7 +20590,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21874,7 +22104,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22739,12 +22969,24 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.26.0':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.10':
     dependencies:
       '@smithy/node-config-provider': 4.3.10
       '@smithy/property-provider': 4.2.10
       '@smithy/types': 4.13.0
       '@smithy/url-parser': 4.2.10
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.8':
@@ -22774,7 +23016,7 @@ snapshots:
   '@smithy/eventstream-serde-universal@4.2.8':
     dependencies:
       '@smithy/eventstream-codec': 4.2.8
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.11':
@@ -22783,6 +23025,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.10
       '@smithy/types': 4.13.0
       '@smithy/util-base64': 4.3.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.9':
@@ -22879,6 +23127,12 @@ snapshots:
       '@smithy/types': 4.13.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.8.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.10':
     dependencies:
       '@smithy/types': 4.13.0
@@ -22891,33 +23145,39 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.10':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/util-uri-escape': 4.2.1
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.10':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.10':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
 
   '@smithy/shared-ini-file-loader@4.4.5':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.10':
     dependencies:
       '@smithy/is-array-buffer': 4.2.1
       '@smithy/protocol-http': 5.3.10
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.15.0
       '@smithy/util-hex-encoding': 4.2.1
       '@smithy/util-middleware': 4.2.10
       '@smithy/util-uri-escape': 4.2.1
       '@smithy/util-utf8': 4.2.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.5.2':
+    dependencies:
+      '@smithy/core': 3.26.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.0':
@@ -23625,7 +23885,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -24393,7 +24653,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 6.0.3
@@ -24406,7 +24666,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -24416,7 +24676,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -24425,7 +24685,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -24434,7 +24694,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -24475,7 +24735,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
@@ -24488,7 +24748,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.43.0(eslint@8.57.1)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -24507,7 +24767,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
@@ -24521,7 +24781,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24538,7 +24798,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -24554,7 +24814,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -24569,7 +24829,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -24978,7 +25238,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25603,7 +25863,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -26454,7 +26714,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -26975,7 +27235,7 @@ snapshots:
 
   docker-modem@5.0.7:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
@@ -27496,7 +27756,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -27614,7 +27874,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -27852,7 +28112,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -28070,7 +28330,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -28084,7 +28344,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -28108,7 +28368,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -28419,7 +28679,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -28961,14 +29221,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -28981,14 +29241,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29168,7 +29428,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -29470,7 +29730,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -31064,7 +31324,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -31072,7 +31332,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -31417,7 +31677,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -31879,7 +32139,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -31892,7 +32152,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -32193,7 +32453,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       pidusage: 2.0.21
       systeminformation: 5.31.6
       tx2: 1.0.5
@@ -32215,7 +32475,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eventemitter2: 6.4.9
       fast-json-patch: 3.1.1
       js-yaml: 4.1.1
@@ -32756,7 +33016,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -32769,7 +33029,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -33472,7 +33732,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -33480,7 +33740,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -33606,7 +33866,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.2):
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       esbuild: 0.27.7
       get-tsconfig: 4.10.1
@@ -33685,7 +33945,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -33832,7 +34092,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -34010,7 +34270,7 @@ snapshots:
       '@kwsites/promise-deferred': 1.1.1
       '@simple-git/args-pathspec': 1.0.3
       '@simple-git/argv-parser': 1.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -34122,7 +34382,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34130,7 +34390,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -34138,7 +34398,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -34189,7 +34449,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -35661,7 +35921,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(typescript@6.0.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@9.1.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21


### PR DESCRIPTION
## What

Adds the **AWS Lambda MicroVMs** `SandboxProvider` — a third sandbox backend alongside `e2b` and `docker`. It's the "E2B-shaped" native-pause backend: `RunMicrovm`/`SuspendMicrovm`/`ResumeMicrovm`/`TerminateMicrovm` map 1:1 onto the existing `create`/`persist`/`resume`/`destroy` interface, so it slots straight onto the native-pause path with a single new `SnapshotRef` variant.

**Ships dark** — `SANDBOX_PROVIDER` still defaults to `e2b`; this provider is opt-in.

## How it maps

- `types.ts`: `SnapshotRef |= { kind: 'lambda-microvm-suspended'; microVmId }`
- `LambdaMicroVmSandboxProvider`: control plane via a typed `MicrovmControlPlane` seam + an `AwsMicrovmControlPlane` adapter over `@aws-sdk/client-lambda-microvms`. Polls to `RUNNING`, re-reads the (separate, stable) endpoint, swallows `ResourceNotFoundException` on terminate.
- `LambdaExecChannel`: the one genuinely new piece — a `commands`/`files` data plane over the microVM's HTTPS proxy endpoint + `X-aws-proxy-auth` (Lambda ships no native exec SDK). `git` is shared with the Docker provider via a new `gitOverCommands` helper.
- `index.ts` factory case + `parseConfig` `LAMBDA_MICROVM_*` config (region, two image ARNs, execution role, connectors, idle policy derived from the existing idle/retention windows) + mock.

## Tests

Unit tests with a fake control plane (provider lifecycle) + the channel driven against a local HTTP server + git command construction. `pnpm -F backend typecheck` + lint green. No migration, no `SnapshotStore` (snapshot is AWS-managed; the `snapshot_ref` jsonb already fits).

## Validation

Validated end-to-end on real AWS — see the stacked **deploy infra** PR: the in-cluster app opened a writeback PR through this provider.

Stacked on #24793 (persist/resume).
