### PR TITLE
feat(sandbox): Lambda MicroVMs deploy infra — exec agent, image pipeline, /k8s-dev wiring

### DIFF
--- a/sandboxes/microvm-agent/README.md
+++ b/sandboxes/microvm-agent/README.md
@@ -1,0 +1,50 @@
+# MicroVM exec agent + image pipeline
+
+Supports the **Lambda MicroVMs** sandbox provider
+(`SANDBOX_PROVIDER=lambda-microvm`). See
+`packages/backend/src/ee/services/SandboxRuntime/LAMBDA_MICROVM_PLAN.md`.
+
+## `agent.js` — the in-microVM exec agent
+
+Lambda MicroVMs ship no native exec SDK, so the backend's `LambdaExecChannel`
+drives this dependency-free Node agent over the microVM's HTTPS proxy endpoint.
+The AWS inbound connector terminates the JWE bearer (`X-aws-proxy-auth`) and
+forwards to port **8080**, so the agent trusts inbound traffic.
+
+It is baked into each sandbox image by a thin `FROM <ecr-image>` Dockerfile (no
+npm install in Lambda's build env) and started as the image entrypoint.
+
+**Contract** (kept in lock-step with `LambdaExecChannel.ts`):
+
+| Route | Behaviour |
+|-------|-----------|
+| `POST /aws/lambda-microvms/runtime/v1/{ready,run,resume,suspend,terminate,validate}` | `200`. The `/ready` build hook gates image creation; the runtime hooks are acked no-ops so inbound traffic is never withheld. |
+| `GET /ready` | `200` (local smoke-test convenience) |
+| `POST /exec` `{cmd,cwd?,envs?,timeoutMs?}` | `200` + newline-delimited JSON: `{"stream":"stdout"\|"stderr","data":<base64>}` chunks then a terminal `{"exitCode":<n>}` or `{"timeout":true}`. The child runs in its own process group so a timeout kills the whole tree. |
+| `GET /files?path=` | raw bytes (`200`) / `404` |
+| `POST /files?path=` | write body, creating parent dirs (`204`) |
+| `DELETE /files?path=` | idempotent remove (`204`) |
+
+The hook path prefix `/aws/lambda-microvms/runtime/v1/` is AWS-defined (see the
+Lambda MicroVMs docs); the `/exec` and `/files` routes are our own data plane.
+
+## `build-microvm-image.sh` — the image pipeline
+
+Reuses the already-built local Docker sandbox image (the validated Phase-B
+pattern: push to ECR, thin `FROM <ecr> + agent` image — don't rebuild the
+npm/dbt stack inside Lambda's ~7.2 GB build env).
+
+```bash
+# Prereq: the local Docker image (built automatically if missing) + `aws login`.
+./build-microvm-image.sh writeback     # -> LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN
+./build-microvm-image.sh data-app      # -> LAMBDA_MICROVM_DATA_APP_IMAGE_ARN
+```
+
+It is idempotent: ensures an ECR repo, a build IAM role (trusts
+`lambda.amazonaws.com`), and an S3 staging bucket exist; pushes the arm64 image
+(MicroVMs are Graviton-only); zips the thin Dockerfile + `agent.js`;
+`create`/`update-microvm-image` on the **4 GB / 16 GB** tier with the `/ready`
+hook ENABLED; polls the build to a terminal state; marks the version `ACTIVE`;
+and prints the image ARN to feed the `LAMBDA_MICROVM_*` env.
+
+Region defaults to **eu-west-1** (the EU MicroVMs launch region).

--- a/sandboxes/microvm-agent/agent.js
+++ b/sandboxes/microvm-agent/agent.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/*
+ * In-microVM exec agent for the Lightdash Lambda MicroVMs sandbox provider.
+ *
+ * Lambda MicroVMs ship no native exec SDK, so the backend's `LambdaExecChannel`
+ * (packages/backend/src/ee/services/SandboxRuntime/LambdaExecChannel.ts) drives
+ * this agent over the microVM's HTTPS proxy endpoint. The AWS inbound connector
+ * terminates the JWE bearer (`X-aws-proxy-auth`) and forwards here on port 8080,
+ * so the agent trusts inbound traffic.
+ *
+ * Dependency-free (Node stdlib only) — it is baked into the sandbox images via a
+ * thin `FROM <ecr-image>` Dockerfile, with no npm install in the microVM build
+ * env. Runs as the image's default user (root in the microVM), so it can exec
+ * any tooling the image carries (git, dbt, claude, lightdash).
+ *
+ * It also answers Lambda's lifecycle/build hooks (the `/ready` build hook gates
+ * image creation; the runtime hooks are no-ops we ack so traffic is never held).
+ * AWS posts these to `/aws/lambda-microvms/runtime/v1/<hook>` on the hook port.
+ *
+ * Contract (kept in lock-step with LambdaExecChannel):
+ *   POST /aws/lambda-microvms/runtime/v1/{ready,validate,run,resume,suspend,terminate}
+ *                                -> 200 (ready gates the image build; rest are acked no-ops)
+ *   GET  /ready                  -> 200 (local smoke-test convenience)
+ *   POST /exec   {cmd,cwd?,envs?,timeoutMs?}
+ *                                -> 200, newline-delimited JSON event stream:
+ *                                   {"stream":"stdout"|"stderr","data":<base64>} chunks,
+ *                                   then a terminal {"exitCode":<n>} or {"timeout":true}
+ *   GET    /files?path=<abs>     -> 200 raw bytes | 404
+ *   POST   /files?path=<abs>     -> 204 (writes body, creating parent dirs)
+ *   DELETE /files?path=<abs>     -> 204 (idempotent)
+ */
+
+'use strict';
+
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { URL } = require('node:url');
+
+const PORT = Number(process.env.LD_AGENT_PORT || 8080);
+
+/** Write one newline-delimited JSON event to the response stream. */
+const writeEvent = (res, event) => {
+    res.write(`${JSON.stringify(event)}\n`);
+};
+
+const readBody = (req) =>
+    new Promise((resolve, reject) => {
+        const chunks = [];
+        req.on('data', (c) => chunks.push(c));
+        req.on('end', () => resolve(Buffer.concat(chunks)));
+        req.on('error', reject);
+    });
+
+/**
+ * Run a shell command, streaming demuxed stdout/stderr as base64 ndjson chunks
+ * and a terminal exit/timeout event. The child runs in its own process group so
+ * a timeout kills the whole tree (e.g. `dbt` spawning subprocesses).
+ */
+const handleExec = async (req, res) => {
+    let payload;
+    try {
+        payload = JSON.parse((await readBody(req)).toString('utf8') || '{}');
+    } catch (error) {
+        res.writeHead(400, { 'content-type': 'text/plain' });
+        res.end(`invalid JSON body: ${error.message}`);
+        return;
+    }
+    const { cmd, cwd, envs, timeoutMs } = payload;
+    if (typeof cmd !== 'string') {
+        res.writeHead(400, { 'content-type': 'text/plain' });
+        res.end('missing "cmd"');
+        return;
+    }
+
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+
+    const child = spawn('/bin/sh', ['-c', cmd], {
+        cwd: cwd || '/',
+        env: { ...process.env, ...(envs || {}) },
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let settled = false;
+    let timer = null;
+    const killGroup = () => {
+        try {
+            process.kill(-child.pid, 'SIGKILL');
+        } catch {
+            // already gone
+        }
+    };
+
+    if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+        timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            killGroup();
+            writeEvent(res, { timeout: true });
+            res.end();
+        }, timeoutMs);
+    }
+
+    child.stdout.on('data', (chunk) => {
+        writeEvent(res, { stream: 'stdout', data: chunk.toString('base64') });
+    });
+    child.stderr.on('data', (chunk) => {
+        writeEvent(res, { stream: 'stderr', data: chunk.toString('base64') });
+    });
+    child.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        writeEvent(res, {
+            stream: 'stderr',
+            data: Buffer.from(`agent: failed to spawn: ${error.message}`).toString(
+                'base64',
+            ),
+        });
+        writeEvent(res, { exitCode: 127 });
+        res.end();
+    });
+    child.on('close', (code, signal) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        // A signal kill with no code maps to the conventional 128+signal code.
+        const exitCode =
+            code === null ? 128 + (signal ? 1 : 0) : code;
+        writeEvent(res, { exitCode });
+        res.end();
+    });
+
+    // If the client disconnects mid-run, don't leak the child.
+    res.on('close', () => {
+        if (!settled) killGroup();
+    });
+};
+
+const handleFiles = async (req, res, url) => {
+    const filePath = url.searchParams.get('path');
+    if (!filePath) {
+        res.writeHead(400, { 'content-type': 'text/plain' });
+        res.end('missing "path"');
+        return;
+    }
+
+    if (req.method === 'GET') {
+        fs.readFile(filePath, (error, data) => {
+            if (error) {
+                res.writeHead(error.code === 'ENOENT' ? 404 : 500, {
+                    'content-type': 'text/plain',
+                });
+                res.end(error.message);
+                return;
+            }
+            res.writeHead(200, { 'content-type': 'application/octet-stream' });
+            res.end(data);
+        });
+        return;
+    }
+
+    if (req.method === 'POST') {
+        const body = await readBody(req);
+        try {
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            fs.writeFileSync(filePath, body);
+            res.writeHead(204);
+            res.end();
+        } catch (error) {
+            res.writeHead(500, { 'content-type': 'text/plain' });
+            res.end(error.message);
+        }
+        return;
+    }
+
+    if (req.method === 'DELETE') {
+        try {
+            fs.unlinkSync(filePath);
+        } catch (error) {
+            if (error.code !== 'ENOENT') {
+                res.writeHead(500, { 'content-type': 'text/plain' });
+                res.end(error.message);
+                return;
+            }
+        }
+        res.writeHead(204);
+        res.end();
+        return;
+    }
+
+    res.writeHead(405, { 'content-type': 'text/plain' });
+    res.end('method not allowed');
+};
+
+// Lambda posts lifecycle/build hooks here (the /ready build hook gates image
+// creation; runtime hooks are acked so inbound traffic is never withheld).
+const HOOK_PREFIX = '/aws/lambda-microvms/runtime/v1/';
+
+const requestHandler = (req, res) => {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    // Log every request so the CloudWatch build log shows exactly what path/port
+    // Lambda's lifecycle hooks hit (the hook delivery port has been buggy).
+    // eslint-disable-next-line no-console
+    console.log(`agent request: ${req.method} ${req.url}`);
+    if (url.pathname.startsWith(HOOK_PREFIX) || url.pathname === '/ready') {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end('ok');
+        return;
+    }
+    if (url.pathname === '/exec' && req.method === 'POST') {
+        handleExec(req, res).catch((error) => {
+            if (!res.headersSent) res.writeHead(500);
+            res.end(`agent error: ${error.message}`);
+        });
+        return;
+    }
+    if (url.pathname === '/files') {
+        handleFiles(req, res, url).catch((error) => {
+            if (!res.headersSent) res.writeHead(500);
+            res.end(`agent error: ${error.message}`);
+        });
+        return;
+    }
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found');
+};
+
+// Listen on the data-plane/hook port (8080) and also 9000 — lifecycle hooks have
+// been observed delivering on 9000 regardless of the configured hook port, so
+// answering both makes the /ready build hook robust to that quirk.
+const HOOK_FALLBACK_PORT = Number(process.env.LD_AGENT_HOOK_PORT || 9000);
+const listenPorts =
+    HOOK_FALLBACK_PORT === PORT ? [PORT] : [PORT, HOOK_FALLBACK_PORT];
+for (const port of listenPorts) {
+    http.createServer(requestHandler).listen(port, '0.0.0.0', () => {
+        // eslint-disable-next-line no-console
+        console.log(`lightdash microvm agent listening on :${port}`);
+    });
+}

