### PR TITLE
feat(ai-reviews): Issues board foundation — manual issues, modal & activity [ZAP-514]

### DIFF
--- a/packages/backend/src/ee/controllers/AiAgentAdminController.ts
+++ b/packages/backend/src/ee/controllers/AiAgentAdminController.ts
@@ -16,9 +16,12 @@ import {
     ApiSuccessEmpty,
     ApiUpdateAiOrganizationSettingsResponse,
     assertRegisteredAccount,
+    CreateAiAgentReviewItem,
+    CreateAiAgentReviewItemComment,
     KnexPaginateArgs,
     ReorderAiAgentReviewItems,
     UpdateAiAgentReviewItemAssignee,
+    UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiOrganizationSettings,
     UpdateAiReviewNotificationSettings,
@@ -189,6 +192,33 @@ export class AiAgentAdminController extends BaseController {
             results: await this.getAiAgentAdminService().listReviewItems(
                 toSessionUser(req.account),
                 status,
+            ),
+        };
+    }
+
+    /**
+     * Create a manual AI agent issue
+     * @summary Create AI agent review item
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('201', 'Created')
+    @Post('/review-items')
+    @OperationId('createAiAgentReviewItem')
+    async createReviewItem(
+        @Request() req: express.Request,
+        @Body() body: CreateAiAgentReviewItem,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(201);
+        return {
+            status: 'ok',
+            results: await this.getAiAgentAdminService().createReviewItem(
+                toSessionUser(req.account),
+                body,
             ),
         };
     }
@@ -369,6 +399,62 @@ export class AiAgentAdminController extends BaseController {
                 toSessionUser(req.account),
                 fingerprint,
                 body.assignedToUserUuid,
+            );
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Set the priority on an AI agent review item
+     * @summary Update AI agent review item priority
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Patch('/review-items/{fingerprint}/priority')
+    @OperationId('updateAiAgentReviewItemPriority')
+    async updateReviewItemPriority(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+        @Body() body: UpdateAiAgentReviewItemPriority,
+    ): Promise<ApiAiAgentReviewItemResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAiAgentAdminService().updateReviewItemPriority(
+                toSessionUser(req.account),
+                fingerprint,
+                body,
+            );
+        return { status: 'ok', results };
+    }
+
+    /**
+     * Add a comment to an AI agent review item
+     * @summary Add AI agent review item comment
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/review-items/{fingerprint}/comments')
+    @OperationId('addAiAgentReviewItemComment')
+    async addReviewItemComment(
+        @Request() req: express.Request,
+        @Path() fingerprint: string,
+        @Body() body: CreateAiAgentReviewItemComment,
+    ): Promise<ApiAiAgentReviewItemActivityResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        const results =
+            await this.getAiAgentAdminService().addReviewItemComment(
+                toSessionUser(req.account),
+                fingerprint,
+                body.body,
             );
         return { status: 'ok', results };
     }

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -14,7 +14,9 @@ import type {
     AiAgentReviewItemEventDetail,
     AiAgentReviewItemEventType,
     AiAgentReviewItemOwnerType,
+    AiAgentReviewItemPriority,
     AiAgentReviewItemPrState,
+    AiAgentReviewItemSource,
     AiAgentReviewItemStatus,
     AiAgentReviewItemWritebackStatus,
     AiAgentReviewRemediationEventDetail,
@@ -235,9 +237,14 @@ export type AiAgentReviewItemEventsTable = Knex.CompositeTableType<
 export type DbAiAgentReviewItem = {
     ai_agent_review_item_uuid: string;
     fingerprint: string;
+    source: AiAgentReviewItemSource;
     organization_uuid: string;
     project_uuid: string | null;
     agent_uuid: string | null;
+    title: string | null;
+    description: string | null;
+    primary_root_cause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
     status: AiAgentReviewItemStatus;
     dismissed_reason: AiAgentReviewItemDismissedReason | null;
     assigned_to_user_uuid: string | null;
@@ -250,6 +257,7 @@ export type DbAiAgentReviewItem = {
     status_updated_at: Date | null;
     status_updated_by_user_uuid: string | null;
     board_position: number | null;
+    created_by_user_uuid: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -263,7 +271,6 @@ export type AiAgentReviewItemTable = Knex.CompositeTableType<
         Partial<
             Omit<
                 DbAiAgentReviewItem,
-                | 'ai_agent_review_item_uuid'
                 | 'created_at'
                 | 'updated_at'
                 | 'fingerprint'
@@ -284,9 +291,9 @@ export type DbAiAgentReviewRemediation = {
     ai_agent_review_remediation_uuid: string;
     fingerprint: string;
     organization_uuid: string;
-    source_ai_agent_review_turn_signal_uuid: string;
-    source_prompt_uuid: string;
-    source_thread_uuid: string;
+    source_ai_agent_review_turn_signal_uuid: string | null;
+    source_prompt_uuid: string | null;
+    source_thread_uuid: string | null;
     source_project_uuid: string;
     source_agent_uuid: string;
     work_thread_uuid: string | null;

--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -11,6 +11,8 @@ import type {
     AiAgentReviewClassifierRunScope,
     AiAgentReviewClassifierRunStatus,
     AiAgentReviewItemDismissedReason,
+    AiAgentReviewItemEventDetail,
+    AiAgentReviewItemEventType,
     AiAgentReviewItemOwnerType,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
@@ -201,6 +203,31 @@ export type AiAgentReviewRemediationEventsTable = Knex.CompositeTableType<
                 DbAiAgentReviewRemediationEvent,
                 'payload' | 'created_by_user_uuid'
             >
+        >,
+    never
+>;
+
+export const AiAgentReviewItemEventsTableName = 'ai_agent_review_item_events';
+
+export type DbAiAgentReviewItemEvent = {
+    ai_agent_review_item_event_uuid: string;
+    fingerprint: string;
+    organization_uuid: string;
+    event_type: AiAgentReviewItemEventType;
+    occurred_at: Date;
+    payload: AiAgentReviewItemEventDetail['payload'];
+    created_by_user_uuid: string | null;
+    created_at: Date;
+};
+
+export type AiAgentReviewItemEventsTable = Knex.CompositeTableType<
+    DbAiAgentReviewItemEvent,
+    Pick<
+        DbAiAgentReviewItemEvent,
+        'fingerprint' | 'organization_uuid' | 'event_type' | 'occurred_at'
+    > &
+        Partial<
+            Pick<DbAiAgentReviewItemEvent, 'payload' | 'created_by_user_uuid'>
         >,
     never
 >;

--- a/packages/backend/src/ee/database/migrations/20260623122000_allow_manual_ai_agent_review_remediation.ts
+++ b/packages/backend/src/ee/database/migrations/20260623122000_allow_manual_ai_agent_review_remediation.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+const remediationTable = 'ai_agent_review_remediation';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table
+            .uuid('source_ai_agent_review_turn_signal_uuid')
+            .nullable()
+            .alter();
+        table.uuid('source_prompt_uuid').nullable().alter();
+        table.uuid('source_thread_uuid').nullable().alter();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(remediationTable, (table) => {
+        table
+            .uuid('source_ai_agent_review_turn_signal_uuid')
+            .notNullable()
+            .alter();
+        table.uuid('source_prompt_uuid').notNullable().alter();
+        table.uuid('source_thread_uuid').notNullable().alter();
+    });
+}

--- a/packages/backend/src/ee/database/migrations/20260624120000_add_ai_agent_review_item_events.ts
+++ b/packages/backend/src/ee/database/migrations/20260624120000_add_ai_agent_review_item_events.ts
@@ -1,0 +1,50 @@
+import { Knex } from 'knex';
+
+const eventsTable = 'ai_agent_review_item_events';
+const reviewItemTable = 'ai_agent_review_item';
+const organizationsTable = 'organizations';
+const usersTable = 'users';
+const eventsByItemIndex =
+    'ai_agent_review_item_events_fingerprint_occurred_idx';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(eventsTable, (table) => {
+        table
+            .uuid('ai_agent_review_item_event_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .text('fingerprint')
+            .notNullable()
+            .references('fingerprint')
+            .inTable(reviewItemTable)
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .notNullable()
+            .references('organization_uuid')
+            .inTable(organizationsTable)
+            .onDelete('CASCADE')
+            .index();
+        table.text('event_type').notNullable();
+        table.timestamp('occurred_at', { useTz: true }).notNullable();
+        table.jsonb('payload').notNullable().defaultTo('{}');
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL')
+            .index();
+        table
+            .timestamp('created_at', { useTz: true })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.index(['fingerprint', 'occurred_at'], eventsByItemIndex);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(eventsTable);
+}

--- a/packages/backend/src/ee/database/migrations/20260624130000_add_manual_ai_agent_review_items.ts
+++ b/packages/backend/src/ee/database/migrations/20260624130000_add_manual_ai_agent_review_items.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const reviewItemTable = 'ai_agent_review_item';
+const usersTable = 'users';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table
+            .text('source')
+            .notNullable()
+            .defaultTo('ai_finding')
+            .checkIn(['ai_finding', 'manual']);
+        table.text('title').nullable();
+        table.text('description').nullable();
+        table.text('primary_root_cause').nullable();
+        table
+            .text('priority')
+            .notNullable()
+            .defaultTo('none')
+            .checkIn(['urgent', 'high', 'medium', 'low', 'none']);
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(usersTable)
+            .onDelete('SET NULL');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(reviewItemTable, (table) => {
+        table.dropColumn('created_by_user_uuid');
+        table.dropColumn('priority');
+        table.dropColumn('primary_root_cause');
+        table.dropColumn('description');
+        table.dropColumn('title');
+        table.dropColumn('source');
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -4,6 +4,7 @@ import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { AiPromptTableName } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
+    AiAgentReviewItemEventsTableName,
     AiAgentReviewItemTableName,
     AiAgentReviewRemediationEventsTableName,
     AiAgentReviewRemediationTableName,
@@ -370,6 +371,78 @@ describe('AiAgentReviewClassifierModel', () => {
                         prNumber: 42,
                     },
                     createdByUserUuid: null,
+                },
+            ]);
+        });
+    });
+
+    describe('review item events', () => {
+        it('inserts an issue event with the mapped columns', async () => {
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
+            const occurredAt = new Date('2026-06-24T10:00:00.000Z');
+
+            await model.createReviewItemEvent({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+                event: {
+                    eventType: 'status_changed',
+                    payload: {
+                        from: 'open',
+                        to: 'in_progress',
+                        dismissedReason: null,
+                    },
+                },
+                occurredAt,
+                createdByUserUuid: USER_UUID,
+            });
+
+            const [insert] = tracker.history.insert;
+            expect(insert.sql).toContain(AiAgentReviewItemEventsTableName);
+            expect(insert.bindings).toContain(FINGERPRINT);
+            expect(insert.bindings).toContain('status_changed');
+            expect(insert.bindings).toContain(USER_UUID);
+            expect(insert.bindings).toContainEqual(occurredAt);
+        });
+
+        it('lists issue events ordered by occurrence', async () => {
+            tracker.on.select(AiAgentReviewItemEventsTableName).responseOnce([
+                {
+                    ai_agent_review_item_event_uuid: 'event-1',
+                    fingerprint: FINGERPRINT,
+                    organization_uuid: ORGANIZATION_UUID,
+                    event_type: 'status_changed',
+                    occurred_at: SEEN_AT,
+                    payload: {
+                        from: 'open',
+                        to: 'in_progress',
+                        dismissedReason: null,
+                    },
+                    created_by_user_uuid: USER_UUID,
+                    created_at: SEEN_AT,
+                },
+            ]);
+
+            const events = await model.listReviewItemEvents({
+                fingerprint: FINGERPRINT,
+                organizationUuid: ORGANIZATION_UUID,
+            });
+
+            const [query] = tracker.history.select;
+            expect(query.sql).toContain('occurred_at');
+            expect(events).toEqual([
+                {
+                    uuid: 'event-1',
+                    fingerprint: FINGERPRINT,
+                    eventType: 'status_changed',
+                    occurredAt: SEEN_AT,
+                    payload: {
+                        from: 'open',
+                        to: 'in_progress',
+                        dismissedReason: null,
+                    },
+                    createdByUserUuid: USER_UUID,
                 },
             ]);
         });

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -1098,6 +1098,83 @@ describe('AiAgentReviewClassifierModel', () => {
     });
 
     describe('createTurnSignal', () => {
+        const promotedFinding = {
+            primaryRootCause: 'semantic_layer' as const,
+            secondaryRootCauses: [],
+            subcategories: [],
+            fixTargets: [],
+            targetRefs: [],
+            evidenceExcerpts: [],
+            recommendation: null,
+            projectContextEntry: null,
+            reviewItem: {
+                fingerprint: FINGERPRINT,
+                title: 'Review airports.country',
+                description: 'Country needs semantic clarification.',
+                ownerType: 'semantic_layer_owner' as const,
+            },
+        };
+
+        it('records a created issue event on first promotion of a fingerprint', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            // No existing item for this fingerprint → first promotion.
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: promotedFinding,
+            });
+
+            const eventInserts = tracker.history.insert.filter((q) =>
+                q.sql.includes(AiAgentReviewItemEventsTableName),
+            );
+            expect(eventInserts).toHaveLength(1);
+            expect(eventInserts[0].bindings).toContain('created');
+        });
+
+        it('records a recurred issue event when the fingerprint already exists', async () => {
+            tracker.on.any(/pg_advisory_xact_lock/).response([]);
+            tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.delete(AiAgentTurnSignalTableName).responseOnce(0);
+            tracker.on
+                .insert(AiAgentTurnSignalTableName)
+                .responseOnce([
+                    { ai_agent_review_turn_signal_uuid: TURN_SIGNAL_UUID },
+                ]);
+            // Existing open item for this fingerprint → recurrence.
+            tracker.on
+                .select(AiAgentReviewItemTableName)
+                .responseOnce([{ status: 'open', dismissed_reason: null }]);
+            tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
+
+            await model.createTurnSignal({
+                runUuid: RUN_UUID,
+                turnSignal,
+                finding: promotedFinding,
+            });
+
+            const eventInserts = tracker.history.insert.filter((q) =>
+                q.sql.includes(AiAgentReviewItemEventsTableName),
+            );
+            expect(eventInserts).toHaveLength(1);
+            expect(eventInserts[0].bindings).toContain('recurred');
+        });
+
         it('persists a classified signal with inline finding fields', async () => {
             tracker.on.any(/pg_advisory_xact_lock/).response([]);
             tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
@@ -1110,6 +1187,9 @@ describe('AiAgentReviewClassifierModel', () => {
             // No existing item for this fingerprint → nothing to reopen.
             tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
 
             const result = await model.createTurnSignal({
                 runUuid: RUN_UUID,
@@ -1151,9 +1231,12 @@ describe('AiAgentReviewClassifierModel', () => {
             expect(tracker.history.delete[0].sql).toContain(
                 AiAgentTurnSignalTableName,
             );
-            expect(tracker.history.insert).toHaveLength(2);
+            expect(tracker.history.insert).toHaveLength(3);
             expect(tracker.history.insert[1].sql).toContain(
                 AiAgentReviewItemTableName,
+            );
+            expect(tracker.history.insert[2].sql).toContain(
+                AiAgentReviewItemEventsTableName,
             );
             // The supersede + item write are serialized behind a per-turn
             // advisory lock so concurrent re-reviews cannot clobber each other.
@@ -1242,6 +1325,9 @@ describe('AiAgentReviewClassifierModel', () => {
                 .select(AiAgentReviewItemTableName)
                 .responseOnce([{ status: 'open', dismissed_reason: null }]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
 
             await model.createTurnSignal({
                 runUuid: RUN_UUID,
@@ -1286,6 +1372,9 @@ describe('AiAgentReviewClassifierModel', () => {
                 .select(AiAgentReviewItemTableName)
                 .responseOnce([{ status: 'resolved', dismissed_reason: null }]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
             tracker.on.update(AiAgentReviewItemTableName).responseOnce(1);
 
             await model.createTurnSignal({
@@ -1333,6 +1422,9 @@ describe('AiAgentReviewClassifierModel', () => {
                 },
             ]);
             tracker.on.insert(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on
+                .insert(AiAgentReviewItemEventsTableName)
+                .responseOnce([]);
 
             await model.createTurnSignal({
                 runUuid: RUN_UUID,

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.test.ts
@@ -575,6 +575,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 .select(AiAgentTurnSignalTableName)
                 .responseOnce([makeTurnSignalRow()]);
             tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on
                 .select(AiAgentReviewRemediationTableName)
                 .responseOnce([]);
@@ -645,6 +646,7 @@ describe('AiAgentReviewClassifierModel', () => {
                     updated_at_age_ms: 0,
                 },
             ]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on
                 .select(AiAgentReviewRemediationTableName)
                 .responseOnce([]);
@@ -676,6 +678,7 @@ describe('AiAgentReviewClassifierModel', () => {
                 .select(AiAgentTurnSignalTableName)
                 .responseOnce([makeTurnSignalRow()]);
             tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on
                 .select(AiAgentReviewRemediationTableName)
                 .responseOnce([makeRemediationRow()]);
@@ -701,6 +704,7 @@ describe('AiAgentReviewClassifierModel', () => {
 
         it('filters by overlaid status', async () => {
             tracker.on.select(AiAgentTurnSignalTableName).responseOnce([]);
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
 
             const result = await model.listReviewItems({
                 organizationUuid: ORGANIZATION_UUID,
@@ -752,6 +756,8 @@ describe('AiAgentReviewClassifierModel', () => {
             tracker.on
                 .select(AiAgentReviewItemTableName)
                 .responseOnce(itemRows);
+            // listReviewItems also queries source='manual' rows; none here.
+            tracker.on.select(AiAgentReviewItemTableName).responseOnce([]);
             tracker.on
                 .select(AiAgentReviewRemediationTableName)
                 .responseOnce(remediationRows);

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -20,6 +20,8 @@ import type {
     AiAgentReviewClassifierTurnCandidate,
     AiAgentReviewClassifierTurnSignal,
     AiAgentReviewItemDismissedReason,
+    AiAgentReviewItemEvent,
+    AiAgentReviewItemEventDetail,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
@@ -49,17 +51,20 @@ import {
 } from '../database/entities/ai';
 import {
     AiAgentReviewClassifierRunTableName,
+    AiAgentReviewItemEventsTableName,
     AiAgentReviewItemTableName,
     AiAgentReviewRemediationEventsTableName,
     AiAgentReviewRemediationTableName,
     AiAgentTurnSignalTableName,
     type AiAgentReviewClassifierRunTable,
+    type AiAgentReviewItemEventsTable,
     type AiAgentReviewItemTable,
     type AiAgentReviewRemediationEventsTable,
     type AiAgentReviewRemediationTable,
     type AiAgentTurnSignalTable,
     type DbAiAgentReviewClassifierRun,
     type DbAiAgentReviewItem,
+    type DbAiAgentReviewItemEvent,
     type DbAiAgentReviewRemediation,
     type DbAiAgentReviewRemediationEvent,
     type DbAiAgentTurnSignal,
@@ -1504,6 +1509,55 @@ export class AiAgentReviewClassifierModel {
             eventType: row.event_type,
             payload: row.payload,
         } as AiAgentReviewRemediationEvent;
+    }
+
+    async createReviewItemEvent(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        event: AiAgentReviewItemEventDetail;
+        occurredAt?: Date;
+        createdByUserUuid?: string | null;
+        trx?: Knex;
+    }): Promise<void> {
+        const db = args.trx ?? this.database;
+        await db<AiAgentReviewItemEventsTable>(
+            AiAgentReviewItemEventsTableName,
+        ).insert({
+            fingerprint: args.fingerprint,
+            organization_uuid: args.organizationUuid,
+            event_type: args.event.eventType,
+            payload: args.event.payload,
+            occurred_at: args.occurredAt ?? (db.fn.now() as never),
+            created_by_user_uuid: args.createdByUserUuid ?? null,
+        });
+    }
+
+    async listReviewItemEvents(args: {
+        fingerprint: string;
+        organizationUuid: string;
+    }): Promise<AiAgentReviewItemEvent[]> {
+        const rows = await this.database<AiAgentReviewItemEventsTable>(
+            AiAgentReviewItemEventsTableName,
+        )
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .orderBy('occurred_at', 'asc')
+            .select('*');
+
+        return rows.map(AiAgentReviewClassifierModel.mapReviewItemEvent);
+    }
+
+    private static mapReviewItemEvent(
+        row: DbAiAgentReviewItemEvent,
+    ): AiAgentReviewItemEvent {
+        return {
+            uuid: row.ai_agent_review_item_event_uuid,
+            fingerprint: row.fingerprint,
+            occurredAt: row.occurred_at,
+            createdByUserUuid: row.created_by_user_uuid,
+            eventType: row.event_type,
+            payload: row.payload,
+        } as AiAgentReviewItemEvent;
     }
 
     /**

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -22,6 +22,7 @@ import type {
     AiAgentReviewItemDismissedReason,
     AiAgentReviewItemEvent,
     AiAgentReviewItemEventDetail,
+    AiAgentReviewItemPriority,
     AiAgentReviewItemPrState,
     AiAgentReviewItemStatus,
     AiAgentReviewItemSummary,
@@ -37,6 +38,7 @@ import type {
     AiAgentTurnSignal,
 } from '@lightdash/common';
 import { type Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
 import { ProjectTableName } from '../../database/entities/projects';
 import { PullRequestsTableName } from '../../database/entities/pullRequests';
 import { QueryHistoryTableName } from '../../database/entities/queryHistory';
@@ -199,8 +201,8 @@ type ListReviewItemsArgs = {
 type UpsertReviewItemStateArgs = {
     fingerprint: string;
     organizationUuid: string;
-    projectUuid: string;
-    agentUuid: string;
+    projectUuid: string | null;
+    agentUuid: string | null;
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     statusUpdatedByUserUuid: string | null;
@@ -209,12 +211,24 @@ type UpsertReviewItemStateArgs = {
     boardPosition?: number | null;
 };
 
+type CreateManualReviewItemArgs = {
+    organizationUuid: string;
+    title: string;
+    description: string | null;
+    projectUuid: string;
+    agentUuid: string | null;
+    assignedToUserUuid: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
+    createdByUserUuid: string | null;
+};
+
 type CreateReviewRemediationArgs = {
     fingerprint: string;
     organizationUuid: string;
-    sourceFindingUuid: string;
-    sourcePromptUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourcePromptUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
     workThreadUuid: string | null;
@@ -1044,27 +1058,29 @@ export class AiAgentReviewClassifierModel {
             .limit(limit)) as ReviewItemAggregateRow[];
 
         const fingerprints = aggregateRows.map((row) => row.fingerprint);
-        if (fingerprints.length === 0) {
-            return [];
-        }
-
-        const latestRows = (await this.database<AiAgentTurnSignalTable>(
-            AiAgentTurnSignalTableName,
-        )
-            .distinctOn('fingerprint')
-            .select('*')
-            .where('organization_uuid', args.organizationUuid)
-            .whereIn('fingerprint', fingerprints)
-            .modify((query) => {
-                if (args.projectUuid) {
-                    void query.where('project_uuid', args.projectUuid);
-                }
-                if (args.agentUuid) {
-                    void query.where('agent_uuid', args.agentUuid);
-                }
-            })
-            .orderBy('fingerprint')
-            .orderBy('created_at', 'desc')) as DbAiAgentTurnSignal[];
+        const latestRows =
+            fingerprints.length === 0
+                ? []
+                : ((await this.database<AiAgentTurnSignalTable>(
+                      AiAgentTurnSignalTableName,
+                  )
+                      .distinctOn('fingerprint')
+                      .select('*')
+                      .where('organization_uuid', args.organizationUuid)
+                      .whereIn('fingerprint', fingerprints)
+                      .modify((query) => {
+                          if (args.projectUuid) {
+                              void query.where(
+                                  'project_uuid',
+                                  args.projectUuid,
+                              );
+                          }
+                          if (args.agentUuid) {
+                              void query.where('agent_uuid', args.agentUuid);
+                          }
+                      })
+                      .orderBy('fingerprint')
+                      .orderBy('created_at', 'desc')) as DbAiAgentTurnSignal[]);
 
         const latestByFingerprint = new Map(
             latestRows
@@ -1115,12 +1131,14 @@ export class AiAgentReviewClassifierModel {
                 return {
                     uuid: fingerprint,
                     fingerprint,
+                    source: item?.source ?? 'ai_finding',
                     organizationUuid: latest.organization_uuid,
                     projectUuid: latest.project_uuid,
                     agentUuid: latest.agent_uuid,
                     title: latest.review_item_title ?? 'Review AI agent issue',
                     description: latest.review_item_description ?? '',
                     primaryRootCause: latest.primary_root_cause ?? 'ambiguous',
+                    priority: item?.priority ?? 'none',
                     status: item?.status ?? 'triage',
                     dismissedReason: item?.dismissed_reason ?? null,
                     ownerType: latest.owner_type ?? 'unknown',
@@ -1141,6 +1159,7 @@ export class AiAgentReviewClassifierModel {
                         ? WRITEBACK_TIMED_OUT_MESSAGE
                         : (item?.pr_writeback_message ?? null),
                     boardPosition: item?.board_position ?? null,
+                    createdByUserUuid: item?.created_by_user_uuid ?? null,
                     writebackEligible: false,
                     writebackEligibility: defaultWritebackEligibility,
                     remediation,
@@ -1168,7 +1187,152 @@ export class AiAgentReviewClassifierModel {
                     reviewItem !== null,
             );
 
-        return reviewItems;
+        const aiFingerprints = new Set(
+            reviewItems.map((item) => item.fingerprint),
+        );
+        const manualRows = (await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .where('organization_uuid', args.organizationUuid)
+            .where('source', 'manual')
+            .modify((query) => {
+                if (args.projectUuid) {
+                    void query.where('project_uuid', args.projectUuid);
+                }
+                if (args.agentUuid) {
+                    void query.where('agent_uuid', args.agentUuid);
+                }
+                if (args.fingerprint) {
+                    void query.where('fingerprint', args.fingerprint);
+                }
+                if (args.statuses) {
+                    void query.whereIn('status', args.statuses);
+                }
+            })
+            .select<ReviewItemRow[]>(
+                '*',
+                this.database.raw(
+                    '(extract(epoch from (now() - updated_at)) * 1000)::float8 as updated_at_age_ms',
+                ),
+            )) as ReviewItemRow[];
+
+        const manualFingerprints = manualRows
+            .map((row) => row.fingerprint)
+            .filter((fingerprint) => !aiFingerprints.has(fingerprint));
+        const manualRemediations =
+            await this.getLatestReviewRemediationsByFingerprint({
+                organizationUuid: args.organizationUuid,
+                fingerprints: manualFingerprints,
+            });
+        const manualItems = manualRows
+            .filter((row) => !aiFingerprints.has(row.fingerprint))
+            .map((row): AiAgentReviewItemSummary => {
+                const writebackStale = isStaleWritebackStatus(
+                    row.pr_writeback_status,
+                    row.updated_at_age_ms,
+                );
+                const remediation =
+                    manualRemediations.get(row.fingerprint) ?? null;
+                return {
+                    uuid: row.ai_agent_review_item_uuid,
+                    fingerprint: row.fingerprint,
+                    source: 'manual',
+                    organizationUuid: row.organization_uuid,
+                    projectUuid: row.project_uuid,
+                    agentUuid: row.agent_uuid,
+                    title: row.title ?? 'Untitled issue',
+                    description: row.description ?? '',
+                    primaryRootCause: row.primary_root_cause ?? 'ambiguous',
+                    priority: row.priority ?? 'none',
+                    status: row.status,
+                    dismissedReason: row.dismissed_reason,
+                    ownerType: 'unknown',
+                    assignedToUserUuid: row.assigned_to_user_uuid,
+                    firstSeenAt: row.created_at,
+                    lastSeenAt: row.updated_at,
+                    findingCount: 0,
+                    statusUpdatedAt: row.status_updated_at ?? row.updated_at,
+                    statusUpdatedByUserUuid: row.status_updated_by_user_uuid,
+                    linkedIssueUrl: row.linked_issue_url,
+                    linkedPrUrl: row.linked_pr_url,
+                    prState: row.pr_state,
+                    prWritebackStatus: writebackStale
+                        ? 'failed'
+                        : row.pr_writeback_status,
+                    prWritebackMessage: writebackStale
+                        ? WRITEBACK_TIMED_OUT_MESSAGE
+                        : row.pr_writeback_message,
+                    boardPosition: row.board_position,
+                    createdByUserUuid: row.created_by_user_uuid,
+                    writebackEligible: false,
+                    writebackEligibility: defaultWritebackEligibility,
+                    remediation,
+                    createdAt: row.created_at,
+                    updatedAt: row.updated_at,
+                    latestFinding: null,
+                };
+            });
+
+        return [...reviewItems, ...manualItems]
+            .sort((a, b) => {
+                if (a.boardPosition == null && b.boardPosition == null) {
+                    return (
+                        new Date(b.lastSeenAt).getTime() -
+                        new Date(a.lastSeenAt).getTime()
+                    );
+                }
+                if (a.boardPosition == null) return 1;
+                if (b.boardPosition == null) return -1;
+                return a.boardPosition - b.boardPosition;
+            })
+            .slice(0, limit);
+    }
+
+    async createManualReviewItem(
+        args: CreateManualReviewItemArgs,
+    ): Promise<AiAgentReviewItemSummary> {
+        const itemUuid = uuidv4();
+        const fingerprint = `manual:${itemUuid}`;
+        await this.database.transaction(async (trx) => {
+            await trx<AiAgentReviewItemTable>(
+                AiAgentReviewItemTableName,
+            ).insert({
+                ai_agent_review_item_uuid: itemUuid,
+                fingerprint,
+                source: 'manual',
+                organization_uuid: args.organizationUuid,
+                project_uuid: args.projectUuid,
+                agent_uuid: args.agentUuid,
+                title: args.title,
+                description: args.description,
+                primary_root_cause: args.primaryRootCause,
+                priority: args.priority,
+                status: 'open',
+                assigned_to_user_uuid: args.assignedToUserUuid,
+                created_by_user_uuid: args.createdByUserUuid,
+                status_updated_at: trx.fn.now() as never,
+                status_updated_by_user_uuid: args.createdByUserUuid,
+            });
+            await this.createReviewItemEvent({
+                fingerprint,
+                organizationUuid: args.organizationUuid,
+                event: {
+                    eventType: 'created',
+                    payload: { rootCause: args.primaryRootCause },
+                },
+                createdByUserUuid: args.createdByUserUuid,
+                trx,
+            });
+        });
+
+        const item = await this.getReviewItem(
+            args.organizationUuid,
+            fingerprint,
+        );
+        if (!item) {
+            throw new Error('Failed to create manual review item');
+        }
+        return item;
     }
 
     async getReviewItemsByFingerprint(
@@ -1681,6 +1845,32 @@ export class AiAgentReviewClassifierModel {
         return { projectUuid: row.project_uuid, agentUuid: row.agent_uuid };
     }
 
+    async getReviewItemScope(
+        organizationUuid: string,
+        fingerprint: string,
+    ): Promise<{
+        projectUuid: string | null;
+        agentUuid: string | null;
+    } | null> {
+        const promoted = await this.getPromotedFingerprintScope(
+            organizationUuid,
+            fingerprint,
+        );
+        if (promoted) {
+            return promoted;
+        }
+        const row = await this.database<AiAgentReviewItemTable>(
+            AiAgentReviewItemTableName,
+        )
+            .where('organization_uuid', organizationUuid)
+            .where('fingerprint', fingerprint)
+            .first('project_uuid', 'agent_uuid');
+        if (!row) {
+            return null;
+        }
+        return { projectUuid: row.project_uuid, agentUuid: row.agent_uuid };
+    }
+
     async upsertReviewItemState(
         args: UpsertReviewItemStateArgs,
     ): Promise<void> {
@@ -1720,8 +1910,8 @@ export class AiAgentReviewClassifierModel {
         organizationUuid: string;
         items: {
             fingerprint: string;
-            projectUuid: string;
-            agentUuid: string;
+            projectUuid: string | null;
+            agentUuid: string | null;
         }[];
     }): Promise<void> {
         if (args.items.length === 0) return;
@@ -1757,6 +1947,20 @@ export class AiAgentReviewClassifierModel {
             .where('organization_uuid', args.organizationUuid)
             .update({
                 assigned_to_user_uuid: args.assignedToUserUuid,
+                updated_at: this.database.fn.now() as never,
+            });
+    }
+
+    async setReviewItemPriority(args: {
+        fingerprint: string;
+        organizationUuid: string;
+        priority: AiAgentReviewItemPriority;
+    }): Promise<void> {
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .where('fingerprint', args.fingerprint)
+            .where('organization_uuid', args.organizationUuid)
+            .update({
+                priority: args.priority,
                 updated_at: this.database.fn.now() as never,
             });
     }

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -1937,6 +1937,33 @@ export class AiAgentReviewClassifierModel {
         });
     }
 
+    // Legacy fingerprints promoted before item rows were written on promotion
+    // are listed with a synthesized 'triage' status but have no
+    // ai_agent_review_item row, so plain UPDATEs match nothing and event
+    // inserts violate the fingerprint FK. Insert the missing row first.
+    async ensureReviewItemRow(args: {
+        organizationUuid: string;
+        fingerprint: string;
+    }): Promise<void> {
+        const scope = await this.getReviewItemScope(
+            args.organizationUuid,
+            args.fingerprint,
+        );
+        if (!scope) {
+            return;
+        }
+        await this.database<AiAgentReviewItemTable>(AiAgentReviewItemTableName)
+            .insert({
+                fingerprint: args.fingerprint,
+                organization_uuid: args.organizationUuid,
+                project_uuid: scope.projectUuid,
+                agent_uuid: scope.agentUuid,
+                status: 'triage',
+            })
+            .onConflict('fingerprint')
+            .ignore();
+    }
+
     async updateReviewItemAssignee(args: {
         fingerprint: string;
         organizationUuid: string;
@@ -2257,25 +2284,33 @@ export class AiAgentReviewClassifierModel {
                 }
 
                 // System-authored issue activity: first promotion opens the
-                // issue; a later promotion of the same fingerprint recurs it.
-                await this.createReviewItemEvent({
-                    fingerprint: newFingerprint,
-                    organizationUuid: turnSignal.subject.organizationUuid,
-                    event: existingItem
-                        ? {
-                              eventType: 'recurred',
-                              payload: {
-                                  threadUuid: turnSignal.subject.threadUuid,
-                                  promptUuid,
+                // issue; a promotion of the same fingerprint from a different
+                // turn recurs it. A re-review of the same turn (supersede path)
+                // is neither — it already produced this fingerprint's event.
+                const isSameTurnReReview =
+                    supersededFingerprints.includes(newFingerprint);
+                if (!isSameTurnReReview) {
+                    await this.createReviewItemEvent({
+                        fingerprint: newFingerprint,
+                        organizationUuid: turnSignal.subject.organizationUuid,
+                        event: existingItem
+                            ? {
+                                  eventType: 'recurred',
+                                  payload: {
+                                      threadUuid: turnSignal.subject.threadUuid,
+                                      promptUuid,
+                                  },
+                              }
+                            : {
+                                  eventType: 'created',
+                                  payload: {
+                                      rootCause: finding.primaryRootCause,
+                                  },
                               },
-                          }
-                        : {
-                              eventType: 'created',
-                              payload: { rootCause: finding.primaryRootCause },
-                          },
-                    createdByUserUuid: null,
-                    trx,
-                });
+                        createdByUserUuid: null,
+                        trx,
+                    });
+                }
             }
 
             // Reconcile: a superseded finding can leave its review item with no

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -2016,7 +2016,7 @@ export class AiAgentReviewClassifierModel {
 
             // Write the review item in the same transaction so a signal and the
             // item it promotes are always created together.
-            if (newFingerprint) {
+            if (newFingerprint && finding) {
                 const existingItem = await trx<AiAgentReviewItemTable>(
                     AiAgentReviewItemTableName,
                 )
@@ -2051,6 +2051,27 @@ export class AiAgentReviewClassifierModel {
                             status_updated_at: trx.fn.now() as never,
                         });
                 }
+
+                // System-authored issue activity: first promotion opens the
+                // issue; a later promotion of the same fingerprint recurs it.
+                await this.createReviewItemEvent({
+                    fingerprint: newFingerprint,
+                    organizationUuid: turnSignal.subject.organizationUuid,
+                    event: existingItem
+                        ? {
+                              eventType: 'recurred',
+                              payload: {
+                                  threadUuid: turnSignal.subject.threadUuid,
+                                  promptUuid,
+                              },
+                          }
+                        : {
+                              eventType: 'created',
+                              payload: { rootCause: finding.primaryRootCause },
+                          },
+                    createdByUserUuid: null,
+                    trx,
+                });
             }
 
             // Reconcile: a superseded finding can leave its review item with no

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -271,6 +271,7 @@ const makeService = ({
             createReviewItemEvent: vi.fn().mockResolvedValue(undefined),
             listReviewItemEvents: vi.fn().mockResolvedValue([]),
             upsertReviewItemState: vi.fn().mockResolvedValue(undefined),
+            ensureReviewItemRow: vi.fn().mockResolvedValue(undefined),
             getThreadWritebackPullRequests: vi
                 .fn()
                 .mockResolvedValue(
@@ -365,6 +366,9 @@ const makeService = ({
         },
         userModel: {
             findSessionUserByUUID: vi.fn().mockResolvedValue(makeAdminUser()),
+            getUserDetailsByUuid: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: ORGANIZATION_UUID }),
             ...userModel,
         },
         aiAgentReviewNotificationService: {

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -489,11 +489,11 @@ describe('AiAgentAdminService.updateReviewItemAssignee', () => {
 
 describe('AiAgentAdminService issue activity', () => {
     it('records status_changed only when the status actually changes', async () => {
-        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const createReviewItemEvent = vi.fn().mockResolvedValue(undefined);
         const service = makeService({
             aiAgentReviewClassifierModel: {
                 createReviewItemEvent,
-                getReviewItem: jest
+                getReviewItem: vi
                     .fn()
                     .mockResolvedValue(makeReviewItem({ status: 'open' })),
             },
@@ -516,11 +516,11 @@ describe('AiAgentAdminService issue activity', () => {
     });
 
     it('does not record status_changed when the status is unchanged', async () => {
-        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const createReviewItemEvent = vi.fn().mockResolvedValue(undefined);
         const service = makeService({
             aiAgentReviewClassifierModel: {
                 createReviewItemEvent,
-                getReviewItem: jest
+                getReviewItem: vi
                     .fn()
                     .mockResolvedValue(makeReviewItem({ status: 'open' })),
             },
@@ -541,14 +541,12 @@ describe('AiAgentAdminService issue activity', () => {
     });
 
     it('records assignee_changed when the assignee changes', async () => {
-        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const createReviewItemEvent = vi.fn().mockResolvedValue(undefined);
         const service = makeService({
             aiAgentReviewClassifierModel: {
                 createReviewItemEvent,
-                updateReviewItemAssignee: jest
-                    .fn()
-                    .mockResolvedValue(undefined),
-                getReviewItem: jest
+                updateReviewItemAssignee: vi.fn().mockResolvedValue(undefined),
+                getReviewItem: vi
                     .fn()
                     .mockResolvedValue(
                         makeReviewItem({ assignedToUserUuid: null }),
@@ -576,12 +574,12 @@ describe('AiAgentAdminService issue activity', () => {
     it('merges issue + remediation events sorted by occurredAt', async () => {
         const service = makeService({
             aiAgentReviewClassifierModel: {
-                getReviewItem: jest
+                getReviewItem: vi
                     .fn()
                     .mockResolvedValue(
                         makeReviewItem({ remediation: makeRemediation() }),
                     ),
-                listReviewItemEvents: jest.fn().mockResolvedValue([
+                listReviewItemEvents: vi.fn().mockResolvedValue([
                     {
                         uuid: 'i1',
                         fingerprint: 'fingerprint-1',
@@ -591,7 +589,7 @@ describe('AiAgentAdminService issue activity', () => {
                         payload: { rootCause: 'semantic_layer' },
                     },
                 ]),
-                listRemediationEvents: jest.fn().mockResolvedValue([
+                listRemediationEvents: vi.fn().mockResolvedValue([
                     {
                         uuid: 'r1',
                         remediationUuid: REMEDIATION_UUID,
@@ -618,10 +616,10 @@ describe('AiAgentAdminService issue activity', () => {
     it('returns issue events even with no remediation', async () => {
         const service = makeService({
             aiAgentReviewClassifierModel: {
-                getReviewItem: jest
+                getReviewItem: vi
                     .fn()
                     .mockResolvedValue(makeReviewItem({ remediation: null })),
-                listReviewItemEvents: jest.fn().mockResolvedValue([
+                listReviewItemEvents: vi.fn().mockResolvedValue([
                     {
                         uuid: 'i1',
                         fingerprint: 'fingerprint-1',

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -42,12 +42,14 @@ const makeReviewItem = (
 ): AiAgentReviewItemSummary => ({
     uuid: 'fingerprint-1',
     fingerprint: 'fingerprint-1',
+    source: 'ai_finding',
     organizationUuid: 'org-1',
     projectUuid: 'project-1',
     agentUuid: 'agent-1',
     title: 'Missing metric',
     description: 'The agent could not answer because a metric was missing.',
     primaryRootCause: 'semantic_layer',
+    priority: 'none',
     status: 'open',
     dismissedReason: null,
     ownerType: 'semantic_layer_owner',
@@ -63,6 +65,7 @@ const makeReviewItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     boardPosition: null,
+    createdByUserUuid: null,
     createdAt: NOW,
     updatedAt: NOW,
     writebackEligible: false,
@@ -248,6 +251,10 @@ const makeService = ({
                 .mockResolvedValue(undefined),
             updateReviewRemediationStatus: vi.fn().mockResolvedValue(undefined),
             getPromotedFingerprintScope: vi.fn().mockResolvedValue({
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+            }),
+            getReviewItemScope: vi.fn().mockResolvedValue({
                 projectUuid: PROJECT_UUID,
                 agentUuid: AGENT_UUID,
             }),
@@ -724,6 +731,53 @@ describe('getAiAgentReviewItemWritebackEligibility', () => {
         });
     });
 
+    it('allows manual project context writeback without a generated finding entry', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    source: 'manual',
+                    latestFinding: null,
+                    findingCount: 0,
+                    primaryRootCause: 'project_context',
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: true,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: false,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toEqual({
+            eligible: true,
+            provider: PullRequestProvider.GITHUB,
+            strategy: 'project_context',
+            reason: null,
+        });
+    });
+
+    it('blocks writeback when no agent is linked', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({ agentUuid: null }),
+                reviewsEnabled: true,
+                projectContextEnabled: false,
+                projectAccess: {
+                    provider: PullRequestProvider.GITHUB,
+                    hasGitAppInstallation: true,
+                },
+                hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toEqual({
+            eligible: false,
+            provider: null,
+            strategy: 'semantic_layer',
+            reason: 'missing_agent',
+        });
+    });
+
     it('blocks project context writeback for GitLab projects', () => {
         expect(
             getAiAgentReviewItemWritebackEligibility({
@@ -872,6 +926,10 @@ describe('AiAgentAdminService.updateReviewItemStatus', () => {
         });
         const aiAgentReviewClassifierModel = {
             getPromotedFingerprintScope: vi.fn().mockResolvedValue({
+                projectUuid: PROJECT_UUID,
+                agentUuid: AGENT_UUID,
+            }),
+            getReviewItemScope: vi.fn().mockResolvedValue({
                 projectUuid: PROJECT_UUID,
                 agentUuid: AGENT_UUID,
             }),
@@ -1303,6 +1361,7 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
                 .fn()
                 .mockResolvedValue(makeReviewItem({ remediation: null })),
             listRemediationEvents: vi.fn(),
+            listReviewItemEvents: vi.fn().mockResolvedValue([]),
         };
         const service = makeService({ aiAgentReviewClassifierModel });
 
@@ -1318,8 +1377,11 @@ describe('AiAgentAdminService.getReviewItemActivity', () => {
             verdictStale: false,
         });
         expect(
-            aiAgentReviewClassifierModel.listRemediationEvents,
-        ).not.toHaveBeenCalled();
+            aiAgentReviewClassifierModel.listReviewItemEvents,
+        ).toHaveBeenCalledWith({
+            organizationUuid: ORGANIZATION_UUID,
+            fingerprint: 'fingerprint-1',
+        });
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -261,6 +261,9 @@ const makeService = ({
             setReviewItemWritebackStatus: vi.fn().mockResolvedValue(undefined),
             createRemediationEvent: vi.fn().mockResolvedValue(undefined),
             listRemediationEvents: vi.fn().mockResolvedValue([]),
+            createReviewItemEvent: vi.fn().mockResolvedValue(undefined),
+            listReviewItemEvents: vi.fn().mockResolvedValue([]),
+            upsertReviewItemState: vi.fn().mockResolvedValue(undefined),
             getThreadWritebackPullRequests: vi
                 .fn()
                 .mockResolvedValue(
@@ -474,6 +477,168 @@ describe('AiAgentAdminService.updateReviewItemAssignee', () => {
             assigneeUserUuid: 'user-2',
             actorUserUuid: USER_UUID,
         });
+    });
+});
+
+describe('AiAgentAdminService issue activity', () => {
+    it('records status_changed only when the status actually changes', async () => {
+        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                createReviewItemEvent,
+                getReviewItem: jest
+                    .fn()
+                    .mockResolvedValue(makeReviewItem({ status: 'open' })),
+            },
+        });
+
+        await service.updateReviewItemStatus(makeAdminUser(), 'fingerprint-1', {
+            status: 'in_progress',
+            dismissedReason: null,
+        });
+
+        expect(createReviewItemEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fingerprint: 'fingerprint-1',
+                event: expect.objectContaining({
+                    eventType: 'status_changed',
+                }),
+                createdByUserUuid: USER_UUID,
+            }),
+        );
+    });
+
+    it('does not record status_changed when the status is unchanged', async () => {
+        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                createReviewItemEvent,
+                getReviewItem: jest
+                    .fn()
+                    .mockResolvedValue(makeReviewItem({ status: 'open' })),
+            },
+        });
+
+        await service.updateReviewItemStatus(makeAdminUser(), 'fingerprint-1', {
+            status: 'open',
+            dismissedReason: null,
+        });
+
+        expect(createReviewItemEvent).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: expect.objectContaining({
+                    eventType: 'status_changed',
+                }),
+            }),
+        );
+    });
+
+    it('records assignee_changed when the assignee changes', async () => {
+        const createReviewItemEvent = jest.fn().mockResolvedValue(undefined);
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                createReviewItemEvent,
+                updateReviewItemAssignee: jest
+                    .fn()
+                    .mockResolvedValue(undefined),
+                getReviewItem: jest
+                    .fn()
+                    .mockResolvedValue(
+                        makeReviewItem({ assignedToUserUuid: null }),
+                    ),
+            },
+        });
+
+        await service.updateReviewItemAssignee(
+            makeAdminUser(),
+            'fingerprint-1',
+            'user-2',
+        );
+
+        expect(createReviewItemEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fingerprint: 'fingerprint-1',
+                event: expect.objectContaining({
+                    eventType: 'assignee_changed',
+                }),
+                createdByUserUuid: USER_UUID,
+            }),
+        );
+    });
+
+    it('merges issue + remediation events sorted by occurredAt', async () => {
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: jest
+                    .fn()
+                    .mockResolvedValue(
+                        makeReviewItem({ remediation: makeRemediation() }),
+                    ),
+                listReviewItemEvents: jest.fn().mockResolvedValue([
+                    {
+                        uuid: 'i1',
+                        fingerprint: 'fingerprint-1',
+                        occurredAt: new Date('2026-06-24T09:00:00Z'),
+                        createdByUserUuid: 'u1',
+                        eventType: 'created',
+                        payload: { rootCause: 'semantic_layer' },
+                    },
+                ]),
+                listRemediationEvents: jest.fn().mockResolvedValue([
+                    {
+                        uuid: 'r1',
+                        remediationUuid: REMEDIATION_UUID,
+                        occurredAt: new Date('2026-06-24T10:00:00Z'),
+                        createdByUserUuid: null,
+                        eventType: 'pr_opened',
+                        payload: { prUrl: 'x', prNumber: 1 },
+                    },
+                ]),
+            },
+        });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.events.map((e) => [e.kind, e.eventType])).toEqual([
+            ['issue', 'created'],
+            ['remediation', 'pr_opened'],
+        ]);
+    });
+
+    it('returns issue events even with no remediation', async () => {
+        const service = makeService({
+            aiAgentReviewClassifierModel: {
+                getReviewItem: jest
+                    .fn()
+                    .mockResolvedValue(makeReviewItem({ remediation: null })),
+                listReviewItemEvents: jest.fn().mockResolvedValue([
+                    {
+                        uuid: 'i1',
+                        fingerprint: 'fingerprint-1',
+                        occurredAt: new Date('2026-06-24T09:00:00Z'),
+                        createdByUserUuid: 'u1',
+                        eventType: 'status_changed',
+                        payload: {
+                            from: 'open',
+                            to: 'resolved',
+                            dismissedReason: null,
+                        },
+                    },
+                ]),
+            },
+        });
+
+        const activity = await service.getReviewItemActivity(
+            makeAdminUser(),
+            'fingerprint-1',
+        );
+
+        expect(activity.events).toHaveLength(1);
+        expect(activity.events[0].kind).toBe('issue');
+        expect(activity.liveState).toBeNull();
     });
 });
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -4,6 +4,7 @@ import {
     AiAgentAdminFilters,
     AiAgentAdminPromptActivityPoint,
     AiAgentAdminSort,
+    AiAgentReviewActivityEvent,
     AiAgentReviewItemActivity,
     AiAgentReviewItemPrDiff,
     AiAgentReviewItemStatus,
@@ -1057,6 +1058,19 @@ export class AiAgentAdminService extends BaseService {
                     newStatus: update.status,
                 },
             });
+            await this.aiAgentReviewClassifierModel.createReviewItemEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'status_changed',
+                    payload: {
+                        from: previousReviewItem?.status ?? null,
+                        to: update.status,
+                        dismissedReason: update.dismissedReason,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
         }
         if (
             update.status === 'resolved' &&
@@ -1145,11 +1159,32 @@ export class AiAgentAdminService extends BaseService {
         }
         this.checkReviewAccess(user, organizationUuid);
 
+        const previousItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+
         await this.aiAgentReviewClassifierModel.updateReviewItemAssignee({
             fingerprint,
             organizationUuid,
             assignedToUserUuid,
         });
+
+        if (previousItem?.assignedToUserUuid !== assignedToUserUuid) {
+            await this.aiAgentReviewClassifierModel.createReviewItemEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'assignee_changed',
+                    payload: {
+                        fromUserUuid: previousItem?.assignedToUserUuid ?? null,
+                        toUserUuid: assignedToUserUuid,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
+        }
 
         const item = await this.getReviewItem(user, fingerprint);
 
@@ -1755,33 +1790,48 @@ export class AiAgentAdminService extends BaseService {
                 reviewItem.projectUuid,
             );
         }
-        if (!reviewItem?.remediation) {
-            return {
-                events: [],
-                liveState: null,
-                liveMessage: null,
-                verdictStale: false,
-            };
-        }
 
-        const events =
-            await this.aiAgentReviewClassifierModel.listRemediationEvents({
-                remediationUuid: reviewItem.remediation.uuid,
+        const issueEvents =
+            await this.aiAgentReviewClassifierModel.listReviewItemEvents({
+                fingerprint,
                 organizationUuid,
             });
 
-        const liveState = AiAgentAdminService.deriveRemediationLiveState(
-            reviewItem.remediation.status,
-            events,
+        const remediationEvents = reviewItem?.remediation
+            ? await this.aiAgentReviewClassifierModel.listRemediationEvents({
+                  remediationUuid: reviewItem.remediation.uuid,
+                  organizationUuid,
+              })
+            : [];
+
+        const events: AiAgentReviewActivityEvent[] = [
+            ...issueEvents.map((e) => ({ kind: 'issue' as const, ...e })),
+            ...remediationEvents.map((e) => ({
+                kind: 'remediation' as const,
+                ...e,
+            })),
+        ].sort(
+            (a, b) =>
+                new Date(a.occurredAt).getTime() -
+                new Date(b.occurredAt).getTime(),
         );
+
+        const liveState = reviewItem?.remediation
+            ? AiAgentAdminService.deriveRemediationLiveState(
+                  reviewItem.remediation.status,
+                  remediationEvents,
+              )
+            : null;
+
         return {
             events,
             liveState,
             liveMessage:
                 liveState === 'writeback'
-                    ? reviewItem.prWritebackMessage
+                    ? (reviewItem?.prWritebackMessage ?? null)
                     : null,
-            verdictStale: AiAgentAdminService.deriveVerdictStale(events),
+            verdictStale:
+                AiAgentAdminService.deriveVerdictStale(remediationEvents),
         };
     }
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -18,6 +18,7 @@ import {
     AiReviewNotificationSettings,
     AlreadyExistsError,
     assertUnreachable,
+    CreateAiAgentReviewItem,
     DbtProjectType,
     extractPreviewProjectUuidFromUrl,
     extractPreviewUrlFromComments,
@@ -33,6 +34,7 @@ import {
     PullRequestProvider,
     PullRequestSource,
     RequestMethod,
+    UpdateAiAgentReviewItemPriority,
     UpdateAiAgentReviewItemStatus,
     UpdateAiReviewNotificationSettings,
     type AiAgentReviewItemWritebackBlockedReason,
@@ -189,6 +191,9 @@ const getWritebackStrategy = (
         };
     }
     if (!item.latestFinding?.projectContextEntry) {
+        if (item.source === 'manual') {
+            return { strategy: 'project_context' };
+        }
         return {
             eligibility: unavailableWritebackEligibility(
                 'missing_project_context_entry',
@@ -258,6 +263,9 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
 
     if (!item.projectUuid) {
         return unavailableWritebackEligibility('missing_project', strategy);
+    }
+    if (!item.agentUuid) {
+        return unavailableWritebackEligibility('missing_agent', strategy);
     }
     if (!projectAccess || !projectAccess.provider) {
         return unavailableWritebackEligibility(
@@ -695,6 +703,63 @@ export class AiAgentAdminService extends BaseService {
         return filtered;
     }
 
+    async createReviewItem(
+        user: SessionUser,
+        body: CreateAiAgentReviewItem,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const title = body.title.trim();
+        if (title.length === 0) {
+            throw new ParameterError('Issue title is required');
+        }
+
+        const project = await this.projectModel.get(body.projectUuid);
+        if (project.organizationUuid !== organizationUuid) {
+            throw new NotFoundError('Project not found');
+        }
+
+        if (body.agentUuid) {
+            const agents = await this.aiAgentModel.findAllAgents({
+                organizationUuid,
+            });
+            if (!agents.some((agent) => agent.uuid === body.agentUuid)) {
+                throw new NotFoundError('Agent not found');
+            }
+        }
+
+        const item =
+            await this.aiAgentReviewClassifierModel.createManualReviewItem({
+                organizationUuid,
+                title,
+                description: body.description?.trim() || null,
+                projectUuid: body.projectUuid,
+                agentUuid: body.agentUuid,
+                assignedToUserUuid: body.assignedToUserUuid,
+                primaryRootCause: body.primaryRootCause,
+                priority: body.priority,
+                createdByUserUuid: user.userUuid,
+            });
+
+        this.analytics.track({
+            event: 'ai_agent_review_item.created',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                fingerprint: item.fingerprint,
+                projectId: item.projectUuid,
+                agentId: item.agentUuid,
+                priority: item.priority,
+            },
+        });
+
+        return item;
+    }
+
     private async areReviewsEnabled(user: SessionUser): Promise<boolean> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
@@ -840,6 +905,10 @@ export class AiAgentAdminService extends BaseService {
             case 'missing_project':
                 throw new ParameterError(
                     'Writeback requires a project-scoped review item',
+                );
+            case 'missing_agent':
+                throw new ParameterError(
+                    'Writeback requires an agent-scoped review item',
                 );
             case 'missing_project_context_entry':
                 throw new ParameterError(
@@ -1014,7 +1083,7 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
@@ -1127,7 +1196,7 @@ export class AiAgentAdminService extends BaseService {
         const resolved = await Promise.all(
             orderedFingerprints.map(async (fingerprint) => {
                 const scope =
-                    await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+                    await this.aiAgentReviewClassifierModel.getReviewItemScope(
                         organizationUuid,
                         fingerprint,
                     );
@@ -1201,6 +1270,48 @@ export class AiAgentAdminService extends BaseService {
         return item;
     }
 
+    async updateReviewItemPriority(
+        user: SessionUser,
+        fingerprint: string,
+        update: UpdateAiAgentReviewItemPriority,
+    ): Promise<AiAgentReviewItemSummary> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const previousReviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        await this.aiAgentReviewClassifierModel.setReviewItemPriority({
+            fingerprint,
+            organizationUuid,
+            priority: update.priority,
+        });
+        if (
+            previousReviewItem &&
+            previousReviewItem.priority !== update.priority
+        ) {
+            await this.aiAgentReviewClassifierModel.createReviewItemEvent({
+                fingerprint,
+                organizationUuid,
+                event: {
+                    eventType: 'priority_changed',
+                    payload: {
+                        from: previousReviewItem?.priority ?? 'none',
+                        to: update.priority,
+                    },
+                },
+                createdByUserUuid: user.userUuid,
+            });
+        }
+
+        return this.getReviewItem(user, fingerprint);
+    }
+
     async createReviewItemWriteback(
         user: SessionUser,
         fingerprint: string,
@@ -1220,11 +1331,6 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
         const finding = reviewItem.latestFinding;
-        if (!finding) {
-            throw new ParameterError(
-                'Writeback requires a promoted review finding',
-            );
-        }
         const [reviewsEnabled, projectContextEnabled] = await Promise.all([
             this.areReviewsEnabled(user),
             reviewItem.primaryRootCause === 'project_context'
@@ -1235,11 +1341,13 @@ export class AiAgentAdminService extends BaseService {
             organizationUuid,
             reviewItem.projectUuid ? [reviewItem.projectUuid] : [],
         );
-        const writebackPrByThread =
-            await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
-                [finding.threadUuid],
-            );
+        const writebackPrByThread = finding
+            ? await this.aiAgentReviewClassifierModel.getThreadWritebackPullRequests(
+                  [finding.threadUuid],
+              )
+            : new Map();
         const sourceThreadHasWritebackPr =
+            finding !== null &&
             (writebackPrByThread.get(finding.threadUuid)?.length ?? 0) > 0;
         const writebackEligibility = getAiAgentReviewItemWritebackEligibility({
             item: reviewItem,
@@ -1256,20 +1364,22 @@ export class AiAgentAdminService extends BaseService {
         }
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
-        if (!scope) {
-            throw new NotFoundError('Review item not found');
+        if (!scope?.projectUuid || !scope.agentUuid) {
+            throw new NotFoundError('Review item scope not found');
         }
+        const { projectUuid } = scope;
+        const { agentUuid } = scope;
 
         // Plan the writeback up front: for semantic_layer we seed a real
         // Build-fix thread with the writeback prompt so the workspace can show
         // it the moment Create PR is clicked; project_context stays a
         // deterministic, threadless writeback.
         const explores = await this.projectModel.findExploresFromCache(
-            scope.projectUuid,
+            projectUuid,
             'name',
         );
         const plan = planReviewWriteback(
@@ -1288,11 +1398,21 @@ export class AiAgentAdminService extends BaseService {
             });
         }
 
-        const retryPrompt =
-            await this.aiAgentReviewClassifierModel.getPromptText({
-                organizationUuid,
-                promptUuid: finding.promptUuid,
-            });
+        let retryPrompt: string | null;
+        if (finding) {
+            retryPrompt = await this.aiAgentReviewClassifierModel.getPromptText(
+                {
+                    organizationUuid,
+                    promptUuid: finding.promptUuid,
+                },
+            );
+        } else if (plan.strategy === 'prompt') {
+            retryPrompt = plan.promptText;
+        } else {
+            retryPrompt = [reviewItem.title, reviewItem.description]
+                .filter(Boolean)
+                .join('\n\n');
+        }
 
         // Create the work thread before the remediation row so a failed
         // unique-index insert leaves only a harmless orphan thread, never a
@@ -1309,10 +1429,10 @@ export class AiAgentAdminService extends BaseService {
             await this.aiAgentModel.createWebAppThreadWithPrompt({
                 thread: {
                     organizationUuid,
-                    projectUuid: scope.projectUuid,
+                    projectUuid,
                     userUuid: user.userUuid,
                     createdFrom: 'web_app' as const,
-                    agentUuid: scope.agentUuid,
+                    agentUuid,
                 },
                 prompt: {
                     createdByUserUuid: user.userUuid,
@@ -1321,11 +1441,15 @@ export class AiAgentAdminService extends BaseService {
                     // structured agent context). The PR/preview pins are added
                     // once those exist — they post-date this seed.
                     context: [
-                        {
-                            type: 'thread',
-                            threadUuid: finding.threadUuid,
-                            promptUuid: finding.promptUuid,
-                        },
+                        ...(finding
+                            ? [
+                                  {
+                                      type: 'thread' as const,
+                                      threadUuid: finding.threadUuid,
+                                      promptUuid: finding.promptUuid,
+                                  },
+                              ]
+                            : []),
                         { type: 'review_finding', fingerprint },
                         { type: 'proposed_change', fingerprint },
                     ],
@@ -1333,7 +1457,7 @@ export class AiAgentAdminService extends BaseService {
             });
         await this.aiAgentModel.updateThreadTitle({
             threadUuid: workThreadUuid,
-            title: `Fix review: ${reviewItem.title}`,
+            title: `Fix issue: ${reviewItem.title}`,
         });
 
         // The one-active-per-fingerprint index can still reject the insert in
@@ -1346,11 +1470,11 @@ export class AiAgentAdminService extends BaseService {
                     {
                         fingerprint,
                         organizationUuid,
-                        sourceFindingUuid: finding.uuid,
-                        sourcePromptUuid: finding.promptUuid,
-                        sourceThreadUuid: finding.threadUuid,
-                        sourceProjectUuid: finding.projectUuid,
-                        sourceAgentUuid: finding.agentUuid,
+                        sourceFindingUuid: finding?.uuid ?? null,
+                        sourcePromptUuid: finding?.promptUuid ?? null,
+                        sourceThreadUuid: finding?.threadUuid ?? null,
+                        sourceProjectUuid: projectUuid,
+                        sourceAgentUuid: agentUuid,
                         workThreadUuid,
                         retryPrompt,
                         createdByUserUuid: user.userUuid,
@@ -1367,25 +1491,27 @@ export class AiAgentAdminService extends BaseService {
 
         // Anchor the feed at the finding itself, backdated to when it was
         // first seen — the remediation row is created much later.
-        await this.aiAgentReviewClassifierModel.createRemediationEvent({
-            remediationUuid: remediation.uuid,
-            organizationUuid,
-            event: {
-                eventType: 'finding_opened',
-                payload: {
-                    excerpt: retryPrompt,
-                    sourceThreadUuid: finding.threadUuid,
-                    sourcePromptUuid: finding.promptUuid,
+        if (finding) {
+            await this.aiAgentReviewClassifierModel.createRemediationEvent({
+                remediationUuid: remediation.uuid,
+                organizationUuid,
+                event: {
+                    eventType: 'finding_opened',
+                    payload: {
+                        excerpt: retryPrompt,
+                        sourceThreadUuid: finding.threadUuid,
+                        sourcePromptUuid: finding.promptUuid,
+                    },
                 },
-            },
-            occurredAt: reviewItem.firstSeenAt,
-        });
+                occurredAt: reviewItem.firstSeenAt,
+            });
+        }
 
         await this.aiAgentReviewClassifierModel.setReviewItemWritebackStatus({
             fingerprint,
             organizationUuid,
-            projectUuid: scope.projectUuid,
-            agentUuid: scope.agentUuid,
+            projectUuid,
+            agentUuid,
             status: 'queued',
             message: 'Queued',
         });
@@ -1393,7 +1519,7 @@ export class AiAgentAdminService extends BaseService {
         await this.schedulerClient.aiAgentReviewWriteback({
             fingerprint,
             organizationUuid,
-            projectUuid: scope.projectUuid,
+            projectUuid,
             userUuid: user.userUuid,
             remediationUuid: remediation.uuid,
         });
@@ -1403,7 +1529,7 @@ export class AiAgentAdminService extends BaseService {
             userId: user.userUuid,
             properties: {
                 organizationId: organizationUuid,
-                projectId: scope.projectUuid,
+                projectId: projectUuid,
                 fingerprint,
                 rootCause: reviewItem.primaryRootCause,
                 strategy: writebackEligibility.strategy,
@@ -1440,7 +1566,7 @@ export class AiAgentAdminService extends BaseService {
             );
 
         const scope =
-            await this.aiAgentReviewClassifierModel.getPromotedFingerprintScope(
+            await this.aiAgentReviewClassifierModel.getReviewItemScope(
                 organizationUuid,
                 fingerprint,
             );
@@ -1449,7 +1575,7 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 fingerprint,
             );
-        if (!scope || !reviewItem) {
+        if (!scope?.projectUuid || !scope.agentUuid || !reviewItem) {
             if (remediationUuid) {
                 await this.aiAgentReviewClassifierModel.updateReviewRemediationStatus(
                     {
@@ -1835,6 +1961,44 @@ export class AiAgentAdminService extends BaseService {
         };
     }
 
+    async addReviewItemComment(
+        user: SessionUser,
+        fingerprint: string,
+        body: string,
+    ): Promise<AiAgentReviewItemActivity> {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+        this.checkOrganizationAdminAccess(user);
+
+        const comment = body.trim();
+        if (comment.length === 0) {
+            throw new ParameterError('Comment body is required');
+        }
+
+        const reviewItem =
+            await this.aiAgentReviewClassifierModel.getReviewItem(
+                organizationUuid,
+                fingerprint,
+            );
+        if (!reviewItem) {
+            throw new NotFoundError('Review item not found');
+        }
+
+        await this.aiAgentReviewClassifierModel.createReviewItemEvent({
+            fingerprint,
+            organizationUuid,
+            event: {
+                eventType: 'comment_added',
+                payload: { body: comment },
+            },
+            createdByUserUuid: user.userUuid,
+        });
+
+        return this.getReviewItemActivity(user, fingerprint);
+    }
+
     /**
      * A verdict is stale when the PR moved on after it was produced: the latest
      * commit-landing event (pr_opened / pr_updated / writeback_completed)
@@ -2089,11 +2253,18 @@ export class AiAgentAdminService extends BaseService {
                             remediation.linkedPrUrl,
                         ),
                         context: [
-                            {
-                                type: 'thread',
-                                threadUuid: remediation.sourceThreadUuid,
-                                promptUuid: remediation.sourcePromptUuid,
-                            },
+                            ...(remediation.sourceThreadUuid &&
+                            remediation.sourcePromptUuid
+                                ? [
+                                      {
+                                          type: 'thread' as const,
+                                          threadUuid:
+                                              remediation.sourceThreadUuid,
+                                          promptUuid:
+                                              remediation.sourcePromptUuid,
+                                      },
+                                  ]
+                                : []),
                         ],
                     },
                 }));

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -390,6 +390,18 @@ export class AiAgentAdminService extends BaseService {
         }
     }
 
+    private async checkAssigneeInOrganization(
+        organizationUuid: string,
+        assignedToUserUuid: string,
+    ): Promise<void> {
+        const assignee = await this.userModel
+            .getUserDetailsByUuid(assignedToUserUuid)
+            .catch(() => null);
+        if (!assignee || assignee.organizationUuid !== organizationUuid) {
+            throw new NotFoundError('Assignee not found');
+        }
+    }
+
     private checkReviewAccess(
         user: SessionUser,
         organizationUuid: string,
@@ -711,7 +723,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const title = body.title.trim();
         if (title.length === 0) {
@@ -730,6 +742,13 @@ export class AiAgentAdminService extends BaseService {
             if (!agents.some((agent) => agent.uuid === body.agentUuid)) {
                 throw new NotFoundError('Agent not found');
             }
+        }
+
+        if (body.assignedToUserUuid) {
+            await this.checkAssigneeInOrganization(
+                organizationUuid,
+                body.assignedToUserUuid,
+            );
         }
 
         const item =
@@ -1233,21 +1252,35 @@ export class AiAgentAdminService extends BaseService {
                 organizationUuid,
                 fingerprint,
             );
+        if (!previousItem) {
+            throw new NotFoundError('Review item not found');
+        }
 
+        if (assignedToUserUuid !== null) {
+            await this.checkAssigneeInOrganization(
+                organizationUuid,
+                assignedToUserUuid,
+            );
+        }
+
+        await this.aiAgentReviewClassifierModel.ensureReviewItemRow({
+            organizationUuid,
+            fingerprint,
+        });
         await this.aiAgentReviewClassifierModel.updateReviewItemAssignee({
             fingerprint,
             organizationUuid,
             assignedToUserUuid,
         });
 
-        if (previousItem?.assignedToUserUuid !== assignedToUserUuid) {
+        if (previousItem.assignedToUserUuid !== assignedToUserUuid) {
             await this.aiAgentReviewClassifierModel.createReviewItemEvent({
                 fingerprint,
                 organizationUuid,
                 event: {
                     eventType: 'assignee_changed',
                     payload: {
-                        fromUserUuid: previousItem?.assignedToUserUuid ?? null,
+                        fromUserUuid: previousItem.assignedToUserUuid,
                         toUserUuid: assignedToUserUuid,
                     },
                 },
@@ -1279,22 +1312,26 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const previousReviewItem =
             await this.aiAgentReviewClassifierModel.getReviewItem(
                 organizationUuid,
                 fingerprint,
             );
+        if (!previousReviewItem) {
+            throw new NotFoundError('Review item not found');
+        }
+        await this.aiAgentReviewClassifierModel.ensureReviewItemRow({
+            organizationUuid,
+            fingerprint,
+        });
         await this.aiAgentReviewClassifierModel.setReviewItemPriority({
             fingerprint,
             organizationUuid,
             priority: update.priority,
         });
-        if (
-            previousReviewItem &&
-            previousReviewItem.priority !== update.priority
-        ) {
+        if (previousReviewItem.priority !== update.priority) {
             await this.aiAgentReviewClassifierModel.createReviewItemEvent({
                 fingerprint,
                 organizationUuid,
@@ -1970,7 +2007,7 @@ export class AiAgentAdminService extends BaseService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        this.checkOrganizationAdminAccess(user);
+        this.checkReviewAccess(user, organizationUuid);
 
         const comment = body.trim();
         if (comment.length === 0) {
@@ -1986,6 +2023,10 @@ export class AiAgentAdminService extends BaseService {
             throw new NotFoundError('Review item not found');
         }
 
+        await this.aiAgentReviewClassifierModel.ensureReviewItemRow({
+            organizationUuid,
+            fingerprint,
+        });
         await this.aiAgentReviewClassifierModel.createReviewItemEvent({
             fingerprint,
             organizationUuid,

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.test.ts
@@ -12,12 +12,14 @@ const baseItem = (
 ): AiAgentReviewItemSummary => ({
     uuid: 'fp',
     fingerprint: 'fp',
+    source: 'ai_finding',
     organizationUuid: 'org',
     projectUuid: 'project',
     agentUuid: 'agent',
     title: 'Agent picked the wrong revenue metric',
     description: 'It used order count instead of revenue.',
     primaryRootCause: 'semantic_layer',
+    priority: 'none',
     status: 'open',
     dismissedReason: null,
     ownerType: 'semantic_layer_owner',
@@ -33,6 +35,7 @@ const baseItem = (
     prWritebackStatus: null,
     prWritebackMessage: null,
     boardPosition: null,
+    createdByUserUuid: null,
     writebackEligible: true,
     writebackEligibility: {
         eligible: true,
@@ -119,6 +122,26 @@ describe('planReviewWriteback', () => {
         expect(plan.promptText).not.toContain('(yaml:');
     });
 
+    it('builds a prompt from a manual semantic-layer issue', () => {
+        const plan = expectPromptPlan(
+            planReviewWriteback(
+                baseItem({
+                    source: 'manual',
+                    latestFinding: null,
+                    findingCount: 0,
+                    title: 'Add a revenue metric on orders',
+                    description: 'Finance needs a governed revenue metric.',
+                }),
+            ),
+        );
+
+        expect(plan.promptText).toContain('Add a revenue metric on orders');
+        expect(plan.promptText).toContain(
+            'Finance needs a governed revenue metric.',
+        );
+        expect(plan.promptText).toContain('No source conversation is attached');
+    });
+
     it('returns a project_context plan when the finding carries an entry', () => {
         const item = baseItem({ primaryRootCause: 'project_context' });
         const entry = {
@@ -135,6 +158,31 @@ describe('planReviewWriteback', () => {
 
         const plan = planReviewWriteback(item);
         expect(plan).toEqual({ strategy: 'project_context', entry });
+    });
+
+    it('builds a project_context entry from a manual issue', () => {
+        const plan = planReviewWriteback(
+            baseItem({
+                source: 'manual',
+                latestFinding: null,
+                findingCount: 0,
+                primaryRootCause: 'project_context',
+                title: 'Document ARR',
+                description: 'ARR should exclude one-off services.',
+            }),
+        );
+
+        expect(plan).toEqual({
+            strategy: 'project_context',
+            entry: {
+                op: 'create',
+                id: null,
+                kind: 'definition',
+                content: 'Document ARR\n\nARR should exclude one-off services.',
+                terms: [],
+                objects: [],
+            },
+        });
     });
 
     it('throws for a project_context item with no entry', () => {

--- a/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
+++ b/packages/backend/src/ee/services/ai/reviewWriteback/buildReviewWritebackPrompt.ts
@@ -87,6 +87,21 @@ const buildSemanticLayerWritebackPrompt = (
     ymlPathByModel: Map<string, string>,
 ): ReviewWritebackPlan => {
     const finding = item.latestFinding;
+    if (item.source === 'manual') {
+        const sections = [
+            'You are improving the dbt/Lightdash semantic layer YAML to resolve a manually filed data issue. Make the smallest change that resolves it.',
+            `Issue: ${item.title}`,
+            item.description ? `Description: ${item.description}` : null,
+            'No source conversation is attached. Use the issue title and description as the source of truth, inspect the dbt project, and open a pull request if a semantic-layer change can resolve the ask.',
+            'Apply the change by updating field descriptions, ai_hint, or labels, or by adding a missing model, join, dimension, or metric as appropriate. Do not change SQL logic or unrelated fields. If the data needed to answer this is genuinely not present in the warehouse/dbt project and cannot be exposed by a semantic-layer edit, do not fabricate fields or invent data — open no pull request and report that upstream dbt modeling or ingestion is required.',
+        ].filter((section): section is string => section !== null);
+
+        return {
+            strategy: 'prompt',
+            promptText: sections.join('\n\n'),
+            aggregationKey: null,
+        };
+    }
     const targetLines = (finding?.targetRefs ?? [])
         .filter(isSemanticTargetRef)
         .map((ref) => `- ${formatSemanticTargetRef(ref, ymlPathByModel)}`);
@@ -134,12 +149,29 @@ export const planReviewWriteback = (
     }
     if (item.primaryRootCause === 'project_context') {
         const entry = item.latestFinding?.projectContextEntry ?? null;
+        if (entry) {
+            return { strategy: 'project_context', entry };
+        }
+        if (item.source === 'manual') {
+            return {
+                strategy: 'project_context',
+                entry: {
+                    op: 'create',
+                    id: null,
+                    kind: 'definition',
+                    content: [item.title, item.description]
+                        .filter(Boolean)
+                        .join('\n\n'),
+                    terms: [],
+                    objects: [],
+                },
+            };
+        }
         if (!entry) {
             throw new Error(
                 'Writeback for project_context requires a projectContextEntry on the finding',
             );
         }
-        return { strategy: 'project_context', entry };
     }
     throw new Error(
         `Writeback is not supported for root cause "${item.primaryRootCause}"`,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1770,14 +1770,6 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
-                instructions: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
                 origin: { dataType: 'string', required: true },
                 type: { ref: 'ExternalConnectionAuthType', required: true },
                 name: { dataType: 'string', required: true },
@@ -1855,13 +1847,6 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
-                instructions: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                },
                 origin: { dataType: 'string', required: true },
                 type: { ref: 'ExternalConnectionAuthType', required: true },
                 name: { dataType: 'string', required: true },
@@ -1909,14 +1894,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                instructions: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -10304,7 +10281,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                scaffoldingVersion: { dataType: 'string' },
                 downloadedAt: { dataType: 'string', required: true },
                 template: {
                     dataType: 'union',
@@ -14980,12 +14956,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -15027,12 +15003,6 @@ const models: TsoaRoute.Models = {
                                                                                                                             'nestedObjectLiteral',
                                                                                                                         nestedProperties:
                                                                                                                             {
-                                                                                                                                required:
-                                                                                                                                    {
-                                                                                                                                        dataType:
-                                                                                                                                            'boolean',
-                                                                                                                                        required: true,
-                                                                                                                                    },
                                                                                                                                 settings:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15057,6 +15027,12 @@ const models: TsoaRoute.Models = {
                                                                                                                                             },
                                                                                                                                         ],
                                                                                                                                 },
+                                                                                                                                required:
+                                                                                                                                    {
+                                                                                                                                        dataType:
+                                                                                                                                            'boolean',
+                                                                                                                                        required: true,
+                                                                                                                                    },
                                                                                                                                 operator:
                                                                                                                                     {
                                                                                                                                         dataType:
@@ -15140,12 +15116,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                label: {
+                                                                                                name: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                name: {
+                                                                                                label: {
                                                                                                     dataType:
                                                                                                         'string',
                                                                                                     required: true,
@@ -15248,6 +15224,46 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
+                                                                                error: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'string',
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                                status: {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'error',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'enum',
+                                                                                                enums: [
+                                                                                                    'success',
+                                                                                                ],
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
                                                                                 results:
                                                                                     {
                                                                                         dataType:
@@ -15338,12 +15354,12 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
+                                                                                                    name: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    name: {
+                                                                                                    label: {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
@@ -15352,50 +15368,10 @@ const models: TsoaRoute.Models = {
                                                                                         },
                                                                                         required: true,
                                                                                     },
-                                                                                error: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'string',
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
                                                                                 label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
-                                                                                },
-                                                                                status: {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'error',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'enum',
-                                                                                                enums: [
-                                                                                                    'success',
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
                                                                                 },
                                                                             },
                                                                     },
@@ -15503,13 +15479,13 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: [
-                                                                'not_found',
-                                                            ],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: [
+                                                                'not_found',
+                                                            ],
                                                         },
                                                     ],
                                                     required: true,
@@ -15542,25 +15518,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15569,26 +15526,6 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                description:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'union',
-                                                                                        subSchemas:
-                                                                                            [
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        null,
-                                                                                                    ],
-                                                                                                },
-                                                                                            ],
-                                                                                        required: true,
-                                                                                    },
                                                                                 isFromJoinedTable:
                                                                                     {
                                                                                         dataType:
@@ -15605,6 +15542,13 @@ const models: TsoaRoute.Models = {
                                                                                                     dataType:
                                                                                                         'enum',
                                                                                                     enums: [
+                                                                                                        'true',
+                                                                                                    ],
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
                                                                                                         'false',
                                                                                                     ],
                                                                                                 },
@@ -15613,13 +15557,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'enum',
                                                                                                     enums: [
                                                                                                         'not_applicable',
-                                                                                                    ],
-                                                                                                },
-                                                                                                {
-                                                                                                    dataType:
-                                                                                                        'enum',
-                                                                                                    enums: [
-                                                                                                        'true',
                                                                                                     ],
                                                                                                 },
                                                                                             ],
@@ -15637,6 +15574,11 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 fieldType:
                                                                                     {
                                                                                         dataType:
@@ -15660,29 +15602,63 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                name: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 fieldId:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                name: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                                description:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'union',
+                                                                                        subSchemas:
+                                                                                            [
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                },
+                                                                                                {
+                                                                                                    dataType:
+                                                                                                        'enum',
+                                                                                                    enums: [
+                                                                                                        null,
+                                                                                                    ],
+                                                                                                },
+                                                                                            ],
+                                                                                        required: true,
+                                                                                    },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                rationale: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 explore: {
@@ -15704,12 +15680,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'nestedObjectLiteral',
                                                                                                     nestedProperties:
                                                                                                         {
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
                                                                                                             settings:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15734,6 +15704,12 @@ const models: TsoaRoute.Models = {
                                                                                                                         },
                                                                                                                     ],
                                                                                                             },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
                                                                                                             operator:
                                                                                                                 {
                                                                                                                     dataType:
@@ -15767,6 +15743,12 @@ const models: TsoaRoute.Models = {
                                                                                             },
                                                                                         ],
                                                                                 },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                             joinedTables:
                                                                                 {
                                                                                     dataType:
@@ -15777,18 +15759,12 @@ const models: TsoaRoute.Models = {
                                                                                     },
                                                                                     required: true,
                                                                                 },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
+                                                                            name: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
                                                                             },
-                                                                            name: {
+                                                                            label: {
                                                                                 dataType:
                                                                                     'string',
                                                                                 required: true,
@@ -15959,7 +15935,7 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                uuid: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -15967,7 +15943,7 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
+                                                uuid: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16081,7 +16057,7 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'compile',
+                                                                                            'read',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16095,14 +16071,14 @@ const models: TsoaRoute.Models = {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'read',
+                                                                                            'search',
                                                                                         ],
                                                                                     },
                                                                                     {
                                                                                         dataType:
                                                                                             'enum',
                                                                                         enums: [
-                                                                                            'search',
+                                                                                            'compile',
                                                                                         ],
                                                                                     },
                                                                                     {
@@ -16231,8 +16207,12 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['unknown'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: [
-                                                                'git_write_permission',
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -16255,12 +16235,8 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['unknown'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
+                                                                'git_write_permission',
                                                             ],
                                                         },
                                                         {
@@ -16316,11 +16292,11 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                name: {
+                                                slug: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
-                                                slug: {
+                                                name: {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
@@ -16391,19 +16367,19 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['timeout'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['timeout'],
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16505,18 +16481,37 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
+                                                                                name: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
-                                                                                name: {
+                                                                                label: {
                                                                                     dataType:
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -16537,25 +16532,6 @@ const models: TsoaRoute.Models = {
                                                                                 enums: [
                                                                                     'metric',
                                                                                 ],
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
                                                                             },
                                                                             {
                                                                                 dataType:
@@ -22844,6 +22820,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['ai_finding'] },
+                { dataType: 'enum', enums: ['manual'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemPriority: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['urgent'] },
+                { dataType: 'enum', enums: ['high'] },
+                { dataType: 'enum', enums: ['medium'] },
+                { dataType: 'enum', enums: ['low'] },
+                { dataType: 'enum', enums: ['none'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewItemStatus: {
         dataType: 'refAlias',
         type: {
@@ -22911,6 +22914,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                createdByUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 boardPosition: {
                     dataType: 'union',
                     subSchemas: [
@@ -22992,6 +23003,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 status: { ref: 'AiAgentReviewItemStatus', required: true },
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
                 primaryRootCause: { ref: 'AiAgentRootCause', required: true },
                 description: { dataType: 'string', required: true },
                 title: { dataType: 'string', required: true },
@@ -23012,6 +23024,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 organizationUuid: { dataType: 'string', required: true },
+                source: { ref: 'AiAgentReviewItemSource', required: true },
                 fingerprint: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
             },
@@ -23039,6 +23052,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['reviews_disabled'] },
                 { dataType: 'enum', enums: ['unsupported_root_cause'] },
                 { dataType: 'enum', enums: ['missing_project'] },
+                { dataType: 'enum', enums: ['missing_agent'] },
                 { dataType: 'enum', enums: ['missing_project_context_entry'] },
                 { dataType: 'enum', enums: ['project_context_disabled'] },
                 { dataType: 'enum', enums: ['unsupported_source_control'] },
@@ -23217,9 +23231,30 @@ const models: TsoaRoute.Models = {
                 },
                 sourceAgentUuid: { dataType: 'string', required: true },
                 sourceProjectUuid: { dataType: 'string', required: true },
-                sourceThreadUuid: { dataType: 'string', required: true },
-                sourcePromptUuid: { dataType: 'string', required: true },
-                sourceFindingUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourcePromptUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceFindingUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 organizationUuid: { dataType: 'string', required: true },
                 fingerprint: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
@@ -23414,6 +23449,51 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiAgentReviewItemSummary_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAiAgentReviewItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
+                primaryRootCause: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiAgentRootCause' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                assignedToUserUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                agentUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                projectUuid: { dataType: 'string', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                title: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiAgentReviewRemediationEventDetail: {
         dataType: 'refAlias',
         type: {
@@ -23426,11 +23506,19 @@ const models: TsoaRoute.Models = {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
                                 sourcePromptUuid: {
-                                    dataType: 'string',
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
                                     required: true,
                                 },
                                 sourceThreadUuid: {
-                                    dataType: 'string',
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
                                     required: true,
                                 },
                                 excerpt: {
@@ -23671,11 +23759,256 @@ const models: TsoaRoute.Models = {
                             required: true,
                         },
                         occurredAt: { dataType: 'datetime', required: true },
-                        remediationUuid: { dataType: 'string', required: true },
+                        remediationUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         uuid: { dataType: 'string', required: true },
                     },
                 },
                 { ref: 'AiAgentReviewRemediationEventDetail' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemEventDetail: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                rootCause: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentRootCause' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['created'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                dismissedReason: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            ref: 'AiAgentReviewItemDismissedReason',
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                to: {
+                                    ref: 'AiAgentReviewItemStatus',
+                                    required: true,
+                                },
+                                from: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'AiAgentReviewItemStatus' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['status_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                toUserUuid: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                fromUserUuid: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['assignee_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                promptUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                threadUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['recurred'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                to: {
+                                    ref: 'AiAgentReviewItemPriority',
+                                    required: true,
+                                },
+                                from: {
+                                    ref: 'AiAgentReviewItemPriority',
+                                    required: true,
+                                },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['priority_changed'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        payload: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                body: { dataType: 'string', required: true },
+                            },
+                            required: true,
+                        },
+                        eventType: {
+                            dataType: 'enum',
+                            enums: ['comment_added'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewItemEvent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        createdByUserUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        occurredAt: { dataType: 'datetime', required: true },
+                        fingerprint: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                { ref: 'AiAgentReviewItemEventDetail' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiAgentReviewActivityEvent: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                kind: {
+                                    dataType: 'enum',
+                                    enums: ['remediation'],
+                                    required: true,
+                                },
+                            },
+                        },
+                        { ref: 'AiAgentReviewRemediationEvent' },
+                    ],
+                },
+                {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                kind: {
+                                    dataType: 'enum',
+                                    enums: ['issue'],
+                                    required: true,
+                                },
+                            },
+                        },
+                        { ref: 'AiAgentReviewItemEvent' },
+                    ],
+                },
             ],
             validators: {},
         },
@@ -23720,7 +24053,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: {
                         dataType: 'refAlias',
-                        ref: 'AiAgentReviewRemediationEvent',
+                        ref: 'AiAgentReviewActivityEvent',
                     },
                     required: true,
                 },
@@ -23856,6 +24189,26 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpdateAiAgentReviewItemPriority: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                priority: { ref: 'AiAgentReviewItemPriority', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CreateAiAgentReviewItemComment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { body: { dataType: 'string', required: true } },
             validators: {},
         },
     },
@@ -29578,8 +29931,22 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 sourceAgentUuid: { dataType: 'string', required: true },
                 sourceProjectUuid: { dataType: 'string', required: true },
-                sourceThreadUuid: { dataType: 'string', required: true },
-                sourceFindingUuid: { dataType: 'string', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                sourceFindingUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 primaryRootCause: { ref: 'AiAgentRootCause', required: true },
                 reviewStatus: {
                     ref: 'AiAgentReviewItemStatus',
@@ -31845,7 +32212,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31855,7 +32222,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31865,7 +32232,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31878,7 +32245,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -32540,7 +32907,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32550,7 +32917,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -32560,7 +32927,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -32573,7 +32940,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -56716,6 +57083,67 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_createReviewItem: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAiAgentReviewItem',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-items',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.createReviewItem,
+        ),
+
+        async function AiAgentAdminController_createReviewItem(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_createReviewItem,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'createReviewItem',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 201,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     const argsAiAgentAdminController_getReviewItem: Record<
         string,
         TsoaRoute.ParameterSchema
@@ -57143,6 +57571,140 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateReviewItemAssignee',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_updateReviewItemPriority: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpdateAiAgentReviewItemPriority',
+        },
+    };
+    app.patch(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/priority',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.updateReviewItemPriority,
+        ),
+
+        async function AiAgentAdminController_updateReviewItemPriority(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_updateReviewItemPriority,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateReviewItemPriority',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiAgentAdminController_addReviewItemComment: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        fingerprint: {
+            in: 'path',
+            name: 'fingerprint',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'CreateAiAgentReviewItemComment',
+        },
+    };
+    app.post(
+        '/api/v1/aiAgents/admin/review-items/:fingerprint/comments',
+        ...fetchMiddlewares<RequestHandler>(AiAgentAdminController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiAgentAdminController.prototype.addReviewItemComment,
+        ),
+
+        async function AiAgentAdminController_addReviewItemComment(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiAgentAdminController_addReviewItemComment,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiAgentAdminController>(
+                        AiAgentAdminController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'addReviewItemComment',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1740,10 +1740,6 @@
                         },
                         "type": "array"
                     },
-                    "instructions": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "origin": {
                         "type": "string"
                     },
@@ -1778,7 +1774,6 @@
                     "allowedContentTypes",
                     "allowedMethods",
                     "allowedPathPrefixes",
-                    "instructions",
                     "origin",
                     "type",
                     "name",
@@ -1856,10 +1851,6 @@
                         },
                         "type": "array"
                     },
-                    "instructions": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "origin": {
                         "type": "string"
                     },
@@ -1908,10 +1899,6 @@
                     },
                     "origin": {
                         "type": "string"
-                    },
-                    "instructions": {
-                        "type": "string",
-                        "nullable": true
                     },
                     "allowedPathPrefixes": {
                         "items": {
@@ -11661,9 +11648,6 @@
             },
             "DataAppManifest": {
                 "properties": {
-                    "scaffoldingVersion": {
-                        "type": "string"
-                    },
                     "downloadedAt": {
                         "type": "string"
                     },
@@ -16449,18 +16433,18 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -16472,13 +16456,13 @@
                                                                         "requiredFilters": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "required": {
-                                                                                        "type": "boolean"
-                                                                                    },
                                                                                     "settings": {},
                                                                                     "values": {
                                                                                         "items": {},
                                                                                         "type": "array"
+                                                                                    },
+                                                                                    "required": {
+                                                                                        "type": "boolean"
                                                                                     },
                                                                                     "operator": {
                                                                                         "type": "string"
@@ -16516,16 +16500,16 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
@@ -16585,6 +16569,16 @@
                                                                             ],
                                                                             "type": "object"
                                                                         },
+                                                                        "error": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "type": "string",
+                                                                            "enum": [
+                                                                                "error",
+                                                                                "success"
+                                                                            ]
+                                                                        },
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
@@ -16609,35 +16603,25 @@
                                                                                     "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "name": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "name": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
                                                                                     "tableName",
-                                                                                    "label",
-                                                                                    "name"
+                                                                                    "name",
+                                                                                    "label"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
                                                                             "type": "array"
                                                                         },
-                                                                        "error": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "label": {
                                                                             "type": "string"
-                                                                        },
-                                                                        "status": {
-                                                                            "type": "string",
-                                                                            "enum": [
-                                                                                "error",
-                                                                                "success"
-                                                                            ]
                                                                         }
                                                                     },
                                                                     "required": [
@@ -16693,8 +16677,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "not_found",
-                                                            "success"
+                                                            "success",
+                                                            "not_found"
                                                         ]
                                                     }
                                                 },
@@ -16720,32 +16704,27 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
-                                                                    },
                                                                     "fields": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
                                                                                 "isFromJoinedTable": {
                                                                                     "type": "boolean"
                                                                                 },
                                                                                 "caseSensitiveFilters": {
                                                                                     "type": "string",
                                                                                     "enum": [
+                                                                                        "true",
                                                                                         "false",
-                                                                                        "not_applicable",
-                                                                                        "true"
+                                                                                        "not_applicable"
                                                                                     ]
                                                                                 },
                                                                                 "fieldFilterType": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "fieldType": {
@@ -16755,47 +16734,52 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "label": {
+                                                                                "fieldId": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "fieldId": {
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
                                                                                     "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "description",
                                                                                 "isFromJoinedTable",
                                                                                 "caseSensitiveFilters",
                                                                                 "fieldFilterType",
                                                                                 "fieldValueType",
-                                                                                "fieldType",
                                                                                 "table",
-                                                                                "label",
+                                                                                "fieldType",
+                                                                                "fieldId",
                                                                                 "name",
-                                                                                "fieldId"
+                                                                                "description",
+                                                                                "label"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
                                                                                 "items": {
                                                                                     "properties": {
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
                                                                                         "settings": {},
                                                                                         "values": {
                                                                                             "items": {},
                                                                                             "type": "array"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
                                                                                         },
                                                                                         "operator": {
                                                                                             "type": "string"
@@ -16821,27 +16805,27 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
+                                                                            "name": {
                                                                                 "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "joinedTables",
                                                                             "baseTable",
-                                                                            "label",
-                                                                            "name"
+                                                                            "joinedTables",
+                                                                            "name",
+                                                                            "label"
                                                                         ],
                                                                         "type": "object"
                                                                     },
@@ -16854,8 +16838,8 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "rationale",
                                                                     "fields",
+                                                                    "rationale",
                                                                     "explore",
                                                                     "status"
                                                                 ],
@@ -16964,13 +16948,13 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "uuid": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
                                                     "name": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
+                                                    "uuid": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -16983,9 +16967,9 @@
                                                     "versionUuids",
                                                     "warnings",
                                                     "href",
-                                                    "uuid",
-                                                    "name",
                                                     "slug",
+                                                    "name",
+                                                    "uuid",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17001,10 +16985,10 @@
                                                                 "kind": {
                                                                     "type": "string",
                                                                     "enum": [
-                                                                        "compile",
-                                                                        "edit",
                                                                         "read",
+                                                                        "edit",
                                                                         "search",
+                                                                        "compile",
                                                                         "stage"
                                                                     ]
                                                                 }
@@ -17063,12 +17047,12 @@
                                                     "errorCode": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "git_write_permission",
+                                                            "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
                                                             "pull_request_not_open",
-                                                            "unknown",
-                                                            "unsupported_source_control",
+                                                            "git_write_permission",
                                                             null
                                                         ],
                                                         "nullable": true
@@ -17087,10 +17071,10 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
-                                                    "name": {
+                                                    "slug": {
                                                         "type": "string"
                                                     },
-                                                    "slug": {
+                                                    "name": {
                                                         "type": "string"
                                                     },
                                                     "status": {
@@ -17101,8 +17085,8 @@
                                                 },
                                                 "required": [
                                                     "href",
-                                                    "name",
                                                     "slug",
+                                                    "name",
                                                     "status"
                                                 ],
                                                 "type": "object"
@@ -17129,10 +17113,10 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "rejected",
-                                                            "success",
-                                                            "timeout"
+                                                            "timeout",
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -17162,22 +17146,26 @@
                                                                         "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "name": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
                                                                         "tableName",
-                                                                        "label",
-                                                                        "name"
+                                                                        "name",
+                                                                        "label"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -17187,16 +17175,12 @@
                                                                     null
                                                                 ],
                                                                 "nullable": true
-                                                            },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
                                                             }
                                                         },
                                                         "required": [
                                                             "fields",
-                                                            "type",
-                                                            "searchQuery"
+                                                            "searchQuery",
+                                                            "type"
                                                         ],
                                                         "type": "object"
                                                     },
@@ -23181,6 +23165,14 @@
             "ApiAiAgentAdminPromptActivityResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentAdminPromptActivityPoint-Array_"
             },
+            "AiAgentReviewItemSource": {
+                "type": "string",
+                "enum": ["ai_finding", "manual"]
+            },
+            "AiAgentReviewItemPriority": {
+                "type": "string",
+                "enum": ["urgent", "high", "medium", "low", "none"]
+            },
             "AiAgentReviewItemStatus": {
                 "type": "string",
                 "enum": [
@@ -23225,6 +23217,10 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "createdByUserUuid": {
+                        "type": "string",
+                        "nullable": true
                     },
                     "boardPosition": {
                         "type": "number",
@@ -23297,6 +23293,9 @@
                     "status": {
                         "$ref": "#/components/schemas/AiAgentReviewItemStatus"
                     },
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    },
                     "primaryRootCause": {
                         "$ref": "#/components/schemas/AiAgentRootCause"
                     },
@@ -23317,6 +23316,9 @@
                     "organizationUuid": {
                         "type": "string"
                     },
+                    "source": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemSource"
+                    },
                     "fingerprint": {
                         "type": "string"
                     },
@@ -23327,6 +23329,7 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "createdByUserUuid",
                     "boardPosition",
                     "prWritebackMessage",
                     "prWritebackStatus",
@@ -23342,12 +23345,14 @@
                     "ownerType",
                     "dismissedReason",
                     "status",
+                    "priority",
                     "primaryRootCause",
                     "description",
                     "title",
                     "agentUuid",
                     "projectUuid",
                     "organizationUuid",
+                    "source",
                     "fingerprint",
                     "uuid"
                 ],
@@ -23363,6 +23368,7 @@
                     "reviews_disabled",
                     "unsupported_root_cause",
                     "missing_project",
+                    "missing_agent",
                     "missing_project_context_entry",
                     "project_context_disabled",
                     "unsupported_source_control",
@@ -23505,13 +23511,16 @@
                         "type": "string"
                     },
                     "sourceThreadUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourcePromptUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourceFindingUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "organizationUuid": {
                         "type": "string"
@@ -23712,6 +23721,49 @@
             "ApiAiAgentReviewItemResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiAgentReviewItemSummary_"
             },
+            "CreateAiAgentReviewItem": {
+                "properties": {
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    },
+                    "primaryRootCause": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiAgentRootCause"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "assignedToUserUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "agentUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "priority",
+                    "primaryRootCause",
+                    "assignedToUserUuid",
+                    "agentUuid",
+                    "projectUuid",
+                    "description",
+                    "title"
+                ],
+                "type": "object"
+            },
             "AiAgentReviewRemediationEventDetail": {
                 "anyOf": [
                     {
@@ -23719,10 +23771,12 @@
                             "payload": {
                                 "properties": {
                                     "sourcePromptUuid": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "nullable": true
                                     },
                                     "sourceThreadUuid": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "nullable": true
                                     },
                                     "excerpt": {
                                         "type": "string",
@@ -23954,7 +24008,8 @@
                                 "format": "date-time"
                             },
                             "remediationUuid": {
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "uuid": {
                                 "type": "string"
@@ -23972,6 +24027,235 @@
                         "$ref": "#/components/schemas/AiAgentReviewRemediationEventDetail"
                     }
                 ]
+            },
+            "AiAgentReviewItemEventDetail": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "rootCause": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentRootCause"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["rootCause"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["created"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "dismissedReason": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentReviewItemDismissedReason"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "to": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                                    },
+                                    "from": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/AiAgentReviewItemStatus"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["dismissedReason", "to", "from"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["status_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "toUserUuid": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "fromUserUuid": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "required": ["toUserUuid", "fromUserUuid"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["assignee_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "promptUuid": {
+                                        "type": "string"
+                                    },
+                                    "threadUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["promptUuid", "threadUuid"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["recurred"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "to": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                                    },
+                                    "from": {
+                                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                                    }
+                                },
+                                "required": ["to", "from"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["priority_changed"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "payload": {
+                                "properties": {
+                                    "body": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["body"],
+                                "type": "object"
+                            },
+                            "eventType": {
+                                "type": "string",
+                                "enum": ["comment_added"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["payload", "eventType"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiAgentReviewItemEvent": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "createdByUserUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "occurredAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "fingerprint": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "createdByUserUuid",
+                            "occurredAt",
+                            "fingerprint",
+                            "uuid"
+                        ],
+                        "type": "object"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AiAgentReviewItemEventDetail"
+                    }
+                ]
+            },
+            "AiAgentReviewActivityEvent": {
+                "anyOf": [
+                    {
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "enum": ["remediation"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["kind"],
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AiAgentReviewRemediationEvent"
+                            }
+                        ]
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "kind": {
+                                        "type": "string",
+                                        "enum": ["issue"],
+                                        "nullable": false
+                                    }
+                                },
+                                "required": ["kind"],
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AiAgentReviewItemEvent"
+                            }
+                        ]
+                    }
+                ],
+                "description": "One row of the merged issue activity feed."
             },
             "AiAgentReviewRemediationLiveState": {
                 "type": "string",
@@ -23999,7 +24283,7 @@
                     },
                     "events": {
                         "items": {
-                            "$ref": "#/components/schemas/AiAgentReviewRemediationEvent"
+                            "$ref": "#/components/schemas/AiAgentReviewActivityEvent"
                         },
                         "type": "array"
                     }
@@ -24153,6 +24437,24 @@
                     }
                 },
                 "required": ["assignedToUserUuid"],
+                "type": "object"
+            },
+            "UpdateAiAgentReviewItemPriority": {
+                "properties": {
+                    "priority": {
+                        "$ref": "#/components/schemas/AiAgentReviewItemPriority"
+                    }
+                },
+                "required": ["priority"],
+                "type": "object"
+            },
+            "CreateAiAgentReviewItemComment": {
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "required": ["body"],
                 "type": "object"
             },
             "AiAgentReviewItemWritebackPreview": {
@@ -30056,10 +30358,12 @@
                         "type": "string"
                     },
                     "sourceThreadUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "sourceFindingUuid": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "primaryRootCause": {
                         "$ref": "#/components/schemas/AiAgentRootCause"
@@ -32486,22 +32790,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -33065,22 +33369,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__description_63_-string-or-undefined--name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -42386,7 +42690,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3289.1",
+        "version": "0.3291.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -49432,6 +49736,45 @@
                         }
                     }
                 ]
+            },
+            "post": {
+                "operationId": "createAiAgentReviewItem",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Create a manual AI agent issue",
+                "summary": "Create AI agent review item",
+                "security": [],
+                "parameters": [],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAiAgentReviewItem"
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/aiAgents/admin/review-items/{fingerprint}": {
@@ -49727,6 +50070,106 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/UpdateAiAgentReviewItemAssignee"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/priority": {
+            "patch": {
+                "operationId": "updateAiAgentReviewItemPriority",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Set the priority on an AI agent review item",
+                "summary": "Update AI agent review item priority",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateAiAgentReviewItemPriority"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/aiAgents/admin/review-items/{fingerprint}/comments": {
+            "post": {
+                "operationId": "addAiAgentReviewItemComment",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiAgentReviewItemActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Add a comment to an AI agent review item",
+                "summary": "Add AI agent review item comment",
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "fingerprint",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateAiAgentReviewItemComment"
                             }
                         }
                     }

--- a/packages/backend/src/models/PullRequestsModel.ts
+++ b/packages/backend/src/models/PullRequestsModel.ts
@@ -46,8 +46,8 @@ type AiThreadInfo = { aiThreadUuid: string; aiAgentUuid: string | null };
 type ReviewSourceInfo = {
     reviewItemTitle: string | null;
     primaryRootCause: AiAgentRootCause | null;
-    sourceFindingUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
 };
@@ -217,18 +217,21 @@ export class PullRequestsModel {
                 'remediation.source_ai_agent_review_turn_signal_uuid',
             )
             .whereIn('remediation.pull_request_uuid', pullRequestUuids)
-            .select<DirectReviewContextRow[]>({
-                pullRequestUuid: 'remediation.pull_request_uuid',
-                fingerprint: 'remediation.fingerprint',
-                reviewStatus: 'review_item.status',
-                reviewItemTitle: 'source_finding.review_item_title',
-                primaryRootCause: 'source_finding.primary_root_cause',
-                sourceFindingUuid:
-                    'remediation.source_ai_agent_review_turn_signal_uuid',
-                sourceThreadUuid: 'remediation.source_thread_uuid',
-                sourceProjectUuid: 'remediation.source_project_uuid',
-                sourceAgentUuid: 'remediation.source_agent_uuid',
-            })
+            .select<DirectReviewContextRow[]>(
+                'remediation.pull_request_uuid as pullRequestUuid',
+                'remediation.fingerprint as fingerprint',
+                'review_item.status as reviewStatus',
+                this.database.raw(
+                    'coalesce(source_finding.review_item_title, review_item.title) as "reviewItemTitle"',
+                ),
+                this.database.raw(
+                    'coalesce(source_finding.primary_root_cause, review_item.primary_root_cause) as "primaryRootCause"',
+                ),
+                'remediation.source_ai_agent_review_turn_signal_uuid as sourceFindingUuid',
+                'remediation.source_thread_uuid as sourceThreadUuid',
+                'remediation.source_project_uuid as sourceProjectUuid',
+                'remediation.source_agent_uuid as sourceAgentUuid',
+            )
             .orderBy('remediation.updated_at', 'desc');
 
         rows.forEach((row) => {

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -766,6 +766,43 @@ export type AiAgentReviewRemediationEvent = {
     createdByUserUuid: string | null;
 } & AiAgentReviewRemediationEventDetail;
 
+export type AiAgentReviewItemEventDetail =
+    | { eventType: 'created'; payload: { rootCause: AiAgentRootCause } }
+    | {
+          eventType: 'status_changed';
+          payload: {
+              from: AiAgentReviewItemStatus | null;
+              to: AiAgentReviewItemStatus;
+              dismissedReason: AiAgentReviewItemDismissedReason | null;
+          };
+      }
+    | {
+          eventType: 'assignee_changed';
+          payload: {
+              fromUserUuid: string | null;
+              toUserUuid: string | null;
+          };
+      }
+    | {
+          eventType: 'recurred';
+          payload: { threadUuid: string; promptUuid: string };
+      };
+
+export type AiAgentReviewItemEventType =
+    AiAgentReviewItemEventDetail['eventType'];
+
+export type AiAgentReviewItemEvent = {
+    uuid: string;
+    fingerprint: string;
+    occurredAt: Date;
+    createdByUserUuid: string | null;
+} & AiAgentReviewItemEventDetail;
+
+/** One row of the merged issue activity feed. */
+export type AiAgentReviewActivityEvent =
+    | ({ kind: 'remediation' } & AiAgentReviewRemediationEvent)
+    | ({ kind: 'issue' } & AiAgentReviewItemEvent);
+
 /**
  * The in-flight step of a remediation, derived from current status + which
  * events exist — never stored. Renders as the single accented "live" row.
@@ -776,7 +813,7 @@ export type AiAgentReviewRemediationLiveState =
     | 'verifying';
 
 export type AiAgentReviewItemActivity = {
-    events: AiAgentReviewRemediationEvent[];
+    events: AiAgentReviewActivityEvent[];
     liveState: AiAgentReviewRemediationLiveState | null;
     /** Streaming progress text for the live row (writeback step messages). */
     liveMessage: string | null;

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -345,6 +345,7 @@ export type AiAgentReviewItemWritebackBlockedReason =
     | 'reviews_disabled'
     | 'unsupported_root_cause'
     | 'missing_project'
