### PR TITLE
feat(ai-agents): capture related explores (targetRefs) when filing an issue [ZAP-515]

### DIFF
--- a/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
+++ b/packages/backend/src/ee/database/entities/aiAgentReviewClassifier.ts
@@ -245,6 +245,7 @@ export type DbAiAgentReviewItem = {
     description: string | null;
     primary_root_cause: AiAgentRootCause | null;
     priority: AiAgentReviewItemPriority;
+    target_refs: AiAgentTargetRef[] | null;
     status: AiAgentReviewItemStatus;
     dismissed_reason: AiAgentReviewItemDismissedReason | null;
     assigned_to_user_uuid: string | null;

--- a/packages/backend/src/ee/database/migrations/20260629140000_add_target_refs_to_ai_agent_review_items.ts
+++ b/packages/backend/src/ee/database/migrations/20260629140000_add_target_refs_to_ai_agent_review_items.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+const TABLE = 'ai_agent_review_item';
+const COLUMN = 'target_refs';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.jsonb(COLUMN).nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE, (table) => {
+        table.dropColumn(COLUMN);
+    });
+}

--- a/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
+++ b/packages/backend/src/ee/models/AiAgentReviewClassifierModel.ts
@@ -220,6 +220,7 @@ type CreateManualReviewItemArgs = {
     assignedToUserUuid: string | null;
     primaryRootCause: AiAgentRootCause | null;
     priority: AiAgentReviewItemPriority;
+    targetRefs: AiAgentTargetRef[];
     createdByUserUuid: string | null;
 };
 
@@ -1307,6 +1308,8 @@ export class AiAgentReviewClassifierModel {
                 description: args.description,
                 primary_root_cause: args.primaryRootCause,
                 priority: args.priority,
+                target_refs:
+                    args.targetRefs.length > 0 ? args.targetRefs : null,
                 status: 'open',
                 assigned_to_user_uuid: args.assignedToUserUuid,
                 created_by_user_uuid: args.createdByUserUuid,

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -761,6 +761,7 @@ export class AiAgentAdminService extends BaseService {
                 assignedToUserUuid: body.assignedToUserUuid,
                 primaryRootCause: body.primaryRootCause,
                 priority: body.priority,
+                targetRefs: body.targetRefs,
                 createdByUserUuid: user.userUuid,
             });
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1770,6 +1770,14 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
+                instructions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 origin: { dataType: 'string', required: true },
                 type: { ref: 'ExternalConnectionAuthType', required: true },
                 name: { dataType: 'string', required: true },
@@ -1847,6 +1855,13 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
+                instructions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 origin: { dataType: 'string', required: true },
                 type: { ref: 'ExternalConnectionAuthType', required: true },
                 name: { dataType: 'string', required: true },
@@ -1894,6 +1909,14 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                instructions: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -10281,6 +10304,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                scaffoldingVersion: { dataType: 'string' },
                 downloadedAt: { dataType: 'string', required: true },
                 template: {
                     dataType: 'union',
@@ -14029,6 +14053,40 @@ const models: TsoaRoute.Models = {
                         type: {
                             dataType: 'enum',
                             enums: ['runtime'],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        tileUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        dashboardUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        chartUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['content'],
                             required: true,
                         },
                     },
@@ -23454,6 +23512,11 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                targetRefs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'AiAgentTargetRef' },
+                    required: true,
+                },
                 priority: { ref: 'AiAgentReviewItemPriority', required: true },
                 primaryRootCause: {
                     dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1740,6 +1740,10 @@
                         },
                         "type": "array"
                     },
+                    "instructions": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "origin": {
                         "type": "string"
                     },
@@ -1774,6 +1778,7 @@
                     "allowedContentTypes",
                     "allowedMethods",
                     "allowedPathPrefixes",
+                    "instructions",
                     "origin",
                     "type",
                     "name",
@@ -1851,6 +1856,10 @@
                         },
                         "type": "array"
                     },
+                    "instructions": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "origin": {
                         "type": "string"
                     },
@@ -1899,6 +1908,10 @@
                     },
                     "origin": {
                         "type": "string"
+                    },
+                    "instructions": {
+                        "type": "string",
+                        "nullable": true
                     },
                     "allowedPathPrefixes": {
                         "items": {
@@ -11648,6 +11661,9 @@
             },
             "DataAppManifest": {
                 "properties": {
+                    "scaffoldingVersion": {
+                        "type": "string"
+                    },
                     "downloadedAt": {
                         "type": "string"
                     },
@@ -15631,6 +15647,34 @@
                             }
                         },
                         "required": ["key", "type"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "tileUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "dashboardUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "chartUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["content"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "tileUuid",
+                            "dashboardUuid",
+                            "chartUuid",
+                            "type"
+                        ],
                         "type": "object"
                     }
                 ]
