### PR TITLE
fix: resolve GeoJSON URL using SDK instance URL in SimpleMap

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -42,6 +42,7 @@ import useLeafletMapConfig, {
 import { useTileFallback } from '../../hooks/leaflet/useTileFallback';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { createMultiColorScale } from '../../utils/colorUtils';
+import { resolveRequestUrl } from '../../utils/request';
 import Callout from '../common/Callout';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -602,7 +603,9 @@ const SimpleMap: FC<SimpleMapProps> = memo(
 
             const loadGeoJson = async () => {
                 try {
-                    const response = await fetch(mapConfig.geoJsonUrl!);
+                    const response = await fetch(
+                        resolveRequestUrl(mapConfig.geoJsonUrl!),
+                    );
                     const data = await response.json();
 
                     // Convert TopoJSON to GeoJSON if needed

--- a/packages/frontend/src/utils/request.ts
+++ b/packages/frontend/src/utils/request.ts
@@ -9,7 +9,7 @@ import { getFromInMemoryStorage } from './inMemoryStorage';
 const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
     '__lightdash_sdk_instance_url';
 
-const resolveRequestUrl = (url: string) => {
+export const resolveRequestUrl = (url: string) => {
     const sdkInstanceUrl = sessionStorage.getItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
     );


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-8555/geojson-files-are-not-working-on-embed

Before

<img width="735" height="653" alt="image" src="https://github.com/user-attachments/assets/eef07485-0ed4-4607-ab11-ada5701e5d0d" />

After

<img width="1376" height="506" alt="image" src="https://github.com/user-attachments/assets/fd62646f-c770-46d6-a4f5-87486572f32a" />


### Description:

Exports `resolveRequestUrl` from `request.ts` and applies it when fetching GeoJSON URLs in `SimpleMap`. This ensures that GeoJSON requests correctly resolve against the SDK instance URL when set, maintaining consistent URL resolution behavior across all requests.