### PR TITLE
refactor(sandbox): provider-owned snapshot storage, storage-agnostic SandboxManager

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -556,6 +556,7 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
             .fn()
             .mockResolvedValue({ kind: 'e2b-paused', sandboxId: 'sb-test' }),
         resume: vi.fn(),
+        deleteSnapshot: vi.fn().mockResolvedValue(undefined),
     };
 
     const runService = (sandbox: AnyType) => {
@@ -634,7 +635,6 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
                 new SandboxManager({
                     provider: fakeSandboxProvider as AnyType,
                     providerKind: 'e2b',
-                    snapshotStore: opts.snapshotStore,
                     registryModel: opts.registryModel,
                     logger: opts.logger,
                     idleTimeoutMs: opts.idleTimeoutMs ?? 0,

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -935,9 +935,14 @@ export class AiWritebackService extends BaseService {
                     this.lightdashConfig.appRuntime
                         .sandboxAiWritebackDockerImage,
                 lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
-                snapshotStore: new S3SnapshotStore({
-                    lightdashConfig: this.lightdashConfig,
-                }),
+                // Object-store snapshots are Docker-only; native-pause providers
+                // never touch S3, so don't construct a client for them.
+                snapshotStore:
+                    this.lightdashConfig.appRuntime.sandboxProvider === 'docker'
+                        ? new S3SnapshotStore({
+                              lightdashConfig: this.lightdashConfig,
+                          })
+                        : null,
                 registryModel: this.sandboxRegistryModel,
                 logger: this.logger,
                 idleTimeoutMs:

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -416,9 +416,14 @@ export class AppGenerateService extends BaseService {
                 e2bApiKey: this.lightdashConfig.appRuntime.e2bApiKey,
                 dockerImage: this.lightdashConfig.appRuntime.sandboxDockerImage,
                 lambdaMicroVm: this.lightdashConfig.appRuntime.lambdaMicroVm,
-                snapshotStore: new S3SnapshotStore({
-                    lightdashConfig: this.lightdashConfig,
-                }),
+                // Object-store snapshots are Docker-only; native-pause providers
+                // never touch S3, so don't construct a client for them.
+                snapshotStore:
+                    this.lightdashConfig.appRuntime.sandboxProvider === 'docker'
+                        ? new S3SnapshotStore({
+                              lightdashConfig: this.lightdashConfig,
+                          })
+                        : null,
                 registryModel: this.sandboxRegistryModel,
                 logger: this.logger,
                 idleTimeoutMs:

--- a/packages/backend/src/ee/services/SandboxRuntime/DockerSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/DockerSandboxProvider.ts
@@ -1,6 +1,6 @@
 import type Docker from 'dockerode';
 import type { Container } from 'dockerode';
-import { randomBytes } from 'node:crypto';
+import { randomBytes, randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
 import { Writable } from 'node:stream';
 import { SandboxCommandError, SandboxTimeoutError } from './errors';
@@ -421,13 +421,16 @@ export class DockerSandboxProvider implements SandboxProvider {
      * paths so resume restores them to the same absolute locations. The tarball
      * is staged to a file and read back as raw bytes (never piped through the
      * string-typed `commands.run` stdout, which would corrupt binary content).
+     * The object-store key is generated here — the key is an opaque storage
+     * detail the provider owns and returns in the ref (the Manager never sees it).
      * Does not stop the container — the caller destroys it after persisting.
      */
     async persist(
         handle: SandboxHandle,
         options: PersistOptions,
     ): Promise<SnapshotRef> {
-        const { workspace, snapshotKey } = options;
+        const { workspace } = options;
+        const snapshotKey = `sandboxes/${randomUUID()}/snapshot.tar.gz`;
         const archivePath = `/tmp/.ld-snapshot-${randomBytes(4).toString(
             'hex',
         )}.tar.gz`;
@@ -482,5 +485,16 @@ export class DockerSandboxProvider implements SandboxProvider {
             `Docker sandbox ${handle.sandboxId} resumed from ${ref.key}`,
         );
         return handle;
+    }
+
+    /**
+     * Delete the snapshot blob backing an s3-tar ref. The Manager calls this on
+     * destroy/GC; storage cleanup lives here next to the tar/untar that wrote it.
+     */
+    async deleteSnapshot(ref: SnapshotRef): Promise<void> {
+        if (ref.kind !== 's3-tar') {
+            return;
+        }
+        await this.snapshotStore.delete(ref.key);
     }
 }

--- a/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/E2bSandboxProvider.ts
@@ -222,4 +222,10 @@ export class E2bSandboxProvider implements SandboxProvider {
         }
         return this.connect(ref.sandboxId);
     }
+
+    // eslint-disable-next-line class-methods-use-this
+    async deleteSnapshot(_ref: SnapshotRef): Promise<void> {
+        // The paused sandbox IS the snapshot; destroy(sandboxId) reclaims it, so
+        // there is no separate blob to delete here.
+    }
 }

--- a/packages/backend/src/ee/services/SandboxRuntime/LambdaMicroVmSandboxProvider.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/LambdaMicroVmSandboxProvider.ts
@@ -272,6 +272,12 @@ export class LambdaMicroVmSandboxProvider implements SandboxProvider {
         return this.connect(ref.microVmId);
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    async deleteSnapshot(_ref: SnapshotRef): Promise<void> {
+        // The suspended microVM IS the snapshot; destroy(microVmId) →
+        // TerminateMicrovm reclaims it, so there is no separate blob to delete.
+    }
+
     /** Resume a suspended microVM (or accept a running one); reject terminal ones. */
     private async ensureRunning(
         microVmId: string,

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.test.ts
@@ -3,7 +3,6 @@ import {
     SandboxManager,
     type SandboxRegistryStore,
 } from './SandboxManager';
-import { type SnapshotStore } from './SnapshotStore';
 import {
     type PersistentWorkspace,
     type SandboxCapabilities,
@@ -54,6 +53,7 @@ const makeProvider = (
                     : { kind: 's3-tar', key: 'sandboxes/sb-1/snapshot.tar.gz' },
             ),
         resume: vi.fn().mockResolvedValue(makeHandle('live-restored')),
+        deleteSnapshot: vi.fn().mockResolvedValue(undefined),
     } as unknown as import('vitest').Mocked<SandboxProvider>;
 };
 
@@ -69,21 +69,13 @@ const makeRegistry = (): import('vitest').Mocked<SandboxRegistryStore> =>
         findExpiredSuspended: vi.fn().mockResolvedValue([]),
     }) as unknown as import('vitest').Mocked<SandboxRegistryStore>;
 
-const makeStore = (): import('vitest').Mocked<SnapshotStore> => ({
-    put: vi.fn().mockResolvedValue(undefined),
-    get: vi.fn(),
-    delete: vi.fn().mockResolvedValue(undefined),
-});
-
 const makeManager = (
     provider: import('vitest').Mocked<SandboxProvider>,
     registry: import('vitest').Mocked<SandboxRegistryStore>,
-    store: import('vitest').Mocked<SnapshotStore>,
 ) =>
     new SandboxManager({
         provider,
         providerKind: provider.capabilities.pauseResume ? 'e2b' : 'docker',
-        snapshotStore: store,
         registryModel: registry,
         logger,
         idleTimeoutMs: 1000,
@@ -94,7 +86,7 @@ describe('SandboxManager', () => {
     it('acquire creates a sandbox and registers it', async () => {
         const provider = makeProvider(false);
         const registry = makeRegistry();
-        const manager = makeManager(provider, registry, makeStore());
+        const manager = makeManager(provider, registry);
 
         const { sandboxUuid, handle } = await manager.acquire({
             spec,
@@ -120,7 +112,7 @@ describe('SandboxManager', () => {
         const registry = makeRegistry();
         const insertError = new Error('registry insert failed');
         registry.create.mockRejectedValueOnce(insertError);
-        const manager = makeManager(provider, registry, makeStore());
+        const manager = makeManager(provider, registry);
 
         await expect(
             manager.acquire({
@@ -142,7 +134,7 @@ describe('SandboxManager', () => {
         const insertError = new Error('registry insert failed');
         registry.create.mockRejectedValueOnce(insertError);
         provider.destroy.mockRejectedValueOnce(new Error('destroy failed'));
-        const manager = makeManager(provider, registry, makeStore());
+        const manager = makeManager(provider, registry);
 
         await expect(
             manager.acquire({
@@ -159,7 +151,7 @@ describe('SandboxManager', () => {
         it('object-store backend snapshots then destroys the container', async () => {
             const provider = makeProvider(false);
             const registry = makeRegistry();
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             await manager.suspend({
                 sandboxUuid: 'sb-1',
@@ -169,10 +161,7 @@ describe('SandboxManager', () => {
 
             expect(provider.persist).toHaveBeenCalledWith(
                 expect.objectContaining({ sandboxId: 'live-1' }),
-                {
-                    workspace,
-                    snapshotKey: 'sandboxes/sb-1/snapshot.tar.gz',
-                },
+                { workspace },
             );
             expect(provider.destroy).toHaveBeenCalledWith('live-1');
             expect(registry.markSuspended).toHaveBeenCalledWith('sb-1', {
@@ -187,7 +176,7 @@ describe('SandboxManager', () => {
         it('native-pause backend keeps the sandbox alive', async () => {
             const provider = makeProvider(true);
             const registry = makeRegistry();
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             await manager.suspend({
                 sandboxUuid: 'sb-1',
@@ -217,7 +206,7 @@ describe('SandboxManager', () => {
                 workspace,
                 lastActivityAt: new Date(0),
             });
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             await manager.suspendByUuid('sb-1');
 
@@ -245,14 +234,17 @@ describe('SandboxManager', () => {
                 workspace,
                 lastActivityAt: new Date(0),
             });
-            const store = makeStore();
-            const manager = makeManager(provider, registry, store);
+            const manager = makeManager(provider, registry);
 
             await manager.suspendByUuid('sb-1');
 
             expect(provider.connect).not.toHaveBeenCalled();
             expect(provider.persist).not.toHaveBeenCalled();
-            expect(store.delete).toHaveBeenCalledWith('k');
+            // Storage cleanup is delegated to the provider, not the Manager.
+            expect(provider.deleteSnapshot).toHaveBeenCalledWith({
+                kind: 's3-tar',
+                key: 'k',
+            });
             expect(registry.deleteBySandboxUuid).toHaveBeenCalledWith('sb-1');
         });
 
@@ -260,7 +252,7 @@ describe('SandboxManager', () => {
             const provider = makeProvider(false);
             const registry = makeRegistry();
             registry.findBySandboxUuid.mockResolvedValue(null);
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             await manager.suspendByUuid('sb-1');
 
@@ -282,7 +274,7 @@ describe('SandboxManager', () => {
                 workspace,
                 lastActivityAt: new Date(0),
             });
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             const handle = await manager.resume({ sandboxUuid: 'sb-1', spec });
 
@@ -304,7 +296,6 @@ describe('SandboxManager', () => {
             // same E2B sandbox (no object storage involved).
             const provider = makeProvider(true);
             const registry = makeRegistry();
-            const store = makeStore();
             registry.findBySandboxUuid.mockResolvedValue({
                 sandboxUuid: 'sb-1',
                 organizationUuid: 'org-1',
@@ -314,16 +305,16 @@ describe('SandboxManager', () => {
                 workspace,
                 lastActivityAt: new Date(0),
             });
-            const manager = makeManager(provider, registry, store);
+            const manager = makeManager(provider, registry);
 
             const handle = await manager.resume({ sandboxUuid: 'sb-1', spec });
 
+            // The paused VM is the snapshot — resume goes straight through the
+            // provider with no object storage (the Manager holds no store).
             expect(provider.resume).toHaveBeenCalledWith(
                 { kind: 'e2b-paused', sandboxId: 'e2b-live-1' },
                 spec,
             );
-            // The paused VM is the snapshot — resume must not read from S3.
-            expect(store.get).not.toHaveBeenCalled();
             expect(registry.markRunning).toHaveBeenCalledWith(
                 'sb-1',
                 'live-restored',
@@ -335,7 +326,7 @@ describe('SandboxManager', () => {
             const provider = makeProvider(false);
             const registry = makeRegistry();
             registry.findBySandboxUuid.mockResolvedValue(null);
-            const manager = makeManager(provider, registry, makeStore());
+            const manager = makeManager(provider, registry);
 
             await expect(
                 manager.resume({ sandboxUuid: 'sb-1', spec }),
@@ -355,8 +346,7 @@ describe('SandboxManager', () => {
             workspace,
             lastActivityAt: new Date(0),
         });
-        const store = makeStore();
-        const manager = makeManager(provider, registry, store);
+        const manager = makeManager(provider, registry);
 
         await manager.destroy({
             sandboxUuid: 'sb-1',
@@ -364,7 +354,11 @@ describe('SandboxManager', () => {
         });
 
         expect(provider.destroy).toHaveBeenCalledWith('live-1');
-        expect(store.delete).toHaveBeenCalledWith('k');
+        // Storage cleanup is delegated to the provider, not the Manager.
+        expect(provider.deleteSnapshot).toHaveBeenCalledWith({
+            kind: 's3-tar',
+            key: 'k',
+        });
         expect(registry.deleteBySandboxUuid).toHaveBeenCalledWith('sb-1');
     });
 
@@ -404,16 +398,18 @@ describe('SandboxManager', () => {
                 workspace,
                 lastActivityAt: new Date(0),
             });
-            const store = makeStore();
-            const manager = makeManager(provider, registry, store);
+            const manager = makeManager(provider, registry);
 
             const result = await manager.reapIdle();
 
             // Idle orphan: reconnected, persisted, destroyed.
             expect(provider.connect).toHaveBeenCalledWith('live-idle');
             expect(provider.persist).toHaveBeenCalledTimes(1);
-            // Expired snapshot GC'd.
-            expect(store.delete).toHaveBeenCalledWith('old');
+            // Expired snapshot GC'd via the provider.
+            expect(provider.deleteSnapshot).toHaveBeenCalledWith({
+                kind: 's3-tar',
+                key: 'old',
+            });
             expect(result).toEqual({ suspended: 1, gced: 1 });
         });
     });

--- a/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/SandboxManager.ts
@@ -1,6 +1,5 @@
 import { getErrorMessage } from '@lightdash/common';
 import { type SandboxProviderKind } from './index';
-import { type SnapshotStore } from './SnapshotStore';
 import {
     type PersistentWorkspace,
     type SandboxHandle,
@@ -57,13 +56,9 @@ export class SandboxExpiredError extends Error {
     }
 }
 
-const snapshotKeyFor = (sandboxUuid: string): string =>
-    `sandboxes/${sandboxUuid}/snapshot.tar.gz`;
-
 export interface SandboxManagerDeps {
     provider: SandboxProvider;
     providerKind: SandboxProviderKind;
-    snapshotStore: SnapshotStore;
     registryModel: SandboxRegistryStore;
     logger: SandboxLogger;
     /** Live sandbox idle before the reaper suspends it (crash safety net). */
@@ -84,8 +79,6 @@ export class SandboxManager {
 
     private readonly providerKind: SandboxProviderKind;
 
-    private readonly snapshotStore: SnapshotStore;
-
     private readonly registry: SandboxRegistryStore;
 
     private readonly logger: SandboxLogger;
@@ -97,7 +90,6 @@ export class SandboxManager {
     constructor(deps: SandboxManagerDeps) {
         this.provider = deps.provider;
         this.providerKind = deps.providerKind;
-        this.snapshotStore = deps.snapshotStore;
         this.registry = deps.registryModel;
         this.logger = deps.logger;
         this.idleTimeoutMs = deps.idleTimeoutMs;
@@ -181,7 +173,6 @@ export class SandboxManager {
     }): Promise<void> {
         const ref = await this.provider.persist(input.handle, {
             workspace: input.workspace,
-            snapshotKey: snapshotKeyFor(input.sandboxUuid),
         });
         if (this.provider.capabilities.pauseResume) {
             await this.registry.markSuspended(input.sandboxUuid, {
@@ -230,8 +221,8 @@ export class SandboxManager {
         if (liveId) {
             await this.provider.destroy(liveId);
         }
-        if (row?.snapshotRef?.kind === 's3-tar') {
-            await this.snapshotStore.delete(row.snapshotRef.key);
+        if (row?.snapshotRef) {
+            await this.provider.deleteSnapshot(row.snapshotRef);
         }
         await this.registry.deleteBySandboxUuid(input.sandboxUuid);
     }

--- a/packages/backend/src/ee/services/SandboxRuntime/index.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/index.ts
@@ -29,8 +29,12 @@ export interface CreateSandboxProviderOptions {
     dockerImage: string;
     /** Required when `provider === 'lambda-microvm'`; ignored otherwise. */
     lambdaMicroVm: LambdaMicroVmProviderConfig | null;
-    /** Backing store for object-store snapshots (used by the Docker provider). */
-    snapshotStore: SnapshotStore;
+    /**
+     * Backing store for object-store snapshots. Required only by the Docker
+     * provider; native-pause providers (E2B, Lambda) keep the snapshot in the
+     * provider and pass `null` so no S3 client is constructed on those paths.
+     */
+    snapshotStore: SnapshotStore | null;
     logger: SandboxLogger;
 }
 
@@ -50,6 +54,11 @@ export const createSandboxProvider = (
             }
             return new E2bSandboxProvider(options.e2bApiKey);
         case 'docker':
+            if (!options.snapshotStore) {
+                throw new MissingConfigError(
+                    'Docker sandbox provider requires an object store for snapshots',
+                );
+            }
             return new DockerSandboxProvider(
                 options.dockerImage,
                 options.logger,
@@ -88,7 +97,8 @@ export interface CreateSandboxManagerOptions {
     e2bApiKey: string | null;
     dockerImage: string;
     lambdaMicroVm: LambdaMicroVmProviderConfig | null;
-    snapshotStore: SnapshotStore;
+    /** Forwarded to the provider; Docker-only (null on native-pause paths). */
+    snapshotStore: SnapshotStore | null;
     registryModel: SandboxRegistryStore;
     logger: SandboxLogger;
     idleTimeoutMs: number;
@@ -113,7 +123,6 @@ export const createSandboxManager = (
     return new SandboxManager({
         provider,
         providerKind: options.provider,
-        snapshotStore: options.snapshotStore,
         registryModel: options.registryModel,
         logger: options.logger,
         idleTimeoutMs: options.idleTimeoutMs,

--- a/packages/backend/src/ee/services/SandboxRuntime/types.ts
+++ b/packages/backend/src/ee/services/SandboxRuntime/types.ts
@@ -187,8 +187,6 @@ export type SnapshotRef =
 export interface PersistOptions {
     /** What to capture. Native-pause providers (E2B) ignore this. */
     workspace: PersistentWorkspace;
-    /** Object-store key to write the snapshot to. Native-pause providers ignore this. */
-    snapshotKey: string;
 }
 
 /**
@@ -216,4 +214,11 @@ export interface SandboxProvider {
     ): Promise<SnapshotRef>;
     /** Re-materialize a sandbox from a {@link SnapshotRef}. */
     resume(ref: SnapshotRef, spec: SandboxSpec): Promise<SandboxHandle>;
+    /**
+     * Dispose a persisted snapshot. No-op for native-pause providers (the
+     * snapshot IS the suspended sandbox, reclaimed by {@link destroy}); object-
+     * store providers (Docker) delete the backing blob. The Manager calls this on
+     * destroy/GC so storage cleanup stays a provider concern.
+     */
+    deleteSnapshot(ref: SnapshotRef): Promise<void>;
 }


### PR DESCRIPTION
Moves snapshot **storage** out of the registry layer and into the provider, so the `SandboxManager` holds only the opaque `SnapshotRef` + lifecycle policy and never touches an object store.

> **Registry/Manager owns the *reference* and the *policy*. The provider owns the *storage mechanism*.**

This makes the pure-AWS (Lambda MicroVMs) and E2B paths reach **zero S3 code** — the whole point of leading on a thin, storage-agnostic foundation — and keeps the seam clean for a future GCS provider (one new `SnapshotRef` variant + a `deleteSnapshot` impl, no Manager change).

## What changed

- **`types.ts`**: add `SandboxProvider.deleteSnapshot(ref)`. Drop `snapshotKey` from `PersistOptions` — object-store providers mint their own opaque key (it's stored in the returned ref; the Manager never sees it). `SnapshotRef` stays a closed union.
- **Providers**:
  - E2B + Lambda `deleteSnapshot` are no-ops — the suspended sandbox/microVM **is** the snapshot, reclaimed by `destroy()` (`Sandbox.kill` / `TerminateMicrovm`). No separate blob.
  - Docker `deleteSnapshot` deletes the `s3-tar` blob; `persist()` now generates its own snapshot key.
- **`SandboxManager`**: drops the `snapshotStore` dep + the `snapshotKeyFor` helper. `destroy()`/GC delegate blob cleanup to `provider.deleteSnapshot(ref)` instead of the inline `if (ref.kind === 's3-tar')` branch. The Manager no longer references S3.
- **Factory + services**: `snapshotStore` is Docker-only (nullable; factory throws for Docker without one). `AppGenerateService` / `AiWritebackService` construct `S3SnapshotStore` only on the `docker` path, so native-pause deployments instantiate no S3 client.

## Behaviour

Native-pause (E2B, Lambda) is behaviour-identical: the old Manager `destroy()` only deleted blobs for `s3-tar` refs, which never matched those providers. Docker dev persistence is unchanged (same tar → store, now keyed by the provider).

## Tests

`pnpm -F backend typecheck:fast` + `lint` green. SandboxRuntime + AiWritebackService suites green (15 files / 220 tests). Added `deleteSnapshot` coverage to each provider test + a factory "Docker requires a store" case; moved the s3-tar GC assertions onto the Docker provider.

Forward-only refactor stacked on the Lambda deploy infra (#24858 → #24857 → #24793). Object-store extraction (shared `BlobStore`/`ObjectStoreSnapshot` strategy) is documented as the GCP extension point but intentionally not built yet (YAGNI).