+    | 'missing_agent'
     | 'missing_project_context_entry'
     | 'project_context_disabled'
     | 'unsupported_source_control'
@@ -381,9 +382,9 @@ export type AiAgentReviewRemediation = {
     uuid: string;
     fingerprint: string;
     organizationUuid: string;
-    sourceFindingUuid: string;
-    sourcePromptUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourcePromptUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
     workThreadUuid: string | null;
@@ -608,12 +609,14 @@ export type AiAgentReviewClassifierJudgeOutput = z.infer<
 export type AiAgentReviewItem = {
     uuid: string;
     fingerprint: string;
+    source: AiAgentReviewItemSource;
     organizationUuid: string;
     projectUuid: string | null;
     agentUuid: string | null;
     title: string;
     description: string;
     primaryRootCause: AiAgentRootCause;
+    priority: AiAgentReviewItemPriority;
     status: AiAgentReviewItemStatus;
     dismissedReason: AiAgentReviewItemDismissedReason | null;
     ownerType: AiAgentReviewItemOwnerType;
@@ -630,9 +633,19 @@ export type AiAgentReviewItem = {
     prWritebackMessage: string | null;
     // Manual board sort key; null = default (last-seen) order.
     boardPosition: number | null;
+    createdByUserUuid: string | null;
     createdAt: Date;
     updatedAt: Date;
 };
+
+export type AiAgentReviewItemSource = 'ai_finding' | 'manual';
+
+export type AiAgentReviewItemPriority =
+    | 'urgent'
+    | 'high'
+    | 'medium'
+    | 'low'
+    | 'none';
 
 export type AiAgentReviewItemSummary = AiAgentReviewItem & {
     /**
@@ -672,6 +685,24 @@ export type UpdateAiAgentReviewItemStatus = {
 
 export type UpdateAiAgentReviewItemAssignee = {
     assignedToUserUuid: string | null;
+};
+
+export type CreateAiAgentReviewItem = {
+    title: string;
+    description: string | null;
+    projectUuid: string;
+    agentUuid: string | null;
+    assignedToUserUuid: string | null;
+    primaryRootCause: AiAgentRootCause | null;
+    priority: AiAgentReviewItemPriority;
+};
+
+export type UpdateAiAgentReviewItemPriority = {
+    priority: AiAgentReviewItemPriority;
+};
+
+export type CreateAiAgentReviewItemComment = {
+    body: string;
 };
 
 // Persists the board's manual card order: the fingerprints of one lane in their
@@ -726,8 +757,8 @@ export type AiAgentReviewRemediationEventDetail =
           eventType: 'finding_opened';
           payload: {
               excerpt: string | null;
-              sourceThreadUuid: string;
-              sourcePromptUuid: string;
+              sourceThreadUuid: string | null;
+              sourcePromptUuid: string | null;
           };
       }
     | {
@@ -761,13 +792,13 @@ export type AiAgentReviewRemediationEventType =
 
 export type AiAgentReviewRemediationEvent = {
     uuid: string;
-    remediationUuid: string;
+    remediationUuid: string | null;
     occurredAt: Date;
     createdByUserUuid: string | null;
 } & AiAgentReviewRemediationEventDetail;
 
 export type AiAgentReviewItemEventDetail =
-    | { eventType: 'created'; payload: { rootCause: AiAgentRootCause } }
+    | { eventType: 'created'; payload: { rootCause: AiAgentRootCause | null } }
     | {
           eventType: 'status_changed';
           payload: {
@@ -786,7 +817,15 @@ export type AiAgentReviewItemEventDetail =
     | {
           eventType: 'recurred';
           payload: { threadUuid: string; promptUuid: string };
-      };
+      }
+    | {
+          eventType: 'priority_changed';
+          payload: {
+              from: AiAgentReviewItemPriority;
+              to: AiAgentReviewItemPriority;
+          };
+      }
+    | { eventType: 'comment_added'; payload: { body: string } };
 
 export type AiAgentReviewItemEventType =
     AiAgentReviewItemEventDetail['eventType'];

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -20,8 +20,8 @@ export type PullRequestReviewContext = {
     reviewTitle: string;
     reviewStatus: AiAgentReviewItemStatus;
     primaryRootCause: AiAgentRootCause;
-    sourceFindingUuid: string;
-    sourceThreadUuid: string;
+    sourceFindingUuid: string | null;
+    sourceThreadUuid: string | null;
     sourceProjectUuid: string;
     sourceAgentUuid: string;
 };

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -77,7 +77,7 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         );
     }
 
-    const reviewsUrl = `/generalSettings/ai/reviews?projects=${encodeURIComponent(
+    const reviewsUrl = `/generalSettings/ai/issues?projects=${encodeURIComponent(
         projectUuid,
     )}`;
 

--- a/packages/frontend/src/ee/CommercialRoutes.tsx
+++ b/packages/frontend/src/ee/CommercialRoutes.tsx
@@ -167,7 +167,11 @@ const COMMERCIAL_AI_AGENTS_ROUTES: RouteObject[] = [
     },
     {
         path: '/ai-agents/admin/reviews',
-        element: <Navigate to="/generalSettings/ai/reviews" replace />,
+        element: <Navigate to="/generalSettings/ai/issues" replace />,
+    },
+    {
+        path: '/ai-agents/admin/issues',
+        element: <Navigate to="/generalSettings/ai/issues" replace />,
     },
     {
         path: '/ai-agents/',

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -101,8 +101,8 @@ const AiSearchBoxInner: FC<Props> = ({
     ).length;
     const reviewsPromoLabel =
         prReadyCount > 0
-            ? 'Review findings, ship PRs, improve agents'
-            : 'Review AI findings to improve future answers';
+            ? 'Review issues, ship PRs, improve agents'
+            : 'Review AI issues to improve future answers';
 
     const noAgentsAvailable =
         !isLoadingAgents && (!agents || agents.length === 0);
@@ -350,7 +350,7 @@ const AiSearchBoxInner: FC<Props> = ({
                                             />
                                         }
                                         component={Link}
-                                        to={`/generalSettings/ai/reviews?projects=${projectUuid}`}
+                                        to={`/generalSettings/ai/issues?projects=${projectUuid}`}
                                         className={styles.reviewsPromoButton}
                                     >
                                         <Group gap="xs" wrap="nowrap">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -106,10 +106,12 @@ const signalLabels: Record<AiAgentTurnSignal, string> = {
 
 type ReviewSurface = 'findings' | 'signals';
 
+// Manual issues have no source thread, so the thread coordinates are null and
+// the detail modal renders from the review item alone.
 export type AiAgentAdminReviewItemPreviewTarget = {
-    projectUuid: string;
-    agentUuid: string;
-    threadUuid: string;
+    projectUuid: string | null;
+    agentUuid: string | null;
+    threadUuid: string | null;
     reviewItemUuid?: string | null;
 };
 
@@ -1208,20 +1210,21 @@ const AiAgentAdminReviewItemsTable = ({
             return {
                 className: styles.bodyRow,
                 style: {
-                    cursor: latestFinding ? 'pointer' : 'default',
+                    cursor: 'pointer',
                     backgroundColor: isSelected
                         ? theme.colors.ldGray[0]
                         : undefined,
                 },
-                onClick: latestFinding
-                    ? () =>
-                          onReviewItemSelect?.({
-                              projectUuid: latestFinding.projectUuid,
-                              agentUuid: latestFinding.agentUuid,
-                              threadUuid: latestFinding.threadUuid,
-                              reviewItemUuid: reviewItem.uuid,
-                          })
-                    : undefined,
+                onClick: () =>
+                    onReviewItemSelect?.({
+                        projectUuid:
+                            latestFinding?.projectUuid ??
+                            reviewItem.projectUuid,
+                        agentUuid:
+                            latestFinding?.agentUuid ?? reviewItem.agentUuid,
+                        threadUuid: latestFinding?.threadUuid ?? null,
+                        reviewItemUuid: reviewItem.uuid,
+                    }),
             };
         },
         renderTopToolbar: ({ table: tableInstance }) => {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminReviewItemsTable.tsx
@@ -135,7 +135,7 @@ const getSignalResultLabel = (signal: AiAgentReviewSignalSummary): string => {
 const getSignalWhyText = (signal: AiAgentReviewSignalSummary): string =>
     signal.promotionReason ??
     signal.finding?.recommendation?.rationale ??
-    'The judge reviewed this turn but did not promote it into a review item.';
+    'The judge reviewed this turn but did not promote it into an issue.';
 
 const getSignalActionText = (signal: AiAgentReviewSignalSummary): string => {
     if (signal.finding?.recommendation) {
@@ -682,7 +682,7 @@ const AiAgentAdminReviewItemsTable = ({
     }: {
         visibleCount: number;
         totalCount: number;
-        noun: 'finding' | 'turn';
+        noun: 'issue' | 'turn';
         isLoading: boolean;
         surface: ReviewSurface;
         selectedCount?: number;
@@ -698,7 +698,7 @@ const AiAgentAdminReviewItemsTable = ({
               ? `${visibleCount} of ${totalCount} ${pluralised}`
               : `${visibleCount} ${pluralised}`;
         const helperCopy =
-            'Findings are issues worth attention. Click a row to inspect details and thread context.';
+            'Issues are items worth attention. Click a row to inspect details and thread context.';
 
         return (
             <Box>
@@ -707,7 +707,7 @@ const AiAgentAdminReviewItemsTable = ({
                         <SearchFilter
                             search={search}
                             setSearch={setSearch}
-                            placeholder="Search findings"
+                            placeholder="Search issues"
                         />
 
                         <Group
@@ -716,7 +716,7 @@ const AiAgentAdminReviewItemsTable = ({
                             className={styles.toolbarHeading}
                         >
                             <Text fz="sm" fw={700} c="ldGray.9">
-                                Findings
+                                Issues
                             </Text>
                             <ReviewConceptHelp />
                         </Group>
@@ -786,7 +786,7 @@ const AiAgentAdminReviewItemsTable = ({
                                         }
                                         onClick={onDismissSelected}
                                     >
-                                        Dismiss findings
+                                        Dismiss issues
                                     </Button>
                                     {onClearSelection && (
                                         <Button
@@ -1245,7 +1245,7 @@ const AiAgentAdminReviewItemsTable = ({
             return renderReviewsToolbar({
                 visibleCount: filteredReviewItems.length,
                 totalCount: searchFilteredReviewItems.length,
-                noun: 'finding',
+                noun: 'issue',
                 isLoading,
                 surface: 'findings',
                 selectedCount: selectedRows.length,
@@ -1256,9 +1256,9 @@ const AiAgentAdminReviewItemsTable = ({
             });
         },
         emptyState: {
-            entityName: 'findings',
+            entityName: 'issues',
             emptyMessage:
-                'Nothing to review yet. When an agent answer looks wrong, it shows up here.',
+                'No issues yet. When an agent answer looks wrong, it shows up here.',
             search,
             hasActiveFilters,
             onClearFilters: clearAllFilters,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
@@ -1,0 +1,30 @@
+.layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 240px;
+    gap: var(--mantine-spacing-xl);
+    align-items: start;
+}
+
+.main {
+    min-width: 0;
+}
+
+.rail {
+    position: sticky;
+    top: 0;
+    padding-left: var(--mantine-spacing-lg);
+    border-left: 1px solid var(--mantine-color-ldGray-2);
+}
+
+@media (max-width: 768px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .rail {
+        border-left: none;
+        padding-left: 0;
+        border-top: 1px solid var(--mantine-color-ldGray-2);
+        padding-top: var(--mantine-spacing-md);
+    }
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
@@ -1,6 +1,6 @@
 .layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 240px;
+    grid-template-columns: minmax(0, 1fr) 232px;
     gap: var(--mantine-spacing-xl);
     align-items: start;
 }
@@ -9,22 +9,158 @@
     min-width: 0;
 }
 
-.rail {
-    position: sticky;
-    top: 0;
-    padding-left: var(--mantine-spacing-lg);
-    border-left: 1px solid var(--mantine-color-ldGray-2);
+/* Issue header --------------------------------------------------------- */
+
+.causeBadge {
+    width: fit-content;
+    margin-bottom: var(--mantine-spacing-sm);
 }
 
-@media (max-width: 768px) {
+.title {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+    color: var(--mantine-color-ldGray-9);
+    margin-bottom: var(--mantine-spacing-lg);
+}
+
+.description {
+    font-size: 13.5px;
+    line-height: 1.65;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.sectionLabel {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--mantine-color-ldGray-7);
+}
+
+/* Activity / Evidence toggle ------------------------------------------- */
+
+.toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+    padding: 3px 8px;
+    border-radius: var(--mantine-radius-sm);
+    transition:
+        color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+        background-color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.toggle:hover {
+    color: var(--mantine-color-ldGray-9);
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.panel {
+    animation: fade-in 180ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* A thread can be arbitrarily long — bound it so the modal never grows past
+   the viewport; the thread scrolls within its own region instead. */
+.evidenceScroll {
+    max-height: 52vh;
+    overflow-y: auto;
+    margin: 0 calc(-1 * var(--mantine-spacing-xs));
+    padding: 0 var(--mantine-spacing-xs);
+}
+
+.toggle:any-link {
+    text-decoration: none;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .panel {
+        animation: none;
+    }
+}
+
+.statusDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+/* Side rail (Linear-style property card) -------------------------------- */
+
+.rail {
+    /* Visual chrome (border, radius, padding) comes from the Mantine Paper. */
+    position: sticky;
+    top: 0;
+}
+
+.railRow {
+    min-height: 38px;
+    padding: 6px 0;
+    gap: var(--mantine-spacing-md);
+}
+
+.railLabel {
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.railValue {
+    min-width: 0;
+    display: flex;
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.railText {
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-9);
+    overflow-wrap: anywhere;
+}
+
+.railLink {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-9);
+    text-decoration: none;
+    transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.railLink:hover {
+    color: light-dark(
+        var(--mantine-color-indigo-7),
+        var(--mantine-color-indigo-4)
+    );
+}
+
+.railActions {
+    margin-top: var(--mantine-spacing-sm);
+    padding-top: var(--mantine-spacing-sm);
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+}
+
+@media (max-width: 820px) {
     .layout {
         grid-template-columns: minmax(0, 1fr);
-    }
-
-    .rail {
-        border-left: none;
-        padding-left: 0;
-        border-top: 1px solid var(--mantine-color-ldGray-2);
-        padding-top: var(--mantine-spacing-md);
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -1,0 +1,123 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { IssueDetailModal } from './IssueDetailModal';
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary =>
+    ({
+        uuid: 'ri-1',
+        fingerprint: 'fp-1',
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        agentUuid: 'agent-1',
+        title: 'Wrong revenue',
+        description: 'desc',
+        primaryRootCause: 'semantic_layer',
+        status: 'open',
+        dismissedReason: null,
+        ownerType: 'semantic_layer_owner',
+        assignedToUserUuid: null,
+        firstSeenAt: new Date('2026-06-24T08:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-24T08:00:00.000Z'),
+        findingCount: 1,
+        statusUpdatedAt: null,
+        statusUpdatedByUserUuid: null,
+        linkedIssueUrl: null,
+        linkedPrUrl: null,
+        prState: null,
+        prWritebackStatus: null,
+        prWritebackMessage: null,
+        boardPosition: null,
+        createdAt: new Date('2026-06-24T08:00:00.000Z'),
+        updatedAt: new Date('2026-06-24T08:00:00.000Z'),
+        writebackEligible: false,
+        writebackEligibility: {
+            eligible: false,
+            reason: 'reviews_disabled',
+            provider: null,
+            strategy: null,
+        },
+        remediation: null,
+        latestFinding: {
+            uuid: 'finding-1',
+            threadUuid: 'thread-1',
+            projectUuid: 'project-1',
+            agentUuid: 'agent-1',
+            primaryRootCause: 'semantic_layer',
+            fixTargets: [],
+            recommendation: null,
+            projectContextEntry: null,
+        },
+        ...overrides,
+    }) as AiAgentReviewItemSummary;
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useAiAgentAdminReviewItems: () => ({
+        data: [makeReviewItem()],
+        isLoading: false,
+    }),
+    useAiAgentReviewItemActivity: () => ({ data: undefined }),
+    useAiAgentAdminReviewItem: () => ({ data: undefined }),
+    useUpdateAiAgentReviewItemStatus: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+    useCreateAiAgentReviewItemWriteback: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useProjectAiAgents', () => ({
+    useAiAgentThread: () => ({
+        data: { uuid: 'thread-1', messages: [] },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../../../../hooks/useProjects', () => ({
+    useProjects: () => ({
+        data: [{ projectUuid: 'project-1', name: 'Jaffle' }],
+    }),
+}));
+
+vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
+    useOrgUsersByUuid: () => new Map(),
+}));
+
+// Heavy children stubbed so the test exercises modal composition, not their
+// full dependency trees.
+vi.mock('../ChatElements/AgentChatDisplay', () => ({
+    AgentChatDisplay: () => <div>chat-evidence</div>,
+}));
+vi.mock('./ReviewItemActions', () => ({
+    ReviewItemActions: () => <div>status-actions</div>,
+}));
+vi.mock('./ReviewAssigneeMenu', () => ({
+    ReviewAssigneeMenu: () => <div>Assign</div>,
+}));
+
+describe('IssueDetailModal', () => {
+    it('renders the issue title, assignee rail, evidence, and activity', () => {
+        renderWithProviders(
+            <IssueDetailModal
+                projectUuid="project-1"
+                agentUuid="agent-1"
+                threadUuid="thread-1"
+                selectedReviewItemUuid="ri-1"
+                isOpen
+                onClose={() => {}}
+            />,
+        );
+
+        expect(screen.getByText('Wrong revenue')).toBeInTheDocument();
+        expect(screen.getByText('Assignee')).toBeInTheDocument();
+        expect(screen.getByText('status-actions')).toBeInTheDocument();
+        expect(screen.getByText('chat-evidence')).toBeInTheDocument();
+        expect(screen.getByText('Evidence')).toBeInTheDocument();
+        expect(screen.getByText('Jaffle')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -1,5 +1,6 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { IssueDetailModal } from './IssueDetailModal';
@@ -101,7 +102,7 @@ vi.mock('./ReviewAssigneeMenu', () => ({
 }));
 
 describe('IssueDetailModal', () => {
-    it('renders the issue title, assignee rail, evidence, and activity', () => {
+    it('renders the issue title, rail, and activity by default', () => {
         renderWithProviders(
             <IssueDetailModal
                 projectUuid="project-1"
@@ -116,8 +117,30 @@ describe('IssueDetailModal', () => {
         expect(screen.getByText('Wrong revenue')).toBeInTheDocument();
         expect(screen.getByText('Assignee')).toBeInTheDocument();
         expect(screen.getByText('status-actions')).toBeInTheDocument();
-        expect(screen.getByText('chat-evidence')).toBeInTheDocument();
-        expect(screen.getByText('Evidence')).toBeInTheDocument();
         expect(screen.getByText('Jaffle')).toBeInTheDocument();
+        // Activity is shown by default; evidence sits behind a toggle.
+        expect(screen.getByText('Activity')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /Show evidence/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('reveals the evidence chat when the toggle is clicked', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <IssueDetailModal
+                projectUuid="project-1"
+                agentUuid="agent-1"
+                threadUuid="thread-1"
+                selectedReviewItemUuid="ri-1"
+                isOpen
+                onClose={() => {}}
+            />,
+        );
+
+        await user.click(
+            screen.getByRole('button', { name: /Show evidence/i }),
+        );
+        expect(await screen.findByText('chat-evidence')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -1,14 +1,25 @@
+import { capitalize } from '@lightdash/common';
 import {
     Anchor,
     Box,
+    Button,
     Group,
     Loader,
+    Paper,
     Stack,
     Text,
-    Title,
+    UnstyledButton,
 } from '@mantine-8/core';
-import { IconGitPullRequest } from '@tabler/icons-react';
-import { type FC, useMemo } from 'react';
+import {
+    IconArrowLeft,
+    IconExternalLink,
+    IconFileHorizontal,
+    IconGitPullRequest,
+    IconLayoutColumns,
+    IconMessageCircle2,
+} from '@tabler/icons-react';
+import { type FC, useMemo, useState } from 'react';
+import { Link } from 'react-router';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
@@ -22,7 +33,7 @@ import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
 import { ReviewItemActions } from './ReviewItemActions';
 import {
     formatReviewDate,
-    getCompactIssueTitle,
+    getIssueTitle,
     getReviewReasoningText,
 } from './reviewItemDetails';
 import {
@@ -30,6 +41,7 @@ import {
     THREAD_REVIEW_ITEM_STATUSES,
     threadReviewRootCauseColors,
     threadReviewRootCauseLabels,
+    threadReviewStatusColors,
 } from './threadReviewContext';
 
 type Props = {
@@ -41,16 +53,14 @@ type Props = {
     onClose: () => void;
 };
 
-const RailField: FC<{ label: string; children: React.ReactNode }> = ({
+const RailRow: FC<{ label: string; children: React.ReactNode }> = ({
     label,
     children,
 }) => (
-    <Stack gap={4}>
-        <Text fz={10} fw={700} c="dimmed" tt="uppercase" lts={0.4}>
-            {label}
-        </Text>
-        {children}
-    </Stack>
+    <Group className={styles.railRow} justify="space-between" wrap="nowrap">
+        <Text className={styles.railLabel}>{label}</Text>
+        <Box className={styles.railValue}>{children}</Box>
+    </Group>
 );
 
 export const IssueDetailModal: FC<Props> = ({
@@ -61,6 +71,7 @@ export const IssueDetailModal: FC<Props> = ({
     isOpen,
     onClose,
 }) => {
+    const [showEvidence, setShowEvidence] = useState(false);
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
         projectUuid,
         agentUuid,
@@ -104,129 +115,204 @@ export const IssueDetailModal: FC<Props> = ({
     const reasoningText = item ? getReviewReasoningText(item) : null;
     const isLoading = isLoadingThread || isLoadingItems;
 
+    const workspaceUrl = item
+        ? `/generalSettings/ai/reviews/${encodeURIComponent(item.fingerprint)}`
+        : null;
+
     return (
         <MantineModal
             opened={isOpen}
             onClose={onClose}
-            size="80%"
+            size="60rem"
             title="Issue"
-            cancelLabel="Close"
-            bodyScrollAreaMaxHeight="calc(85vh - 140px)"
+            icon={IconFileHorizontal}
+            cancelLabel={false}
+            modalBodyProps={{ py: 'lg' }}
+            bodyScrollAreaMaxHeight="calc(85vh - 120px)"
+            headerActions={
+                item?.remediation && workspaceUrl ? (
+                    <Button
+                        component={Link}
+                        to={workspaceUrl}
+                        onClick={onClose}
+                        size="xs"
+                        variant="default"
+                        radius="md"
+                        leftSection={
+                            <MantineIcon icon={IconLayoutColumns} size={14} />
+                        }
+                    >
+                        Open workspace
+                    </Button>
+                ) : null
+            }
         >
             {isLoading || !item || !threadData ? (
-                <Group justify="center" p="xl">
-                    <Loader color="gray" />
+                <Group justify="center" p="5rem">
+                    <Loader color="gray" size="sm" />
                 </Group>
             ) : (
                 <Box className={styles.layout}>
-                    <Stack className={styles.main} gap="lg">
-                        <Stack gap="xs">
-                            <Group gap={8} wrap="wrap">
-                                <CategoryBadge
-                                    variant="dot"
-                                    label={
-                                        threadReviewRootCauseLabels[
-                                            item.primaryRootCause
-                                        ]
-                                    }
-                                    color={
-                                        threadReviewRootCauseColors[
-                                            item.primaryRootCause
-                                        ]
-                                    }
-                                />
-                            </Group>
-                            <Title order={4} fw={600}>
-                                {getCompactIssueTitle(item)}
-                            </Title>
-                            {reasoningText && (
-                                <Text fz="sm" c="ldGray.7" lh={1.55}>
-                                    {reasoningText}
+                    <Stack className={styles.main} gap={0}>
+                        <CategoryBadge
+                            variant="dot"
+                            label={
+                                threadReviewRootCauseLabels[
+                                    item.primaryRootCause
+                                ]
+                            }
+                            color={
+                                threadReviewRootCauseColors[
+                                    item.primaryRootCause
+                                ]
+                            }
+                            className={styles.causeBadge}
+                        />
+                        <Text className={styles.title}>
+                            {getIssueTitle(item)}
+                        </Text>
+
+                        {reasoningText && (
+                            <Text className={styles.description}>
+                                {reasoningText}
+                            </Text>
+                        )}
+
+                        <Stack gap="sm" mt="xl">
+                            <Group justify="space-between" align="center">
+                                <Text className={styles.sectionLabel}>
+                                    {showEvidence ? 'Evidence' : 'Activity'}
                                 </Text>
+                                <Group gap="md" wrap="nowrap">
+                                    {showEvidence && (
+                                        <Anchor
+                                            href={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className={styles.toggle}
+                                        >
+                                            Open full thread
+                                            <MantineIcon
+                                                icon={IconExternalLink}
+                                                size={13}
+                                                stroke={1.5}
+                                            />
+                                        </Anchor>
+                                    )}
+                                    <UnstyledButton
+                                        className={styles.toggle}
+                                        onClick={() =>
+                                            setShowEvidence((open) => !open)
+                                        }
+                                    >
+                                        <MantineIcon
+                                            icon={
+                                                showEvidence
+                                                    ? IconArrowLeft
+                                                    : IconMessageCircle2
+                                            }
+                                            size={13}
+                                            stroke={1.5}
+                                        />
+                                        {showEvidence
+                                            ? 'Back to activity'
+                                            : 'Show evidence'}
+                                    </UnstyledButton>
+                                </Group>
+                            </Group>
+
+                            {showEvidence ? (
+                                <Box
+                                    className={`${styles.panel} ${styles.evidenceScroll}`}
+                                >
+                                    <AgentChatDisplay
+                                        thread={threadData}
+                                        projectUuid={projectUuid}
+                                        agentUuid={agentUuid}
+                                        renderArtifactsInline
+                                        showAddToEvalsButton
+                                    />
+                                </Box>
+                            ) : (
+                                <Box className={styles.panel}>
+                                    <RemediationActivityTimeline
+                                        reviewItem={item}
+                                    />
+                                </Box>
                             )}
-                        </Stack>
-
-                        <Stack gap="xs">
-                            <Text
-                                fz={10}
-                                fw={700}
-                                tt="uppercase"
-                                lts={0.4}
-                                c="ldGray.7"
-                            >
-                                Evidence
-                            </Text>
-                            <AgentChatDisplay
-                                thread={threadData}
-                                projectUuid={projectUuid}
-                                agentUuid={agentUuid}
-                                renderArtifactsInline
-                                showAddToEvalsButton
-                            />
-                        </Stack>
-
-                        <Stack gap="xs">
-                            <Text
-                                fz={10}
-                                fw={700}
-                                tt="uppercase"
-                                lts={0.4}
-                                c="ldGray.7"
-                            >
-                                Activity
-                            </Text>
-                            <RemediationActivityTimeline reviewItem={item} />
                         </Stack>
                     </Stack>
 
-                    <Stack className={styles.rail} gap="lg">
-                        <RailField label="Status">
-                            <ReviewItemActions
-                                reviewItem={item}
-                                mode="drawer"
-                            />
-                        </RailField>
-                        <RailField label="Assignee">
-                            <ReviewAssigneeMenu
-                                projectUuid={item.projectUuid}
-                                fingerprint={item.fingerprint}
-                                assignedToUserUuid={item.assignedToUserUuid}
-                            />
-                        </RailField>
-                        {projectName && (
-                            <RailField label="Project">
-                                <Text fz="sm" fw={500} c="ldGray.9">
-                                    {projectName}
-                                </Text>
-                            </RailField>
-                        )}
-                        {seenValue && (
-                            <RailField label="Seen">
-                                <Text fz="sm" fw={500} c="ldGray.9">
-                                    {seenValue}
-                                </Text>
-                            </RailField>
-                        )}
-                        {item.linkedPrUrl && (
-                            <RailField label="Pull request">
-                                <Anchor
-                                    href={item.linkedPrUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    fz="sm"
-                                    fw={500}
-                                >
-                                    <Group gap={4} wrap="nowrap">
+                    <Paper
+                        component="aside"
+                        withBorder
+                        radius="md"
+                        p="md"
+                        className={styles.rail}
+                        aria-label="Issue properties"
+                    >
+                        <Stack gap={2}>
+                            <RailRow label="Status">
+                                <Group gap={6} wrap="nowrap">
+                                    <Box
+                                        className={styles.statusDot}
+                                        bg={`${threadReviewStatusColors[item.status]}.6`}
+                                    />
+                                    <Text className={styles.railText}>
+                                        {capitalize(
+                                            item.status.replaceAll('_', ' '),
+                                        )}
+                                    </Text>
+                                </Group>
+                            </RailRow>
+                            <RailRow label="Assignee">
+                                <ReviewAssigneeMenu
+                                    projectUuid={item.projectUuid}
+                                    fingerprint={item.fingerprint}
+                                    assignedToUserUuid={item.assignedToUserUuid}
+                                />
+                            </RailRow>
+                            {projectName && (
+                                <RailRow label="Project">
+                                    <Text className={styles.railText}>
+                                        {projectName}
+                                    </Text>
+                                </RailRow>
+                            )}
+                            {seenValue && (
+                                <RailRow label="Seen">
+                                    <Text className={styles.railText}>
+                                        {seenValue}
+                                    </Text>
+                                </RailRow>
+                            )}
+                            {item.linkedPrUrl && (
+                                <RailRow label="Pull request">
+                                    <Anchor
+                                        href={item.linkedPrUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className={styles.railLink}
+                                    >
                                         <MantineIcon
                                             icon={IconGitPullRequest}
                                             size={14}
+                                            stroke={1.4}
                                         />
                                         View PR
-                                    </Group>
-                                </Anchor>
-                            </RailField>
-                        )}
-                    </Stack>
+                                    </Anchor>
+                                </RailRow>
+                            )}
+                        </Stack>
+
+                        <Box className={styles.railActions}>
+                            <ReviewItemActions
+                                reviewItem={item}
+                                mode="drawer"
+                                hideWorkspaceLink
+                            />
+                        </Box>
+                    </Paper>
                 </Box>
             )}
         </MantineModal>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -37,7 +37,6 @@ import {
     getReviewReasoningText,
 } from './reviewItemDetails';
 import {
-    summarizeThreadReviewItems,
     THREAD_REVIEW_ITEM_STATUSES,
     threadReviewRootCauseColors,
     threadReviewRootCauseLabels,
@@ -45,9 +44,11 @@ import {
 } from './threadReviewContext';
 
 type Props = {
-    projectUuid: string;
-    agentUuid: string;
-    threadUuid: string;
+    // Thread coordinates are null for manual issues, which have no source
+    // thread — the modal then renders from the review item alone.
+    projectUuid: string | null;
+    agentUuid: string | null;
+    threadUuid: string | null;
     selectedReviewItemUuid: string;
     isOpen: boolean;
     onClose: () => void;
@@ -72,9 +73,10 @@ export const IssueDetailModal: FC<Props> = ({
     onClose,
 }) => {
     const [showEvidence, setShowEvidence] = useState(false);
+    const hasThread = Boolean(projectUuid && agentUuid && threadUuid);
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
-        projectUuid,
-        agentUuid,
+        projectUuid ?? '',
+        agentUuid ?? undefined,
         threadUuid,
     );
     const { data: reviewItems = [], isLoading: isLoadingItems } =
@@ -84,16 +86,12 @@ export const IssueDetailModal: FC<Props> = ({
         );
     const { data: projects = [] } = useProjects();
 
-    const reviewSummary = useMemo(
-        () => summarizeThreadReviewItems(reviewItems, threadUuid),
-        [reviewItems, threadUuid],
-    );
     const item = useMemo(
         () =>
-            reviewSummary.items.find(
+            reviewItems.find(
                 (reviewItem) => reviewItem.uuid === selectedReviewItemUuid,
             ) ?? null,
-        [reviewSummary.items, selectedReviewItemUuid],
+        [reviewItems, selectedReviewItemUuid],
     );
 
     const projectName = useMemo(() => {
@@ -113,7 +111,7 @@ export const IssueDetailModal: FC<Props> = ({
             : `${formatReviewDate(item.firstSeenAt)} – ${formatReviewDate(item.lastSeenAt)}`
         : null;
     const reasoningText = item ? getReviewReasoningText(item) : null;
-    const isLoading = isLoadingThread || isLoadingItems;
+    const isLoading = isLoadingItems || (hasThread && isLoadingThread);
 
     const workspaceUrl = item
         ? `/generalSettings/ai/reviews/${encodeURIComponent(item.fingerprint)}`
@@ -147,7 +145,7 @@ export const IssueDetailModal: FC<Props> = ({
                 ) : null
             }
         >
-            {isLoading || !item || !threadData ? (
+            {isLoading || !item || (hasThread && !threadData) ? (
                 <Group justify="center" p="5rem">
                     <Loader color="gray" size="sm" />
                 </Group>
@@ -183,45 +181,50 @@ export const IssueDetailModal: FC<Props> = ({
                                 <Text className={styles.sectionLabel}>
                                     {showEvidence ? 'Evidence' : 'Activity'}
                                 </Text>
-                                <Group gap="md" wrap="nowrap">
-                                    {showEvidence && (
-                                        <Anchor
-                                            href={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
+                                {hasThread && (
+                                    <Group gap="md" wrap="nowrap">
+                                        {showEvidence && (
+                                            <Anchor
+                                                href={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className={styles.toggle}
+                                            >
+                                                Open full thread
+                                                <MantineIcon
+                                                    icon={IconExternalLink}
+                                                    size={13}
+                                                    stroke={1.5}
+                                                />
+                                            </Anchor>
+                                        )}
+                                        <UnstyledButton
                                             className={styles.toggle}
+                                            onClick={() =>
+                                                setShowEvidence((open) => !open)
+                                            }
                                         >
-                                            Open full thread
                                             <MantineIcon
-                                                icon={IconExternalLink}
+                                                icon={
+                                                    showEvidence
+                                                        ? IconArrowLeft
+                                                        : IconMessageCircle2
+                                                }
                                                 size={13}
                                                 stroke={1.5}
                                             />
-                                        </Anchor>
-                                    )}
-                                    <UnstyledButton
-                                        className={styles.toggle}
-                                        onClick={() =>
-                                            setShowEvidence((open) => !open)
-                                        }
-                                    >
-                                        <MantineIcon
-                                            icon={
-                                                showEvidence
-                                                    ? IconArrowLeft
-                                                    : IconMessageCircle2
-                                            }
-                                            size={13}
-                                            stroke={1.5}
-                                        />
-                                        {showEvidence
-                                            ? 'Back to activity'
-                                            : 'Show evidence'}
-                                    </UnstyledButton>
-                                </Group>
+                                            {showEvidence
+                                                ? 'Back to activity'
+                                                : 'Show evidence'}
+                                        </UnstyledButton>
+                                    </Group>
+                                )}
                             </Group>
 
-                            {showEvidence ? (
+                            {showEvidence &&
+                            threadData &&
+                            projectUuid &&
+                            agentUuid ? (
                                 <Box
                                     className={`${styles.panel} ${styles.evidenceScroll}`}
                                 >

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -1,0 +1,234 @@
+import {
+    Anchor,
+    Box,
+    Group,
+    Loader,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconGitPullRequest } from '@tabler/icons-react';
+import { type FC, useMemo } from 'react';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { useProjects } from '../../../../../hooks/useProjects';
+import { useAiAgentAdminReviewItems } from '../../hooks/useAiAgentAdmin';
+import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
+import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
+import styles from './IssueDetailModal.module.css';
+import { RemediationActivityTimeline } from './RemediationActivityTimeline';
+import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
+import { ReviewItemActions } from './ReviewItemActions';
+import {
+    formatReviewDate,
+    getCompactIssueTitle,
+    getReviewReasoningText,
+} from './reviewItemDetails';
+import {
+    summarizeThreadReviewItems,
+    THREAD_REVIEW_ITEM_STATUSES,
+    threadReviewRootCauseColors,
+    threadReviewRootCauseLabels,
+} from './threadReviewContext';
+
+type Props = {
+    projectUuid: string;
+    agentUuid: string;
+    threadUuid: string;
+    selectedReviewItemUuid: string;
+    isOpen: boolean;
+    onClose: () => void;
+};
+
+const RailField: FC<{ label: string; children: React.ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Stack gap={4}>
+        <Text fz={10} fw={700} c="dimmed" tt="uppercase" lts={0.4}>
+            {label}
+        </Text>
+        {children}
+    </Stack>
+);
+
+export const IssueDetailModal: FC<Props> = ({
+    projectUuid,
+    agentUuid,
+    threadUuid,
+    selectedReviewItemUuid,
+    isOpen,
+    onClose,
+}) => {
+    const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
+        projectUuid,
+        agentUuid,
+        threadUuid,
+    );
+    const { data: reviewItems = [], isLoading: isLoadingItems } =
+        useAiAgentAdminReviewItems(
+            { statuses: THREAD_REVIEW_ITEM_STATUSES },
+            { enabled: isOpen },
+        );
+    const { data: projects = [] } = useProjects();
+
+    const reviewSummary = useMemo(
+        () => summarizeThreadReviewItems(reviewItems, threadUuid),
+        [reviewItems, threadUuid],
+    );
+    const item = useMemo(
+        () =>
+            reviewSummary.items.find(
+                (reviewItem) => reviewItem.uuid === selectedReviewItemUuid,
+            ) ?? null,
+        [reviewSummary.items, selectedReviewItemUuid],
+    );
+
+    const projectName = useMemo(() => {
+        if (!item) return null;
+        const reviewProjectUuid =
+            item.latestFinding?.projectUuid ?? item.projectUuid ?? projectUuid;
+        return (
+            projects.find((p) => p.projectUuid === reviewProjectUuid)?.name ??
+            null
+        );
+    }, [item, projects, projectUuid]);
+
+    const seenValue = item
+        ? formatReviewDate(item.firstSeenAt) ===
+          formatReviewDate(item.lastSeenAt)
+            ? formatReviewDate(item.lastSeenAt)
+            : `${formatReviewDate(item.firstSeenAt)} – ${formatReviewDate(item.lastSeenAt)}`
+        : null;
+    const reasoningText = item ? getReviewReasoningText(item) : null;
+    const isLoading = isLoadingThread || isLoadingItems;
+
+    return (
+        <MantineModal
+            opened={isOpen}
+            onClose={onClose}
+            size="80%"
+            title="Issue"
+            cancelLabel="Close"
+            bodyScrollAreaMaxHeight="calc(85vh - 140px)"
+        >
+            {isLoading || !item || !threadData ? (
+                <Group justify="center" p="xl">
+                    <Loader color="gray" />
+                </Group>
+            ) : (
+                <Box className={styles.layout}>
+                    <Stack className={styles.main} gap="lg">
+                        <Stack gap="xs">
+                            <Group gap={8} wrap="wrap">
+                                <CategoryBadge
+                                    variant="dot"
+                                    label={
+                                        threadReviewRootCauseLabels[
+                                            item.primaryRootCause
+                                        ]
+                                    }
+                                    color={
+                                        threadReviewRootCauseColors[
+                                            item.primaryRootCause
+                                        ]
+                                    }
+                                />
+                            </Group>
+                            <Title order={4} fw={600}>
+                                {getCompactIssueTitle(item)}
+                            </Title>
+                            {reasoningText && (
+                                <Text fz="sm" c="ldGray.7" lh={1.55}>
+                                    {reasoningText}
+                                </Text>
+                            )}
+                        </Stack>
+
+                        <Stack gap="xs">
+                            <Text
+                                fz={10}
+                                fw={700}
+                                tt="uppercase"
+                                lts={0.4}
+                                c="ldGray.7"
+                            >
+                                Evidence
+                            </Text>
+                            <AgentChatDisplay
+                                thread={threadData}
+                                projectUuid={projectUuid}
+                                agentUuid={agentUuid}
+                                renderArtifactsInline
+                                showAddToEvalsButton
+                            />
+                        </Stack>
+
+                        <Stack gap="xs">
+                            <Text
+                                fz={10}
+                                fw={700}
+                                tt="uppercase"
+                                lts={0.4}
+                                c="ldGray.7"
+                            >
+                                Activity
+                            </Text>
+                            <RemediationActivityTimeline reviewItem={item} />
+                        </Stack>
+                    </Stack>
+
+                    <Stack className={styles.rail} gap="lg">
+                        <RailField label="Status">
+                            <ReviewItemActions
+                                reviewItem={item}
+                                mode="drawer"
+                            />
+                        </RailField>
+                        <RailField label="Assignee">
+                            <ReviewAssigneeMenu
+                                projectUuid={item.projectUuid}
+                                fingerprint={item.fingerprint}
+                                assignedToUserUuid={item.assignedToUserUuid}
+                            />
+                        </RailField>
+                        {projectName && (
+                            <RailField label="Project">
+                                <Text fz="sm" fw={500} c="ldGray.9">
+                                    {projectName}
+                                </Text>
+                            </RailField>
+                        )}
+                        {seenValue && (
+                            <RailField label="Seen">
+                                <Text fz="sm" fw={500} c="ldGray.9">
+                                    {seenValue}
+                                </Text>
+                            </RailField>
+                        )}
+                        {item.linkedPrUrl && (
+                            <RailField label="Pull request">
+                                <Anchor
+                                    href={item.linkedPrUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    fz="sm"
+                                    fw={500}
+                                >
+                                    <Group gap={4} wrap="nowrap">
+                                        <MantineIcon
+                                            icon={IconGitPullRequest}
+                                            size={14}
+                                        />
+                                        View PR
+                                    </Group>
+                                </Anchor>
+                            </RailField>
+                        )}
+                    </Stack>
+                </Box>
+            )}
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/MarkResolvedModal.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 /**
- * Resolves a review item from the workspace: optionally merge the open PR, then
+ * Resolves an issue from the workspace: optionally merge the open PR, then
  * mark the item resolved (which also closes its remediation server-side).
  */
 export const MarkResolvedModal: FC<Props> = ({
@@ -50,13 +50,13 @@ export const MarkResolvedModal: FC<Props> = ({
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Resolve review item"
+            title="Resolve issue"
             icon={IconCircleCheck}
             size="md"
         >
             <Stack gap="md">
                 <Text size="sm" c="dimmed">
-                    Resolving marks this review item as done and closes its
+                    Resolving marks this issue as done and closes its
                     remediation.
                     {prUrl
                         ? ' Merge the pull request first, or resolve without merging.'

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
@@ -12,16 +12,16 @@
 .timeline::before {
     content: '';
     position: absolute;
-    left: 5px;
-    top: 10px;
-    bottom: 10px;
+    left: 3.5px;
+    top: 8px;
+    bottom: 8px;
     width: 1px;
     background: var(--mantine-color-ldGray-2);
 }
 
 .item {
     position: relative;
-    padding: 0 0 14px 24px;
+    padding: 0 0 10px 18px;
 }
 
 .item:last-child {
@@ -32,8 +32,8 @@
     position: absolute;
     left: 0;
     top: 4px;
-    width: 11px;
-    height: 11px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background: var(--mantine-color-body);
     border: 1.5px solid var(--mantine-color-ldGray-4);
@@ -58,8 +58,8 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: var(--mantine-spacing-xs);
-    font-size: 13px;
+    gap: 6px;
+    font-size: 12px;
     font-weight: 500;
     letter-spacing: -0.01em;
     color: var(--mantine-color-ldGray-9);
@@ -69,7 +69,7 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    font-size: 12px;
+    font-size: 11px;
     font-weight: 400;
     color: var(--mantine-color-ldGray-6);
 }
@@ -81,16 +81,16 @@
 
 .when {
     float: right;
-    font-size: 11px;
+    font-size: 10px;
     font-variant-numeric: tabular-nums;
     color: var(--mantine-color-ldGray-5);
     margin-left: var(--mantine-spacing-xs);
 }
 
 .meta {
-    font-size: 12px;
-    line-height: 1.45;
-    margin-top: 2px;
+    font-size: 11px;
+    line-height: 1.4;
+    margin-top: 1px;
     color: var(--mantine-color-ldGray-6);
     overflow-wrap: anywhere;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
@@ -55,10 +55,23 @@
 }
 
 .event {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--mantine-spacing-xs);
     font-size: 13px;
     font-weight: 500;
     letter-spacing: -0.01em;
     color: var(--mantine-color-ldGray-9);
+}
+
+.author {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--mantine-color-ldGray-6);
 }
 
 .item[data-live] .event,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.test.tsx
@@ -1,0 +1,102 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import { RemediationActivityTimeline } from './RemediationActivityTimeline';
+
+const mockUseAiAgentReviewItemActivity = vi.fn();
+
+vi.mock('../../hooks/useAiAgentAdmin', () => ({
+    useAiAgentReviewItemActivity: (...args: unknown[]) =>
+        mockUseAiAgentReviewItemActivity(...args),
+}));
+
+vi.mock('../../../../../hooks/useOrganizationUsers', () => ({
+    useOrgUsersByUuid: () =>
+        new Map([
+            [
+                'u1',
+                {
+                    userUuid: 'u1',
+                    firstName: 'Jo',
+                    lastName: 'V',
+                    email: 'jo@x.com',
+                },
+            ],
+        ]),
+}));
+
+const makeReviewItem = (
+    overrides: Partial<AiAgentReviewItemSummary> = {},
+): AiAgentReviewItemSummary =>
+    ({
+        uuid: 'fp-1',
+        fingerprint: 'fp-1',
+        organizationUuid: 'org-1',
+        projectUuid: 'project-1',
+        agentUuid: 'agent-1',
+        title: 'Wrong revenue',
+        description: 'desc',
+        primaryRootCause: 'semantic_layer',
+        status: 'open',
+        dismissedReason: null,
+        ownerType: 'semantic_layer_owner',
+        assignedToUserUuid: null,
+        firstSeenAt: new Date('2026-06-24T08:00:00.000Z'),
+        lastSeenAt: new Date('2026-06-24T08:00:00.000Z'),
+        findingCount: 1,
+        statusUpdatedAt: null,
+        statusUpdatedByUserUuid: null,
+        linkedIssueUrl: null,
+        linkedPrUrl: null,
+        prState: null,
+        prWritebackStatus: null,
+        prWritebackMessage: null,
+        boardPosition: null,
+        createdAt: new Date('2026-06-24T08:00:00.000Z'),
+        updatedAt: new Date('2026-06-24T08:00:00.000Z'),
+        writebackEligible: false,
+        writebackEligibility: {
+            eligible: false,
+            reason: 'reviews_disabled',
+            provider: null,
+            strategy: null,
+        },
+        remediation: null,
+        latestFinding: null,
+        ...overrides,
+    }) as AiAgentReviewItemSummary;
+
+describe('RemediationActivityTimeline', () => {
+    it('renders an issue event row with its author', () => {
+        mockUseAiAgentReviewItemActivity.mockReturnValue({
+            data: {
+                events: [
+                    {
+                        kind: 'issue',
+                        uuid: 'i1',
+                        fingerprint: 'fp-1',
+                        occurredAt: '2026-06-24T09:00:00Z',
+                        createdByUserUuid: 'u1',
+                        eventType: 'status_changed',
+                        payload: {
+                            from: 'open',
+                            to: 'in_progress',
+                            dismissedReason: null,
+                        },
+                    },
+                ],
+                liveState: null,
+                liveMessage: null,
+                verdictStale: false,
+            },
+        });
+
+        renderWithProviders(
+            <RemediationActivityTimeline reviewItem={makeReviewItem()} />,
+        );
+
+        expect(screen.getByText(/in progress/i)).toBeInTheDocument();
+        expect(screen.getByText(/Jo V/)).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -61,6 +61,16 @@ const issueEventRow = (
             };
         case 'recurred':
             return { label: 'Recurred — seen again', meta: null };
+        case 'priority_changed':
+            return {
+                label: 'Priority changed',
+                meta: `${event.payload.from} → ${event.payload.to}`,
+            };
+        case 'comment_added':
+            return {
+                label: 'Comment added',
+                meta: truncate(event.payload.body, 160),
+            };
         default:
             return { label: 'Activity', meta: null };
     }
@@ -82,11 +92,13 @@ const eventRow = (
     const remediation = reviewItem.remediation;
     switch (event.eventType) {
         case 'finding_opened': {
-            const threadPath = buildThreadPath(
-                reviewItem.projectUuid,
-                reviewItem.agentUuid,
-                event.payload.sourceThreadUuid,
-            );
+            const threadPath = event.payload.sourceThreadUuid
+                ? buildThreadPath(
+                      reviewItem.projectUuid,
+                      reviewItem.agentUuid,
+                      event.payload.sourceThreadUuid,
+                  )
+                : null;
             return {
                 label: 'Finding opened',
                 meta: (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -1,4 +1,5 @@
 import {
+    type AiAgentReviewActivityEvent,
     type AiAgentReviewItemSummary,
     type AiAgentReviewRemediationEvent,
     type AiAgentReviewRemediationLiveState,
@@ -7,6 +8,8 @@ import { Anchor, Box } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import { useMemo, type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
+import { useOrgUsersByUuid } from '../../../../../hooks/useOrganizationUsers';
 import { useAiAgentReviewItemActivity } from '../../hooks/useAiAgentAdmin';
 import styles from './RemediationActivityTimeline.module.css';
 
@@ -33,6 +36,34 @@ type TimelineRow = {
     meta: ReactNode;
     when: string;
     state: 'done' | 'live';
+    author: ReactNode;
+};
+
+const humanizeStatus = (status: string) => status.replaceAll('_', ' ');
+
+const issueEventRow = (
+    event: Extract<AiAgentReviewActivityEvent, { kind: 'issue' }>,
+): Pick<TimelineRow, 'label' | 'meta'> => {
+    switch (event.eventType) {
+        case 'created':
+            return { label: 'Issue opened', meta: null };
+        case 'status_changed':
+            return {
+                label: `Status changed to ${humanizeStatus(event.payload.to)}`,
+                meta: event.payload.from
+                    ? `from ${humanizeStatus(event.payload.from)}`
+                    : null,
+            };
+        case 'assignee_changed':
+            return {
+                label: event.payload.toUserUuid ? 'Assigned' : 'Unassigned',
+                meta: null,
+            };
+        case 'recurred':
+            return { label: 'Recurred — seen again', meta: null };
+        default:
+            return { label: 'Activity', meta: null };
+    }
 };
 
 const buildThreadPath = (
@@ -167,6 +198,7 @@ const liveRow = (
               : 'Re-running the original question in the preview…',
     when: 'now',
     state: 'live',
+    author: null,
 });
 
 type Props = {
@@ -174,8 +206,8 @@ type Props = {
 };
 
 export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
+    const usersByUuid = useOrgUsersByUuid();
     const { data } = useAiAgentReviewItemActivity(reviewItem.fingerprint, {
-        enabled: !!reviewItem.remediation,
         // Poll only while a step is in flight — settled feeds are static.
         refetchInterval: (latest) =>
             latest?.liveState === 'writeback'
@@ -185,39 +217,43 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
                   : false,
     });
 
-    const workThreadUrl = useMemo(() => {
-        const r = reviewItem.remediation;
-        if (
-            r?.previewProjectUuid &&
-            r.previewAgentUuid &&
-            r.previewThreadUuid
-        ) {
-            return `/projects/${r.previewProjectUuid}/ai-agents/${r.previewAgentUuid}/threads/${r.previewThreadUuid}`;
-        }
-        return null;
-    }, [reviewItem.remediation]);
-
     const rows = useMemo<TimelineRow[]>(() => {
         if (!data || data.events.length === 0) {
             return [];
         }
+        const authorNode = (userUuid: string | null): ReactNode => {
+            if (!userUuid) return null;
+            const user = usersByUuid.get(userUuid);
+            if (!user) return null;
+            const name =
+                `${user.firstName} ${user.lastName}`.trim() || user.email;
+            return (
+                <span className={styles.author}>
+                    <LightdashUserAvatar size="xs" radius="xl" name={name} />
+                    {name}
+                </span>
+            );
+        };
         let previous: Date | null = null;
         const eventRows = data.events.map((event) => {
             const when = formatWhen(event.occurredAt, previous);
             previous = dayjs(event.occurredAt).toDate();
+            const base =
+                event.kind === 'issue'
+                    ? issueEventRow(event)
+                    : eventRow(event, reviewItem);
             return {
                 key: event.uuid,
                 when,
                 state: 'done' as const,
-                ...eventRow(event, reviewItem),
+                author: authorNode(event.createdByUserUuid),
+                ...base,
             };
         });
-        const liveRows = data.liveState
+        return data.liveState
             ? [...eventRows, liveRow(data.liveState, data.liveMessage)]
             : eventRows;
-        if (!workThreadUrl) return liveRows;
-        return liveRows;
-    }, [data, reviewItem, workThreadUrl]);
+    }, [data, reviewItem, usersByUuid]);
 
     if (rows.length === 0) {
         return null;
@@ -234,7 +270,10 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
                 >
                     <span className={styles.when}>{row.when}</span>
                     <div className={styles.node} />
-                    <div className={styles.event}>{row.label}</div>
+                    <div className={styles.event}>
+                        {row.label}
+                        {row.author}
+                    </div>
                     {row.meta ? (
                         <div className={styles.meta}>{row.meta}</div>
                     ) : null}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.test.tsx
@@ -112,7 +112,7 @@ describe('ReviewItemActions', () => {
         );
 
         expect(
-            screen.getByText('No project is linked to this finding'),
+            screen.getByText('No project is linked to this issue'),
         ).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -30,11 +30,14 @@ import {
 type ReviewItemActionsProps = {
     reviewItem: AiAgentReviewItemSummary;
     mode?: 'table' | 'drawer';
+    /** Suppress the "Open workspace" button (e.g. when it lives elsewhere). */
+    hideWorkspaceLink?: boolean;
 };
 
 export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     reviewItem,
     mode = 'table',
+    hideWorkspaceLink = false,
 }) => {
     const createWriteback = useCreateAiAgentReviewItemWriteback();
     const updateStatus = useUpdateAiAgentReviewItemStatus();
@@ -143,42 +146,42 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                         {/* Once a remediation exists, the workspace is the one
                             place to view the PR and the verification — collapse
                             to a single entry point. */}
-                        {current.remediation ? (
-                            <Button
-                                component={Link}
-                                to={workspaceUrl}
-                                onClick={stopPropagation}
-                                size={buttonSize}
-                                fz="xs"
-                                variant="light"
-                                color="indigo"
-                                leftSection={
-                                    <MantineIcon
-                                        size="sm"
-                                        icon={IconLayoutColumns}
-                                    />
-                                }
-                            >
-                                Open workspace
-                            </Button>
-                        ) : (
-                            current.linkedPrUrl && (
-                                <Button
-                                    component="a"
-                                    href={current.linkedPrUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    onClick={stopPropagation}
-                                    size={buttonSize}
-                                    fz="xs"
-                                    loading={createWriteback.isLoading}
-                                    variant="subtle"
-                                    color="gray"
-                                >
-                                    View PR
-                                </Button>
-                            )
-                        )}
+                        {current.remediation
+                            ? !hideWorkspaceLink && (
+                                  <Button
+                                      component={Link}
+                                      to={workspaceUrl}
+                                      onClick={stopPropagation}
+                                      size={buttonSize}
+                                      fz="xs"
+                                      variant="light"
+                                      color="indigo"
+                                      leftSection={
+                                          <MantineIcon
+                                              size="sm"
+                                              icon={IconLayoutColumns}
+                                          />
+                                      }
+                                  >
+                                      Open workspace
+                                  </Button>
+                              )
+                            : current.linkedPrUrl && (
+                                  <Button
+                                      component="a"
+                                      href={current.linkedPrUrl}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      onClick={stopPropagation}
+                                      size={buttonSize}
+                                      fz="xs"
+                                      loading={createWriteback.isLoading}
+                                      variant="subtle"
+                                      color="gray"
+                                  >
+                                      View PR
+                                  </Button>
+                              )}
 
                         {canCreatePr && !current.linkedPrUrl && (
                             <Tooltip

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -44,7 +44,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     const navigate = useNavigate();
     const [previewOpen, setPreviewOpen] = useState(false);
 
-    const workspaceUrl = `/generalSettings/ai/reviews/${encodeURIComponent(
+    const workspaceUrl = `/generalSettings/ai/issues/${encodeURIComponent(
         reviewItem.fingerprint,
     )}`;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.test.tsx
@@ -25,6 +25,10 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
         mutate: vi.fn(),
         isLoading: false,
     }),
+    useUpdateAiAgentReviewItemPriority: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
 }));
 
 vi.mock('../../../../../hooks/useProjectUsersWithRolesV2', () => ({

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -91,13 +91,12 @@ type Props = {
 
 const toTarget = (
     item: AiAgentReviewItemSummary,
-): AiAgentAdminReviewItemPreviewTarget | null => {
+): AiAgentAdminReviewItemPreviewTarget => {
     const finding = item.latestFinding;
-    if (!finding) return null;
     return {
-        projectUuid: finding.projectUuid,
-        agentUuid: finding.agentUuid,
-        threadUuid: finding.threadUuid,
+        projectUuid: finding?.projectUuid ?? item.projectUuid,
+        agentUuid: finding?.agentUuid ?? item.agentUuid,
+        threadUuid: finding?.threadUuid ?? null,
         reviewItemUuid: item.uuid,
     };
 };
@@ -604,26 +603,23 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                                         </Text>
                                                     </Box>
                                                 ) : (
-                                                    displayed.map((item) => {
-                                                        const target =
-                                                            toTarget(item);
-                                                        return (
-                                                            <SortableCard
-                                                                key={item.uuid}
-                                                                item={item}
-                                                                isSelected={
-                                                                    selectedReviewItemUuid ===
-                                                                    item.uuid
-                                                                }
-                                                                onSelect={() => {
-                                                                    if (target)
-                                                                        onReviewItemSelect(
-                                                                            target,
-                                                                        );
-                                                                }}
-                                                            />
-                                                        );
-                                                    })
+                                                    displayed.map((item) => (
+                                                        <SortableCard
+                                                            key={item.uuid}
+                                                            item={item}
+                                                            isSelected={
+                                                                selectedReviewItemUuid ===
+                                                                item.uuid
+                                                            }
+                                                            onSelect={() =>
+                                                                onReviewItemSelect(
+                                                                    toTarget(
+                                                                        item,
+                                                                    ),
+                                                                )
+                                                            }
+                                                        />
+                                                    ))
                                                 )}
                                                 {hasMore && (
                                                     <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -37,6 +37,7 @@ import {
 } from './reviewItemDetails';
 import styles from './ReviewKanbanBoard.module.css';
 import { getStartWritebackKind, isWritebackRetry } from './reviewLane';
+import { ReviewPriorityMenu } from './ReviewPriorityMenu';
 
 type Props = {
     item: AiAgentReviewItemSummary;
@@ -86,7 +87,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
 
     const remediation = item.remediation;
     const hasWorkspace = Boolean(remediation);
-    const workspaceHref = `/generalSettings/ai/reviews/${encodeURIComponent(
+    const workspaceHref = `/generalSettings/ai/issues/${encodeURIComponent(
         item.fingerprint,
     )}`;
     const activityLabel = getWorkspaceActivityLabel(item);
@@ -178,6 +179,10 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                 label={
                                     reviewRootCauseLabels[item.primaryRootCause]
                                 }
+                            />
+                            <ReviewPriorityMenu
+                                fingerprint={item.fingerprint}
+                                priority={item.priority}
                             />
                         </Group>
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -180,10 +180,12 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     reviewRootCauseLabels[item.primaryRootCause]
                                 }
                             />
-                            <ReviewPriorityMenu
-                                fingerprint={item.fingerprint}
-                                priority={item.priority}
-                            />
+                            {!isExample && (
+                                <ReviewPriorityMenu
+                                    fingerprint={item.fingerprint}
+                                    priority={item.priority}
+                                />
+                            )}
                         </Group>
 
                         {!isExample && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
@@ -1,0 +1,65 @@
+import { type AiAgentReviewItemPriority } from '@lightdash/common';
+import { Menu, UnstyledButton } from '@mantine-8/core';
+import { type FC } from 'react';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
+import { useUpdateAiAgentReviewItemPriority } from '../../hooks/useAiAgentAdmin';
+import {
+    reviewPriorityColors,
+    reviewPriorityLabels,
+} from './reviewItemDetails';
+
+type Props = {
+    fingerprint: string;
+    priority: AiAgentReviewItemPriority;
+};
+
+const priorities: AiAgentReviewItemPriority[] = [
+    'urgent',
+    'high',
+    'medium',
+    'low',
+    'none',
+];
+
+export const ReviewPriorityMenu: FC<Props> = ({ fingerprint, priority }) => {
+    const updatePriority = useUpdateAiAgentReviewItemPriority();
+
+    return (
+        <Menu width={160} position="bottom-start" shadow="sm" withinPortal>
+            <Menu.Target>
+                <UnstyledButton
+                    aria-label="Change priority"
+                    onClick={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                >
+                    <CategoryBadge
+                        color={reviewPriorityColors[priority]}
+                        label={reviewPriorityLabels[priority]}
+                    />
+                </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+            >
+                {priorities.map((nextPriority) => (
+                    <Menu.Item
+                        key={nextPriority}
+                        disabled={
+                            nextPriority === priority ||
+                            updatePriority.isLoading
+                        }
+                        onClick={() =>
+                            updatePriority.mutate({
+                                fingerprint,
+                                priority: nextPriority,
+                            })
+                        }
+                    >
+                        {reviewPriorityLabels[nextPriority]}
+                    </Menu.Item>
+                ))}
+            </Menu.Dropdown>
+        </Menu>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewRemediationWorkspace.tsx
@@ -179,13 +179,13 @@ export const ReviewRemediationWorkspace = () => {
                 <PageBreadcrumbs
                     items={[
                         { title: 'Ask AI', to: '/generalSettings/ai/general' },
-                        { title: 'Reviews', to: '/generalSettings/ai/reviews' },
+                        { title: 'Issues', to: '/generalSettings/ai/issues' },
                         { title: 'Workspace', active: true },
                     ]}
                 />
                 <Text c="dimmed">
-                    No remediation workspace for this finding yet. Open a pull
-                    request from the reviews board first.
+                    No remediation workspace for this issue yet. Open a pull
+                    request from the issues board first.
                 </Text>
             </Stack>
         );
@@ -357,8 +357,8 @@ export const ReviewRemediationWorkspace = () => {
                                 to: '/generalSettings/ai/general',
                             },
                             {
-                                title: 'Reviews',
-                                to: '/generalSettings/ai/reviews',
+                                title: 'Issues',
+                                to: '/generalSettings/ai/issues',
                             },
                             { title: reviewItem.title, active: true },
                         ]}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewVerificationPanel.tsx
@@ -99,7 +99,7 @@ export const ReviewVerificationPanel: FC<Props> = ({
     const isResolved = reviewItem.status === 'resolved';
     const previewProjectUuid = remediation?.previewProjectUuid ?? null;
     const sourceThreadUrl =
-        remediation &&
+        remediation?.sourceThreadUuid &&
         `/projects/${remediation.sourceProjectUuid}/ai-agents/${remediation.sourceAgentUuid}/threads/${remediation.sourceThreadUuid}`;
 
     const { data: prDiff, isLoading: isLoadingPrDiff } =
@@ -373,11 +373,11 @@ export const ReviewVerificationPanel: FC<Props> = ({
                 {isResolved ? (
                     <Anchor
                         component={Link}
-                        to="/generalSettings/ai/reviews"
+                        to="/generalSettings/ai/issues"
                         fz="sm"
                         fw={500}
                     >
-                        Back to reviews
+                        Back to issues
                     </Anchor>
                 ) : (
                     <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.test.tsx
@@ -91,6 +91,23 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
         isLoading: false,
         mutate: vi.fn(),
     }),
+    useAddAiAgentReviewItemComment: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+    useUpdateAiAgentReviewItemPriority: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
+    useAiAgentReviewItemActivity: () => ({
+        data: {
+            events: [],
+            liveState: null,
+            liveMessage: null,
+            verdictStale: false,
+        },
+        isLoading: false,
+    }),
 }));
 
 vi.mock('../../hooks/useProjectAiAgents', () => ({

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -9,6 +9,7 @@ import {
     LoadingOverlay,
     Stack,
     Text,
+    Textarea,
     Title,
     Tooltip,
     UnstyledButton,
@@ -20,6 +21,7 @@ import {
     IconChevronRight,
     IconExternalLink,
     IconGitPullRequest,
+    IconSend,
     IconSettings,
     IconX,
 } from '@tabler/icons-react';
@@ -29,6 +31,7 @@ import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useProjects } from '../../../../../hooks/useProjects';
 import {
+    useAddAiAgentReviewItemComment,
     useAiAgentAdminAgents,
     useAiAgentAdminReviewItems,
 } from '../../hooks/useAiAgentAdmin';
@@ -44,6 +47,7 @@ import {
     getReviewReasoningText,
     getReviewSecondaryDetail,
 } from './reviewItemDetails';
+import { ReviewPriorityMenu } from './ReviewPriorityMenu';
 import { ReviewValidationList } from './ReviewValidationList';
 import styles from './ThreadPreviewSidebar.module.css';
 import {
@@ -141,6 +145,8 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
 }) => {
     const theme = useMantineTheme();
     const navigate = useNavigate();
+    const addComment = useAddAiAgentReviewItemComment();
+    const [commentBody, setCommentBody] = useState('');
     const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
         projectUuid,
         agentUuid,
@@ -315,6 +321,14 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                         ]
                                                     }
                                                 />
+                                                <ReviewPriorityMenu
+                                                    fingerprint={
+                                                        selectedReviewItem.fingerprint
+                                                    }
+                                                    priority={
+                                                        selectedReviewItem.priority
+                                                    }
+                                                />
                                             </Group>
 
                                             <Title order={5} fw={600}>
@@ -477,22 +491,62 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         </Collapse>
                                     )}
 
-                                    {selectedReviewItem.remediation && (
-                                        <Stack gap={6} pt="xs">
-                                            <Text
-                                                size="10px"
-                                                fw={700}
-                                                tt="uppercase"
-                                                lts={0.4}
-                                                c="ldGray.7"
+                                    <Stack gap={6} pt="xs">
+                                        <Text
+                                            size="10px"
+                                            fw={700}
+                                            tt="uppercase"
+                                            lts={0.4}
+                                            c="ldGray.7"
+                                        >
+                                            Activity
+                                        </Text>
+                                        <RemediationActivityTimeline
+                                            reviewItem={selectedReviewItem}
+                                        />
+                                        <Textarea
+                                            value={commentBody}
+                                            onChange={(event) =>
+                                                setCommentBody(
+                                                    event.currentTarget.value,
+                                                )
+                                            }
+                                            minRows={2}
+                                            placeholder="Add a comment"
+                                        />
+                                        <Group justify="flex-end">
+                                            <Button
+                                                size="compact-xs"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconSend}
+                                                    />
+                                                }
+                                                loading={addComment.isLoading}
+                                                disabled={!commentBody.trim()}
+                                                onClick={() => {
+                                                    const body =
+                                                        commentBody.trim();
+                                                    if (!body) return;
+                                                    addComment.mutate(
+                                                        {
+                                                            fingerprint:
+                                                                selectedReviewItem.fingerprint,
+                                                            body,
+                                                        },
+                                                        {
+                                                            onSuccess: () =>
+                                                                setCommentBody(
+                                                                    '',
+                                                                ),
+                                                        },
+                                                    );
+                                                }}
                                             >
-                                                Activity
-                                            </Text>
-                                            <RemediationActivityTimeline
-                                                reviewItem={selectedReviewItem}
-                                            />
-                                        </Stack>
-                                    )}
+                                                Comment
+                                            </Button>
+                                        </Group>
+                                    </Stack>
                                 </Stack>
                             </Stack>
 
@@ -507,7 +561,7 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                         align="center"
                                     >
                                         <Title order={6} fw={600}>
-                                            Review findings
+                                            Issues
                                         </Title>
                                         <Badge variant="light" color="violet">
                                             {reviewSummary.findingCount}
@@ -639,11 +693,11 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
                                                                 reviewItem.uuid,
                                                             );
                                                             void navigate(
-                                                                `/generalSettings/ai/reviews?${params.toString()}`,
+                                                                `/generalSettings/ai/issues?${params.toString()}`,
                                                             );
                                                         }}
                                                     >
-                                                        View review
+                                                        View issue
                                                     </Button>
 
                                                     {reviewItem.linkedPrUrl && (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/exampleData.ts
@@ -22,6 +22,7 @@ const makeExampleReviewItem = (
         >,
 ): AiAgentReviewItemSummary => ({
     fingerprint: overrides.uuid,
+    source: 'ai_finding',
     organizationUuid: '',
     projectUuid: null,
     agentUuid: null,
@@ -31,6 +32,7 @@ const makeExampleReviewItem = (
     firstSeenAt: EXAMPLE_SEEN_AT,
     lastSeenAt: EXAMPLE_SEEN_AT,
     findingCount: 1,
+    priority: 'none',
     statusUpdatedAt: EXAMPLE_SEEN_AT,
     statusUpdatedByUserUuid: null,
     linkedIssueUrl: null,
@@ -47,6 +49,7 @@ const makeExampleReviewItem = (
     },
     remediation: null,
     boardPosition: null,
+    createdByUserUuid: null,
     createdAt: EXAMPLE_SEEN_AT,
     updatedAt: EXAMPLE_SEEN_AT,
     latestFinding: null,

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/onboarding/steps.tsx
@@ -2,7 +2,7 @@ import { Stack, Text } from '@mantine-8/core';
 import { type GuidedTourStep } from '../../../../../../components/common/GuidedTour';
 import { ReviewsLoopDiagram } from './ReviewsLoopDiagram';
 
-// First-visit tour for the Reviews board. All step copy lives here.
+// First-visit tour for the Issues board. All step copy lives here.
 export const REVIEWS_TOUR_STEPS: GuidedTourStep[] = [
     {
         target: '[data-tour="reviews-intro"]',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -1,5 +1,6 @@
 import {
     type AiAgentRecommendationAction,
+    type AiAgentReviewItemPriority,
     type AiAgentReviewItemSummary,
     type AiAgentReviewItemWritebackBlockedReason,
     type AiAgentRootCause,
@@ -37,13 +38,30 @@ export const reviewRootCauseColors: Record<AiAgentRootCause, string> = {
     ambiguous: 'gray',
 };
 
+export const reviewPriorityLabels: Record<AiAgentReviewItemPriority, string> = {
+    urgent: 'Urgent',
+    high: 'High',
+    medium: 'Medium',
+    low: 'Low',
+    none: 'No priority',
+};
+
+export const reviewPriorityColors: Record<AiAgentReviewItemPriority, string> = {
+    urgent: 'red',
+    high: 'orange',
+    medium: 'yellow',
+    low: 'blue',
+    none: 'gray',
+};
+
 export const writebackBlockedReasonLabels: Record<
     AiAgentReviewItemWritebackBlockedReason,
     string
 > = {
-    reviews_disabled: 'Reviews are not enabled for this organization',
+    reviews_disabled: 'Issues are not enabled for this organization',
     unsupported_root_cause: 'No writeback strategy for this root cause',
-    missing_project: 'No project is linked to this finding',
+    missing_project: 'No project is linked to this issue',
+    missing_agent: 'No agent is linked to this issue',
     missing_project_context_entry: 'No project context entry was generated',
     project_context_disabled: 'Project context is not enabled',
     unsupported_source_control: 'Project is not connected to GitHub or GitLab',
@@ -52,7 +70,7 @@ export const writebackBlockedReasonLabels: Record<
     pull_request_open: 'A pull request is already open',
     source_thread_writeback_exists:
         'The agent already opened a pull request in the source thread',
-    terminal_state: 'Finding is already closed',
+    terminal_state: 'Issue is already closed',
     writeback_in_progress: 'Writeback is already in progress',
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -164,8 +164,10 @@ const getTargetLabel = (targetRefs: AiAgentTargetRef[]): string | null => {
 };
 
 const isTriageReviewItem = (reviewItem: AiAgentReviewItemSummary): boolean =>
-    reviewItem.primaryRootCause === 'ambiguous' ||
-    reviewItem.latestFinding?.fixTargets.includes('feedback_needed') === true;
+    reviewItem.source !== 'manual' &&
+    (reviewItem.primaryRootCause === 'ambiguous' ||
+        reviewItem.latestFinding?.fixTargets.includes('feedback_needed') ===
+            true);
 
 export const getIssueTitle = (reviewItem: AiAgentReviewItemSummary): string => {
     if (isTriageReviewItem(reviewItem)) {
@@ -197,6 +199,10 @@ export const getCompactIssueTitle = (
 export const getWhyText = (reviewItem: AiAgentReviewItemSummary): string => {
     if (isTriageReviewItem(reviewItem)) {
         return 'Could be a real failure or a normal change in user intent.';
+    }
+
+    if (reviewItem.source === 'manual') {
+        return reviewItem.description || 'Manually filed issue.';
     }
 
     return (

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiGeneralSettingsPage.tsx
@@ -250,13 +250,13 @@ export const AiGeneralSettingsPage = () => {
                                         {settings.aiAgentReviewsEnabled && (
                                             <>
                                                 {' '}
-                                                See findings in{' '}
+                                                See issues in{' '}
                                                 <Anchor
                                                     component={Link}
-                                                    to="/generalSettings/ai/reviews"
+                                                    to="/generalSettings/ai/issues"
                                                     fz="inherit"
                                                 >
-                                                    Ask AI &gt; Reviews
+                                                    Ask AI &gt; Issues
                                                 </Anchor>
                                                 .
                                             </>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
@@ -47,7 +47,7 @@ vi.mock('../AiAgentAdminReviewItemsTable', () => ({
                     })
                 }
             >
-                Open review
+                Open issue
             </button>
         );
     },
@@ -76,14 +76,14 @@ describe('AiReviewsSettingsPage', () => {
         localStorage.clear();
     });
 
-    it('opens the drawer after selecting a finding from the table', async () => {
+    it('opens the drawer after selecting an issue from the table', async () => {
         const user = userEvent.setup();
 
         renderWithProviders(
-            <MemoryRouter initialEntries={['/generalSettings/ai/reviews']}>
+            <MemoryRouter initialEntries={['/generalSettings/ai/issues']}>
                 <Routes>
                     <Route
-                        path="/generalSettings/ai/reviews"
+                        path="/generalSettings/ai/issues"
                         element={<AiReviewsSettingsPage />}
                     />
                 </Routes>
@@ -92,7 +92,7 @@ describe('AiReviewsSettingsPage', () => {
 
         // Board is the default view; switch to the table for this flow.
         await user.click(screen.getByText('Table'));
-        await user.click(screen.getByRole('button', { name: 'Open review' }));
+        await user.click(screen.getByRole('button', { name: 'Open issue' }));
 
         expect(
             await screen.findByText('Modal thread thread-1 / demo-review:1'),
@@ -103,12 +103,12 @@ describe('AiReviewsSettingsPage', () => {
         renderWithProviders(
             <MemoryRouter
                 initialEntries={[
-                    '/generalSettings/ai/reviews?reviewProjectUuid=project-1&reviewAgentUuid=agent-1&reviewThreadUuid=thread-1&reviewItemUuid=demo-review:1',
+                    '/generalSettings/ai/issues?reviewProjectUuid=project-1&reviewAgentUuid=agent-1&reviewThreadUuid=thread-1&reviewItemUuid=demo-review:1',
                 ]}
             >
                 <Routes>
                     <Route
-                        path="/generalSettings/ai/reviews"
+                        path="/generalSettings/ai/issues"
                         element={<AiReviewsSettingsPage />}
                     />
                 </Routes>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
@@ -57,15 +57,17 @@ vi.mock('../ReviewKanbanBoard', () => ({
     ReviewKanbanBoard: () => <div>Board view</div>,
 }));
 
-vi.mock('../ThreadPreviewSidebar', () => ({
-    ThreadPreviewSidebar: (props: {
+vi.mock('../IssueDetailModal', () => ({
+    IssueDetailModal: (props: {
         threadUuid: string;
-        selectedReviewItemUuid?: string;
-    }) => (
-        <div>
-            Sidebar thread {props.threadUuid} / {props.selectedReviewItemUuid}
-        </div>
-    ),
+        selectedReviewItemUuid: string;
+        isOpen: boolean;
+    }) =>
+        props.isOpen ? (
+            <div>
+                Modal thread {props.threadUuid} / {props.selectedReviewItemUuid}
+            </div>
+        ) : null,
 }));
 
 describe('AiReviewsSettingsPage', () => {
@@ -93,7 +95,7 @@ describe('AiReviewsSettingsPage', () => {
         await user.click(screen.getByRole('button', { name: 'Open review' }));
 
         expect(
-            await screen.findByText('Sidebar thread thread-1 / demo-review:1'),
+            await screen.findByText('Modal thread thread-1 / demo-review:1'),
         ).toBeInTheDocument();
     });
 
@@ -114,7 +116,7 @@ describe('AiReviewsSettingsPage', () => {
         );
 
         expect(
-            screen.getByText('Sidebar thread thread-1 / demo-review:1'),
+            screen.getByText('Modal thread thread-1 / demo-review:1'),
         ).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -83,7 +83,9 @@ export const AiReviewsSettingsPage = () => {
         const threadUuid = searchParams.get('reviewThreadUuid');
         const reviewItemUuid = searchParams.get('reviewItemUuid');
 
-        if (!projectUuid || !agentUuid || !threadUuid || !reviewItemUuid) {
+        // Manual issues have no source thread, so only the item uuid is
+        // required; thread coordinates are present for AI findings only.
+        if (!reviewItemUuid) {
             return null;
         }
 
@@ -141,9 +143,15 @@ export const AiReviewsSettingsPage = () => {
         nextParams.delete('reviewItemUuid');
 
         if (reviewItem) {
-            nextParams.set('reviewProjectUuid', reviewItem.projectUuid);
-            nextParams.set('reviewAgentUuid', reviewItem.agentUuid);
-            nextParams.set('reviewThreadUuid', reviewItem.threadUuid);
+            if (reviewItem.projectUuid) {
+                nextParams.set('reviewProjectUuid', reviewItem.projectUuid);
+            }
+            if (reviewItem.agentUuid) {
+                nextParams.set('reviewAgentUuid', reviewItem.agentUuid);
+            }
+            if (reviewItem.threadUuid) {
+                nextParams.set('reviewThreadUuid', reviewItem.threadUuid);
+            }
             if (reviewItem.reviewItemUuid) {
                 nextParams.set('reviewItemUuid', reviewItem.reviewItemUuid);
             }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,12 +1,36 @@
-import { Button, Group, SegmentedControl, Stack, Text } from '@mantine-8/core';
+import {
+    type AiAgentReviewItemPriority,
+    type AiAgentRootCause,
+} from '@lightdash/common';
+import {
+    Button,
+    Group,
+    SegmentedControl,
+    Select,
+    Stack,
+    Text,
+    Textarea,
+    TextInput,
+} from '@mantine-8/core';
 import { useLocalStorage } from '@mantine-8/hooks';
-import { IconLayoutKanban, IconRoute, IconTable } from '@tabler/icons-react';
-import { useMemo } from 'react';
+import {
+    IconLayoutKanban,
+    IconPlus,
+    IconRoute,
+    IconTable,
+} from '@tabler/icons-react';
+import { useMemo, useState, type FormEvent } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../../components/common/MantineModal';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
+import { useProjects } from '../../../../../../hooks/useProjects';
+import {
+    useAiAgentAdminAgents,
+    useCreateAiAgentReviewItem,
+} from '../../../hooks/useAiAgentAdmin';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
@@ -16,11 +40,41 @@ import { REVIEWS_TOUR_STEPS } from '../onboarding';
 import { ReviewKanbanBoard } from '../ReviewKanbanBoard';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 
+const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
+    { value: 'semantic_layer', label: 'Semantic layer' },
+    { value: 'project_context', label: 'Project context' },
+    { value: 'agent_configuration', label: 'Agent configuration' },
+    { value: 'product_capability', label: 'Product capability' },
+    { value: 'runtime_reliability', label: 'Runtime reliability' },
+    { value: 'feedback_quality', label: 'Feedback quality' },
+    { value: 'not_a_failure', label: 'Not a failure' },
+    { value: 'ambiguous', label: 'Ambiguous' },
+];
+
+const priorityOptions: { value: AiAgentReviewItemPriority; label: string }[] = [
+    { value: 'none', label: 'None' },
+    { value: 'urgent', label: 'Urgent' },
+    { value: 'high', label: 'High' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'low', label: 'Low' },
+];
+
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
+    const { data: projects = [] } = useProjects();
+    const { data: agents = [] } = useAiAgentAdminAgents();
+    const createIssue = useCreateAiAgentReviewItem();
     const [searchParams, setSearchParams] = useSearchParams();
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const [agentUuid, setAgentUuid] = useState<string | null>(null);
+    const [primaryRootCause, setPrimaryRootCause] =
+        useState<AiAgentRootCause | null>(null);
+    const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
 
-    // The selected review item and the sidebar's open state are derived
+    // The selected issue and the sidebar's open state are derived
     // directly from the URL — every mutation (deep-link, row select, close)
     // goes through `setSearchParams`, so there's no separate state to sync.
     const selectedReviewItem = useMemo(() => {
@@ -108,6 +162,41 @@ export const AiReviewsSettingsPage = () => {
         updateReviewSearchParams(null);
     };
 
+    const resetCreateForm = () => {
+        setTitle('');
+        setDescription('');
+        setProjectUuid(null);
+        setAgentUuid(null);
+        setPrimaryRootCause(null);
+        setPriority('none');
+    };
+
+    const handleCreateIssue = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!projectUuid || title.trim().length === 0) return;
+        createIssue.mutate(
+            {
+                title: title.trim(),
+                description: description.trim() || null,
+                projectUuid,
+                agentUuid,
+                assignedToUserUuid: null,
+                primaryRootCause,
+                priority,
+            },
+            {
+                onSuccess: () => {
+                    resetCreateForm();
+                    setIsCreateOpen(false);
+                },
+            },
+        );
+    };
+
+    const agentOptions = agents
+        .filter((agent) => !projectUuid || agent.projectUuid === projectUuid)
+        .map((agent) => ({ value: agent.uuid, label: agent.name }));
+
     return (
         <Stack mb="lg" gap="md">
             <Stack gap={4} data-tour="reviews-intro">
@@ -118,10 +207,17 @@ export const AiReviewsSettingsPage = () => {
                                 title: 'Ask AI',
                                 to: '/generalSettings/ai/general',
                             },
-                            { title: 'Reviews', active: true },
+                            { title: 'Issues', active: true },
                         ]}
                     />
                     <Group gap="xs">
+                        <Button
+                            size="compact-xs"
+                            leftSection={<MantineIcon icon={IconPlus} />}
+                            onClick={() => setIsCreateOpen(true)}
+                        >
+                            New issue
+                        </Button>
                         <SegmentedControl
                             size="xs"
                             value={effectiveView}
@@ -164,9 +260,9 @@ export const AiReviewsSettingsPage = () => {
                 </Group>
 
                 <Text c="dimmed" fz="sm" maw={760}>
-                    An actionable queue of answers your agents probably got
-                    wrong. Click a finding to inspect the thread, metadata, and
-                    suggested fix.{' '}
+                    An actionable queue of data issues from AI findings and
+                    human asks. Open an issue to inspect the thread, metadata,
+                    and suggested fix.{' '}
                     <Text span fw={600} fz="inherit">
                         Semantic layer
                     </Text>{' '}
@@ -211,6 +307,97 @@ export const AiReviewsSettingsPage = () => {
                     onClose={handleCloseSidebar}
                 />
             )}
+
+            <MantineModal
+                opened={isCreateOpen}
+                onClose={() => setIsCreateOpen(false)}
+                title="New issue"
+                icon={IconPlus}
+                size="lg"
+            >
+                <form onSubmit={handleCreateIssue}>
+                    <Stack gap="sm">
+                        <TextInput
+                            label="Title"
+                            value={title}
+                            onChange={(event) =>
+                                setTitle(event.currentTarget.value)
+                            }
+                            required
+                            autoFocus
+                        />
+                        <Textarea
+                            label="Description"
+                            value={description}
+                            onChange={(event) =>
+                                setDescription(event.currentTarget.value)
+                            }
+                            minRows={4}
+                        />
+                        <Select
+                            label="Project"
+                            data={projects.map((project) => ({
+                                value: project.projectUuid,
+                                label: project.name,
+                            }))}
+                            value={projectUuid}
+                            onChange={(value) => {
+                                setProjectUuid(value);
+                                setAgentUuid(null);
+                            }}
+                            searchable
+                            required
+                        />
+                        <Select
+                            label="Agent"
+                            data={agentOptions}
+                            value={agentUuid}
+                            onChange={setAgentUuid}
+                            searchable
+                            clearable
+                            disabled={!projectUuid}
+                        />
+                        <Select
+                            label="Root cause"
+                            data={rootCauseOptions}
+                            value={primaryRootCause}
+                            onChange={(value) =>
+                                setPrimaryRootCause(
+                                    value as AiAgentRootCause | null,
+                                )
+                            }
+                            clearable
+                        />
+                        <Select
+                            label="Priority"
+                            data={priorityOptions}
+                            value={priority}
+                            onChange={(value) =>
+                                setPriority(
+                                    (value ??
+                                        'none') as AiAgentReviewItemPriority,
+                                )
+                            }
+                        />
+                        <Group justify="flex-end">
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                onClick={() => setIsCreateOpen(false)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                loading={createIssue.isLoading}
+                                disabled={!projectUuid || !title.trim()}
+                            >
+                                Create issue
+                            </Button>
+                        </Group>
+                    </Stack>
+                </form>
+            </MantineModal>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,29 +1,20 @@
-import {
-    Button,
-    Drawer,
-    Group,
-    SegmentedControl,
-    Stack,
-    Text,
-} from '@mantine-8/core';
+import { Button, Group, SegmentedControl, Stack, Text } from '@mantine-8/core';
 import { useLocalStorage } from '@mantine-8/hooks';
 import { IconLayoutKanban, IconRoute, IconTable } from '@tabler/icons-react';
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
-import { NAVBAR_HEIGHT } from '../../../../../../components/common/Page/constants';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
 } from '../AiAgentAdminReviewItemsTable';
+import { IssueDetailModal } from '../IssueDetailModal';
 import { REVIEWS_TOUR_STEPS } from '../onboarding';
 import { ReviewKanbanBoard } from '../ReviewKanbanBoard';
-import { ThreadPreviewSidebar } from '../ThreadPreviewSidebar';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
-import drawerClasses from './ThreadPreviewDrawer.module.css';
 
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
@@ -210,35 +201,16 @@ export const AiReviewsSettingsPage = () => {
                 onClose={closeTour}
             />
 
-            <Drawer
-                opened={isSidebarOpen}
-                onClose={handleCloseSidebar}
-                position="right"
-                size="lg"
-                withCloseButton={false}
-                padding={0}
-                classNames={{
-                    inner: drawerClasses.inner,
-                    overlay: drawerClasses.overlay,
-                }}
-                __vars={{
-                    '--drawer-top-offset': `${NAVBAR_HEIGHT}px`,
-                }}
-            >
-                {!!selectedReviewItem && (
-                    <ThreadPreviewSidebar
-                        projectUuid={selectedReviewItem.projectUuid}
-                        agentUuid={selectedReviewItem.agentUuid}
-                        threadUuid={selectedReviewItem.threadUuid}
-                        selectedReviewItemUuid={
-                            selectedReviewItem.reviewItemUuid ?? undefined
-                        }
-                        isOpen={isSidebarOpen}
-                        onClose={handleCloseSidebar}
-                        showAddToEvalsButton
-                    />
-                )}
-            </Drawer>
+            {!!selectedReviewItem && (
+                <IssueDetailModal
+                    projectUuid={selectedReviewItem.projectUuid}
+                    agentUuid={selectedReviewItem.agentUuid}
+                    threadUuid={selectedReviewItem.threadUuid}
+                    selectedReviewItemUuid={selectedReviewItem.reviewItemUuid}
+                    isOpen={isSidebarOpen}
+                    onClose={handleCloseSidebar}
+                />
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ReviewFindingsPreview.tsx
@@ -136,7 +136,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
             </Box>
 
             <Group justify="space-between" px="xs" pt={4} pb={2} wrap="nowrap">
-                <Text className={classes.heading}>Review findings</Text>
+                <Text className={classes.heading}>Issues</Text>
                 <Text className={classes.heading}>{totalOpen} open</Text>
             </Group>
 
@@ -144,7 +144,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
                 <Box
                     key={item.fingerprint}
                     component={Link}
-                    to={`/generalSettings/ai/reviews/${encodeURIComponent(
+                    to={`/generalSettings/ai/issues/${encodeURIComponent(
                         item.fingerprint,
                     )}`}
                     className={classes.row}
@@ -167,7 +167,7 @@ export const ReviewFindingsPreview: FC<Props> = ({
 
             <Box component={Link} to={reviewsUrl} className={classes.footer}>
                 <Text size="xs" fw={500}>
-                    View all reviews
+                    View all issues
                 </Text>
                 <MantineIcon icon={IconArrowRight} size={12} />
             </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentAdmin.ts
@@ -15,8 +15,11 @@ import {
     type ApiAiAgentVerifiedArtifactsResponse,
     type ApiError,
     type ApiUpstreamDiffResponse,
+    type CreateAiAgentReviewItemComment,
+    type CreateAiAgentReviewItem,
     type ReorderAiAgentReviewItems,
     type UpdateAiAgentReviewItemAssignee,
+    type UpdateAiAgentReviewItemPriority,
     type UpdateAiAgentReviewItemStatus,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
@@ -175,6 +178,44 @@ const getAiAgentAdminReviewItems = async (args: {
 
 const AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY = 'ai-agent-admin-review-items';
 
+const createAiAgentReviewItem = async (body: CreateAiAgentReviewItem) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items`,
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+};
+
+export const useCreateAiAgentReviewItem = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemResponse['results'],
+        ApiError,
+        CreateAiAgentReviewItem
+    >({
+        mutationFn: createAiAgentReviewItem,
+        onSuccess: (createdItem) => {
+            showToastSuccess({ title: 'Issue created' });
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item', createdItem.fingerprint],
+                createdItem,
+            );
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to create issue',
+                apiError: error,
+            });
+        },
+    });
+};
+
 export const updateCachedReviewItemLists = (
     queryClient: QueryClient,
     updatedItem: AiAgentReviewItemSummary,
@@ -319,6 +360,47 @@ export const useRetestAiAgentReviewRemediation = () => {
         },
         onError: ({ error }) => {
             showToastApiError({ title: 'Failed to retest', apiError: error });
+        },
+    });
+};
+
+const addAiAgentReviewItemComment = async (args: {
+    fingerprint: string;
+    body: string;
+}) => {
+    return lightdashApi<ApiAiAgentReviewItemActivityResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(
+            args.fingerprint,
+        )}/comments`,
+        method: 'POST',
+        body: JSON.stringify({
+            body: args.body,
+        } satisfies CreateAiAgentReviewItemComment),
+    });
+};
+
+export const useAddAiAgentReviewItemComment = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemActivityResponse['results'],
+        ApiError,
+        { fingerprint: string; body: string }
+    >({
+        mutationFn: addAiAgentReviewItemComment,
+        onSuccess: (activity, { fingerprint }) => {
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item-activity', fingerprint],
+                activity,
+            );
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to add comment',
+                apiError: error,
+            });
         },
     });
 };
@@ -516,6 +598,53 @@ export const useUpdateAiAgentReviewItemAssignee = () => {
         onError: ({ error }) => {
             showToastApiError({
                 title: 'Failed to update assignee',
+                apiError: error,
+            });
+        },
+    });
+};
+
+const updateAiAgentReviewItemPriority = async (args: {
+    fingerprint: string;
+    priority: UpdateAiAgentReviewItemPriority['priority'];
+}) => {
+    return lightdashApi<ApiAiAgentReviewItemResponse['results']>({
+        version: 'v1',
+        url: `/aiAgents/admin/review-items/${encodeURIComponent(args.fingerprint)}/priority`,
+        method: 'PATCH',
+        body: JSON.stringify({
+            priority: args.priority,
+        } satisfies UpdateAiAgentReviewItemPriority),
+    });
+};
+
+export const useUpdateAiAgentReviewItemPriority = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<
+        ApiAiAgentReviewItemResponse['results'],
+        ApiError,
+        {
+            fingerprint: string;
+            priority: UpdateAiAgentReviewItemPriority['priority'];
+        }
+    >({
+        mutationFn: updateAiAgentReviewItemPriority,
+        onSuccess: (updatedItem, { fingerprint }) => {
+            showToastSuccess({ title: 'Priority updated' });
+            queryClient.setQueryData(
+                ['ai-agent-admin-review-item', fingerprint],
+                updatedItem,
+            );
+            updateCachedReviewItemLists(queryClient, updatedItem);
+            void queryClient.invalidateQueries({
+                queryKey: [AI_AGENT_ADMIN_REVIEW_ITEMS_QUERY_KEY],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update priority',
                 apiError: error,
             });
         },

--- a/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
+++ b/packages/frontend/src/features/pullRequests/components/PullRequestsPage.tsx
@@ -294,7 +294,7 @@ const PullRequestsPage: FC<Props> = ({ projectUuid }) => {
                                                     variant="subtle"
                                                     color="gray"
                                                 >
-                                                    View review
+                                                    View issue
                                                 </Button>
                                             )}
                                             {threadPreviewTarget && (

--- a/packages/frontend/src/features/pullRequests/utils.test.ts
+++ b/packages/frontend/src/features/pullRequests/utils.test.ts
@@ -51,7 +51,7 @@ describe('pullRequests utils', () => {
         });
     });
 
-    it('builds a reviews deep link for pull requests tied to findings', () => {
+    it('builds an issues deep link for pull requests tied to findings', () => {
         expect(
             getReviewPath(
                 makeRow({
@@ -69,7 +69,7 @@ describe('pullRequests utils', () => {
                 }),
             ),
         ).toBe(
-            '/generalSettings/ai/reviews?reviewProjectUuid=review-project-1&reviewAgentUuid=review-agent-1&reviewThreadUuid=review-thread-1&reviewItemUuid=fingerprint-1',
+            '/generalSettings/ai/issues?reviewProjectUuid=review-project-1&reviewAgentUuid=review-agent-1&reviewThreadUuid=review-thread-1&reviewItemUuid=fingerprint-1',
         );
     });
 

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -84,7 +84,7 @@ export const getThreadPath = (row: PullRequestRow): string | null => {
 export const getThreadPreviewTarget = (
     row: PullRequestRow,
 ): PullRequestThreadPreviewTarget | null => {
-    if (row.reviewContext) {
+    if (row.reviewContext?.sourceThreadUuid) {
         return {
             projectUuid: row.reviewContext.sourceProjectUuid,
             agentUuid: row.reviewContext.sourceAgentUuid,
@@ -112,8 +112,10 @@ export const getReviewPath = (row: PullRequestRow): string | null => {
     const params = new URLSearchParams();
     params.set('reviewProjectUuid', row.reviewContext.sourceProjectUuid);
     params.set('reviewAgentUuid', row.reviewContext.sourceAgentUuid);
-    params.set('reviewThreadUuid', row.reviewContext.sourceThreadUuid);
+    if (row.reviewContext.sourceThreadUuid) {
+        params.set('reviewThreadUuid', row.reviewContext.sourceThreadUuid);
+    }
     params.set('reviewItemUuid', row.reviewContext.reviewItemUuid);
 
-    return `/generalSettings/ai/reviews?${params.toString()}`;
+    return `/generalSettings/ai/issues?${params.toString()}`;
 };

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -413,10 +413,10 @@ export const useSettingsNavigation = (
 
             if (shouldShowAiAgentReviews) {
                 aiChildren.push({
-                    label: 'Reviews',
-                    to: '/generalSettings/ai/reviews',
+                    label: 'Issues',
+                    to: '/generalSettings/ai/issues',
                     icon: IconListCheck,
-                    keywords: ['classifier'],
+                    keywords: ['classifier', 'reviews'],
                     children: [],
                     exact: true,
                 });

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -21,6 +21,7 @@ import {
     matchPath,
     Navigate,
     useLocation,
+    useParams,
     useRoutes,
     type RouteObject,
 } from 'react-router';
@@ -87,6 +88,27 @@ import { PageName } from '../types/Events';
 import classes from './Settings.module.css';
 
 const SETTINGS_SIDEBAR_COLLAPSED_STORAGE_KEY = 'settings:sidebar-collapsed';
+
+const AiReviewsToIssuesRedirect = ({
+    itemRoute = false,
+}: {
+    itemRoute?: boolean;
+}) => {
+    const { fingerprint } = useParams<{ fingerprint: string }>();
+    const location = useLocation();
+
+    const pathname =
+        itemRoute && fingerprint
+            ? `/generalSettings/ai/issues/${encodeURIComponent(fingerprint)}`
+            : '/generalSettings/ai/issues';
+
+    return (
+        <Navigate
+            to={`${pathname}${location.search}${location.hash}`}
+            replace
+        />
+    );
+};
 
 const Settings: FC = () => {
     const context = useSettingsContext();
@@ -585,7 +607,7 @@ const Settings: FC = () => {
             });
             if (shouldShowAiAgentReviews) {
                 allowedRoutes.push({
-                    path: '/ai/reviews',
+                    path: '/ai/issues',
                     element: (
                         <AiSettingsProviders>
                             <AiReviewsSettingsPage />
@@ -593,12 +615,20 @@ const Settings: FC = () => {
                     ),
                 });
                 allowedRoutes.push({
-                    path: '/ai/reviews/:fingerprint',
+                    path: '/ai/issues/:fingerprint',
                     element: (
                         <AiSettingsProviders>
                             <ReviewRemediationWorkspace />
                         </AiSettingsProviders>
                     ),
+                });
+                allowedRoutes.push({
+                    path: '/ai/reviews',
+                    element: <AiReviewsToIssuesRedirect />,
+                });
+                allowedRoutes.push({
+                    path: '/ai/reviews/:fingerprint',
+                    element: <AiReviewsToIssuesRedirect itemRoute />,
                 });
             }
         }
@@ -746,6 +776,14 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 { path: '/generalSettings/ai/reviews/:fingerprint' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/issues' },
+                location.pathname,
+            ) &&
+            !matchPath(
+                { path: '/generalSettings/ai/issues/:fingerprint' },
                 location.pathname,
             )
         );


### PR DESCRIPTION
## Summary

Foundation for **"Issues" — a Linear for data**: turns the AI review board (`/generalSettings/ai/reviews`, EE) into a tracker where humans file issues alongside machine-generated findings, each issue has a real activity feed, and a focused issue modal replaces the cramped drawer.

This is **PR #1 of a Graphite stack**. It reconciles two previously-unmerged branches onto current `main`:
- `joaoviana/issues-linear-data` (closed PR #24633) — manual issue creation + priority + manual-issue writeback.
- `feat/issue-detail-modal` — the Linear-style `IssueDetailModal` + a purpose-built `ai_agent_review_item_events` activity table.

Linear: ZAP-514 (proactive review ticket creation).

## What's in this PR

- **Manual issues** — `source: 'ai_finding' | 'manual'`, `priority`, `POST /review-items` + `PATCH …/priority`, a "New issue" modal on the board, `ReviewPriorityMenu` on cards. Manual issues start in **To Do**, get a synthetic unique `fingerprint = 'manual:<uuid>'` so every existing `{fingerprint}`-keyed endpoint keeps working.
- **Issue detail modal** — `IssueDetailModal` (built on shared `MantineModal`) replaces the right drawer on the Issues page only; Linear-style header + metadata rail + activity feed with per-event authors.
- **Issue activity** — new `ai_agent_review_item_events` table; `getReviewItemActivity` merges issue events (`created`/`status_changed`/`assignee_changed`/`priority_changed`/`comment_added`/`recurred`) with remediation events into one chronological feed.
- **Manual-issue writeback** — manual issues with a writeback-capable root cause (`semantic_layer` / `project_context`) + project + agent can run the deterministic writeback exactly like findings.
- **Reviews → Issues** user-facing copy + `/generalSettings/ai/issues` (old route redirects).

## Reconciliation decision

The two source branches modeled "activity" incompatibly. This PR **consolidates on the dedicated `ai_agent_review_item_events` table** and **drops** the other branch's `generalize_ai_agent_review_activity` migration (which had added a nullable `fingerprint` to the remediation-events table). Item-level event writes were repointed to `createReviewItemEvent`; duplicate emissions the merge produced were removed; `priority_changed` / `comment_added` moved into the item-event union.

## Regression analysis

- **Existing AI findings** are unaffected: their title/description/root-cause still derive from the latest finding (`source` defaults to `'ai_finding'`); the remediation timeline and its derived `liveState` / `verdictStale` are unchanged (issue events are additive, sorted into the same feed).
- **Migrations are pure expand** (two new columns with defaults + one new table) — no data mutation, safe under rolling deploy. Existing rows default to `source='ai_finding'`, `priority='none'`, and simply have no historical issue events until their next change.
- **No new permissions / no feature flag** — access stays gated to the existing `manage:AiAgent` admin path, same as the board today.

## Test plan

- `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`, `pnpm generate-api` — clean.
- `AiAgentAdminService` unit tests: 45/45 pass.
- Manual: file an issue from the board → lands in To Do with the author as `created_by`; open the issue modal → change status/assignee/priority + comment → each appears in the activity feed with an author; confirm an existing AI finding still renders its finding-derived fields and remediation timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## API breaking change — acknowledged (`allow-api-breaking-change`)

oasdiff flags 20 `response-property-became-nullable` errors plus a new `missing_agent` enum value. These are **intended** and confined to internal `/aiAgents/admin/...` endpoints whose only consumer is the Lightdash frontend (updated in the same stack):

- The manual-issues feature means a remediation can originate from a human-filed issue with **no** source finding/prompt/thread, so `AiAgentReviewRemediation.{sourceFindingUuid,sourcePromptUuid,sourceThreadUuid}` (and the equivalent `PullRequestReviewContext` fields) are now `string | null`. Forcing them non-nullable would misrepresent manual issues.
- `missing_agent` is a new writeback-eligibility reason (additive).

Reverting these would break the feature, so the change is acknowledged here rather than "fixed".

---

## Post-review fixes (multi-agent final review before merge)

- **Manual issues are now openable everywhere**: board cards, table rows, and deep links resolve manual items (no source thread) to the issue detail modal, which renders from the review item alone (evidence section and conversation modal are hidden when there is no thread). The preview-target contract is now explicitly nullable (`projectUuid`/`agentUuid`/`threadUuid: string | null`).
- **Permissions**: `createReviewItem` / `updateReviewItemPriority` / `addReviewItemComment` now use `checkReviewAccess` (`manage OrganizationAiAgent`) instead of `checkOrganizationAdminAccess`, matching every other board mutation (status, assignee, reorder). **Who's affected**: org developers gain create/priority/comment on the issues board — the same principals who can already drag cards and reassign; org admins unchanged; project-level custom roles unchanged (org-level check as before); service accounts unchanged (endpoints are session-user surfaces). This removes a state where developers saw the UI but got 403s.
- **Legacy-fingerprint FK hardening**: priority/comment/assignee mutations now `ensureReviewItemRow` first (insert-on-conflict-ignore with promoted-signal scope), so fingerprints promoted before item rows existed no longer 500 on the events FK, and priority updates no longer silently match 0 rows. Priority/assignee endpoints now 404 on unknown fingerprints instead of half-succeeding.
- **Activity noise**: a same-turn re-review (supersede path) no longer emits a spurious `recurred` event; `recurred` now means the fingerprint reappeared from a different turn.
- **Assignee validation**: `createReviewItem` and `updateReviewItemAssignee` verify the assignee belongs to the caller's organization (404 otherwise).
- **Onboarding example cards** no longer render a live priority menu (was firing a real PATCH against the demo fingerprint).
- Regenerated TSOA `routes.ts`/`swagger.json` — the three new endpoints were missing from the committed routes and would have 404'd in production.
