### PR TITLE
fix(ai-reviews): suppress intro tour when deep-linking to an open review sidebar

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -54,11 +54,19 @@ export const AiReviewsSettingsPage = () => {
 
     // While the tour runs, the board always shows the same sample cards so the
     // spotlights land every time. Closing it flips back to real data.
+    //
+    // Deep-linking straight to a review opens the sidebar on mount; the tour
+    // anchors the board behind it, so don't auto-fire it over an open sidebar.
+    // The hook only reads `autoStartOnFirstVisit` once (mount), and we don't
+    // mark the tour seen, so it still auto-fires on a later board-only visit.
     const {
         isOpen: isTourOpen,
         startTour,
         closeTour,
-    } = useGuidedTour({ storageKey: 'ld.aiReviews.tour.v2' });
+    } = useGuidedTour({
+        storageKey: 'ld.aiReviews.tour.v2',
+        autoStartOnFirstVisit: !isSidebarOpen,
+    });
 
     const [view, setView] = useLocalStorage<'board' | 'table'>({
         key: 'ld.aiReviews.view',


### PR DESCRIPTION
## Problem

When a first-time user deep-links directly to an agent review issue, the thread-preview sidebar opens on mount. The guided intro tour auto-fired on first visit regardless, anchoring the board *behind* the open sidebar — so the tour popovers misaligned.

## Fix

`useGuidedTour` reads `autoStartOnFirstVisit` only in its mount-time `useState` initializer, so we pass `!isSidebarOpen` to skip auto-start when a review sidebar is already open on landing.

The tour is **not** marked as seen in this case, so it still auto-fires on a later board-only visit, and the "Take the tour" button keeps working as before.
