### PR TITLE
feat(ai-agents): create data issues from dashboards, tiles & charts [ZAP-514]

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -114,6 +114,7 @@ const getDashboardTileErrorMessage = (
 };
 
 import { AskAiAgentButton } from '../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentButton';
+import { CreateIssueMenuItem } from '../../ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem';
 import { DashboardTileComments } from '../../features/comments';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
 import { DateZoomInfoOnTile } from '../../features/dateZoom';
@@ -1522,6 +1523,13 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                             userCanManageChart ||
                             userCanExportData) && (
                             <>
+                                <CreateIssueMenuItem
+                                    projectUuid={projectUuid}
+                                    chartUuid={savedChartUuid ?? undefined}
+                                    dashboardUuid={dashboardUuid}
+                                    tileUuid={tileUuid}
+                                    withDivider
+                                />
                                 <Tooltip
                                     disabled={!isEditMode}
                                     label="Finish editing dashboard to use these actions"

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -52,6 +52,7 @@ import {
 } from 'react';
 import { useBlocker, useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { CreateIssueMenuItem } from '../../../ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem';
 import {
     explorerActions,
     selectHasUnsavedChanges,
@@ -635,12 +636,18 @@ const SavedChartsHeader: FC = () => {
                         >
                             <Menu.Dropdown>
                                 {savedChart && (
-                                    <AskAiAgentMenuItem
-                                        projectUuid={projectUuid}
-                                        chartUuid={savedChart.uuid}
-                                        clickedFrom="saved_chart_header"
-                                        withDivider
-                                    />
+                                    <>
+                                        <AskAiAgentMenuItem
+                                            projectUuid={projectUuid}
+                                            chartUuid={savedChart.uuid}
+                                            clickedFrom="saved_chart_header"
+                                        />
+                                        <CreateIssueMenuItem
+                                            projectUuid={projectUuid}
+                                            chartUuid={savedChart.uuid}
+                                            withDivider
+                                        />
+                                    </>
                                 )}
                                 <Menu.Label>Manage</Menu.Label>
                                 {userCanManageChart &&

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -49,6 +49,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { useToggle } from 'react-use';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { CreateIssueMenuItem } from '../../../ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem';
 import AIDashboardSummary from '../../../ee/features/ambientAi/components/aiDashboardSummary';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
 import {
@@ -739,6 +740,10 @@ const DashboardHeader = memo(
                                         projectUuid={projectUuid}
                                         dashboardUuid={dashboard.uuid}
                                         clickedFrom="dashboard_header"
+                                    />
+                                    <CreateIssueMenuItem
+                                        projectUuid={projectUuid}
+                                        dashboardUuid={dashboard.uuid}
                                         withDivider
                                     />
                                     {!!userCanManageDashboard && (

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -29,6 +29,7 @@ import {
 import { type FC, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { AskAiAgentMenuItem } from '../../../ee/features/aiCopilot/components/AskAiAgentMenuItem/AskAiAgentMenuItem';
+import { CreateIssueMenuItem } from '../../../ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem';
 import { PromoteAppModal } from '../../../features/apps/components/PromoteAppModal';
 import { useDuplicateApp } from '../../../features/apps/hooks/useDuplicateApp';
 import { PromotionConfirmDialog } from '../../../features/promotion/components/PromotionConfirmDialog';
@@ -327,21 +328,36 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     )}
 
                     {isChartOrDashboard && !isSqlChart && (
-                        <AskAiAgentMenuItem
-                            projectUuid={projectUuid}
-                            chartUuid={
-                                isResourceViewItemChart(item)
-                                    ? item.data.uuid
-                                    : undefined
-                            }
-                            dashboardUuid={
-                                isResourceViewItemDashboard(item)
-                                    ? item.data.uuid
-                                    : undefined
-                            }
-                            clickedFrom="resource_action_menu"
-                            withDivider={userCanManage && !favoritesContext}
-                        />
+                        <>
+                            <AskAiAgentMenuItem
+                                projectUuid={projectUuid}
+                                chartUuid={
+                                    isResourceViewItemChart(item)
+                                        ? item.data.uuid
+                                        : undefined
+                                }
+                                dashboardUuid={
+                                    isResourceViewItemDashboard(item)
+                                        ? item.data.uuid
+                                        : undefined
+                                }
+                                clickedFrom="resource_action_menu"
+                            />
+                            <CreateIssueMenuItem
+                                projectUuid={projectUuid}
+                                chartUuid={
+                                    isResourceViewItemChart(item)
+                                        ? item.data.uuid
+                                        : undefined
+                                }
+                                dashboardUuid={
+                                    isResourceViewItemDashboard(item)
+                                        ? item.data.uuid
+                                        : undefined
+                                }
+                                withDivider={userCanManage && !favoritesContext}
+                            />
+                        </>
                     )}
 
                     {userCanManage && favoritesContext && <Menu.Divider />}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.test.tsx
@@ -21,6 +21,10 @@ vi.mock('../../../hooks/useAiOrganizationSettings', () => ({
     }),
 }));
 
+vi.mock('../../../store/hooks', () => ({
+    useAiAgentStoreDispatch: () => vi.fn(),
+}));
+
 vi.mock('../../../../../../components/common/GuidedTour', () => ({
     GuidedTour: () => null,
 }));

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/settings/AiReviewsSettingsPage.tsx
@@ -1,17 +1,4 @@
-import {
-    type AiAgentReviewItemPriority,
-    type AiAgentRootCause,
-} from '@lightdash/common';
-import {
-    Button,
-    Group,
-    SegmentedControl,
-    Select,
-    Stack,
-    Text,
-    Textarea,
-    TextInput,
-} from '@mantine-8/core';
+import { Button, Group, SegmentedControl, Stack, Text } from '@mantine-8/core';
 import { useLocalStorage } from '@mantine-8/hooks';
 import {
     IconLayoutKanban,
@@ -19,19 +6,15 @@ import {
     IconRoute,
     IconTable,
 } from '@tabler/icons-react';
-import { useMemo, useState, type FormEvent } from 'react';
+import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { GuidedTour } from '../../../../../../components/common/GuidedTour';
 import MantineIcon from '../../../../../../components/common/MantineIcon';
-import MantineModal from '../../../../../../components/common/MantineModal';
 import PageBreadcrumbs from '../../../../../../components/common/PageBreadcrumbs';
 import { useGuidedTour } from '../../../../../../hooks/useGuidedTour';
-import { useProjects } from '../../../../../../hooks/useProjects';
-import {
-    useAiAgentAdminAgents,
-    useCreateAiAgentReviewItem,
-} from '../../../hooks/useAiAgentAdmin';
 import { useAiOrganizationSettings } from '../../../hooks/useAiOrganizationSettings';
+import { openCreateIssue } from '../../../store/createIssueSlice';
+import { useAiAgentStoreDispatch } from '../../../store/hooks';
 import AiAgentAdminReviewItemsTable, {
     type AiAgentAdminReviewItemPreviewTarget,
 } from '../AiAgentAdminReviewItemsTable';
@@ -40,39 +23,10 @@ import { REVIEWS_TOUR_STEPS } from '../onboarding';
 import { ReviewKanbanBoard } from '../ReviewKanbanBoard';
 import { AiFeaturesDisabledAlert } from './AiFeaturesDisabledAlert';
 
-const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
-    { value: 'semantic_layer', label: 'Semantic layer' },
-    { value: 'project_context', label: 'Project context' },
-    { value: 'agent_configuration', label: 'Agent configuration' },
-    { value: 'product_capability', label: 'Product capability' },
-    { value: 'runtime_reliability', label: 'Runtime reliability' },
-    { value: 'feedback_quality', label: 'Feedback quality' },
-    { value: 'not_a_failure', label: 'Not a failure' },
-    { value: 'ambiguous', label: 'Ambiguous' },
-];
-
-const priorityOptions: { value: AiAgentReviewItemPriority; label: string }[] = [
-    { value: 'none', label: 'None' },
-    { value: 'urgent', label: 'Urgent' },
-    { value: 'high', label: 'High' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'low', label: 'Low' },
-];
-
 export const AiReviewsSettingsPage = () => {
     const { data: settings } = useAiOrganizationSettings();
-    const { data: projects = [] } = useProjects();
-    const { data: agents = [] } = useAiAgentAdminAgents();
-    const createIssue = useCreateAiAgentReviewItem();
+    const dispatch = useAiAgentStoreDispatch();
     const [searchParams, setSearchParams] = useSearchParams();
-    const [isCreateOpen, setIsCreateOpen] = useState(false);
-    const [title, setTitle] = useState('');
-    const [description, setDescription] = useState('');
-    const [projectUuid, setProjectUuid] = useState<string | null>(null);
-    const [agentUuid, setAgentUuid] = useState<string | null>(null);
-    const [primaryRootCause, setPrimaryRootCause] =
-        useState<AiAgentRootCause | null>(null);
-    const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
 
     // The selected issue and the sidebar's open state are derived
     // directly from the URL — every mutation (deep-link, row select, close)
@@ -170,41 +124,6 @@ export const AiReviewsSettingsPage = () => {
         updateReviewSearchParams(null);
     };
 
-    const resetCreateForm = () => {
-        setTitle('');
-        setDescription('');
-        setProjectUuid(null);
-        setAgentUuid(null);
-        setPrimaryRootCause(null);
-        setPriority('none');
-    };
-
-    const handleCreateIssue = (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-        if (!projectUuid || title.trim().length === 0) return;
-        createIssue.mutate(
-            {
-                title: title.trim(),
-                description: description.trim() || null,
-                projectUuid,
-                agentUuid,
-                assignedToUserUuid: null,
-                primaryRootCause,
-                priority,
-            },
-            {
-                onSuccess: () => {
-                    resetCreateForm();
-                    setIsCreateOpen(false);
-                },
-            },
-        );
-    };
-
-    const agentOptions = agents
-        .filter((agent) => !projectUuid || agent.projectUuid === projectUuid)
-        .map((agent) => ({ value: agent.uuid, label: agent.name }));
-
     return (
         <Stack mb="lg" gap="md">
             <Stack gap={4} data-tour="reviews-intro">
@@ -222,7 +141,7 @@ export const AiReviewsSettingsPage = () => {
                         <Button
                             size="compact-xs"
                             leftSection={<MantineIcon icon={IconPlus} />}
-                            onClick={() => setIsCreateOpen(true)}
+                            onClick={() => dispatch(openCreateIssue(null))}
                         >
                             New issue
                         </Button>
@@ -315,97 +234,6 @@ export const AiReviewsSettingsPage = () => {
                     onClose={handleCloseSidebar}
                 />
             )}
-
-            <MantineModal
-                opened={isCreateOpen}
-                onClose={() => setIsCreateOpen(false)}
-                title="New issue"
-                icon={IconPlus}
-                size="lg"
-            >
-                <form onSubmit={handleCreateIssue}>
-                    <Stack gap="sm">
-                        <TextInput
-                            label="Title"
-                            value={title}
-                            onChange={(event) =>
-                                setTitle(event.currentTarget.value)
-                            }
-                            required
-                            autoFocus
-                        />
-                        <Textarea
-                            label="Description"
-                            value={description}
-                            onChange={(event) =>
-                                setDescription(event.currentTarget.value)
-                            }
-                            minRows={4}
-                        />
-                        <Select
-                            label="Project"
-                            data={projects.map((project) => ({
-                                value: project.projectUuid,
-                                label: project.name,
-                            }))}
-                            value={projectUuid}
-                            onChange={(value) => {
-                                setProjectUuid(value);
-                                setAgentUuid(null);
-                            }}
-                            searchable
-                            required
-                        />
-                        <Select
-                            label="Agent"
-                            data={agentOptions}
-                            value={agentUuid}
-                            onChange={setAgentUuid}
-                            searchable
-                            clearable
-                            disabled={!projectUuid}
-                        />
-                        <Select
-                            label="Root cause"
-                            data={rootCauseOptions}
-                            value={primaryRootCause}
-                            onChange={(value) =>
-                                setPrimaryRootCause(
-                                    value as AiAgentRootCause | null,
-                                )
-                            }
-                            clearable
-                        />
-                        <Select
-                            label="Priority"
-                            data={priorityOptions}
-                            value={priority}
-                            onChange={(value) =>
-                                setPriority(
-                                    (value ??
-                                        'none') as AiAgentReviewItemPriority,
-                                )
-                            }
-                        />
-                        <Group justify="flex-end">
-                            <Button
-                                variant="subtle"
-                                color="gray"
-                                onClick={() => setIsCreateOpen(false)}
-                            >
-                                Cancel
-                            </Button>
-                            <Button
-                                type="submit"
-                                loading={createIssue.isLoading}
-                                disabled={!projectUuid || !title.trim()}
-                            >
-                                Create issue
-                            </Button>
-                        </Group>
-                    </Stack>
-                </form>
-            </MantineModal>
         </Stack>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueMenuItem.tsx
@@ -1,0 +1,51 @@
+import { Menu } from '@mantine-8/core';
+import { IconClipboardPlus } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useCreateIssueAction } from './useCreateIssueAction';
+
+type Props = {
+    projectUuid: string | undefined;
+    chartUuid?: string;
+    dashboardUuid?: string;
+    tileUuid?: string;
+    /**
+     * Render a `<Menu.Divider />` after the item. Only rendered when the item
+     * itself is visible, so callers don't need to gate it.
+     */
+    withDivider?: boolean;
+};
+
+/**
+ * Menu item that opens the create-issue modal pre-filled with the content's
+ * context. Renders nothing when the user can't create issues (not org admin,
+ * AI agents disabled, or no project).
+ */
+export const CreateIssueMenuItem: FC<Props> = ({
+    projectUuid,
+    chartUuid,
+    dashboardUuid,
+    tileUuid,
+    withDivider = false,
+}) => {
+    const { canCreate, handleClick } = useCreateIssueAction({
+        projectUuid,
+        chartUuid,
+        dashboardUuid,
+        tileUuid,
+    });
+
+    if (!canCreate) return null;
+
+    return (
+        <>
+            <Menu.Item
+                leftSection={<MantineIcon icon={IconClipboardPlus} />}
+                onClick={handleClick}
+            >
+                Create issue
+            </Menu.Item>
+            {withDivider && <Menu.Divider />}
+        </>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -16,7 +16,7 @@ import {
     IconLayoutDashboard,
     IconPlus,
 } from '@tabler/icons-react';
-import { useEffect, useMemo, useState, type FC, type FormEvent } from 'react';
+import { useMemo, useState, type FC, type FormEvent } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useDashboardQuery } from '../../../../../hooks/dashboard/useDashboard';
@@ -99,20 +99,15 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
 
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
-    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    // The host mounts this modal fresh on each open, so seeding from the
+    // launch context in the initializer is enough — no effect-sync needed.
+    const [projectUuid, setProjectUuid] = useState<string | null>(
+        context?.projectUuid ?? null,
+    );
     const [agentUuid, setAgentUuid] = useState<string | null>(null);
     const [primaryRootCause, setPrimaryRootCause] =
         useState<AiAgentRootCause | null>(null);
     const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
-
-    // The content's project is authoritative when launched from a dashboard /
-    // tile / chart — lock the select to it. Re-seed whenever the modal opens
-    // against a new context (keyed on open + projectUuid, not on every render).
-    useEffect(() => {
-        if (opened && context?.projectUuid) {
-            setProjectUuid(context.projectUuid);
-        }
-    }, [opened, context?.projectUuid]);
 
     const projectLocked = !!context?.projectUuid;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -1,0 +1,265 @@
+import {
+    type AiAgentReviewItemPriority,
+    type AiAgentRootCause,
+} from '@lightdash/common';
+import {
+    Badge,
+    Button,
+    Group,
+    Select,
+    Stack,
+    Textarea,
+    TextInput,
+} from '@mantine-8/core';
+import {
+    IconChartBar,
+    IconLayoutDashboard,
+    IconPlus,
+} from '@tabler/icons-react';
+import { useEffect, useMemo, useState, type FC, type FormEvent } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import MantineModal from '../../../../../components/common/MantineModal';
+import { useDashboardQuery } from '../../../../../hooks/dashboard/useDashboard';
+import { useProjects } from '../../../../../hooks/useProjects';
+import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
+import {
+    useAiAgentAdminAgents,
+    useCreateAiAgentReviewItem,
+} from '../../hooks/useAiAgentAdmin';
+import { type CreateIssueContext } from '../../store/createIssueSlice';
+
+const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
+    { value: 'semantic_layer', label: 'Semantic layer' },
+    { value: 'project_context', label: 'Project context' },
+    { value: 'agent_configuration', label: 'Agent configuration' },
+    { value: 'product_capability', label: 'Product capability' },
+    { value: 'runtime_reliability', label: 'Runtime reliability' },
+    { value: 'feedback_quality', label: 'Feedback quality' },
+    { value: 'not_a_failure', label: 'Not a failure' },
+    { value: 'ambiguous', label: 'Ambiguous' },
+];
+
+const priorityOptions: { value: AiAgentReviewItemPriority; label: string }[] = [
+    { value: 'none', label: 'None' },
+    { value: 'urgent', label: 'Urgent' },
+    { value: 'high', label: 'High' },
+    { value: 'medium', label: 'Medium' },
+    { value: 'low', label: 'Low' },
+];
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    context: CreateIssueContext | null;
+};
+
+// The chip showing which piece of content the issue was filed from. Resolves
+// the chart/dashboard name; falls back to a generic label while it loads.
+const ReportedFromChip: FC<{ context: CreateIssueContext }> = ({ context }) => {
+    const { data: chart } = useSavedQuery({
+        uuidOrSlug: context.chartUuid,
+        projectUuid: context.projectUuid,
+    });
+    const { data: dashboard } = useDashboardQuery({
+        uuidOrSlug: context.dashboardUuid,
+        projectUuid: context.projectUuid,
+    });
+
+    if (context.chartUuid) {
+        return (
+            <Badge
+                variant="light"
+                color="gray"
+                leftSection={<MantineIcon icon={IconChartBar} size={12} />}
+            >
+                Reported from {chart?.name ?? 'a chart'}
+            </Badge>
+        );
+    }
+    if (context.dashboardUuid) {
+        return (
+            <Badge
+                variant="light"
+                color="gray"
+                leftSection={
+                    <MantineIcon icon={IconLayoutDashboard} size={12} />
+                }
+            >
+                Reported from {dashboard?.name ?? 'a dashboard'}
+            </Badge>
+        );
+    }
+    return null;
+};
+
+export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
+    const { data: projects = [] } = useProjects();
+    const { data: agents = [] } = useAiAgentAdminAgents();
+    const createIssue = useCreateAiAgentReviewItem();
+
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [projectUuid, setProjectUuid] = useState<string | null>(null);
+    const [agentUuid, setAgentUuid] = useState<string | null>(null);
+    const [primaryRootCause, setPrimaryRootCause] =
+        useState<AiAgentRootCause | null>(null);
+    const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
+
+    // The content's project is authoritative when launched from a dashboard /
+    // tile / chart — lock the select to it. Re-seed whenever the modal opens
+    // against a new context (keyed on open + projectUuid, not on every render).
+    useEffect(() => {
+        if (opened && context?.projectUuid) {
+            setProjectUuid(context.projectUuid);
+        }
+    }, [opened, context?.projectUuid]);
+
+    const projectLocked = !!context?.projectUuid;
+
+    const agentOptions = useMemo(
+        () =>
+            agents
+                .filter(
+                    (agent) =>
+                        !projectUuid || agent.projectUuid === projectUuid,
+                )
+                .map((agent) => ({ value: agent.uuid, label: agent.name })),
+        [agents, projectUuid],
+    );
+
+    const resetForm = () => {
+        setTitle('');
+        setDescription('');
+        setProjectUuid(context?.projectUuid ?? null);
+        setAgentUuid(null);
+        setPrimaryRootCause(null);
+        setPriority('none');
+    };
+
+    const handleClose = () => {
+        resetForm();
+        onClose();
+    };
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!projectUuid || title.trim().length === 0) return;
+        createIssue.mutate(
+            {
+                title: title.trim(),
+                description: description.trim() || null,
+                projectUuid,
+                agentUuid,
+                assignedToUserUuid: null,
+                primaryRootCause,
+                priority,
+            },
+            {
+                onSuccess: () => {
+                    resetForm();
+                    onClose();
+                },
+            },
+        );
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleClose}
+            title="New issue"
+            icon={IconPlus}
+            size="lg"
+        >
+            <form onSubmit={handleSubmit}>
+                <Stack gap="sm">
+                    {context &&
+                        (context.chartUuid || context.dashboardUuid) && (
+                            <Group gap="xs">
+                                <ReportedFromChip context={context} />
+                            </Group>
+                        )}
+                    <TextInput
+                        label="Title"
+                        value={title}
+                        onChange={(event) =>
+                            setTitle(event.currentTarget.value)
+                        }
+                        required
+                        autoFocus
+                    />
+                    <Textarea
+                        label="Description"
+                        description="Describe the gap or fix, and the outcome you want."
+                        value={description}
+                        onChange={(event) =>
+                            setDescription(event.currentTarget.value)
+                        }
+                        minRows={4}
+                    />
+                    <Select
+                        label="Project"
+                        data={projects.map((project) => ({
+                            value: project.projectUuid,
+                            label: project.name,
+                        }))}
+                        value={projectUuid}
+                        onChange={(value) => {
+                            setProjectUuid(value);
+                            setAgentUuid(null);
+                        }}
+                        searchable
+                        required
+                        disabled={projectLocked}
+                    />
+                    <Select
+                        label="Agent"
+                        data={agentOptions}
+                        value={agentUuid}
+                        onChange={setAgentUuid}
+                        searchable
+                        clearable
+                        disabled={!projectUuid}
+                    />
+                    <Select
+                        label="Root cause"
+                        data={rootCauseOptions}
+                        value={primaryRootCause}
+                        onChange={(value) =>
+                            setPrimaryRootCause(
+                                value as AiAgentRootCause | null,
+                            )
+                        }
+                        clearable
+                    />
+                    <Select
+                        label="Priority"
+                        data={priorityOptions}
+                        value={priority}
+                        onChange={(value) =>
+                            setPriority(
+                                (value ?? 'none') as AiAgentReviewItemPriority,
+                            )
+                        }
+                    />
+                    <Group justify="flex-end">
+                        <Button
+                            variant="subtle"
+                            color="gray"
+                            onClick={handleClose}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="submit"
+                            loading={createIssue.isLoading}
+                            disabled={!projectUuid || !title.trim()}
+                        >
+                            Create issue
+                        </Button>
+                    </Group>
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModalHost.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModalHost.tsx
@@ -1,0 +1,27 @@
+import { type FC } from 'react';
+import { closeCreateIssue } from '../../store/createIssueSlice';
+import {
+    useAiAgentStoreDispatch,
+    useAiAgentStoreSelector,
+} from '../../store/hooks';
+import { CreateIssueModal } from './CreateIssueModal';
+
+/**
+ * Always-mounted host for the create-issue modal so any content entry point
+ * (dashboard / tile / chart) can open it via the `createIssue` store slice,
+ * without each call site owning the modal.
+ */
+export const CreateIssueModalHost: FC = () => {
+    const dispatch = useAiAgentStoreDispatch();
+    const { open, context } = useAiAgentStoreSelector(
+        (state) => state.createIssue,
+    );
+
+    return (
+        <CreateIssueModal
+            opened={open}
+            context={context}
+            onClose={() => dispatch(closeCreateIssue())}
+        />
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModalHost.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModalHost.tsx
@@ -7,9 +7,11 @@ import {
 import { CreateIssueModal } from './CreateIssueModal';
 
 /**
- * Always-mounted host for the create-issue modal so any content entry point
+ * App-wide host for the create-issue modal so any content entry point
  * (dashboard / tile / chart) can open it via the `createIssue` store slice,
- * without each call site owning the modal.
+ * without each call site owning the modal. The modal itself mounts only while
+ * open so its queries (projects, admin agents) never fire for users who don't
+ * use it, and each open starts from freshly-seeded form state.
  */
 export const CreateIssueModalHost: FC = () => {
     const dispatch = useAiAgentStoreDispatch();
@@ -17,9 +19,11 @@ export const CreateIssueModalHost: FC = () => {
         (state) => state.createIssue,
     );
 
+    if (!open) return null;
+
     return (
         <CreateIssueModal
-            opened={open}
+            opened
             context={context}
             onClose={() => dispatch(closeCreateIssue())}
         />

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/useCreateIssueAction.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/useCreateIssueAction.ts
@@ -1,0 +1,47 @@
+import useApp from '../../../../../providers/App/useApp';
+import { useAiAgentButtonVisibility } from '../../hooks/useAiAgentsButtonVisibility';
+import { openCreateIssue } from '../../store/createIssueSlice';
+import { useAiAgentStoreDispatch } from '../../store/hooks';
+
+type Args = {
+    projectUuid: string | undefined;
+    chartUuid?: string;
+    dashboardUuid?: string;
+    tileUuid?: string;
+};
+
+/**
+ * Shared logic for the "Create issue" entry points (dashboard / tile / chart):
+ * resolves whether the action should be shown and opens the create-issue modal
+ * pre-filled with the content's context on click. `canCreate` mirrors the
+ * `POST /review-items` permission (org admin) plus AI agents being enabled, so
+ * the affordance never 403s.
+ */
+export const useCreateIssueAction = ({
+    projectUuid,
+    chartUuid,
+    dashboardUuid,
+    tileUuid,
+}: Args) => {
+    const isAiEnabled = useAiAgentButtonVisibility();
+    const { user } = useApp();
+    const dispatch = useAiAgentStoreDispatch();
+
+    const isOrgAdmin =
+        user.data?.ability.can('manage', 'Organization') ?? false;
+    const canCreate = isAiEnabled && isOrgAdmin && !!projectUuid;
+
+    const handleClick = () => {
+        if (!projectUuid) return;
+        dispatch(
+            openCreateIssue({
+                projectUuid,
+                chartUuid,
+                dashboardUuid,
+                tileUuid,
+            }),
+        );
+    };
+
+    return { canCreate, handleClick };
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Launcher/AiAgentsGlobalProvider.tsx
@@ -11,6 +11,7 @@ import { useLocation, useMatches } from 'react-router';
 import { useActiveProjectUuid } from '../../../../../hooks/useActiveProject';
 import { store } from '../../store';
 import { AiAgentThreadStreamAbortControllerContextProvider } from '../../streaming/AiAgentThreadStreamAbortControllerContextProvider';
+import { CreateIssueModalHost } from '../CreateIssue/CreateIssueModalHost';
 import { PendingPromptProvider } from '../PendingPromptContext/PendingPromptContext';
 import { LauncherDockProvider } from './LauncherDockProvider';
 import { launcherSession } from './launcherSession';
@@ -64,6 +65,7 @@ export const AiAgentsGlobalProvider: FC<PropsWithChildren> = ({ children }) => (
                     <Sentry.ErrorBoundary fallback={<></>}>
                         <AiAgentsLauncherSessionTracker />
                         <AiAgentsLauncherGate />
+                        <CreateIssueModalHost />
                     </Sentry.ErrorBoundary>
                 </LauncherDockProvider>
             </PendingPromptProvider>

--- a/packages/frontend/src/ee/features/aiCopilot/store/createIssueSlice.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/createIssueSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+// The piece of content a data issue is being filed against. Captured at the
+// click site (dashboard / tile / chart) and used to pre-fill the modal.
+export type CreateIssueContext = {
+    projectUuid: string;
+    chartUuid?: string;
+    dashboardUuid?: string;
+    tileUuid?: string;
+};
+
+export interface CreateIssueState {
+    open: boolean;
+    context: CreateIssueContext | null;
+}
+
+const initialState: CreateIssueState = {
+    open: false,
+    context: null,
+};
+
+export const createIssueSlice = createSlice({
+    name: 'createIssue',
+    initialState,
+    reducers: {
+        openCreateIssue: (
+            state,
+            action: PayloadAction<CreateIssueContext | null>,
+        ) => {
+            state.open = true;
+            state.context = action.payload;
+        },
+        closeCreateIssue: (state) => {
+            state.open = false;
+            state.context = null;
+        },
+    },
+});
+
+export const { openCreateIssue, closeCreateIssue } = createIssueSlice.actions;

--- a/packages/frontend/src/ee/features/aiCopilot/store/index.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/store/index.ts
@@ -3,6 +3,7 @@ import { aiAgentLauncherSlice } from './aiAgentLauncherSlice';
 import { aiAgentThreadModeSlice } from './aiAgentThreadModeSlice';
 import { aiAgentThreadStreamSlice } from './aiAgentThreadStreamSlice';
 import { aiArtifactSlice } from './aiArtifactSlice';
+import { createIssueSlice } from './createIssueSlice';
 
 export const store = configureStore({
     reducer: {
@@ -10,6 +11,7 @@ export const store = configureStore({
         aiAgentThreadMode: aiAgentThreadModeSlice.reducer,
         aiArtifact: aiArtifactSlice.reducer,
         aiAgentLauncher: aiAgentLauncherSlice.reducer,
+        createIssue: createIssueSlice.reducer,
     },
 });
 


### PR DESCRIPTION
## Summary

Lets users **file a data issue straight from a dashboard, a dashboard tile, or a chart** — the same spots that offer "Ask AI Agent", but **track-first**: instead of opening a chat it creates a tracked issue on the board, pre-filled with the content's context.

**PR #2 of the Issues stack** — stacked on #24869 (manual-issue foundation). Linear: ZAP-514.

## What's in this PR

- **Entry points** (`CreateIssueMenuItem`, mirroring `AskAiAgentMenuItem`) added next to the existing "Ask AI Agent" affordances in:
  - the **dashboard header** 3-dot menu,
  - the **chart / explore header** 3-dot menu,
  - the **resource row** menu (spaces / home),
  - the **dashboard chart tile** 3-dot menu (carries `tileUuid`).
- **Shared `CreateIssueModal`** opened from a new `createIssue` Redux slice via an always-mounted `CreateIssueModalHost` (co-located with the AI launcher in `AiAgentsGlobalProvider`), so any call site can open it without owning the modal. The modal is pre-filled with the content's **project (locked)** and shows a **"Reported from <chart/dashboard>"** chip.
- **`useCreateIssueAction`** gates visibility on **org-admin + AI agents enabled** — the same permission `POST /review-items` enforces — so the affordance never 403s.

The issue lands on the board in **To Do** (via the foundation's manual-create path), ready to move to In Progress → writeback.

## Scope / follow-ups

- The captured content context (`chartUuid` / `dashboardUuid` / `tileUuid`) is surfaced in the modal now; **persisting it as `targetRefs` + a suggested agent + desired-outcome** is the next PR (Slice E, ZAP-515).
- Visibility is org-admin only for now (matches the create endpoint). Broadening to any user (per the "any user can file" vision) is a deliberate later backend change.

## Test plan

- `pnpm -F frontend typecheck:fast` clean; pre-commit lint/format/unused-exports pass.
- Manual: as an org admin on a dashboard, open a chart tile's 3-dot menu → **Create issue** → modal opens with the project locked + a "Reported from <chart>" chip → submit → toast + card appears on the Issues board in To Do. Repeat from the dashboard header, chart header, and a resource row. As a non-admin, confirm the item does not render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-review fixes (multi-agent final review before merge)

- `CreateIssueModalHost` now mounts the modal only while open — previously `useProjects()` and the admin-only `useAiAgentAdminAgents()` fired on every page load for every user with AI enabled (a guaranteed 403 for non-admins).
- Form state seeds from the launch context in `useState` initializers instead of `useEffect` prop-sync (host remounts the modal per open), per the frontend state-management guide.
- The issues board's "New issue" button now dispatches `openCreateIssue(null)` and reuses this shared modal — the settings page's duplicated inline create form (own `rootCauseOptions`/`priorityOptions` copies, no related-explores or agent-suggest) is deleted.
