### PR TITLE
chore: filter AI review findings by project from the home promo

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -121,6 +121,7 @@ type AiAgentAdminReviewItemsTableProps = {
      * tour has findings to highlight. Flips to real data once the tour is done.
      */
     showOnboardingExamples?: boolean;
+    initialProjectUuids?: string[];
 };
 
 const getSignalResultLabel = (signal: AiAgentReviewSignalSummary): string => {
@@ -374,13 +375,14 @@ const AiAgentAdminReviewItemsTable = ({
     onReviewItemSelect,
     selectedReviewItemUuid,
     showOnboardingExamples = false,
+    initialProjectUuids = [],
 }: AiAgentAdminReviewItemsTableProps) => {
     const theme = useMantineTheme();
     const [search, setSearch] = useState<string | undefined>(undefined);
     const [reviewSurface, _setReviewSurface] =
         useState<ReviewSurface>('findings');
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
-        [],
+        () => initialProjectUuids,
     );
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -86,6 +86,7 @@ type Props = {
     selectedReviewItemUuid?: string | null;
     onReviewItemSelect: (target: AiAgentAdminReviewItemPreviewTarget) => void;
     showOnboardingExamples?: boolean;
+    initialProjectUuids?: string[];
 };
 
 const toTarget = (
@@ -175,11 +176,12 @@ export const ReviewKanbanBoard: FC<Props> = ({
     selectedReviewItemUuid,
     onReviewItemSelect,
     showOnboardingExamples = false,
+    initialProjectUuids = [],
 }) => {
     const [search, setSearch] = useState<string | undefined>(undefined);
     const deferredSearch = useDeferredValue(search);
     const [selectedProjectUuids, setSelectedProjectUuids] = useState<string[]>(
-        [],
+        () => initialProjectUuids,
     );
     const [selectedRootCauses, setSelectedRootCauses] = useState<
         AiAgentRootCause[]

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -52,6 +52,14 @@ export const AiReviewsSettingsPage = () => {
 
     const isSidebarOpen = selectedReviewItem !== null;
 
+    // Seeds the board/table project filter when arriving from a project's
+    // "Review AI findings" promo (e.g. `?projects=<uuid>`).
+    const initialProjectUuids = useMemo(() => {
+        const projectsParam = searchParams.get('projects');
+        if (!projectsParam) return [];
+        return projectsParam.split(',').filter(Boolean);
+    }, [searchParams]);
+
     // While the tour runs, the board always shows the same sample cards so the
     // spotlights land every time. Closing it flips back to real data.
     const {
@@ -178,11 +186,13 @@ export const AiReviewsSettingsPage = () => {
                     selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
                     onReviewItemSelect={handleReviewItemSelect}
                     showOnboardingExamples={isTourOpen}
+                    initialProjectUuids={initialProjectUuids}
                 />
             ) : (
                 <AiAgentAdminReviewItemsTable
                     selectedReviewItemUuid={selectedReviewItem?.reviewItemUuid}
                     onReviewItemSelect={handleReviewItemSelect}
+                    initialProjectUuids={initialProjectUuids}
                 />
             )}
 


### PR DESCRIPTION
The home "Review AI findings" promo already links to `/generalSettings/ai/reviews?projects=<uuid>`, but the reviews view ignored the `projects` param and always opened unfiltered.

Now `AiReviewsSettingsPage` reads the param and passes it as `initialProjectUuids` to both the board and table views, which seed their project filter from it on mount (lazy `useState` initializer — no `useEffect` syncing). So clicking the promo from a project lands on the reviews view already filtered to that project, while subsequent manual filter changes work as before.

Supports a comma-separated list for forward compatibility, though the promo currently sends a single uuid.
