### PR TITLE
fix: add --strip-pivot-series download option on the CLI

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.test.ts
+++ b/packages/backend/src/services/CoderService/CoderService.test.ts
@@ -1,6 +1,8 @@
 // CoderService.test.ts
 import {
     AnyType,
+    CartesianSeriesType,
+    ChartType,
     DashboardDAO,
     DashboardFilterRule,
     DashboardTileTarget,
@@ -9,6 +11,156 @@ import {
 import { CoderService } from './CoderService';
 
 describe('CoderService', () => {
+    describe('transformChart', () => {
+        it('preserves per-value pivot series customizations for chart-as-code download', () => {
+            const chartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    eChartsConfig: {
+                        series: [
+                            {
+                                color: '#1f77b4',
+                                encode: {
+                                    xRef: { field: 'events_date_day' },
+                                    yRef: {
+                                        field: 'events_count',
+                                        pivotValues: [
+                                            {
+                                                field: 'events_event_tier',
+                                                value: 'High',
+                                            },
+                                        ],
+                                    },
+                                },
+                                isFilteredOut: false,
+                                name: 'High tier custom blue',
+                                type: CartesianSeriesType.LINE,
+                                yAxisIndex: 0,
+                            },
+                            {
+                                color: '#d62728',
+                                encode: {
+                                    xRef: { field: 'events_date_day' },
+                                    yRef: {
+                                        field: 'events_count',
+                                        pivotValues: [
+                                            {
+                                                field: 'events_event_tier',
+                                                value: 'Low',
+                                            },
+                                        ],
+                                    },
+                                },
+                                isFilteredOut: true,
+                                name: 'Low tier hidden red',
+                                type: CartesianSeriesType.LINE,
+                                yAxisIndex: 0,
+                            },
+                            {
+                                color: '#2ca02c',
+                                encode: {
+                                    xRef: { field: 'events_date_day' },
+                                    yRef: {
+                                        field: 'events_count',
+                                        pivotValues: [
+                                            {
+                                                field: 'events_event_tier',
+                                                value: 'Very high',
+                                            },
+                                        ],
+                                    },
+                                },
+                                isFilteredOut: false,
+                                name: 'Very high tier green',
+                                type: CartesianSeriesType.LINE,
+                                yAxisIndex: 0,
+                            },
+                        ],
+                        showAxisTicks: false,
+                    },
+                    layout: {
+                        xField: 'events_date_day',
+                        yField: ['events_count'],
+                    },
+                },
+            };
+
+            const result = (
+                CoderService as unknown as {
+                    transformChart: (...args: AnyType[]) => AnyType;
+                }
+            ).transformChart(
+                {
+                    chartConfig,
+                    dashboardUuid: null,
+                    description: null,
+                    metricQuery: {
+                        additionalMetrics: [],
+                        customDimensions: [],
+                        dimensionOverrides: {},
+                        dimensions: ['events_event_tier', 'events_date_day'],
+                        exploreName: 'events',
+                        filters: {},
+                        limit: 500,
+                        metricOverrides: {},
+                        metrics: ['events_count'],
+                        sorts: [
+                            {
+                                descending: false,
+                                fieldId: 'events_event_tier',
+                            },
+                        ],
+                        tableCalculations: [],
+                        timezone: 'project_timezone',
+                    },
+                    name: 'PROD-8534 pivot hidden series test',
+                    parameters: undefined,
+                    pivotConfig: {
+                        columns: ['events_event_tier'],
+                    },
+                    slug: 'prod-8534-pivot-hidden-series-test',
+                    spaceUuid: 'space-uuid',
+                    tableConfig: {
+                        columnOrder: [
+                            'events_event_tier',
+                            'events_date_day',
+                            'events_count',
+                        ],
+                    },
+                    tableName: 'events',
+                    updatedAt: new Date('2026-06-29T11:49:43.855Z'),
+                    uuid: 'chart-uuid',
+                },
+                [
+                    {
+                        name: 'Jaffle shop',
+                        path: 'jaffle_shop',
+                        uuid: 'space-uuid',
+                    },
+                ],
+                {},
+                new Map(),
+            );
+
+            const { series } = result.chartConfig.config.eChartsConfig;
+            expect(series).toHaveLength(3);
+            expect(
+                series.map((s: AnyType) => s.encode.yRef.pivotValues[0]),
+            ).toEqual([
+                { field: 'events_event_tier', value: 'High' },
+                { field: 'events_event_tier', value: 'Low' },
+                { field: 'events_event_tier', value: 'Very high' },
+            ]);
+            expect(series[1]).toEqual(
+                expect.objectContaining({
+                    color: '#d62728',
+                    isFilteredOut: true,
+                    name: 'Low tier hidden red',
+                }),
+            );
+        });
+    });
+
     describe('getChartSlugForTileUuid', () => {
         it('should return undefined when chart tile slug is null', () => {
             const mockDashboard = {

--- a/packages/cli/src/handlers/download.test.ts
+++ b/packages/cli/src/handlers/download.test.ts
@@ -1,10 +1,22 @@
-import { DashboardAsCode, FilterOperator } from '@lightdash/common';
+import {
+    CartesianSeriesType,
+    ChartType,
+    DashboardAsCode,
+    FilterOperator,
+    type CartesianChartConfig,
+    type ChartAsCode,
+    type Series,
+} from '@lightdash/common';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { testHelpers } from './download';
 
-const { getDashboardChartSlugs, sanitizeDashboardForUpload } = testHelpers;
+const {
+    getDashboardChartSlugs,
+    sanitizeChartForDownload,
+    sanitizeDashboardForUpload,
+} = testHelpers;
 
 type LooseDashboard = DashboardAsCode & { needsUpdating: boolean };
 
@@ -37,6 +49,62 @@ const writeFolderDashboard = async (
     const yaml = `contentType: dashboard\nname: ${slug}\nslug: ${slug}\nspaceSlug: test-space\ntiles:\n${tilesYaml}\nversion: 1\n`;
     await fs.writeFile(path.join(baseDir, 'dashboards', `${slug}.yml`), yaml);
 };
+
+const pivotedSeries = (
+    pivotValue: string,
+    overrides: Partial<Series> = {},
+): Series => ({
+    type: CartesianSeriesType.BAR,
+    encode: {
+        xRef: { field: 'events_date_day' },
+        yRef: {
+            field: 'orders_count',
+            pivotValues: [{ field: 'orders_status', value: pivotValue }],
+        },
+        x: 'events_date_day',
+        y: `orders_count.orders_status.${pivotValue}`,
+    },
+    ...overrides,
+});
+
+const makeChart = (series: Series[]): ChartAsCode =>
+    ({
+        name: 'pivoted chart',
+        slug: 'pivoted-chart',
+        spaceSlug: 'test-space',
+        tableName: 'orders',
+        version: 1,
+        metricQuery: {
+            additionalMetrics: [],
+            customDimensions: [],
+            dimensionOverrides: {},
+            dimensions: ['orders_status', 'events_date_day'],
+            exploreName: 'orders',
+            filters: {},
+            limit: 500,
+            metricOverrides: {},
+            metrics: ['orders_count'],
+            sorts: [],
+            tableCalculations: [],
+            timezone: 'project_timezone',
+        },
+        chartConfig: {
+            type: ChartType.CARTESIAN,
+            config: {
+                layout: {
+                    xField: 'events_date_day',
+                    yField: ['orders_count'],
+                },
+                eChartsConfig: {
+                    series,
+                },
+            },
+        } satisfies CartesianChartConfig,
+        pivotConfig: {
+            columns: ['orders_status'],
+        },
+        dashboardSlug: undefined,
+    }) as ChartAsCode;
 
 describe('getDashboardChartSlugs', () => {
     let tmpDir: string;
@@ -209,5 +277,65 @@ describe('sanitizeDashboardForUpload (PROD-7445)', () => {
         expect(result.dashboard.filters?.dimensions).toEqual([]);
         expect(result.dashboard.filters?.metrics).toEqual([]);
         expect(result.dashboard.filters?.tableCalculations).toEqual([]);
+    });
+});
+
+describe('sanitizeChartForDownload', () => {
+    it('preserves per-value pivot series customizations by default', () => {
+        const chart = makeChart([
+            pivotedSeries('completed', {
+                name: 'Completed orders',
+                color: '#1f77b4',
+                isFilteredOut: false,
+            }),
+            pivotedSeries('returned', {
+                name: 'Returned orders',
+                color: '#d62728',
+                isFilteredOut: true,
+            }),
+        ]);
+
+        const result = sanitizeChartForDownload(chart, false);
+
+        expect(result).toBe(chart);
+        const series = (result.chartConfig as CartesianChartConfig).config
+            ?.eChartsConfig.series;
+        expect(series).toHaveLength(2);
+        expect(series?.[1]).toEqual(
+            expect.objectContaining({
+                name: 'Returned orders',
+                color: '#d62728',
+                isFilteredOut: true,
+            }),
+        );
+        expect(series?.[1].encode.yRef.pivotValues).toEqual([
+            { field: 'orders_status', value: 'returned' },
+        ]);
+    });
+
+    it('strips and dedupes per-value pivot series when requested', () => {
+        const chart = makeChart([
+            pivotedSeries('completed', {
+                name: 'Completed orders',
+                color: '#1f77b4',
+            }),
+            pivotedSeries('returned', {
+                name: 'Returned orders',
+                color: '#d62728',
+            }),
+        ]);
+
+        const result = sanitizeChartForDownload(chart, true);
+
+        expect(result).not.toBe(chart);
+        const series = (result.chartConfig as CartesianChartConfig).config
+            ?.eChartsConfig.series;
+        expect(series).toHaveLength(1);
+        expect(series?.[0].name).toBeUndefined();
+        expect(series?.[0].color).toBeUndefined();
+        expect(series?.[0].encode).toEqual({
+            xRef: { field: 'events_date_day' },
+            yRef: { field: 'orders_count' },
+        });
     });
 });

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -19,6 +19,7 @@ import {
     Project,
     PromotionAction,
     PromotionChanges,
+    removePivotedSeriesValuesFromChartConfig,
     SqlChartAsCode,
     type SpaceAsCode,
 } from '@lightdash/common';
@@ -57,6 +58,7 @@ export type DownloadHandlerOptions = {
     includeCharts: boolean;
     nested: boolean; // Use nested folder structure (projectName/spaceSlug/charts|dashboards)
     skipSpaces: boolean; // Skip writing space metadata files during download
+    stripPivotSeries: boolean; // Strip per-value pivot series config for portable chart YAML
     validate?: boolean; // Validate charts and dashboards after upload
     concurrency: number;
     gzip?: boolean;
@@ -157,19 +159,36 @@ type MetadataEntry = {
     downloadedAt: string;
 };
 
+const sanitizeChartForDownload = (
+    chart: ChartAsCode,
+    stripPivotSeries: boolean,
+): ChartAsCode =>
+    stripPivotSeries
+        ? {
+              ...chart,
+              chartConfig: removePivotedSeriesValuesFromChartConfig(
+                  chart.chartConfig,
+              ),
+          }
+        : chart;
+
 const writeContent = async (
     contentAsCode: ContentAsCodeType,
     outputDir: string,
     languageMap: boolean,
+    stripPivotSeries: boolean = false,
 ): Promise<MetadataEntry> => {
+    const content =
+        contentAsCode.type === 'chart'
+            ? sanitizeChartForDownload(contentAsCode.content, stripPivotSeries)
+            : contentAsCode.content;
     const extension = getFileExtension(contentAsCode.type);
-    const itemPath = path.join(
-        outputDir,
-        `${contentAsCode.content.slug}${extension}`,
-    );
+    const itemPath = path.join(outputDir, `${content.slug}${extension}`);
     // Strip timestamps — they go to .lightdash-metadata.json instead
-    const { updatedAt, downloadedAt, ...cleanContent } =
-        contentAsCode.content as ChartAsCode | SqlChartAsCode | DashboardAsCode;
+    const { updatedAt, downloadedAt, ...cleanContent } = content as
+        | ChartAsCode
+        | SqlChartAsCode
+        | DashboardAsCode;
     const chartYml = yaml.dump(cleanContent, {
         quotingType: '"',
         sortKeys: true,
@@ -179,7 +198,7 @@ const writeContent = async (
     if (contentAsCode.translationMap && languageMap) {
         const translationPath = path.join(
             outputDir,
-            `${contentAsCode.content.slug}.language.map.yml`,
+            `${content.slug}.language.map.yml`,
         );
         await fs.writeFile(
             translationPath,
@@ -200,7 +219,7 @@ const writeContent = async (
     }
 
     return {
-        slug: contentAsCode.content.slug,
+        slug: content.slug,
         type: metadataType,
         downloadedAt: downloadedAtString,
     };
@@ -555,6 +574,7 @@ const writeSpaceContent = async <
     customPath,
     languageMap,
     folderScheme,
+    stripPivotSeries,
 }: {
     projectName: string;
     spaceSlug: string;
@@ -568,6 +588,7 @@ const writeSpaceContent = async <
     customPath?: string;
     languageMap: boolean;
     folderScheme: FolderScheme;
+    stripPivotSeries: boolean;
 }): Promise<MetadataEntry[]> => {
     const outputDir = await createDirForContent(
         projectName,
@@ -591,6 +612,7 @@ const writeSpaceContent = async <
             } as ContentAsCodeType,
             outputDir,
             languageMap,
+            stripPivotSeries,
         );
         entries.push(entry);
     }
@@ -656,6 +678,7 @@ export const downloadContent = async (
     languageMap: boolean = false,
     nested: boolean = false,
     skipSpaces: boolean = false,
+    stripPivotSeries: boolean = false,
 ): Promise<[number, string[], MetadataEntry[], SpaceAsCode[]]> => {
     const spinner = GlobalState.getActiveSpinner();
     const contentFilters = parseContentFilters(ids);
@@ -718,6 +741,7 @@ export const downloadContent = async (
                     customPath,
                     languageMap,
                     folderScheme,
+                    stripPivotSeries: false,
                 });
                 allMetadataEntries = [...allMetadataEntries, ...entries];
             }
@@ -736,6 +760,7 @@ export const downloadContent = async (
                     customPath,
                     languageMap,
                     folderScheme,
+                    stripPivotSeries: false,
                 });
                 allMetadataEntries = [...allMetadataEntries, ...entries];
             }
@@ -758,6 +783,7 @@ export const downloadContent = async (
                     customPath,
                     languageMap,
                     folderScheme,
+                    stripPivotSeries,
                 });
                 allMetadataEntries = [...allMetadataEntries, ...entries];
             }
@@ -858,6 +884,7 @@ export const downloadHandler = async (
                     options.languageMap,
                     options.nested,
                     skipSpaces,
+                    options.stripPivotSeries,
                 );
             spinner.succeed(`Downloaded ${regularChartTotal} charts`);
             allMetadataEntries = [...allMetadataEntries, ...regularChartMeta];
@@ -875,6 +902,7 @@ export const downloadHandler = async (
                     options.languageMap,
                     options.nested,
                     skipSpaces,
+                    false,
                 );
             spinner.succeed(`Downloaded ${sqlChartTotal} SQL charts`);
             allMetadataEntries = [...allMetadataEntries, ...sqlChartMeta];
@@ -903,6 +931,7 @@ export const downloadHandler = async (
                     options.languageMap,
                     options.nested,
                     skipSpaces,
+                    false,
                 );
             allMetadataEntries = [...allMetadataEntries, ...dashMeta];
             allSpaces = [...allSpaces, ...dashSpaces];
@@ -924,6 +953,7 @@ export const downloadHandler = async (
                         options.languageMap,
                         options.nested,
                         skipSpaces,
+                        options.stripPivotSeries,
                     );
                 allMetadataEntries = [
                     ...allMetadataEntries,
@@ -1696,5 +1726,6 @@ export const uploadHandler = async (
 
 export const testHelpers = {
     getDashboardChartSlugs,
+    sanitizeChartForDownload,
     sanitizeDashboardForUpload,
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -754,6 +754,11 @@ program
         'skip writing space metadata files during download',
         false,
     )
+    .option(
+        '--strip-pivot-series',
+        'strip per-value pivot series config from chart YAML for portable downloads',
+        false,
+    )
     .action(downloadHandler);
 
 program

--- a/packages/common/src/types/savedCharts.test.ts
+++ b/packages/common/src/types/savedCharts.test.ts
@@ -1,0 +1,147 @@
+import {
+    CartesianSeriesType,
+    ChartType,
+    removePivotedSeriesValuesFromChartConfig,
+    type CartesianChartConfig,
+    type ChartConfig,
+    type Series,
+} from './savedCharts';
+
+const pivotedSeries = (
+    field: string,
+    pivotField: string,
+    pivotValue: string,
+    overrides: Partial<Series> = {},
+): Series => ({
+    type: CartesianSeriesType.BAR,
+    stack: 'default',
+    isFilteredOut: true,
+    encode: {
+        xRef: { field: 'orders_created_date' },
+        yRef: {
+            field,
+            pivotValues: [{ field: pivotField, value: pivotValue }],
+        },
+        x: 'orders_created_date',
+        y: `${field}.${pivotField}.${pivotValue}`,
+    },
+    ...overrides,
+});
+
+const cartesianConfig = (series: Series[]): CartesianChartConfig => ({
+    type: ChartType.CARTESIAN,
+    config: {
+        layout: {
+            xField: 'orders_created_date',
+            yField: ['orders_count'],
+        },
+        eChartsConfig: {
+            series,
+        },
+    },
+});
+
+describe('removePivotedSeriesValuesFromChartConfig', () => {
+    it('strips data-level pivot values and dedupes pivoted series', () => {
+        const result = removePivotedSeriesValuesFromChartConfig(
+            cartesianConfig([
+                pivotedSeries('orders_count', 'orders_status', 'completed', {
+                    name: 'Completed orders',
+                    color: '#1f77b4',
+                }),
+                pivotedSeries('orders_count', 'orders_status', 'returned', {
+                    name: 'Returned orders',
+                    color: '#d62728',
+                    isFilteredOut: false,
+                }),
+            ]),
+        );
+
+        expect(result.type).toBe(ChartType.CARTESIAN);
+        const series = (result as CartesianChartConfig).config?.eChartsConfig
+            .series;
+        expect(series).toHaveLength(1);
+        expect(series?.[0]).toEqual(
+            expect.objectContaining({
+                type: CartesianSeriesType.BAR,
+                stack: 'default',
+                isFilteredOut: true,
+            }),
+        );
+        expect(series?.[0].name).toBeUndefined();
+        expect(series?.[0].color).toBeUndefined();
+        expect(series?.[0].encode).toEqual({
+            xRef: { field: 'orders_created_date' },
+            yRef: { field: 'orders_count' },
+        });
+    });
+
+    it('keeps multiple metrics separate', () => {
+        const result = removePivotedSeriesValuesFromChartConfig(
+            cartesianConfig([
+                pivotedSeries('orders_count', 'orders_status', 'completed'),
+                pivotedSeries('orders_total', 'orders_status', 'completed'),
+            ]),
+        );
+
+        const series = (result as CartesianChartConfig).config?.eChartsConfig
+            .series;
+        expect(series).toHaveLength(2);
+        expect(series?.map((s) => s.encode.yRef.field)).toEqual([
+            'orders_count',
+            'orders_total',
+        ]);
+    });
+
+    it('leaves non-pivoted series customizations untouched', () => {
+        const nonPivoted = pivotedSeries(
+            'orders_count',
+            'orders_status',
+            'completed',
+            {
+                color: '#2ca02c',
+                name: 'Orders count',
+                encode: {
+                    xRef: { field: 'orders_created_date' },
+                    yRef: { field: 'orders_count' },
+                    x: 'orders_created_date',
+                    y: 'orders_count',
+                },
+            },
+        );
+        const result = removePivotedSeriesValuesFromChartConfig(
+            cartesianConfig([nonPivoted]),
+        );
+
+        const series = (result as CartesianChartConfig).config?.eChartsConfig
+            .series;
+        expect(series).toEqual([nonPivoted]);
+    });
+
+    it('returns non-cartesian configs unchanged', () => {
+        const config = {
+            type: ChartType.TABLE,
+            config: { columns: {} },
+        } as ChartConfig;
+
+        expect(removePivotedSeriesValuesFromChartConfig(config)).toBe(config);
+    });
+
+    it('handles missing or empty series', () => {
+        const missingSeries = {
+            type: ChartType.CARTESIAN,
+            config: {
+                layout: {},
+                eChartsConfig: {},
+            },
+        } as CartesianChartConfig;
+        const emptySeries = cartesianConfig([]);
+
+        expect(removePivotedSeriesValuesFromChartConfig(missingSeries)).toBe(
+            missingSeries,
+        );
+        expect(removePivotedSeriesValuesFromChartConfig(emptySeries)).toBe(
+            emptySeries,
+        );
+    });
+});

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -1079,6 +1079,58 @@ export const getSeriesId = (series: Series) =>
         series.encode.yRef,
     )}`;
 
+const stripPivotValuesFromSeries = (series: Series): Series => {
+    const { encode, name, color, ...rest } = series;
+    return {
+        ...rest,
+        encode: {
+            xRef: { field: encode.xRef.field },
+            yRef: { field: encode.yRef.field },
+        },
+    };
+};
+
+export const removePivotedSeriesValuesFromChartConfig = (
+    chartConfig: ChartConfig,
+): ChartConfig => {
+    if (chartConfig.type !== ChartType.CARTESIAN || !chartConfig.config) {
+        return chartConfig;
+    }
+
+    const { series } = chartConfig.config.eChartsConfig;
+    if (!series || series.length === 0) {
+        return chartConfig;
+    }
+
+    const seenSeriesIds = new Set<string>();
+    const portableSeries = series.reduce<Series[]>((acc, currentSeries) => {
+        const hasPivotValues =
+            isPivotReferenceWithValues(currentSeries.encode.yRef) ||
+            isPivotReferenceWithValues(currentSeries.encode.xRef);
+        const portableSerie = hasPivotValues
+            ? stripPivotValuesFromSeries(currentSeries)
+            : currentSeries;
+        const seriesId = getSeriesId(portableSerie);
+        if (seenSeriesIds.has(seriesId)) {
+            return acc;
+        }
+
+        seenSeriesIds.add(seriesId);
+        return [...acc, portableSerie];
+    }, []);
+
+    return {
+        ...chartConfig,
+        config: {
+            ...chartConfig.config,
+            eChartsConfig: {
+                ...chartConfig.config.eChartsConfig,
+                series: portableSeries,
+            },
+        },
+    };
+};
+
 export const ECHARTS_DEFAULT_COLORS = [
     '#5470c6',
     '#fc8452',


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8534/chart-as-code-per-value-pivot-series-customizations-lost-on-download

### Description
Moves pivot-series stripping to an explicit CLI download option. Server chart-as-code output remains full fidelity, and `lightdash download` preserves per-value pivot series config by default. Passing `--strip-pivot-series` strips pivot value anchors and dedupes pivoted cartesian series for portable, value-agnostic YAML.



Before

<img width="406" height="500" alt="CleanShot 2026-06-29 at 14 22 38" src="https://github.com/user-attachments/assets/49d8cc79-c380-4e4c-ba20-4af6561a5b7d" />

After

<img width="452" height="372" alt="CleanShot 2026-06-29 at 14 43 59" src="https://github.com/user-attachments/assets/406601af-164e-4b16-bec9-3a7cbace017a" />




### Testing
- `lightdash download --strip-pivot-series` to download charts pivot series with metadata
- `lightdash download` to download charts with all metadata

### Known unrelated check failure
- `pnpm -F backend typecheck` still fails on existing `apiAccess` embed/permissions type errors outside this change.

Closes PROD-8534
Closes #24835
Relates PROD-8299