### PR TITLE
feat(ai-agents): suggest the best agent when filing a data issue [ZAP-515]

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -8,6 +8,7 @@ import {
     Group,
     Select,
     Stack,
+    Text,
     Textarea,
     TextInput,
 } from '@mantine-8/core';
@@ -15,6 +16,7 @@ import {
     IconChartBar,
     IconLayoutDashboard,
     IconPlus,
+    IconWand,
 } from '@tabler/icons-react';
 import { useMemo, useState, type FC, type FormEvent } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -26,6 +28,7 @@ import {
     useAiAgentAdminAgents,
     useCreateAiAgentReviewItem,
 } from '../../hooks/useAiAgentAdmin';
+import { useAiRouterRoute } from '../../hooks/useAiRouter';
 import { type CreateIssueContext } from '../../store/createIssueSlice';
 
 const rootCauseOptions: { value: AiAgentRootCause; label: string }[] = [
@@ -96,6 +99,7 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
     const { data: projects = [] } = useProjects();
     const { data: agents = [] } = useAiAgentAdminAgents();
     const createIssue = useCreateAiAgentReviewItem();
+    const routeAgent = useAiRouterRoute();
 
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
@@ -105,6 +109,9 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
         context?.projectUuid ?? null,
     );
     const [agentUuid, setAgentUuid] = useState<string | null>(null);
+    const [suggestionReasoning, setSuggestionReasoning] = useState<
+        string | null
+    >(null);
     const [primaryRootCause, setPrimaryRootCause] =
         useState<AiAgentRootCause | null>(null);
     const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
@@ -127,8 +134,27 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
         setDescription('');
         setProjectUuid(context?.projectUuid ?? null);
         setAgentUuid(null);
+        setSuggestionReasoning(null);
         setPrimaryRootCause(null);
         setPriority('none');
+    };
+
+    // Reuse the AI router to pick the best-fit agent from the issue title +
+    // description, then pre-select it (the user can still override).
+    const handleSuggestAgent = () => {
+        if (!projectUuid || title.trim().length === 0) return;
+        const prompt = [title.trim(), description.trim()]
+            .filter(Boolean)
+            .join('\n\n');
+        routeAgent.mutate(
+            { prompt, projectUuid },
+            {
+                onSuccess: (result) => {
+                    setAgentUuid(result.decision.suggestedAgentUuid);
+                    setSuggestionReasoning(result.decision.reasoning);
+                },
+            },
+        );
     };
 
     const handleClose = () => {
@@ -207,15 +233,46 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
                         required
                         disabled={projectLocked}
                     />
-                    <Select
-                        label="Agent"
-                        data={agentOptions}
-                        value={agentUuid}
-                        onChange={setAgentUuid}
-                        searchable
-                        clearable
-                        disabled={!projectUuid}
-                    />
+                    <Stack gap={4}>
+                        <Group
+                            justify="space-between"
+                            align="flex-end"
+                            gap="xs"
+                        >
+                            <Select
+                                label="Agent"
+                                data={agentOptions}
+                                value={agentUuid}
+                                onChange={(value) => {
+                                    setAgentUuid(value);
+                                    setSuggestionReasoning(null);
+                                }}
+                                searchable
+                                clearable
+                                disabled={!projectUuid}
+                                flex={1}
+                            />
+                            {agentOptions.length > 0 && (
+                                <Button
+                                    variant="subtle"
+                                    size="compact-sm"
+                                    leftSection={
+                                        <MantineIcon icon={IconWand} />
+                                    }
+                                    loading={routeAgent.isLoading}
+                                    disabled={!projectUuid || !title.trim()}
+                                    onClick={handleSuggestAgent}
+                                >
+                                    Suggest
+                                </Button>
+                            )}
+                        </Group>
+                        {suggestionReasoning && (
+                            <Text c="dimmed" fz="xs">
+                                Suggested: {suggestionReasoning}
+                            </Text>
+                        )}
+                    </Stack>
                     <Select
                         label="Root cause"
                         data={rootCauseOptions}


### PR DESCRIPTION
## Summary

When filing a data issue, **suggest the best-fit agent** instead of making the user know which agent owns which models.

**PR #3 of the Issues stack** — stacked on #24870. Linear: ZAP-515.

## What's in this PR

- A **"Suggest"** button on the create-issue modal's Agent field that reuses the **existing AI router** (`POST /org/aiRouter/route` → `AiRouterService.routePromptToAgent` → `selectAgent`). It routes the issue **title + description** as the prompt, pre-selects `decision.suggestedAgentUuid`, and shows the router's `reasoning` as a hint. The user can still override; clearing the agent clears the hint.
- Zero new backend — the router already differentiates agents by their data access (explores), description, and verified questions.

## Why router-first

The router is an LLM that already reasons over each agent's explore coverage + description, so it handles the fuzzy "which agent should own this?" question better than a keyword match. A deterministic explore-coverage fallback (matching the issue's `targetRefs` against each agent's `getAgentExploreAccessSummary`) is a natural follow-up once issues carry `targetRefs` (next PR).

## Not in this PR (next: Slice E2)

- Persisting the captured content as **`targetRefs`** (the `ai_agent_review_item.target_refs` column already exists) + an explore/field multi-select in the modal. That feeds the manual-issue writeback and enables the deterministic agent-match fallback.
- "Desired outcome" is captured today via the description field's guidance copy (no dedicated column in v1).

## Test plan

- `pnpm -F frontend typecheck:fast` clean; pre-commit lint/format/unused-exports pass.
- Manual: open the create-issue modal, type a title/description, click **Suggest** → an agent is pre-selected with a reasoning hint; override it manually → hint clears; submit → issue is created against the chosen agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)