--- a/sandboxes/microvm-agent/build-microvm-image.sh
+++ b/sandboxes/microvm-agent/build-microvm-image.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Build a Lambda MicroVM image for the Lightdash sandbox provider
+# (SANDBOX_PROVIDER=lambda-microvm), reusing the already-built local Docker
+# sandbox image rather than rebuilding the npm/dbt stack inside Lambda's ~7.2 GB
+# build env (the validated Phase-B pattern — see SandboxRuntime/LAMBDA_MICROVM_PLAN.md §0).
+#
+# Pipeline:
+#   1. Ensure the local Docker image exists (build via the sibling build-local-image.sh).
+#   2. Ensure AWS prerequisites exist (ECR repo, build IAM role, S3 staging bucket).
+#   3. Push the local arm64 image to ECR (MicroVMs are Graviton/ARM_64 only).
+#   4. Assemble a thin `FROM <ecr-image>` + agent Dockerfile, zip it with agent.js,
+#      upload to S3.
+#   5. create-or-update the MicroVM image (4 GB/16 GB tier, /ready hook on 8080).
+#   6. Poll the build to a terminal state, mark the version ACTIVE.
+#   7. Print the image ARN to feed LAMBDA_MICROVM_DATA_APP_IMAGE_ARN /
+#      LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN.
+#
+# Usage: ./build-microvm-image.sh <data-app|writeback> [local-image-tag]
+set -euo pipefail
+cd "$(dirname "$0")"
+
+FEATURE="${1:-}"
+if [[ "$FEATURE" != "data-app" && "$FEATURE" != "writeback" ]]; then
+    echo "usage: $0 <data-app|writeback> [local-image-tag]" >&2
+    exit 1
+fi
+
+# ---- Config (override via env) ----------------------------------------------
+REGION="${LAMBDA_MICROVM_REGION:-eu-west-1}"
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+ECR_REPO="${LD_MICROVM_ECR_REPO:-lightdash-sandbox-microvm}"
+BUILD_ROLE_NAME="${LD_MICROVM_BUILD_ROLE:-lightdash-microvm-build-role}"
+STAGING_BUCKET="${LD_MICROVM_STAGING_BUCKET:-lightdash-microvm-build-${ACCOUNT_ID}-${REGION}}"
+MEM_MIB="${LD_MICROVM_MEM_MIB:-4096}" # 4 GB baseline => 16 GB disk, 2 vCPU
+READY_TIMEOUT="${LD_MICROVM_READY_TIMEOUT:-300}"
+
+if [[ "$FEATURE" == "data-app" ]]; then
+    LOCAL_TAG="${2:-lightdash-sandbox:local}"
+    LOCAL_DIR="../data-apps"
+    ECR_TAG="data-app"
+    IMAGE_NAME="lightdash-data-app-microvm"
+    HOME_DIR="/app"
+else
+    LOCAL_TAG="${2:-lightdash-ai-writeback:local}"
+    LOCAL_DIR="../ai-writeback"
+    ECR_TAG="writeback"
+    IMAGE_NAME="lightdash-ai-writeback-microvm"
+    HOME_DIR="/home/user"
+fi
+
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO}:${ECR_TAG}"
+
+log() { echo "[build-microvm-image:${FEATURE}] $*"; }
+
+# ---- 1. Local Docker image --------------------------------------------------
+if ! docker image inspect "$LOCAL_TAG" >/dev/null 2>&1; then
+    log "local image $LOCAL_TAG missing — building via $LOCAL_DIR/build-local-image.sh"
+    (cd "$LOCAL_DIR" && ./build-local-image.sh "$LOCAL_TAG")
+fi
+
+# ---- 2. AWS prerequisites (idempotent) --------------------------------------
+ensure_ecr() {
+    aws ecr describe-repositories --region "$REGION" --repository-names "$ECR_REPO" \
+        >/dev/null 2>&1 ||
+        aws ecr create-repository --region "$REGION" --repository-name "$ECR_REPO" \
+            --image-scanning-configuration scanOnPush=true >/dev/null
+}
+
+ensure_bucket() {
+    if ! aws s3api head-bucket --bucket "$STAGING_BUCKET" >/dev/null 2>&1; then
+        aws s3api create-bucket --bucket "$STAGING_BUCKET" --region "$REGION" \
+            --create-bucket-configuration LocationConstraint="$REGION" >/dev/null
+    fi
+}
+
+ensure_build_role() {
+    if aws iam get-role --role-name "$BUILD_ROLE_NAME" >/dev/null 2>&1; then
+        BUILD_ROLE_ARN="$(aws iam get-role --role-name "$BUILD_ROLE_NAME" --query Role.Arn --output text)"
+        return
+    fi
+    log "creating build role $BUILD_ROLE_NAME"
+    local trust principal
+    principal="${LD_MICROVM_BUILD_PRINCIPAL:-lambda.amazonaws.com}"
+    trust="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"${principal}\"},\"Action\":[\"sts:AssumeRole\",\"sts:TagSession\"]}]}"
+    BUILD_ROLE_ARN="$(aws iam create-role --role-name "$BUILD_ROLE_NAME" \
+        --assume-role-policy-document "$trust" --query Role.Arn --output text)"
+    # Build needs to pull the base ECR image, read the staged zip, and write its
+    # CloudWatch build logs.
+    aws iam put-role-policy --role-name "$BUILD_ROLE_NAME" \
+        --policy-name lightdash-microvm-build \
+        --policy-document "{
+            \"Version\":\"2012-10-17\",
+            \"Statement\":[
+                {\"Effect\":\"Allow\",\"Action\":[\"ecr:GetAuthorizationToken\"],\"Resource\":\"*\"},
+                {\"Effect\":\"Allow\",\"Action\":[\"ecr:BatchGetImage\",\"ecr:GetDownloadUrlForLayer\",\"ecr:BatchCheckLayerAvailability\"],\"Resource\":\"arn:aws:ecr:${REGION}:${ACCOUNT_ID}:repository/${ECR_REPO}\"},
+                {\"Effect\":\"Allow\",\"Action\":[\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::${STAGING_BUCKET}/*\"},
+                {\"Effect\":\"Allow\",\"Action\":[\"logs:CreateLogGroup\",\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"arn:aws:logs:${REGION}:${ACCOUNT_ID}:*\"}
+            ]
+        }" >/dev/null
+    log "waiting for IAM role propagation"
+    sleep 12
+}
+
+ensure_ecr
+ensure_bucket
+ensure_build_role
+
+# ---- 3. Push local image to ECR (arm64) -------------------------------------
+log "pushing $LOCAL_TAG -> $ECR_URI"
+aws ecr get-login-password --region "$REGION" |
+    docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com" >/dev/null
+docker tag "$LOCAL_TAG" "$ECR_URI"
+docker push "$ECR_URI" >/dev/null
+log "pushed $ECR_URI"
+
+# ---- 4. Thin MicroVM Dockerfile + zip + S3 ----------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp agent.js "$WORK/agent.js"
+cat >"$WORK/Dockerfile" <<DOCKERFILE
+FROM ${ECR_URI}
+COPY agent.js /opt/agent/agent.js
+ENV HOME=${HOME_DIR}
+# The agent binds 8080 and answers /ready, so Lambda snapshots only once it is
+# listening (the build /ready hook). node resolves via PATH on both base images.
+ENTRYPOINT ["node", "/opt/agent/agent.js"]
+DOCKERFILE
+
+ZIP="$WORK/context.zip"
+(cd "$WORK" && zip -q "$ZIP" Dockerfile agent.js)
+S3_KEY="microvm-build/${IMAGE_NAME}/$(date +%s).zip"
+aws s3 cp "$ZIP" "s3://${STAGING_BUCKET}/${S3_KEY}" >/dev/null
+S3_URI="s3://${STAGING_BUCKET}/${S3_KEY}"
+log "staged build context at $S3_URI"
+
+# ---- 5. Base image ARN + create/update image --------------------------------
+BASE_IMAGE_ARN="${LD_MICROVM_BASE_IMAGE_ARN:-}"
+if [[ -z "$BASE_IMAGE_ARN" ]]; then
+    BASE_IMAGE_ARN="$(aws lambda-microvms list-managed-microvm-images --region "$REGION" \
+        --query "items[?contains(name, 'al2023')].imageArn | [0]" --output text 2>/dev/null || true)"
+fi
+if [[ -z "$BASE_IMAGE_ARN" || "$BASE_IMAGE_ARN" == "None" ]]; then
+    BASE_IMAGE_ARN="arn:aws:lambda:${REGION}:aws:microvm-image:al2023-1"
+fi
+log "base image: $BASE_IMAGE_ARN"
+
+REQUEST_JSON="$WORK/request.json"
+cat >"$REQUEST_JSON" <<JSON
+{
+    "baseImageArn": "${BASE_IMAGE_ARN}",
+    "buildRoleArn": "${BUILD_ROLE_ARN}",
+    "name": "${IMAGE_NAME}",
+    "description": "Lightdash ${FEATURE} sandbox (exec agent on 8080)",
+    "codeArtifact": { "uri": "${S3_URI}" },
+    "cpuConfigurations": [ { "architecture": "ARM_64" } ],
+    "resources": [ { "minimumMemoryInMiB": ${MEM_MIB} } ],
+    "hooks": {
+        "port": 8080,
+        "microvmImageHooks": { "ready": "ENABLED", "readyTimeoutInSeconds": ${READY_TIMEOUT} }
+    }
+}
+JSON
+
+EXISTING_ARN="$(aws lambda-microvms list-microvm-images --region "$REGION" \
+    --query "items[?name=='${IMAGE_NAME}'].imageArn | [0]" --output text 2>/dev/null || true)"
+
+if [[ -n "$EXISTING_ARN" && "$EXISTING_ARN" != "None" ]]; then
+    log "updating existing image $EXISTING_ARN (new version)"
+    # update reuses the same name; pass the image identifier + new code artifact.
+    python3 - "$REQUEST_JSON" "$EXISTING_ARN" <<'PY'
+import json, sys
+req = json.load(open(sys.argv[1]))
+req.pop("name", None)
+req.pop("baseImageArn", None)
+req["imageIdentifier"] = sys.argv[2]
+json.dump(req, open(sys.argv[1], "w"))
+PY
+    aws lambda-microvms update-microvm-image --region "$REGION" \
+        --cli-input-json "file://${REQUEST_JSON}" >"$WORK/create.json"
+    IMAGE_ARN="$EXISTING_ARN"
+else
+    aws lambda-microvms create-microvm-image --region "$REGION" \
+        --cli-input-json "file://${REQUEST_JSON}" >"$WORK/create.json"
+    IMAGE_ARN="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["imageArn"])' "$WORK/create.json")"
+fi
+log "image: $IMAGE_ARN"
+
+# ---- 6. Poll image build to a terminal state --------------------------------
+# The image state goes CREATING/UPDATING -> CREATED/UPDATED (success, with
+# latestActiveImageVersion set) or *_FAILED (with latestFailedImageVersion).
+log "waiting for image build (typically ~3-4 min for the heavy image)…"
+DEADLINE=$(( $(date +%s) + 1200 ))
+VERSION=""
+while :; do
+    INFO="$(aws lambda-microvms get-microvm-image --region "$REGION" \
+        --image-identifier "$IMAGE_ARN" 2>/dev/null || echo '{}')"
+    read -r STATE VERSION FAILED < <(echo "$INFO" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(d.get("state", "?"), d.get("latestActiveImageVersion", "") or "-", d.get("latestFailedImageVersion", "") or "-")
+')
+    log "imageState=${STATE} activeVersion=${VERSION} failedVersion=${FAILED}"
+    case "$STATE" in
+        CREATED|UPDATED) break ;;
+        CREATE_FAILED|UPDATE_FAILED)
+            log "image build FAILED (version ${FAILED})"
+            aws lambda-microvms get-microvm-image-version --region "$REGION" \
+                --image-identifier "$IMAGE_ARN" --image-version "$FAILED" \
+                --query '{state:state,reason:stateReason}' --output json || true
+            exit 1 ;;
+    esac
+    if (( $(date +%s) > DEADLINE )); then log "timed out waiting for build"; exit 1; fi
+    sleep 15
+done
+
+# The first successful version is published ACTIVE automatically; ensure it.
+aws lambda-microvms update-microvm-image-version --region "$REGION" \
+    --image-identifier "$IMAGE_ARN" --image-version "$VERSION" --status ACTIVE \
+    >/dev/null 2>&1 || true
+
+echo
+echo "============================================================"
+echo "MicroVM image ready: $IMAGE_ARN"
+echo "  version: $VERSION"
+if [[ "$FEATURE" == "data-app" ]]; then
+    echo "  export LAMBDA_MICROVM_DATA_APP_IMAGE_ARN=$IMAGE_ARN"
+else
+    echo "  export LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN=$IMAGE_ARN"
+fi
+echo "============================================================"

--- a/scripts/k8s-dev/config.example.env
+++ b/scripts/k8s-dev/config.example.env
@@ -21,6 +21,17 @@ export K8S_NAMESPACE="lightdash"
 export IMAGE_REPO="lightdash/lightdash"
 export IMAGE_TAG="latest"
 
+# --- Lambda MicroVMs sandbox provider (cross-region in eu-west-1) ---
+# The cluster runs in AWS_REGION above (eu-west-2); MicroVMs run in eu-west-1
+# (the EU launch region; eu-west-2 has none). The backend calls cross-region.
+# Build the images + capture the ARNs with:
+#   sandboxes/microvm-agent/build-microvm-image.sh writeback   # -> AI_WRITEBACK arn
+#   sandboxes/microvm-agent/build-microvm-image.sh data-app    # -> DATA_APP arn
+# Then paste the printed ARNs here. (The execution-role ARN comes from terraform.)
+export LAMBDA_MICROVM_REGION="eu-west-1"
+export LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN=""
+export LAMBDA_MICROVM_DATA_APP_IMAGE_ARN=""
+
 # --- Public hostname / TLS ---
 # SITE_HOST_MODE:
 #   sslip   -> auto: lightdash.<nlb-ip>.sslip.io  (no DNS access needed; recommended)

--- a/scripts/k8s-dev/terraform/irsa.tf
+++ b/scripts/k8s-dev/terraform/irsa.tf
@@ -90,3 +90,88 @@ resource "aws_iam_role_policy" "lightdash_s3" {
   role   = aws_iam_role.lightdash_app.id
   policy = data.aws_iam_policy_document.lightdash_s3.json
 }
+
+# ---------- Lambda MicroVMs ----------
+# The backend drives the Lambda MicroVMs control plane cross-region (cluster in
+# eu-west-2, MicroVMs in eu-west-1 — the EU launch region). IAM is global, so the
+# app role's permissions and the execution role apply regardless of region.
+
+# Execution role assumed BY the microVM at runtime (RunMicrovm executionRoleArn).
+# Our sandbox workload reaches the internet (Anthropic/GitHub) via the egress
+# connector, not the AWS API, so this role needs only its own CloudWatch logs.
+data "aws_iam_policy_document" "microvm_execution_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "microvm_execution" {
+  name               = "${var.cluster_name}-microvm-execution"
+  assume_role_policy = data.aws_iam_policy_document.microvm_execution_assume.json
+}
+
+resource "aws_iam_role_policy" "microvm_execution_logs" {
+  name = "cloudwatch-logs"
+  role = aws_iam_role.microvm_execution.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+      Resource = "arn:aws:logs:*:${data.aws_caller_identity.current.account_id}:*"
+    }]
+  })
+}
+
+# Lets the backend pods run the MicroVM lifecycle + pass the execution role.
+data "aws_iam_policy_document" "lightdash_microvms" {
+  # The IAM action prefix for this newly-launched service is not yet in the
+  # Service Authorization Reference (Access Analyzer rejects both), so grant the
+  # lifecycle actions under both candidate prefixes — `lambda-microvms:` (the
+  # API/SDK/CLI namespace) and `lambda:` (the umbrella service). IAM does not
+  # validate action existence, so the unused prefix is simply inert; the real
+  # one is confirmed by the first RunMicrovm call.
+  statement {
+    sid    = "MicrovmLifecycle"
+    effect = "Allow"
+    actions = [
+      "lambda-microvms:RunMicrovm",
+      "lambda-microvms:GetMicrovm",
+      "lambda-microvms:SuspendMicrovm",
+      "lambda-microvms:ResumeMicrovm",
+      "lambda-microvms:TerminateMicrovm",
+      "lambda-microvms:CreateMicrovmAuthToken",
+      "lambda-microvms:CreateMicrovmShellAuthToken",
+      "lambda:RunMicrovm",
+      "lambda:GetMicrovm",
+      "lambda:SuspendMicrovm",
+      "lambda:ResumeMicrovm",
+      "lambda:TerminateMicrovm",
+      "lambda:CreateMicrovmAuthToken",
+      "lambda:CreateMicrovmShellAuthToken",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "PassExecutionRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.microvm_execution.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "lightdash_microvms" {
+  name   = "lambda-microvms"
+  role   = aws_iam_role.lightdash_app.id
+  policy = data.aws_iam_policy_document.lightdash_microvms.json
+}

--- a/scripts/k8s-dev/terraform/irsa.tf
+++ b/scripts/k8s-dev/terraform/irsa.tf
@@ -157,16 +157,15 @@ data "aws_iam_policy_document" "lightdash_microvms" {
     ]
     resources = ["*"]
   }
+  # PassRole for the microVM execution role. No iam:PassedToService condition:
+  # RunMicrovm passes the role to the Lambda MicroVMs service principal, which is
+  # not `lambda.amazonaws.com`, so a condition on it denies the pass. Scoped to
+  # the single execution role ARN, which is sufficient for the testbed.
   statement {
     sid       = "PassExecutionRole"
     effect    = "Allow"
     actions   = ["iam:PassRole"]
     resources = [aws_iam_role.microvm_execution.arn]
-    condition {
-      test     = "StringEquals"
-      variable = "iam:PassedToService"
-      values   = ["lambda.amazonaws.com"]
-    }
   }
   # RunMicrovm must be allowed to attach the ingress/egress network connectors;
   # the AWS-managed connector ARNs are passed via lambda:PassNetworkConnector

--- a/scripts/k8s-dev/terraform/irsa.tf
+++ b/scripts/k8s-dev/terraform/irsa.tf
@@ -168,6 +168,18 @@ data "aws_iam_policy_document" "lightdash_microvms" {
       values   = ["lambda.amazonaws.com"]
     }
   }