@@ -23723,6 +23767,12 @@
             },
             "CreateAiAgentReviewItem": {
                 "properties": {
+                    "targetRefs": {
+                        "items": {
+                            "$ref": "#/components/schemas/AiAgentTargetRef"
+                        },
+                        "type": "array"
+                    },
                     "priority": {
                         "$ref": "#/components/schemas/AiAgentReviewItemPriority"
                     },
@@ -23754,6 +23804,7 @@
                     }
                 },
                 "required": [
+                    "targetRefs",
                     "priority",
                     "primaryRootCause",
                     "assignedToUserUuid",

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -235,7 +235,15 @@ export type AiAgentTargetRef =
     | { type: 'agent'; agentUuid: string }
     | { type: 'agent_config'; setting: AiAgentConfigurationSetting }
     | { type: 'product_capability'; capabilityKey: string }
-    | { type: 'runtime'; key: string };
+    | { type: 'runtime'; key: string }
+    // Content the issue was filed from (manual issues): keeps chart/dashboard
+    // provenance so the board and writeback know what the issue is about.
+    | {
+          type: 'content';
+          chartUuid: string | null;
+          dashboardUuid: string | null;
+          tileUuid: string | null;
+      };
 
 export type AiAgentEvidenceExcerpt = {
     source:

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -695,6 +695,8 @@ export type CreateAiAgentReviewItem = {
     assignedToUserUuid: string | null;
     primaryRootCause: AiAgentRootCause | null;
     priority: AiAgentReviewItemPriority;
+    // Explores/fields the issue is about; feeds the manual-issue writeback.
+    targetRefs: AiAgentTargetRef[];
 };
 
 export type UpdateAiAgentReviewItemPriority = {

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -1,11 +1,13 @@
 import {
     type AiAgentReviewItemPriority,
     type AiAgentRootCause,
+    type AiAgentTargetRef,
 } from '@lightdash/common';
 import {
     Badge,
     Button,
     Group,
+    MultiSelect,
     Select,
     Stack,
     Text,
@@ -22,6 +24,7 @@ import { useMemo, useState, type FC, type FormEvent } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useDashboardQuery } from '../../../../../hooks/dashboard/useDashboard';
+import { useExplores } from '../../../../../hooks/useExplores';
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
 import {
@@ -109,12 +112,28 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
         context?.projectUuid ?? null,
     );
     const [agentUuid, setAgentUuid] = useState<string | null>(null);
+    const [targetExploreNamesOverride, setTargetExploreNamesOverride] =
+        useState<string[] | null>(null);
     const [suggestionReasoning, setSuggestionReasoning] = useState<
         string | null
     >(null);
     const [primaryRootCause, setPrimaryRootCause] =
         useState<AiAgentRootCause | null>(null);
     const [priority, setPriority] = useState<AiAgentReviewItemPriority>('none');
+
+    const { data: explores = [] } = useExplores(projectUuid ?? undefined);
+    const { data: seedChart } = useSavedQuery({
+        uuidOrSlug: context?.chartUuid,
+        projectUuid: context?.projectUuid,
+    });
+
+    // Seed the related explores with the chart's base explore when filing from
+    // a chart, so the writeback starts from the right model. Derived, not
+    // effect-synced: once the user edits the multiselect their override wins,
+    // so a late-resolving chart query can't clobber it.
+    const targetExploreNames =
+        targetExploreNamesOverride ??
+        (seedChart?.tableName ? [seedChart.tableName] : []);
 
     const projectLocked = !!context?.projectUuid;
 
@@ -129,11 +148,21 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
         [agents, projectUuid],
     );
 
+    const exploreOptions = useMemo(
+        () =>
+            explores.map((explore) => ({
+                value: explore.name,
+                label: explore.label,
+            })),
+        [explores],
+    );
+
     const resetForm = () => {
         setTitle('');
         setDescription('');
         setProjectUuid(context?.projectUuid ?? null);
         setAgentUuid(null);
+        setTargetExploreNamesOverride(null);
         setSuggestionReasoning(null);
         setPrimaryRootCause(null);
         setPriority('none');
@@ -165,6 +194,9 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
     const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         if (!projectUuid || title.trim().length === 0) return;
+        const targetRefs: AiAgentTargetRef[] = targetExploreNames.map(
+            (name) => ({ type: 'explore', modelName: name, exploreName: name }),
+        );
         createIssue.mutate(
             {
                 title: title.trim(),
@@ -174,6 +206,7 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
                 assignedToUserUuid: null,
                 primaryRootCause,
                 priority,
+                targetRefs,
             },
             {
                 onSuccess: () => {
@@ -228,10 +261,22 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
                         onChange={(value) => {
                             setProjectUuid(value);
                             setAgentUuid(null);
+                            setTargetExploreNamesOverride([]);
                         }}
                         searchable
                         required
                         disabled={projectLocked}
+                    />
+                    <MultiSelect
+                        label="Related explores"
+                        description="Which models this issue is about — guides the fix."
+                        data={exploreOptions}
+                        value={targetExploreNames}
+                        onChange={setTargetExploreNamesOverride}
+                        searchable
+                        clearable
+                        disabled={!projectUuid}
+                        nothingFoundMessage="No explores"
                     />
                     <Stack gap={4}>
                         <Group

--- a/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/CreateIssue/CreateIssueModal.tsx
@@ -197,6 +197,15 @@ export const CreateIssueModal: FC<Props> = ({ opened, onClose, context }) => {
         const targetRefs: AiAgentTargetRef[] = targetExploreNames.map(
             (name) => ({ type: 'explore', modelName: name, exploreName: name }),
         );
+        // Persist which content the issue was filed from, not just its explores.
+        if (context && (context.chartUuid || context.dashboardUuid)) {
+            targetRefs.push({
+                type: 'content',
+                chartUuid: context.chartUuid ?? null,
+                dashboardUuid: context.dashboardUuid ?? null,
+                tileUuid: context.tileUuid ?? null,
+            });
+        }
         createIssue.mutate(
             {
                 title: title.trim(),


### PR DESCRIPTION
## Summary

Capture **which explores a data issue is about** when filing it, and persist them as `targetRefs` on the issue — so the manual-issue writeback starts from the right model.

**PR #4 of the Issues stack** — stacked on #24872. Linear: ZAP-515.

## What's in this PR

- A **"Related explores"** multi-select in the create-issue modal, populated from the project's explores. When filing from a chart, it's **pre-seeded with the chart's base explore**.
- Selected explores are mapped to `AiAgentTargetRef[]` (`{ type: 'explore', modelName, exploreName }`) and persisted on the manual review item.
- **Migration**: adds a nullable `target_refs` jsonb column to `ai_agent_review_item` (pure expand — no data mutation, safe under rolling deploy).
- `CreateAiAgentReviewItem` gains a required `targetRefs` field (empty array when none); both the content modal and the board's "New issue" modal pass it.

## Why explore-level (for now)

`AiAgentSemanticTargetRef` supports field-level refs too, but explore-level selection is the high-value 80%: it scopes the writeback to the right model and (later) lets us match the issue against each agent's explore coverage. Field-level granularity is an additive follow-up.

## How it feeds writeback

The manual-issue writeback (already on the foundation PR) currently seeds from title + description. A follow-up will include these `targetRefs` in the writeback prompt so the agent edits the right YAML. The column + capture land here first.

## Test plan

- Migration applied locally (`Batch run: … target_refs`); `\d ai_agent_review_item` shows the column.
- `pnpm -F backend typecheck:fast`, `pnpm -F frontend typecheck:fast`, `pnpm generate-api` clean.
- Backend unit tests: `AiAgentAdminService` + `AiAgentReviewClassifierModel` — 89/89 pass.
- Manual: file an issue from a chart → "Related explores" is pre-seeded with the chart's explore; add/remove explores; submit → the item persists `target_refs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## API breaking change — acknowledged (`allow-api-breaking-change`)

oasdiff flags 20 `response-property-became-nullable` errors plus a new `missing_agent` enum value. These are **intended** and confined to internal `/aiAgents/admin/...` endpoints whose only consumer is the Lightdash frontend (updated in the same stack):

- The manual-issues feature means a remediation can originate from a human-filed issue with **no** source finding/prompt/thread, so `AiAgentReviewRemediation.{sourceFindingUuid,sourcePromptUuid,sourceThreadUuid}` (and the equivalent `PullRequestReviewContext` fields) are now `string | null`. Forcing them non-nullable would misrepresent manual issues.
- `missing_agent` is a new writeback-eligibility reason (additive).

Reverting these would break the feature, so the change is acknowledged here rather than "fixed".

---

## Post-review fixes (multi-agent final review before merge)

- Manual issues now persist which content they were filed from: a new `content` variant on `AiAgentTargetRef` (`chartUuid`/`dashboardUuid`/`tileUuid`, all nullable) is appended on submit alongside the explore refs. Previously the "Reported from" chip was display-only and the provenance was dropped. Writeback prompt building filters via `isSemanticTargetRef`, so the new variant flows through storage untouched.
- The chart-seeded "Related explores" value is derived (`override ?? seed`) rather than effect-synced, so a late-resolving chart query can no longer clobber a user's edits.
- Regenerated TSOA `routes.ts`/`swagger.json` for the `CreateAiAgentReviewItem.targetRefs` body change.
