### PR TITLE
fix: commit pending filter input value when Apply is clicked

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -25,6 +25,8 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
     disabled,
     onChange,
     popoverProps,
+    commitPendingValueRef,
+    onPendingValueChange,
 }: FilterInputsProps<T>) => {
     const { getField } = useFiltersContext();
     const suggestions = isFilterRule(rule)
@@ -65,6 +67,8 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
+                            commitPendingValueRef={commitPendingValueRef}
+                            onPendingValueChange={onPendingValueChange}
                             values={(rule.values || []).filter(isString)}
                             onChange={(values) =>
                                 onChange({
@@ -85,6 +89,8 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
+                            commitPendingValueRef={commitPendingValueRef}
+                            onPendingValueChange={onPendingValueChange}
                             values={(rule.values || []).filter(isString)}
                             singleValue={isSingleValue}
                             showNullOption={

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiStringInput.tsx
@@ -1,7 +1,14 @@
 import { Group, MultiSelect, Text, type MultiSelectProps } from '@mantine/core';
 import { IconPlus } from '@tabler/icons-react';
 import uniq from 'lodash/uniq';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type FC,
+    type MutableRefObject,
+} from 'react';
 import MantineIcon from '../../MantineIcon';
 import MultiValuePastePopover from './MultiValuePastePopover';
 import { formatDisplayValue } from './utils';
@@ -9,6 +16,8 @@ import { formatDisplayValue } from './utils';
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     values: string[];
     onChange: (values: string[]) => void;
+    commitPendingValueRef?: MutableRefObject<(() => boolean) | undefined>;
+    onPendingValueChange?: (hasPendingValue: boolean) => void;
 };
 
 const FilterMultiStringInput: FC<Props> = ({
@@ -16,6 +25,8 @@ const FilterMultiStringInput: FC<Props> = ({
     disabled,
     onChange,
     placeholder,
+    commitPendingValueRef,
+    onPendingValueChange,
     ...rest
 }) => {
     const [search, setSearch] = useState('');
@@ -45,6 +56,33 @@ const FilterMultiStringInput: FC<Props> = ({
             return newValue;
         },
         [handleChange, values],
+    );
+
+    useEffect(() => {
+        if (!commitPendingValueRef) return undefined;
+
+        commitPendingValueRef.current = () => {
+            if (search === '') return false;
+
+            handleAdd(search);
+            handleResetSearch();
+            return true;
+        };
+
+        return () => {
+            commitPendingValueRef.current = undefined;
+        };
+    }, [commitPendingValueRef, handleAdd, handleResetSearch, search]);
+
+    useEffect(() => {
+        onPendingValueChange?.(search !== '');
+    }, [onPendingValueChange, search]);
+
+    useEffect(
+        () => () => {
+            onPendingValueChange?.(false);
+        },
+        [onPendingValueChange],
     );
 
     const handleAddMultiple = useCallback(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -28,6 +28,7 @@ import {
     useRef,
     useState,
     type FC,
+    type MutableRefObject,
     type ReactNode,
 } from 'react';
 import useHealth from '../../../../hooks/health/useHealth';
@@ -65,6 +66,8 @@ type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     showNullOption?: boolean;
     includeNull?: boolean;
     onIncludeNullChange?: (includeNull: boolean) => void;
+    commitPendingValueRef?: MutableRefObject<(() => boolean) | undefined>;
+    onPendingValueChange?: (hasPendingValue: boolean) => void;
 };
 
 // Single value component that mimics a single select behavior - maxSelectedValues={1} behaves weirdly so we don't use it.
@@ -142,6 +145,8 @@ const FilterStringAutoComplete: FC<Props> = ({
     showNullOption,
     includeNull,
     onIncludeNullChange,
+    commitPendingValueRef,
+    onPendingValueChange,
     ...rest
 }) => {
     // The "(null)" option is only meaningful for multi-value filters.
@@ -322,6 +327,33 @@ const FilterStringAutoComplete: FC<Props> = ({
             }
         },
         [handleAdd, handleResetSearch, search],
+    );
+
+    useEffect(() => {
+        if (!commitPendingValueRef) return undefined;
+
+        commitPendingValueRef.current = () => {
+            if (search === '') return false;
+
+            handleAdd(search);
+            handleResetSearch();
+            return true;
+        };
+
+        return () => {
+            commitPendingValueRef.current = undefined;
+        };
+    }, [commitPendingValueRef, handleAdd, handleResetSearch, search]);
+
+    useEffect(() => {
+        onPendingValueChange?.(search !== '');
+    }, [onPendingValueChange, search]);
+
+    useEffect(
+        () => () => {
+            onPendingValueChange?.(false);
+        },
+        [onPendingValueChange],
     );
 
     const ValueComponent = useCallback(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -5,6 +5,7 @@ import {
     type FilterableItem,
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
+import { type MutableRefObject } from 'react';
 import BooleanFilterInputs from './BooleanFilterInputs';
 import DateFilterInputs from './DateFilterInputs';
 import DefaultFilterInputs from './DefaultFilterInputs';
@@ -16,6 +17,8 @@ export type FilterInputsProps<T extends BaseFilterRule> = {
     onChange: (value: T) => void;
     disabled?: boolean;
     popoverProps?: Omit<PopoverProps, 'children'>;
+    commitPendingValueRef?: MutableRefObject<(() => boolean) | undefined>;
+    onPendingValueChange?: (hasPendingValue: boolean) => void;
 };
 
 const FilterInputComponent = <T extends BaseFilterRule>(

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterSettings.tsx
@@ -22,7 +22,13 @@ import {
     type PopoverProps,
 } from '@mantine/core';
 import { IconHelpCircle, IconX } from '@tabler/icons-react';
-import { useEffect, useMemo, useState, type FC } from 'react';
+import {
+    useEffect,
+    useMemo,
+    useState,
+    type FC,
+    type MutableRefObject,
+} from 'react';
 import FilterInputComponent from '../../../components/common/Filters/FilterInputs';
 import { filterOperatorDescription } from '../../../components/common/Filters/FilterInputs/constants';
 import { getFilterOperatorOptions } from '../../../components/common/Filters/FilterInputs/utils';
@@ -38,6 +44,8 @@ interface FilterSettingsProps {
     filterRule: DashboardFilterRule;
     popoverProps?: Omit<PopoverProps, 'children'>;
     onChangeFilterRule: (value: DashboardFilterRule) => void;
+    commitPendingValueRef?: MutableRefObject<(() => boolean) | undefined>;
+    onPendingValueChange?: (hasPendingValue: boolean) => void;
 }
 
 const FilterSettings: FC<FilterSettingsProps> = ({
@@ -48,6 +56,8 @@ const FilterSettings: FC<FilterSettingsProps> = ({
     filterRule,
     popoverProps,
     onChangeFilterRule,
+    commitPendingValueRef,
+    onPendingValueChange,
 }) => {
     const { user } = useApp();
     const canManageExplore = user.data?.ability?.can('manage', 'Explore');
@@ -220,6 +230,8 @@ const FilterSettings: FC<FilterSettingsProps> = ({
                                         newFilterRule as DashboardFilterRule,
                                     )
                                 }
+                                commitPendingValueRef={commitPendingValueRef}
+                                onPendingValueChange={onPendingValueChange}
                             />
                         </Box>
                         {canManageExplore &&

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.test.tsx
@@ -1,0 +1,111 @@
+import {
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+} from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import FilterConfiguration from './index';
+
+vi.mock('../../../providers/Dashboard/useDashboardTileStatusContext', () => ({
+    default: vi.fn((selector) => selector({ sqlChartTilesMetadata: {} })),
+}));
+
+vi.mock('../../../components/common/Filters/useFiltersContext', () => ({
+    default: vi.fn(() => ({
+        projectUuid: 'test-project-uuid',
+        getAutocompleteFilterGroup: vi.fn(() => undefined),
+        getField: vi.fn(() => undefined),
+        parameterValues: {},
+    })),
+}));
+
+vi.mock('../../../hooks/useFieldValues', () => ({
+    MAX_AUTOCOMPLETE_RESULTS: 100,
+    useFieldValues: vi.fn(() => ({
+        isInitialLoading: false,
+        results: [],
+        refreshedAt: new Date(),
+        refetch: vi.fn(),
+        reset: vi.fn(),
+        error: null,
+        isError: false,
+    })),
+}));
+
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: vi.fn(() => ({
+        data: { hasCacheAutocompleResults: false },
+    })),
+}));
+
+const mockField = {
+    name: 'first_name',
+    type: DimensionType.STRING,
+    table: 'customers',
+    tableLabel: 'Customers',
+    label: 'First name',
+    fieldType: FieldType.DIMENSION,
+    sql: 'first_name',
+    hidden: false,
+} as DashboardFilterableField;
+
+const anyValueRule: DashboardFilterRule = {
+    id: 'filter-1',
+    target: {
+        fieldId: 'customers_first_name',
+        tableName: 'customers',
+    },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    disabled: false,
+    label: undefined,
+};
+
+describe('FilterConfiguration', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('saves a typed string filter value when Apply is clicked without pressing Enter', async () => {
+        const user = userEvent.setup({ pointerEventsCheck: 0 });
+        const onSave = vi.fn();
+
+        renderWithProviders(
+            <FilterConfiguration
+                isEditMode={false}
+                tiles={[]}
+                tabs={[]}
+                availableTileFilters={{}}
+                field={mockField}
+                defaultFilterRule={anyValueRule}
+                originalFilterRule={anyValueRule}
+                onSave={onSave}
+            />,
+        );
+
+        const input = screen.getByPlaceholderText(
+            'Start typing to filter results',
+        );
+        const applyButton = screen.getByRole('button', { name: 'Apply' });
+
+        expect(applyButton).toBeDisabled();
+
+        fireEvent.focus(input);
+        await user.type(input, 'adam');
+
+        expect(applyButton).toBeEnabled();
+
+        fireEvent.mouseDown(applyButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledWith(
+                expect.objectContaining({ values: ['adam'] }),
+            );
+        });
+    });
+});

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -33,7 +33,14 @@ import {
 } from '@mantine/core';
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -100,6 +107,13 @@ const FilterConfiguration: FC<Props> = ({
     const [draftFilterRule, setDraftFilterRule] = useState<
         DashboardFilterRule | undefined
     >(defaultFilterRule);
+    const commitPendingValueRef = useRef<(() => boolean) | undefined>(
+        undefined,
+    );
+    const [hasPendingFilterInputValue, setHasPendingFilterInputValue] =
+        useState(false);
+    const [shouldSaveCommittedValue, setShouldSaveCommittedValue] =
+        useState(false);
 
     const isFilterModified = useMemo(() => {
         if (!originalFilterRule || !draftFilterRule) return false;
@@ -348,11 +362,28 @@ const FilterConfiguration: FC<Props> = ({
         ],
     );
 
-    const isApplyDisabled = !isFilterEnabled(
-        draftFilterRule,
-        isEditMode,
-        isCreatingNew,
-    );
+    const isApplyDisabled =
+        !hasPendingFilterInputValue &&
+        !isFilterEnabled(draftFilterRule, isEditMode, isCreatingNew);
+
+    useEffect(() => {
+        if (!shouldSaveCommittedValue) return;
+
+        setShouldSaveCommittedValue(false);
+        if (draftFilterRule) onSave(draftFilterRule);
+    }, [draftFilterRule, onSave, shouldSaveCommittedValue]);
+
+    const handleApply = useCallback(() => {
+        setSelectedTabId(FilterTabs.SETTINGS);
+
+        if (commitPendingValueRef.current?.()) {
+            setHasPendingFilterInputValue(false);
+            setShouldSaveCommittedValue(true);
+            return;
+        }
+
+        if (draftFilterRule) onSave(draftFilterRule);
+    }, [draftFilterRule, onSave]);
 
     const isLockedRequiredMissingValue =
         !!draftFilterRule?.lockedTabUuids?.length &&
@@ -493,6 +524,10 @@ const FilterConfiguration: FC<Props> = ({
                                 filterRule={draftFilterRule}
                                 onChangeFilterRule={handleChangeFilterRule}
                                 popoverProps={popoverProps}
+                                commitPendingValueRef={commitPendingValueRef}
+                                onPendingValueChange={
+                                    setHasPendingFilterInputValue
+                                }
                             />
                         )}
 
@@ -573,10 +608,7 @@ const FilterConfiguration: FC<Props> = ({
                             // mousedown and the subsequent click event never
                             // reaches the Apply button — so a real-user click
                             // would otherwise need two presses to apply.
-                            onMouseDown={() => {
-                                setSelectedTabId(FilterTabs.SETTINGS);
-                                if (!!draftFilterRule) onSave(draftFilterRule);
-                            }}
+                            onMouseDown={handleApply}
                         >
                             Apply
                         </Button>


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

When a user types a value into a dashboard filter string input but does not press Enter to confirm it, clicking "Apply" would previously discard the typed text. This fixes that behavior by committing any pending (unconfirmed) typed value before saving the filter.

A `commitPendingValueRef` is introduced and passed down through `FilterConfiguration` → `FilterSettings` → `FilterInputsProps` → `FilterStringAutoComplete` / `FilterMultiStringInput`. When the Apply button is clicked, it first calls `commitPendingValueRef.current()` to flush any in-progress search text into the filter values, then triggers the save. An `onPendingValueChange` callback is also threaded through the same chain so that the Apply button becomes enabled as soon as the user starts typing, even before pressing Enter.

A test is added to `FilterConfiguration` that verifies a typed string value is included in the saved filter rule when Apply is clicked without pressing Enter.