+  # RunMicrovm must be allowed to attach the ingress/egress network connectors;
+  # the AWS-managed connector ARNs are passed via lambda:PassNetworkConnector
+  # (confirmed empirically — the prefix here is `lambda:`, not `lambda-microvms:`).
+  statement {
+    sid    = "PassNetworkConnectors"
+    effect = "Allow"
+    actions = [
+      "lambda:PassNetworkConnector",
+      "lambda-microvms:PassNetworkConnector",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role_policy" "lightdash_microvms" {

--- a/scripts/k8s-dev/terraform/main.tf
+++ b/scripts/k8s-dev/terraform/main.tf
@@ -39,6 +39,8 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
   azs = slice(data.aws_availability_zones.available.names, 0, 2)
   # OIDC issuer host/path with the https:// stripped — used to build IRSA trust conditions.

--- a/scripts/k8s-dev/terraform/outputs.tf
+++ b/scripts/k8s-dev/terraform/outputs.tf
@@ -27,6 +27,11 @@ output "app_role_arn" {
   value       = aws_iam_role.lightdash_app.arn
 }
 
+output "microvm_execution_role_arn" {
+  description = "IAM role assumed by Lambda MicroVMs at runtime (RunMicrovm executionRoleArn)."
+  value       = aws_iam_role.microvm_execution.arn
+}
+
 output "ecr_repository_url" {
   value = aws_ecr_repository.lightdash.repository_url
 }

--- a/scripts/k8s-dev/up.sh
+++ b/scripts/k8s-dev/up.sh
@@ -18,7 +18,16 @@ ok "terraform applied"
 APP_ROLE_ARN="$(tf_output app_role_arn)"
 S3_BUCKET="$(tf_output s3_bucket)"
 ECR_URL="$(tf_output ecr_repository_url)"
+MICROVM_EXECUTION_ROLE_ARN="$(tf_output microvm_execution_role_arn)"
 [ -n "$APP_ROLE_ARN" ] && [ -n "$S3_BUCKET" ] || fail "terraform -- missing outputs (app_role_arn/s3_bucket)"
+
+# Lambda MicroVMs (cross-region in eu-west-1). Image ARNs come from config.env,
+# produced by sandboxes/microvm-agent/build-microvm-image.sh. Warn (don't fail)
+# if unset so the cluster can still come up on the E2B fallback.
+LAMBDA_MICROVM_REGION="${LAMBDA_MICROVM_REGION:-eu-west-1}"
+if [ -z "${LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN:-}" ] || [ -z "${LAMBDA_MICROVM_DATA_APP_IMAGE_ARN:-}" ]; then
+  echo "WARN: LAMBDA_MICROVM_*_IMAGE_ARN not set in config.env — run sandboxes/microvm-agent/build-microvm-image.sh and export them, or set SANDBOX_PROVIDER=e2b."
+fi
 
 # ---------------------------------------------------------------------------
 step "configure kubectl"
@@ -133,6 +142,10 @@ APP_ROLE_ARN="$APP_ROLE_ARN" \
 S3_BUCKET="$S3_BUCKET" \
 S3_REGION="$AWS_REGION" \
 SITE_HOST="$SITE_HOST" \
+LAMBDA_MICROVM_REGION="$LAMBDA_MICROVM_REGION" \
+LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN="${LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN:-}" \
+LAMBDA_MICROVM_DATA_APP_IMAGE_ARN="${LAMBDA_MICROVM_DATA_APP_IMAGE_ARN:-}" \
+LAMBDA_MICROVM_EXECUTION_ROLE_ARN="$MICROVM_EXECUTION_ROLE_ARN" \
   envsubst < "$K8S_DEV_DIR/values.aws.yaml.tpl" > "$RENDERED"
 ok "values rendered -> $RENDERED"
 

--- a/scripts/k8s-dev/values.aws.yaml.tpl
+++ b/scripts/k8s-dev/values.aws.yaml.tpl
@@ -108,6 +108,11 @@ ingress:
     # buffer overflows → 502 on asset routes ("upstream sent too big header"). Bump it.
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    # AI writeback runs synchronously and can take minutes (microVM boot + Claude
+    # + dbt compile + PR). The default 60s proxy timeout returns a 504 to the
+    # client even though the run succeeds server-side — bump it to 10 minutes.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
   hosts:
     - host: "${SITE_HOST}"
       paths:
@@ -146,6 +151,13 @@ extraEnv:
   - name: AI_DEFAULT_PROVIDER
     value: "anthropic"
   - name: ANTHROPIC_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: lightdash-app
+        key: ANTHROPIC_API_KEY
+  # AI writeback reads a SEPARATE Anthropic key env var from the data-app/AI
+  # service; point it at the same secret so writeback can run Claude.
+  - name: AI_WRITEBACK_ANTHROPIC_API_KEY
     valueFrom:
       secretKeyRef:
         name: lightdash-app

--- a/scripts/k8s-dev/values.aws.yaml.tpl
+++ b/scripts/k8s-dev/values.aws.yaml.tpl
@@ -150,17 +150,28 @@ extraEnv:
       secretKeyRef:
         name: lightdash-app
         key: ANTHROPIC_API_KEY
-  # E2B runs the agent sandbox in E2B's cloud (cluster egress via NAT). Swap to
-  # SANDBOX_PROVIDER=kubernetes later — see SandboxRuntime/DESIGN.md.
+  # --- Sandbox backend: AWS Lambda MicroVMs (native suspend/resume) ---
+  # The backend drives the MicroVMs control plane cross-region: this cluster is
+  # in eu-west-2, MicroVMs in eu-west-1 (the EU launch region). The control plane
+  # is a normal API and the data plane is public HTTPS, so cross-region is fine;
+  # IAM (app role + execution role) is global. Image ARNs come from the
+  # sandboxes/microvm-agent/build-microvm-image.sh pipeline.
   - name: SANDBOX_PROVIDER
-    value: "e2b"
+    value: "lambda-microvm"
+  - name: LAMBDA_MICROVM_REGION
+    value: "${LAMBDA_MICROVM_REGION}"
+  - name: LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN
+    value: "${LAMBDA_MICROVM_AI_WRITEBACK_IMAGE_ARN}"
+  - name: LAMBDA_MICROVM_DATA_APP_IMAGE_ARN
+    value: "${LAMBDA_MICROVM_DATA_APP_IMAGE_ARN}"
+  - name: LAMBDA_MICROVM_EXECUTION_ROLE_ARN
+    value: "${LAMBDA_MICROVM_EXECUTION_ROLE_ARN}"
+  # E2B fallback (set SANDBOX_PROVIDER=e2b to switch back). Key kept in the secret.
   - name: E2B_API_KEY
     valueFrom:
       secretKeyRef:
         name: lightdash-app
         key: E2B_API_KEY
-  # Template tag defaults to the running version; pin to the rolling :latest so a missing
-  # per-version template doesn't fail sandbox creation on this pinned image.
   - name: E2B_TEMPLATE_TAG
     value: "latest"
   # --- GitHub App (dbt-over-GitHub + AI writeback). Creds from the lightdash-app secret. ---


### PR DESCRIPTION
## What

Deploy/infra for the Lambda MicroVMs provider (the parent PR in this stack). Two pieces, both out-of-band like the E2B templates:

**WS2 — `sandboxes/microvm-agent/`**
- `agent.js`: the dependency-free in-microVM exec agent — `/exec` ndjson streaming (stdout/stderr/exit), binary `/files`, Lambda lifecycle/build hook routing under `/aws/lambda-microvms/runtime/v1/`, dual-listen on 8080 **and** 9000 (hook-port quirk).
- `build-microvm-image.sh`: the ECR-reuse image pipeline — push the already-built local sandbox image to ECR, thin `FROM <ecr> + agent` Dockerfile, `create-microvm-image` on the 4 GB/16 GB tier with the `/ready` hook, mark `ACTIVE`, emit the image ARN.

**WS3 — `scripts/k8s-dev/`**
- terraform: a MicroVM execution role + app-role `lambda-microvms` perms (incl. `lambda:PassNetworkConnector` + `iam:PassRole`).
- `values.aws.yaml.tpl` → `SANDBOX_PROVIDER=lambda-microvm` cross-region (cluster eu-west-2, MicroVMs eu-west-1) + `LAMBDA_MICROVM_*` + `AI_WRITEBACK_ANTHROPIC_API_KEY` + a longer ingress timeout for the synchronous writeback.
- `up.sh` renders the new vars; `config.example.env` documents them.

## Validated end-to-end

Deployed the production-like app on EKS and ran AI writeback through the provider: the in-cluster backend called `RunMicrovm` → a microVM ran Claude → cloned a dbt-over-GitHub repo, edited a model, `lightdash compile` (0 failures), committed → **opened a PR**. The IAM-prefix / hook-path / endpoint-scheme / env-var fixes in these commits were all surfaced by that e2e.

Stacked on the provider PR.
