### PR TITLE
fix: show disabled "Add tile" button alongside "Add tab" when tab is full

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -255,9 +255,22 @@ const AddTileButton: FC<Props> = ({
                     </Menu.Dropdown>
                 </Menu>
             ) : canAddTab ? (
-                <Tooltip
-                    label={`Maximum ${maxTilesPerTab} tiles per tab. Create a new tab (${currentTabsCount}/${maxTabsPerDashboard}).`}
-                >
+                <Group gap="xs" wrap="nowrap">
+                    <Tooltip
+                        label={`This tab has reached the ${maxTilesPerTab}-tile limit. Add a new tab to continue adding tiles.`}
+                    >
+                        <span>
+                            <Button
+                                size="xs"
+                                variant="default"
+                                radius={radius}
+                                disabled
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                            >
+                                Add tile
+                            </Button>
+                        </span>
+                    </Tooltip>
                     <Button
                         size="xs"
                         variant="default"
@@ -268,20 +281,22 @@ const AddTileButton: FC<Props> = ({
                     >
                         Add tab
                     </Button>
-                </Tooltip>
+                </Group>
             ) : (
                 <Tooltip
                     label={`Maximum limits reached: ${maxTilesPerTab} tiles per tab, ${maxTabsPerDashboard} tabs per dashboard.`}
                 >
-                    <Button
-                        size="xs"
-                        variant="default"
-                        radius={radius}
-                        disabled
-                        leftSection={<MantineIcon icon={IconPlus} />}
-                    >
-                        Add tile
-                    </Button>
+                    <span>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            radius={radius}
+                            disabled
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                        >
+                            Add tile
+                        </Button>
+                    </span>
                 </Tooltip>
             )}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-8430/dashboard-edit-mode-explain-why-add-tile-changes-to-add-tab-when-tile

<img width="465" height="138" alt="CleanShot 2026-06-29 at 15 16 18" src="https://github.com/user-attachments/assets/cbc1a426-4317-4354-8ada-e7f02a579376" />


### Description:

When a tab has reached the maximum tile limit but new tabs can still be created, both the disabled "Add tile" button and the "Add tab" button are now shown side by side. Previously, only the "Add tab" button was shown with a tooltip explaining the tile limit, which made it unclear that adding tiles was blocked.

The tooltip message for this state has also been updated to be more user-friendly: `"This tab has reached the {n}-tile limit. Add a new tab to continue adding tiles."`

Additionally, the disabled "Add tile" button in the fully locked state (max tiles and max tabs reached) is now wrapped in a `<span>` to ensure the tooltip renders correctly on a disabled element.