### PR TITLE
chore(ai-agent): exclude done items from reviews project badge counts

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -270,6 +270,9 @@ export const ReviewKanbanBoard: FC<Props> = ({
     const projectFacetOptions = useMemo((): FilterFacetOption[] => {
         const counts = new Map<string, number>();
         for (const item of searchFilteredItems.filter((item) => {
+            // Exclude done items (resolved, dismissed, duplicate) so the badge
+            // reflects only open work in each project.
+            if (getReviewLane(item) === 'done') return false;
             if (selectedRootCauses.length === 0) return true;
             return selectedRootCauses.includes(item.primaryRootCause);
         })) {


### PR DESCRIPTION
The project filter badge counts in the reviews `KanbanBoard` were counting every review item, including ones in the **Done** lane. This makes the per-project counts in the `FilterFacet` reflect only open work by excluding items whose lane is `done` (statuses `resolved`, `dismissed`, and `duplicate`).

Single-line filter added to the `projectFacetOptions` computation in `ReviewKanbanBoard.tsx`.