### PR TITLE
fix(roles): update org-level custom role assignment api-test

### DIFF
--- a/packages/api-tests/tests/roles.test.ts
+++ b/packages/api-tests/tests/roles.test.ts
@@ -3,6 +3,7 @@ import {
     SEED_GROUP,
     SEED_ORG_1,
     SEED_ORG_1_ADMIN,
+    SEED_ORG_1_EDITOR,
     SEED_PROJECT,
 } from '@lightdash/common';
 import { Body } from '../helpers/api-client';
@@ -410,9 +411,10 @@ describe('Roles API Tests', () => {
     describe('Unified Role Assignments', () => {
         const testUserUuid = SEED_ORG_1_ADMIN.user_uuid;
 
-        it('should reject custom role assignment at organization level', async () => {
+        it('should reject assigning a project-level custom role at organization level', async () => {
             const roleName = `User Assignment Role ${Date.now()}`;
 
+            // Roles created via this endpoint default to project level
             const createResp = await admin.post<Body<RoleResult>>(
                 `${orgRolesApiUrl}/${testOrgUuid}/roles`,
                 {
@@ -423,16 +425,17 @@ describe('Roles API Tests', () => {
             const { roleUuid } = createResp.body.results;
             rolesToCleanup.push(roleUuid);
 
-            // Try to assign custom role to user - should return 400 (only system roles allowed)
+            // Assign to a non-admin user so we hit the level check rather than
+            // the "organization must have at least one admin" guard
             const assignResp = await admin.post<ErrorBody>(
-                `${orgRolesApiUrl}/${testOrgUuid}/roles/assignments/user/${testUserUuid}`,
+                `${orgRolesApiUrl}/${testOrgUuid}/roles/assignments/user/${SEED_ORG_1_EDITOR.user_uuid}`,
                 { roleId: roleUuid },
                 { failOnStatusCode: false },
             );
 
             expect(assignResp.status).toBe(400);
             expect(assignResp.body.error.message).toContain(
-                'Only system roles can be assigned at organization level',
+                'can only be assigned at project level',
             );
         });
 


### PR DESCRIPTION
## Summary

The api-test `should reject custom role assignment at organization level` has been failing in CI since PROD-8195 merged. PROD-8195 ([PR #24589](https://github.com/lightdash/lightdash/pull/24589)) made custom roles assignable at the organization level and deliberately removed the restriction the test asserted, but did not update the test.

## Root cause

PR #24589 deleted the guard that the test depended on:

```ts
// Ensure only system roles can be assigned at organization level
if (roleId !== OrganizationMemberRole.MEMBER && !isSystemRole(roleId)) {
    throw new ParameterError(
        'Only system roles can be assigned at organization level',
    );
}
```

The test still expected HTTP 400 + `Only system roles can be assigned at organization level`. With that guard gone, the request falls through to the still-valid "at least one admin" check (the test assigned to the sole org admin, `SEED_ORG_1_ADMIN`), so the assertion now sees the wrong message:

```
Expected: "Only system roles can be assigned at organization level"
Received: "Organization must have at least one admin"
```

`#24589` didn't introduce a behaviour bug — it left a stale test behind. Its unit tests (`RolesService.test.ts`) were updated; this api-test was not.

## Fix

Rewrite the test to assert the real remaining rejection: a **project-level** custom role cannot be assigned at the organization level. Roles created via the org roles endpoint default to `level: 'project'`, and `validateCustomRoleLevel(role, 'organization')` rejects them. The test now targets a non-admin user (`SEED_ORG_1_EDITOR`) so the level check runs instead of the admin-count guard.

- `packages/api-tests/tests/roles.test.ts` — rename to `should reject assigning a project-level custom role at organization level`; assign to a non-admin user; assert the message contains `can only be assigned at project level`.

## Before / After

```
Before:  × should reject custom role assignment at organization level
           AssertionError: expected 'Organization must have at least one a…'
                           to contain 'Only system roles can be assigned at …'

After:   ✓ should reject assigning a project-level custom role at organization level
```

## Test plan

- [x] `pnpm -F api-tests lint && pnpm -F api-tests typecheck`
- [x] `npx vitest run tests/roles.test.ts` against a local instance — target test passes
- [x] Confirmed the two unrelated failures in this suite (`should create group project access` 500, `should allow project-scoped custom role to create preview...`) also fail on `main` — pre-existing, not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)