### PR TITLE
feat(ai-agents): keep the issues board reachable from the navbar when empty [ZAP-516]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ AGENTS.md
 
 # release-safety marker is a generated release asset (PROD-8359), never committed
 /release-safety.json
+
+# Superpowers brainstorm scratch
+.superpowers/

--- a/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
+++ b/packages/frontend/src/components/NavBar/AiAgentsButton.tsx
@@ -1,6 +1,7 @@
-import { Button, HoverCard, Text } from '@mantine-8/core';
+import { Anchor, Button, HoverCard, Stack, Text } from '@mantine-8/core';
+import { IconArrowRight } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon';
 import { ReviewFindingsPreview } from '../../ee/features/aiCopilot/components/ReviewFindingsPreview';
 import {
@@ -10,6 +11,7 @@ import {
 import { useAiAgentOrgPermission } from '../../ee/features/aiCopilot/hooks/useAiAgentPermission';
 import { useAiAgentButtonVisibility } from '../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useAiOrganizationSettings } from '../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
+import MantineIcon from '../common/MantineIcon';
 
 const PREVIEW_LIMIT = 3;
 const PROMPT_TREND_DAYS = 30;
@@ -60,8 +62,12 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         return null;
     }
 
-    // Original button — nothing to surface (no review access, or no active findings).
-    if (!showReviews || reviewCount === 0) {
+    const reviewsUrl = `/generalSettings/ai/issues?projects=${encodeURIComponent(
+        projectUuid,
+    )}`;
+
+    // No review access — plain Ask AI button, board not reachable from here.
+    if (!showReviews) {
         return (
             <Button
                 size="xs"
@@ -77,9 +83,59 @@ export const AiAgentsButton = ({ projectUuid }: Props) => {
         );
     }
 
-    const reviewsUrl = `/generalSettings/ai/issues?projects=${encodeURIComponent(
-        projectUuid,
-    )}`;
+    // Reviews enabled but nothing open yet — keep the board reachable (users can
+    // file issues manually), without the findings preview / trend chart.
+    if (reviewCount === 0) {
+        return (
+            <HoverCard
+                width={240}
+                shadow="lg"
+                position="bottom-start"
+                offset={6}
+                openDelay={120}
+                closeDelay={80}
+                withinPortal
+                portalProps={{ target: '#navbar-header' }}
+            >
+                <HoverCard.Target>
+                    <Button
+                        size="xs"
+                        variant="default"
+                        fz="sm"
+                        leftSection={<AiAgentIcon size={14} />}
+                        onClick={goToAskAi}
+                    >
+                        <Text span truncate="end" maw={150} size="sm">
+                            Ask AI
+                        </Text>
+                    </Button>
+                </HoverCard.Target>
+                <HoverCard.Dropdown p="sm">
+                    <Stack gap={6}>
+                        <Text fz="xs" c="dimmed">
+                            No open issues yet. Track a data gap, correction, or
+                            request from a chart, dashboard, or the board.
+                        </Text>
+                        <Anchor
+                            component={Link}
+                            to={reviewsUrl}
+                            fz="xs"
+                            fw={500}
+                        >
+                            <Text span fz="xs" fw={500}>
+                                Go to the issues board
+                            </Text>{' '}
+                            <MantineIcon
+                                icon={IconArrowRight}
+                                size={12}
+                                display="inline"
+                            />
+                        </Anchor>
+                    </Stack>
+                </HoverCard.Dropdown>
+            </HoverCard>
+        );
+    }
 
     return (
         <HoverCard

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
@@ -1,28 +1,52 @@
-/* A quiet transcript — no rules, no chips, just air between turns and a
-   whisper-light role label above each. */
-.excerpts {
-    gap: 14px;
+/* Transcript ledger — the same gutter grammar as the Activity timeline:
+   speaker right-aligned in a fixed column, quoted text beside it. */
+.transcript {
+    display: grid;
+    grid-template-columns: 70px minmax(0, 1fr);
+    column-gap: 12px;
+    row-gap: 12px;
+    align-items: start;
 }
 
-.label {
+.speaker {
     font-size: 10px;
     font-weight: 600;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
+    text-align: right;
+    padding-top: 3px;
     color: var(--mantine-color-ldGray-6);
+    white-space: nowrap;
 }
 
-.label[data-muted] {
+.speaker[data-muted] {
     color: var(--mantine-color-ldGray-5);
+    font-weight: 500;
 }
 
-/* AiMarkdown owns the body typography; we only dim the secondary
-   (context / tool) sources so the cited user & assistant turns lead. */
+/* Quoted turns — AiMarkdown owns the inner typography; we tighten it to the
+   transcript scale. Secondary (context / tool) sources dim so the cited user
+   & assistant turns lead. */
 .text {
     font-size: 12.5px;
     color: var(--mantine-color-ldGray-8);
+    min-width: 0;
+}
+
+.text p {
+    font-size: 12.5px;
+    line-height: 1.55;
 }
 
 .text[data-muted] {
-    opacity: 0.6;
+    opacity: 0.65;
+}
+
+/* Tool call/result — machine output reads as machine output. */
+.text[data-mono] {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
+    line-height: 1.5;
+    padding-top: 2px;
+    overflow-wrap: anywhere;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
@@ -1,0 +1,22 @@
+.excerpts {
+    border-left: 2px solid var(--mantine-color-ldGray-2);
+    padding-left: var(--mantine-spacing-md);
+}
+
+.label {
+    /* Match AiMarkdown's 7px left padding so labels line up with their text. */
+    padding-left: 7px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--mantine-color-ldGray-6);
+}
+
+.label[data-muted] {
+    color: var(--mantine-color-ldGray-5);
+}
+
+/* AiMarkdown owns the body typography; we only dim the secondary
+   (context / tool) sources so the cited user & assistant turns lead. */
+.text[data-muted] {
+    opacity: 0.7;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.module.css
@@ -1,13 +1,14 @@
+/* A quiet transcript — no rules, no chips, just air between turns and a
+   whisper-light role label above each. */
 .excerpts {
-    border-left: 2px solid var(--mantine-color-ldGray-2);
-    padding-left: var(--mantine-spacing-md);
+    gap: 14px;
 }
 
 .label {
-    /* Match AiMarkdown's 7px left padding so labels line up with their text. */
-    padding-left: 7px;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
     color: var(--mantine-color-ldGray-6);
 }
 
@@ -17,6 +18,11 @@
 
 /* AiMarkdown owns the body typography; we only dim the secondary
    (context / tool) sources so the cited user & assistant turns lead. */
+.text {
+    font-size: 12.5px;
+    color: var(--mantine-color-ldGray-8);
+}
+
 .text[data-muted] {
-    opacity: 0.7;
+    opacity: 0.6;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.test.tsx
@@ -63,11 +63,11 @@ describe('EvidenceExcerpts', () => {
             />,
         );
 
-        expect(screen.getByText('User asked')).toBeInTheDocument();
+        expect(screen.getByText('User')).toBeInTheDocument();
         expect(screen.getByText('What is our revenue?')).toBeInTheDocument();
-        expect(screen.getByText('Assistant answered')).toBeInTheDocument();
+        expect(screen.getByText('Assistant')).toBeInTheDocument();
         expect(screen.getByText('It is $4,149.12')).toBeInTheDocument();
-        expect(screen.getByText('User then said')).toBeInTheDocument();
+        expect(screen.getByText('User reply')).toBeInTheDocument();
         expect(screen.getByText("That's wrong")).toBeInTheDocument();
     });
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.test.tsx
@@ -1,0 +1,85 @@
+import { type AiAgentEvidenceExcerpt } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../testing/testUtils';
+import {
+    cleanExcerptText,
+    getRenderableExcerpts,
+} from './evidenceExcerptHelpers';
+import { EvidenceExcerpts } from './EvidenceExcerpts';
+
+// Render markdown as plain text so assertions match the excerpt source.
+vi.mock('../../../../../components/common/AiMarkdown', () => ({
+    AiMarkdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+const ex = (
+    overrides: Partial<AiAgentEvidenceExcerpt> = {},
+): AiAgentEvidenceExcerpt => ({
+    source: 'user_prompt',
+    text: 'some text',
+    redacted: false,
+    ...overrides,
+});
+
+describe('getRenderableExcerpts', () => {
+    it('drops redacted and empty-text excerpts', () => {
+        const result = getRenderableExcerpts([
+            ex({ text: 'keep me' }),
+            ex({ text: 'secret', redacted: true }),
+            ex({ text: '   ' }),
+            ex({ text: '' }),
+        ]);
+
+        expect(result).toEqual([ex({ text: 'keep me' })]);
+    });
+});
+
+describe('cleanExcerptText', () => {
+    it('strips the "previous turn (uuid): prompt=" context prefix', () => {
+        expect(
+            cleanExcerptText(
+                'previous turn (c2869f2f-9ee3-4df9-99bf-95a7c2ef906f): prompt=That revenue is wrong.',
+            ),
+        ).toBe('That revenue is wrong.');
+    });
+
+    it('leaves ordinary text untouched', () => {
+        expect(cleanExcerptText('What is our revenue?')).toBe(
+            'What is our revenue?',
+        );
+    });
+});
+
+describe('EvidenceExcerpts', () => {
+    it('renders a friendly label and text for each renderable excerpt', () => {
+        renderWithProviders(
+            <EvidenceExcerpts
+                excerpts={[
+                    ex({ source: 'user_prompt', text: 'What is our revenue?' }),
+                    ex({ source: 'assistant_answer', text: 'It is $4,149.12' }),
+                    ex({ source: 'next_user_prompt', text: "That's wrong" }),
+                ]}
+            />,
+        );
+
+        expect(screen.getByText('User asked')).toBeInTheDocument();
+        expect(screen.getByText('What is our revenue?')).toBeInTheDocument();
+        expect(screen.getByText('Assistant answered')).toBeInTheDocument();
+        expect(screen.getByText('It is $4,149.12')).toBeInTheDocument();
+        expect(screen.getByText('User then said')).toBeInTheDocument();
+        expect(screen.getByText("That's wrong")).toBeInTheDocument();
+    });
+
+    it('renders nothing when there are no renderable excerpts', () => {
+        renderWithProviders(
+            <EvidenceExcerpts
+                excerpts={[ex({ text: 'secret', redacted: true })]}
+            />,
+        );
+
+        expect(
+            screen.queryByTestId('evidence-excerpts'),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
@@ -1,6 +1,6 @@
 import { type AiAgentEvidenceExcerpt } from '@lightdash/common';
-import { Box, Stack, Text } from '@mantine-8/core';
-import { type FC } from 'react';
+import { Box, Text } from '@mantine-8/core';
+import { Fragment, type FC } from 'react';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import {
     cleanExcerptText,
@@ -9,13 +9,13 @@ import {
 import styles from './EvidenceExcerpts.module.css';
 
 const SOURCE_LABELS: Record<AiAgentEvidenceExcerpt['source'], string> = {
-    user_prompt: 'User asked',
-    assistant_answer: 'Assistant answered',
-    next_user_prompt: 'User then said',
+    user_prompt: 'User',
+    assistant_answer: 'Assistant',
+    next_user_prompt: 'User reply',
     conversation_context: 'Context',
     tool_call: 'Tool call',
     tool_result: 'Tool result',
-    agent_config: 'Agent config',
+    agent_config: 'Config',
 };
 
 const PRIMARY_SOURCES = new Set<AiAgentEvidenceExcerpt['source']>([
@@ -24,10 +24,21 @@ const PRIMARY_SOURCES = new Set<AiAgentEvidenceExcerpt['source']>([
     'next_user_prompt',
 ]);
 
+const MONO_SOURCES = new Set<AiAgentEvidenceExcerpt['source']>([
+    'tool_call',
+    'tool_result',
+]);
+
 type Props = {
     excerpts: AiAgentEvidenceExcerpt[];
 };
 
+/**
+ * Cited turns rendered as a compact transcript ledger: speaker in a
+ * right-aligned gutter (the same column grammar as the Activity timeline),
+ * the quoted text beside it. Consecutive turns from the same speaker keep
+ * one label so the exchange reads as a conversation, not a list of blocks.
+ */
 export const EvidenceExcerpts: FC<Props> = ({ excerpts }) => {
     const renderable = getRenderableExcerpts(excerpts);
 
@@ -49,35 +60,40 @@ export const EvidenceExcerpts: FC<Props> = ({ excerpts }) => {
     }
 
     return (
-        <Stack
-            data-testid="evidence-excerpts"
-            className={styles.excerpts}
-            gap="md"
-        >
-            {deduped.map((excerpt) => {
+        <Box data-testid="evidence-excerpts" className={styles.transcript}>
+            {deduped.map((excerpt, index) => {
+                const label = SOURCE_LABELS[excerpt.source];
+                const repeated =
+                    index > 0 &&
+                    SOURCE_LABELS[deduped[index - 1].source] === label;
                 const muted = !PRIMARY_SOURCES.has(excerpt.source);
+                const mono = MONO_SOURCES.has(excerpt.source);
                 return (
-                    <Stack
+                    <Fragment
                         key={`${excerpt.source}-${excerpt.text.slice(0, 48)}`}
-                        gap={3}
                     >
                         <Text
-                            className={styles.label}
+                            className={styles.speaker}
                             data-muted={muted || undefined}
                         >
-                            {SOURCE_LABELS[excerpt.source]}
+                            {repeated ? '' : label}
                         </Text>
                         <Box
                             className={styles.text}
                             data-muted={muted || undefined}
+                            data-mono={mono || undefined}
                         >
-                            <AiMarkdown>
-                                {cleanExcerptText(excerpt.text)}
-                            </AiMarkdown>
+                            {mono ? (
+                                cleanExcerptText(excerpt.text)
+                            ) : (
+                                <AiMarkdown>
+                                    {cleanExcerptText(excerpt.text)}
+                                </AiMarkdown>
+                            )}
                         </Box>
-                    </Stack>
+                    </Fragment>
                 );
             })}
-        </Stack>
+        </Box>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
@@ -31,7 +31,20 @@ type Props = {
 export const EvidenceExcerpts: FC<Props> = ({ excerpts }) => {
     const renderable = getRenderableExcerpts(excerpts);
 
-    if (renderable.length === 0) {
+    // A `next_user_prompt` that repeats an earlier turn verbatim is the user
+    // re-asking — the signal is the repeat, not a new question. Showing the
+    // same text twice under two labels reads as a bug, so drop the echo.
+    const seen = new Set<string>();
+    const deduped = renderable.filter((excerpt) => {
+        const key = cleanExcerptText(excerpt.text).trim().toLowerCase();
+        if (excerpt.source === 'next_user_prompt' && seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+
+    if (deduped.length === 0) {
         return null;
     }
 
@@ -41,7 +54,7 @@ export const EvidenceExcerpts: FC<Props> = ({ excerpts }) => {
             className={styles.excerpts}
             gap="md"
         >
-            {renderable.map((excerpt) => {
+            {deduped.map((excerpt) => {
                 const muted = !PRIMARY_SOURCES.has(excerpt.source);
                 return (
                     <Stack

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvidenceExcerpts.tsx
@@ -1,0 +1,70 @@
+import { type AiAgentEvidenceExcerpt } from '@lightdash/common';
+import { Box, Stack, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import {
+    cleanExcerptText,
+    getRenderableExcerpts,
+} from './evidenceExcerptHelpers';
+import styles from './EvidenceExcerpts.module.css';
+
+const SOURCE_LABELS: Record<AiAgentEvidenceExcerpt['source'], string> = {
+    user_prompt: 'User asked',
+    assistant_answer: 'Assistant answered',
+    next_user_prompt: 'User then said',
+    conversation_context: 'Context',
+    tool_call: 'Tool call',
+    tool_result: 'Tool result',
+    agent_config: 'Agent config',
+};
+
+const PRIMARY_SOURCES = new Set<AiAgentEvidenceExcerpt['source']>([
+    'user_prompt',
+    'assistant_answer',
+    'next_user_prompt',
+]);
+
+type Props = {
+    excerpts: AiAgentEvidenceExcerpt[];
+};
+
+export const EvidenceExcerpts: FC<Props> = ({ excerpts }) => {
+    const renderable = getRenderableExcerpts(excerpts);
+
+    if (renderable.length === 0) {
+        return null;
+    }
+
+    return (
+        <Stack
+            data-testid="evidence-excerpts"
+            className={styles.excerpts}
+            gap="md"
+        >
+            {renderable.map((excerpt) => {
+                const muted = !PRIMARY_SOURCES.has(excerpt.source);
+                return (
+                    <Stack
+                        key={`${excerpt.source}-${excerpt.text.slice(0, 48)}`}
+                        gap={3}
+                    >
+                        <Text
+                            className={styles.label}
+                            data-muted={muted || undefined}
+                        >
+                            {SOURCE_LABELS[excerpt.source]}
+                        </Text>
+                        <Box
+                            className={styles.text}
+                            data-muted={muted || undefined}
+                        >
+                            <AiMarkdown>
+                                {cleanExcerptText(excerpt.text)}
+                            </AiMarkdown>
+                        </Box>
+                    </Stack>
+                );
+            })}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
@@ -1,41 +1,63 @@
 .layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 232px;
+    grid-template-columns: minmax(0, 1fr) 248px;
     gap: var(--mantine-spacing-xl);
     align-items: start;
 }
 
 .main {
     min-width: 0;
+    animation: rise 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-/* Issue header --------------------------------------------------------- */
-
-.causeBadge {
-    width: fit-content;
-    margin-bottom: var(--mantine-spacing-sm);
-}
-
-.title {
-    font-size: 20px;
-    font-weight: 600;
-    line-height: 1.3;
-    letter-spacing: -0.02em;
+/* Header title — rendered in the modal header bar, replaces the generic
+   "Issue" label so the bar reads as the issue itself. */
+.headerTitle {
+    font-size: 16px;
+    font-weight: 650;
+    line-height: 1.35;
+    letter-spacing: -0.013em;
     color: var(--mantine-color-ldGray-9);
-    margin-bottom: var(--mantine-spacing-lg);
 }
 
-.description {
-    font-size: 13.5px;
-    line-height: 1.65;
+/* Body lead ------------------------------------------------------------ */
+
+.metaRow {
+    margin-bottom: var(--mantine-spacing-md);
+}
+
+.targetChip {
+    display: inline-block;
+    max-width: 22rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    vertical-align: middle;
+    font-family: var(--mantine-font-family-monospace);
+    font-size: 11.5px;
     color: var(--mantine-color-ldGray-7);
+    background-color: var(--mantine-color-ldGray-1);
+    padding: 2px 7px;
+    border-radius: var(--mantine-radius-sm);
+}
+
+.recurrence {
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
+}
+
+/* AiMarkdown owns the typography; we only cap the measure for readability. */
+.description {
+    max-width: 64ch;
 }
 
 .sectionLabel {
-    font-size: 11px;
+    font-size: 10.5px;
     font-weight: 600;
-    letter-spacing: 0.02em;
-    color: var(--mantine-color-ldGray-7);
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
 }
 
 /* Activity / Evidence toggle ------------------------------------------- */
@@ -50,8 +72,8 @@
     padding: 3px 8px;
     border-radius: var(--mantine-radius-sm);
     transition:
-        color 150ms cubic-bezier(0.23, 1, 0.32, 1),
-        background-color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+        color 150ms cubic-bezier(0.16, 1, 0.3, 1),
+        background-color 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .toggle:hover {
@@ -59,53 +81,46 @@
     background-color: var(--mantine-color-ldGray-1);
 }
 
-.panel {
-    animation: fade-in 180ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-/* A thread can be arbitrarily long — bound it so the modal never grows past
-   the viewport; the thread scrolls within its own region instead. */
-.evidenceScroll {
-    max-height: 52vh;
-    overflow-y: auto;
-    margin: 0 calc(-1 * var(--mantine-spacing-xs));
-    padding: 0 var(--mantine-spacing-xs);
-}
-
 .toggle:any-link {
     text-decoration: none;
 }
 
-@keyframes fade-in {
-    from {
-        opacity: 0;
-        transform: translateY(2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+.panel {
+    animation: fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .panel {
-        animation: none;
-    }
+/* Evidence header action — opens the full conversation in a stacked modal.
+   Lives next to the "Evidence" label so it's always reachable without
+   scrolling past the cited excerpts. */
+.conversationButton {
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-6);
 }
 
-.statusDot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    flex-shrink: 0;
+.conversationButton:hover {
+    color: var(--mantine-color-ldGray-9);
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.evidenceEmpty {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--mantine-color-ldGray-6);
+    max-width: 60ch;
 }
 
 /* Side rail (Linear-style property card) -------------------------------- */
 
-.rail {
-    /* Visual chrome (border, radius, padding) comes from the Mantine Paper. */
+.railColumn {
     position: sticky;
     top: 0;
+    animation: rise 280ms cubic-bezier(0.16, 1, 0.3, 1) 70ms both;
+}
+
+/* Writeback-blocked note — sits below the property card (not inside it) so it
+   reads as a standalone hint about why an auto-fix isn't available. */
+.blockedNote {
+    padding: 0 var(--mantine-spacing-xs);
 }
 
 .railRow {
@@ -135,6 +150,24 @@
     overflow-wrap: anywhere;
 }
 
+/* Status chip — a quiet pill so the current state reads at a glance. */
+.statusPill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 9px 2px 8px;
+    border-radius: 999px;
+    background-color: var(--mantine-color-ldGray-1);
+    box-shadow: inset 0 0 0 1px var(--mantine-color-ldGray-2);
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
 .railLink {
     display: inline-flex;
     align-items: center;
@@ -143,7 +176,7 @@
     font-weight: 500;
     color: var(--mantine-color-ldGray-9);
     text-decoration: none;
-    transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+    transition: color 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .railLink:hover {
@@ -159,8 +192,38 @@
     border-top: 1px solid var(--mantine-color-ldGray-2);
 }
 
+@keyframes fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rise {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 @media (max-width: 820px) {
     .layout {
         grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .panel,
+    .main,
+    .rail {
+        animation: none;
     }
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
@@ -1,8 +1,20 @@
 .layout {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 248px;
-    gap: var(--mantine-spacing-xl);
-    align-items: start;
+    grid-template-columns: minmax(0, 1fr) 1px 232px;
+    gap: 28px;
+    align-items: stretch;
+}
+
+/* Hairline above the Evidence section, centred in the gap below Activity. */
+.evidenceSection {
+    margin-top: 26px;
+    padding-top: 26px;
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+/* Full-height hairline between the body and the rail. */
+.divider {
+    background-color: var(--mantine-color-ldGray-2);
 }
 
 .main {
@@ -10,25 +22,50 @@
     animation: rise 280ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-/* Header title — rendered in the modal header bar, replaces the generic
-   "Issue" label so the bar reads as the issue itself. */
+/* Header title — rendered in the modal header bar. Light, roomy, low-contrast
+   weight so the bar reads as the issue without shouting. */
 .headerTitle {
     font-size: 16px;
-    font-weight: 650;
-    line-height: 1.35;
-    letter-spacing: -0.013em;
+    font-weight: 550;
+    line-height: 1.4;
+    letter-spacing: -0.014em;
     color: var(--mantine-color-ldGray-9);
 }
 
 /* Body lead ------------------------------------------------------------ */
 
 .metaRow {
-    margin-bottom: var(--mantine-spacing-md);
+    margin-bottom: var(--mantine-spacing-xl);
 }
 
+/* Root-cause marker — a bare dot + label, no chip fill. */
+.causeBadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-7);
+}
+
+.causeDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.metaSep {
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background-color: var(--mantine-color-ldGray-3);
+}
+
+/* Target ref — quiet monospace, no chip background. */
 .targetChip {
     display: inline-block;
-    max-width: 22rem;
+    max-width: 24rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -36,28 +73,30 @@
     font-family: var(--mantine-font-family-monospace);
     font-size: 11.5px;
     color: var(--mantine-color-ldGray-7);
-    background-color: var(--mantine-color-ldGray-1);
-    padding: 2px 7px;
-    border-radius: var(--mantine-radius-sm);
 }
 
 .recurrence {
-    font-size: 11.5px;
+    font-size: 11px;
     font-weight: 500;
     color: var(--mantine-color-ldGray-6);
 }
 
-/* AiMarkdown owns the typography; we only cap the measure for readability. */
+/* Fills the column — the prose grows to the available width. */
 .description {
-    max-width: 64ch;
+    max-width: 100%;
 }
 
+/* Quiet section markers — small, tracked, but with enough weight to read. */
 .sectionLabel {
-    font-size: 10.5px;
+    font-size: 10px;
     font-weight: 600;
-    letter-spacing: 0.07em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--mantine-color-ldGray-6);
+}
+
+.section {
+    margin-top: 32px;
 }
 
 /* Activity / Evidence toggle ------------------------------------------- */
@@ -68,17 +107,14 @@
     gap: 5px;
     font-size: 11px;
     font-weight: 500;
-    color: var(--mantine-color-ldGray-6);
-    padding: 3px 8px;
+    color: var(--mantine-color-ldGray-5);
+    padding: 3px 6px;
     border-radius: var(--mantine-radius-sm);
-    transition:
-        color 150ms cubic-bezier(0.16, 1, 0.3, 1),
-        background-color 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    transition: color 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .toggle:hover {
     color: var(--mantine-color-ldGray-9);
-    background-color: var(--mantine-color-ldGray-1);
 }
 
 .toggle:any-link {
@@ -89,76 +125,90 @@
     animation: fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* Evidence header action — opens the full conversation in a stacked modal.
-   Lives next to the "Evidence" label so it's always reachable without
-   scrolling past the cited excerpts. */
+/* Evidence header action — opens the full conversation in a stacked modal. */
 .conversationButton {
     font-weight: 500;
-    color: var(--mantine-color-ldGray-6);
+    color: var(--mantine-color-ldGray-5);
 }
 
 .conversationButton:hover {
     color: var(--mantine-color-ldGray-9);
-    background-color: var(--mantine-color-ldGray-1);
+    background-color: transparent;
 }
 
 .evidenceEmpty {
     font-size: 13px;
     line-height: 1.6;
-    color: var(--mantine-color-ldGray-6);
+    color: var(--mantine-color-ldGray-5);
     max-width: 60ch;
 }
 
-/* Side rail (Linear-style property card) -------------------------------- */
-
+/* Side rail — a borderless definition list, set off from the body by a
+   single hairline divider. Air, not boxes. */
 .railColumn {
+    align-self: start;
     position: sticky;
     top: 0;
     animation: rise 280ms cubic-bezier(0.16, 1, 0.3, 1) 70ms both;
 }
 
-/* Writeback-blocked note — sits below the property card (not inside it) so it
-   reads as a standalone hint about why an auto-fix isn't available. */
+.railCard {
+    display: block;
+}
+
+/* Writeback-blocked note — only shown for actionable reasons (e.g. connect
+   GitHub / GitLab). Quiet, no icon. */
 .blockedNote {
-    padding: 0 var(--mantine-spacing-xs);
+    margin-top: var(--mantine-spacing-lg);
+    padding-top: var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.blockedTitle {
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--mantine-color-ldGray-8);
+}
+
+.blockedText {
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--mantine-color-ldGray-6);
 }
 
 .railRow {
-    min-height: 38px;
-    padding: 6px 0;
-    gap: var(--mantine-spacing-md);
+    min-height: 26px;
+    padding: 3px 0;
 }
 
 .railLabel {
-    flex-shrink: 0;
-    font-size: 11px;
-    font-weight: 500;
+    flex: none;
+    width: 66px;
+    font-size: 11.5px;
+    font-weight: 400;
     color: var(--mantine-color-ldGray-6);
 }
 
 .railValue {
     min-width: 0;
+    flex: 1;
     display: flex;
-    justify-content: flex-end;
-    text-align: right;
+    justify-content: flex-start;
+    text-align: left;
 }
 
 .railText {
-    font-size: 12.5px;
+    font-size: 12px;
     font-weight: 500;
     color: var(--mantine-color-ldGray-9);
     overflow-wrap: anywhere;
 }
 
-/* Status chip — a quiet pill so the current state reads at a glance. */
+/* Status — a bare dot + label, no pill. */
 .statusPill {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 2px 9px 2px 8px;
-    border-radius: 999px;
-    background-color: var(--mantine-color-ldGray-1);
-    box-shadow: inset 0 0 0 1px var(--mantine-color-ldGray-2);
+    gap: 7px;
 }
 
 .statusDot {
@@ -187,9 +237,9 @@
 }
 
 .railActions {
-    margin-top: var(--mantine-spacing-sm);
-    padding-top: var(--mantine-spacing-sm);
-    border-top: 1px solid var(--mantine-color-ldGray-2);
+    margin-top: var(--mantine-spacing-lg);
+    padding-top: var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-ldGray-1);
 }
 
 @keyframes fade-in {
@@ -217,6 +267,11 @@
 @media (max-width: 820px) {
     .layout {
         grid-template-columns: minmax(0, 1fr);
+        gap: var(--mantine-spacing-xl);
+    }
+
+    .divider {
+        display: none;
     }
 }
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.module.css
@@ -38,23 +38,6 @@
     margin-bottom: var(--mantine-spacing-xl);
 }
 
-/* Root-cause marker — a bare dot + label, no chip fill. */
-.causeBadge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--mantine-color-ldGray-7);
-}
-
-.causeDot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
 .metaSep {
     width: 3px;
     height: 3px;
@@ -65,7 +48,7 @@
 /* Target ref — quiet monospace, no chip background. */
 .targetChip {
     display: inline-block;
-    max-width: 24rem;
+    max-width: 32rem;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -177,7 +160,7 @@
 }
 
 .railRow {
-    min-height: 26px;
+    min-height: 28px;
     padding: 3px 0;
 }
 
@@ -204,11 +187,35 @@
     overflow-wrap: anywhere;
 }
 
-/* Status — a bare dot + label, no pill. */
+/* Status — a bare dot + label, no pill. The dot sits in an 18px column
+   (6px dot + 6px side margins) so it middle-aligns with the 18px avatars in
+   the Assignee/Agent rows and every value's text starts at the same x. */
 .statusPill {
     display: inline-flex;
     align-items: center;
-    gap: 7px;
+    gap: 6px;
+}
+
+.statusPill .statusDot {
+    margin: 0 6px;
+}
+
+/* Priority dot badge, tuned to read identically to the Status row: same
+   6px dot in the same 18px column, same 12px/500 value text. Doubled
+   selector so it reliably outranks CategoryBadge's own module class
+   regardless of import order. */
+.railBadge.railBadge {
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: var(--mantine-font-family);
+    color: var(--mantine-color-ldGray-9);
+}
+
+.railBadge.railBadge > div:first-of-type {
+    width: 6px;
+    height: 6px;
+    margin: 0 6px;
 }
 
 .statusDot {
@@ -234,12 +241,6 @@
         var(--mantine-color-indigo-7),
         var(--mantine-color-indigo-4)
     );
-}
-
-.railActions {
-    margin-top: var(--mantine-spacing-lg);
-    padding-top: var(--mantine-spacing-md);
-    border-top: 1px solid var(--mantine-color-ldGray-1);
 }
 
 @keyframes fade-in {

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -1,9 +1,11 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../../testing/testUtils';
 import { IssueDetailModal } from './IssueDetailModal';
+
+const { threadHookSpy } = vi.hoisted(() => ({ threadHookSpy: vi.fn() }));
 
 const makeReviewItem = (
     overrides: Partial<AiAgentReviewItemSummary> = {},
@@ -44,20 +46,39 @@ const makeReviewItem = (
         remediation: null,
         latestFinding: {
             uuid: 'finding-1',
+            promptUuid: 'prompt-1',
             threadUuid: 'thread-1',
             projectUuid: 'project-1',
             agentUuid: 'agent-1',
-            primaryRootCause: 'semantic_layer',
+            subcategories: [],
             fixTargets: [],
+            targetRefs: [],
+            evidenceExcerpts: [
+                {
+                    source: 'user_prompt',
+                    text: 'What is our total revenue?',
+                    redacted: false,
+                },
+                {
+                    source: 'next_user_prompt',
+                    text: 'That is wrong — it ignores discounts.',
+                    redacted: false,
+                },
+            ],
             recommendation: null,
             projectContextEntry: null,
+            createdAt: new Date('2026-06-24T08:00:00.000Z'),
         },
         ...overrides,
     }) as AiAgentReviewItemSummary;
 
+const { mockReviewItem } = vi.hoisted(() => ({
+    mockReviewItem: { current: null as AiAgentReviewItemSummary | null },
+}));
+
 vi.mock('../../hooks/useAiAgentAdmin', () => ({
     useAiAgentAdminReviewItems: () => ({
-        data: [makeReviewItem()],
+        data: [mockReviewItem.current],
         isLoading: false,
     }),
     useAiAgentReviewItemActivity: () => ({ data: undefined }),
@@ -73,10 +94,13 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
 }));
 
 vi.mock('../../hooks/useProjectAiAgents', () => ({
-    useAiAgentThread: () => ({
-        data: { uuid: 'thread-1', messages: [] },
-        isLoading: false,
-    }),
+    useAiAgentThread: (...args: unknown[]) => {
+        threadHookSpy(...args);
+        return {
+            data: { uuid: 'thread-1', messages: [], compactions: [] },
+            isLoading: false,
+        };
+    },
 }));
 
 vi.mock('../../../../../hooks/useProjects', () => ({
@@ -100,47 +124,101 @@ vi.mock('./ReviewItemActions', () => ({
 vi.mock('./ReviewAssigneeMenu', () => ({
     ReviewAssigneeMenu: () => <div>Assign</div>,
 }));
+// Render markdown excerpts as plain text so assertions match the source.
+vi.mock('../../../../../components/common/AiMarkdown', () => ({
+    AiMarkdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+const renderModal = () =>
+    renderWithProviders(
+        <IssueDetailModal
+            projectUuid="project-1"
+            agentUuid="agent-1"
+            threadUuid="thread-1"
+            selectedReviewItemUuid="ri-1"
+            isOpen
+            onClose={() => {}}
+        />,
+    );
 
 describe('IssueDetailModal', () => {
-    it('renders the issue title, rail, and activity by default', () => {
-        renderWithProviders(
-            <IssueDetailModal
-                projectUuid="project-1"
-                agentUuid="agent-1"
-                threadUuid="thread-1"
-                selectedReviewItemUuid="ri-1"
-                isOpen
-                onClose={() => {}}
-            />,
-        );
+    beforeEach(() => {
+        threadHookSpy.mockClear();
+        mockReviewItem.current = makeReviewItem();
+    });
 
-        expect(screen.getByText('Wrong revenue')).toBeInTheDocument();
+    it('renders the issue title, rail, activity, and evidence excerpts', () => {
+        renderModal();
+
+        expect(screen.getAllByText('Wrong revenue').length).toBeGreaterThan(0);
         expect(screen.getByText('Assignee')).toBeInTheDocument();
         expect(screen.getByText('status-actions')).toBeInTheDocument();
         expect(screen.getByText('Jaffle')).toBeInTheDocument();
-        // Activity is shown by default; evidence sits behind a toggle.
         expect(screen.getByText('Activity')).toBeInTheDocument();
+
+        // Curated excerpts are shown inline; the full chat is NOT rendered yet.
+        expect(screen.getByText('User asked')).toBeInTheDocument();
         expect(
-            screen.getByRole('button', { name: /Show evidence/i }),
+            screen.getByText('What is our total revenue?'),
         ).toBeInTheDocument();
+        expect(screen.queryByText('chat-evidence')).not.toBeInTheDocument();
     });
 
-    it('reveals the evidence chat when the toggle is clicked', async () => {
+    it('opens the full conversation in a stacked modal on demand', async () => {
         const user = userEvent.setup();
-        renderWithProviders(
-            <IssueDetailModal
-                projectUuid="project-1"
-                agentUuid="agent-1"
-                threadUuid="thread-1"
-                selectedReviewItemUuid="ri-1"
-                isOpen
-                onClose={() => {}}
-            />,
+        renderModal();
+
+        await user.click(
+            screen.getByRole('button', { name: /Read full conversation/i }),
+        );
+
+        expect(await screen.findByText('chat-evidence')).toBeInTheDocument();
+    });
+
+    it('does not fetch the thread until the conversation is opened', async () => {
+        const user = userEvent.setup();
+        renderModal();
+
+        expect(threadHookSpy).toHaveBeenLastCalledWith(
+            'project-1',
+            'agent-1',
+            'thread-1',
+            expect.objectContaining({ enabled: false }),
         );
 
         await user.click(
-            screen.getByRole('button', { name: /Show evidence/i }),
+            screen.getByRole('button', { name: /Read full conversation/i }),
         );
+
+        expect(threadHookSpy).toHaveBeenLastCalledWith(
+            'project-1',
+            'agent-1',
+            'thread-1',
+            expect.objectContaining({ enabled: true }),
+        );
+    });
+
+    it('keeps the conversation link when there are no excerpts', async () => {
+        const user = userEvent.setup();
+        mockReviewItem.current = makeReviewItem({
+            latestFinding: {
+                ...makeReviewItem().latestFinding!,
+                evidenceExcerpts: [],
+            },
+        });
+        renderModal();
+
+        expect(
+            screen.queryByTestId('evidence-excerpts'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText(/No excerpts were captured/i),
+        ).toBeInTheDocument();
+
+        await user.click(
+            screen.getByRole('button', { name: /Read full conversation/i }),
+        );
+
         expect(await screen.findByText('chat-evidence')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -91,6 +91,10 @@ vi.mock('../../hooks/useAiAgentAdmin', () => ({
         isLoading: false,
         mutate: vi.fn(),
     }),
+    useUpdateAiAgentReviewItemPriority: () => ({
+        isLoading: false,
+        mutate: vi.fn(),
+    }),
 }));
 
 vi.mock('../../hooks/useProjectAiAgents', () => ({
@@ -158,7 +162,7 @@ describe('IssueDetailModal', () => {
         expect(screen.getByText('Activity')).toBeInTheDocument();
 
         // Curated excerpts are shown inline; the full chat is NOT rendered yet.
-        expect(screen.getByText('User asked')).toBeInTheDocument();
+        expect(screen.getByText('User')).toBeInTheDocument();
         expect(
             screen.getByText('What is our total revenue?'),
         ).toBeInTheDocument();

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.test.tsx
@@ -101,6 +101,7 @@ vi.mock('../../hooks/useProjectAiAgents', () => ({
             isLoading: false,
         };
     },
+    useProjectAiAgent: () => ({ data: undefined, isLoading: false }),
 }));
 
 vi.mock('../../../../../hooks/useProjects', () => ({

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -5,7 +5,6 @@ import {
     Button,
     Group,
     Loader,
-    Paper,
     Stack,
     Text,
     Tooltip,
@@ -15,19 +14,21 @@ import {
     IconArrowRight,
     IconExternalLink,
     IconGitPullRequest,
-    IconInfoCircle,
     IconLayoutColumns,
     IconMessages,
 } from '@tabler/icons-react';
 import { type FC, useMemo } from 'react';
 import { Link } from 'react-router';
+import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
-import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminReviewItems } from '../../hooks/useAiAgentAdmin';
-import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
+import {
+    useAiAgentThread,
+    useProjectAiAgent,
+} from '../../hooks/useProjectAiAgents';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
 import { getRenderableExcerpts } from './evidenceExcerptHelpers';
 import { EvidenceExcerpts } from './EvidenceExcerpts';
@@ -66,7 +67,7 @@ const RailRow: FC<{ label: string; children: React.ReactNode }> = ({
     label,
     children,
 }) => (
-    <Group className={styles.railRow} justify="space-between" wrap="nowrap">
+    <Group className={styles.railRow} wrap="nowrap" gap="sm">
         <Text className={styles.railLabel}>{label}</Text>
         <Box className={styles.railValue}>{children}</Box>
     </Group>
@@ -95,6 +96,7 @@ export const IssueDetailModal: FC<Props> = ({
             { enabled: isOpen },
         );
     const { data: projects = [] } = useProjects();
+    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
 
     const item = useMemo(
         () =>
@@ -132,6 +134,9 @@ export const IssueDetailModal: FC<Props> = ({
     const blockedReasonLabel = shouldShowWritebackBlockedReason(blockedReason)
         ? writebackBlockedReasonLabels[blockedReason]
         : null;
+    // Only the actionable reasons carry a description (e.g. "connect GitHub /
+    // GitLab"). Gate the rail note on it so noisy states like "a PR is already
+    // open" stay out — they're not something the user needs to act on here.
     const blockedReasonDescription = shouldShowWritebackBlockedReason(
         blockedReason,
     )
@@ -149,7 +154,7 @@ export const IssueDetailModal: FC<Props> = ({
             <MantineModal
                 opened={isOpen}
                 onClose={onClose}
-                size="60rem"
+                size="72rem"
                 title={
                     <Text
                         component="span"
@@ -191,45 +196,59 @@ export const IssueDetailModal: FC<Props> = ({
                     <Box className={styles.layout}>
                         <Stack className={styles.main} gap={0}>
                             <Group
-                                gap="xs"
+                                gap="sm"
                                 align="center"
                                 wrap="wrap"
                                 className={styles.metaRow}
                             >
-                                <CategoryBadge
-                                    variant="dot"
-                                    label={
+                                <Box
+                                    component="span"
+                                    className={styles.causeBadge}
+                                >
+                                    <Box
+                                        component="span"
+                                        className={styles.causeDot}
+                                        bg={`${threadReviewRootCauseColors[item.primaryRootCause]}.6`}
+                                    />
+                                    {
                                         threadReviewRootCauseLabels[
                                             item.primaryRootCause
                                         ]
                                     }
-                                    color={
-                                        threadReviewRootCauseColors[
-                                            item.primaryRootCause
-                                        ]
-                                    }
-                                />
+                                </Box>
                                 {targetAnchor && (
-                                    <Tooltip
-                                        label={targetAnchor}
-                                        withArrow
-                                        openDelay={300}
-                                        multiline
-                                        maw={340}
-                                    >
-                                        <Text className={styles.targetChip}>
-                                            {targetAnchor}
-                                        </Text>
-                                    </Tooltip>
+                                    <>
+                                        <Box
+                                            component="span"
+                                            className={styles.metaSep}
+                                        />
+                                        <Tooltip
+                                            label={targetAnchor}
+                                            withArrow
+                                            openDelay={300}
+                                            multiline
+                                            maw={340}
+                                        >
+                                            <Text className={styles.targetChip}>
+                                                {targetAnchor}
+                                            </Text>
+                                        </Tooltip>
+                                    </>
                                 )}
                                 {item.findingCount > 1 && (
-                                    <Text className={styles.recurrence}>
-                                        Recurs {item.findingCount}×
-                                    </Text>
+                                    <>
+                                        <Box
+                                            component="span"
+                                            className={styles.metaSep}
+                                        />
+                                        <Text className={styles.recurrence}>
+                                            Recurs {item.findingCount}×
+                                        </Text>
+                                    </>
                                 )}
                             </Group>
 
-                            <Stack gap="sm">
+                            <Stack gap="md">
                                 <Text className={styles.sectionLabel}>
                                     Description
                                 </Text>
@@ -240,10 +259,10 @@ export const IssueDetailModal: FC<Props> = ({
                                 )}
                             </Stack>
 
-                            <Stack gap="xl" mt="xl">
+                            <Stack gap={0} mt={28}>
                                 {/* Activity — the issue lifecycle. Short and
                                 high-signal, so it leads. */}
-                                <Stack gap="sm">
+                                <Stack gap="md">
                                     <Text className={styles.sectionLabel}>
                                         Activity
                                     </Text>
@@ -260,7 +279,10 @@ export const IssueDetailModal: FC<Props> = ({
                                 Manual issues have neither, so the section is
                                 omitted. */}
                                 {(hasThread || hasExcerpts) && (
-                                    <Stack gap="sm">
+                                    <Stack
+                                        gap="md"
+                                        className={styles.evidenceSection}
+                                    >
                                         <Group
                                             justify="space-between"
                                             align="center"
@@ -319,12 +341,12 @@ export const IssueDetailModal: FC<Props> = ({
                             </Stack>
                         </Stack>
 
+                        <Box className={styles.divider} />
+
                         <Stack gap="sm" className={styles.railColumn}>
-                            <Paper
+                            <Box
                                 component="aside"
-                                withBorder
-                                radius="md"
-                                p="md"
+                                className={styles.railCard}
                                 aria-label="Issue properties"
                             >
                                 <Stack gap={2}>
@@ -356,6 +378,22 @@ export const IssueDetailModal: FC<Props> = ({
                                             }
                                         />
                                     </RailRow>
+                                    {agent && (
+                                        <RailRow label="Agent">
+                                            <Group gap={6} wrap="nowrap">
+                                                <LightdashUserAvatar
+                                                    size={18}
+                                                    name={agent.name}
+                                                    src={agent.imageUrl}
+                                                />
+                                                <Text
+                                                    className={styles.railText}
+                                                >
+                                                    {agent.name}
+                                                </Text>
+                                            </Group>
+                                        </RailRow>
+                                    )}
                                     {projectName && (
                                         <RailRow label="Project">
                                             <Text className={styles.railText}>
@@ -389,6 +427,20 @@ export const IssueDetailModal: FC<Props> = ({
                                     )}
                                 </Stack>
 
+                                {blockedReasonDescription && (
+                                    <Stack
+                                        gap={3}
+                                        className={styles.blockedNote}
+                                    >
+                                        <Text className={styles.blockedTitle}>
+                                            {blockedReasonLabel}
+                                        </Text>
+                                        <Text className={styles.blockedText}>
+                                            {blockedReasonDescription}
+                                        </Text>
+                                    </Stack>
+                                )}
+
                                 <Box className={styles.railActions}>
                                     <ReviewItemActions
                                         reviewItem={item}
@@ -397,37 +449,7 @@ export const IssueDetailModal: FC<Props> = ({
                                         hideBlockedReason
                                     />
                                 </Box>
-                            </Paper>
-
-                            {blockedReasonLabel && (
-                                <Group
-                                    className={styles.blockedNote}
-                                    gap={10}
-                                    wrap="nowrap"
-                                    align="flex-start"
-                                >
-                                    <MantineIcon
-                                        icon={IconInfoCircle}
-                                        size={14}
-                                        stroke={1.6}
-                                        color="ldGray.5"
-                                    />
-                                    <Stack gap={2}>
-                                        <Text fz="xs" fw={600} c="ldGray.7">
-                                            {blockedReasonLabel}
-                                        </Text>
-                                        {blockedReasonDescription && (
-                                            <Text
-                                                fz="xs"
-                                                c="ldGray.6"
-                                                lh={1.45}
-                                            >
-                                                {blockedReasonDescription}
-                                            </Text>
-                                        )}
-                                    </Stack>
-                                </Group>
-                            )}
+                            </Box>
                         </Stack>
                     </Box>
                 )}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -8,18 +8,20 @@ import {
     Paper,
     Stack,
     Text,
-    UnstyledButton,
+    Tooltip,
 } from '@mantine-8/core';
+import { useDisclosure } from '@mantine/hooks';
 import {
-    IconArrowLeft,
+    IconArrowRight,
     IconExternalLink,
-    IconFileHorizontal,
     IconGitPullRequest,
+    IconInfoCircle,
     IconLayoutColumns,
-    IconMessageCircle2,
+    IconMessages,
 } from '@tabler/icons-react';
-import { type FC, useMemo, useState } from 'react';
+import { type FC, useMemo } from 'react';
 import { Link } from 'react-router';
+import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
@@ -27,6 +29,8 @@ import { useProjects } from '../../../../../hooks/useProjects';
 import { useAiAgentAdminReviewItems } from '../../hooks/useAiAgentAdmin';
 import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
 import { AgentChatDisplay } from '../ChatElements/AgentChatDisplay';
+import { getRenderableExcerpts } from './evidenceExcerptHelpers';
+import { EvidenceExcerpts } from './EvidenceExcerpts';
 import styles from './IssueDetailModal.module.css';
 import { RemediationActivityTimeline } from './RemediationActivityTimeline';
 import { ReviewAssigneeMenu } from './ReviewAssigneeMenu';
@@ -35,6 +39,10 @@ import {
     formatReviewDate,
     getIssueTitle,
     getReviewReasoningText,
+    getTargetAnchor,
+    shouldShowWritebackBlockedReason,
+    writebackBlockedReasonDescriptions,
+    writebackBlockedReasonLabels,
 } from './reviewItemDetails';
 import {
     THREAD_REVIEW_ITEM_STATUSES,
@@ -72,12 +80,14 @@ export const IssueDetailModal: FC<Props> = ({
     isOpen,
     onClose,
 }) => {
-    const [showEvidence, setShowEvidence] = useState(false);
+    const [threadOpened, { open: openThread, close: closeThread }] =
+        useDisclosure(false);
     const hasThread = Boolean(projectUuid && agentUuid && threadUuid);
-    const { data: threadData, isLoading: isLoadingThread } = useAiAgentThread(
+    const { data: threadData } = useAiAgentThread(
         projectUuid ?? '',
         agentUuid ?? undefined,
         threadUuid,
+        { enabled: threadOpened && hasThread },
     );
     const { data: reviewItems = [], isLoading: isLoadingItems } =
         useAiAgentAdminReviewItems(
@@ -111,213 +121,359 @@ export const IssueDetailModal: FC<Props> = ({
             : `${formatReviewDate(item.firstSeenAt)} – ${formatReviewDate(item.lastSeenAt)}`
         : null;
     const reasoningText = item ? getReviewReasoningText(item) : null;
-    const isLoading = isLoadingItems || (hasThread && isLoadingThread);
+    const targetAnchor = item ? getTargetAnchor(item) : null;
+    const excerpts = item?.latestFinding?.evidenceExcerpts ?? [];
+    const hasExcerpts = getRenderableExcerpts(excerpts).length > 0;
+
+    const blockedReason =
+        item && !item.writebackEligibility.eligible
+            ? item.writebackEligibility.reason
+            : null;
+    const blockedReasonLabel = shouldShowWritebackBlockedReason(blockedReason)
+        ? writebackBlockedReasonLabels[blockedReason]
+        : null;
+    const blockedReasonDescription = shouldShowWritebackBlockedReason(
+        blockedReason,
+    )
+        ? (writebackBlockedReasonDescriptions[blockedReason] ?? null)
+        : null;
 
     const workspaceUrl = item
         ? `/generalSettings/ai/reviews/${encodeURIComponent(item.fingerprint)}`
         : null;
 
+    const headerTitle = item ? getIssueTitle(item) : 'Issue';
+
     return (
-        <MantineModal
-            opened={isOpen}
-            onClose={onClose}
-            size="60rem"
-            title="Issue"
-            icon={IconFileHorizontal}
-            cancelLabel={false}
-            modalBodyProps={{ py: 'lg' }}
-            bodyScrollAreaMaxHeight="calc(85vh - 120px)"
-            headerActions={
-                item?.remediation && workspaceUrl ? (
-                    <Button
-                        component={Link}
-                        to={workspaceUrl}
-                        onClick={onClose}
-                        size="xs"
-                        variant="default"
-                        radius="md"
-                        leftSection={
-                            <MantineIcon icon={IconLayoutColumns} size={14} />
-                        }
+        <>
+            <MantineModal
+                opened={isOpen}
+                onClose={onClose}
+                size="60rem"
+                title={
+                    <Text
+                        component="span"
+                        className={styles.headerTitle}
+                        lineClamp={2}
                     >
-                        Open workspace
-                    </Button>
-                ) : null
-            }
-        >
-            {isLoading || !item || (hasThread && !threadData) ? (
-                <Group justify="center" p="5rem">
-                    <Loader color="gray" size="sm" />
-                </Group>
-            ) : (
-                <Box className={styles.layout}>
-                    <Stack className={styles.main} gap={0}>
-                        <CategoryBadge
-                            variant="dot"
-                            label={
-                                threadReviewRootCauseLabels[
-                                    item.primaryRootCause
-                                ]
+                        {headerTitle}
+                    </Text>
+                }
+                cancelLabel={false}
+                modalBodyProps={{ py: 'lg' }}
+                bodyScrollAreaMaxHeight="calc(85vh - 120px)"
+                headerActions={
+                    item?.remediation && workspaceUrl ? (
+                        <Button
+                            component={Link}
+                            to={workspaceUrl}
+                            onClick={onClose}
+                            size="xs"
+                            variant="default"
+                            radius="md"
+                            leftSection={
+                                <MantineIcon
+                                    icon={IconLayoutColumns}
+                                    size={14}
+                                />
                             }
-                            color={
-                                threadReviewRootCauseColors[
-                                    item.primaryRootCause
-                                ]
-                            }
-                            className={styles.causeBadge}
-                        />
-                        <Text className={styles.title}>
-                            {getIssueTitle(item)}
-                        </Text>
-
-                        {reasoningText && (
-                            <Text className={styles.description}>
-                                {reasoningText}
-                            </Text>
-                        )}
-
-                        <Stack gap="sm" mt="xl">
-                            <Group justify="space-between" align="center">
-                                <Text className={styles.sectionLabel}>
-                                    {showEvidence ? 'Evidence' : 'Activity'}
-                                </Text>
-                                {hasThread && (
-                                    <Group gap="md" wrap="nowrap">
-                                        {showEvidence && (
-                                            <Anchor
-                                                href={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className={styles.toggle}
-                                            >
-                                                Open full thread
-                                                <MantineIcon
-                                                    icon={IconExternalLink}
-                                                    size={13}
-                                                    stroke={1.5}
-                                                />
-                                            </Anchor>
-                                        )}
-                                        <UnstyledButton
-                                            className={styles.toggle}
-                                            onClick={() =>
-                                                setShowEvidence((open) => !open)
-                                            }
-                                        >
-                                            <MantineIcon
-                                                icon={
-                                                    showEvidence
-                                                        ? IconArrowLeft
-                                                        : IconMessageCircle2
-                                                }
-                                                size={13}
-                                                stroke={1.5}
-                                            />
-                                            {showEvidence
-                                                ? 'Back to activity'
-                                                : 'Show evidence'}
-                                        </UnstyledButton>
-                                    </Group>
+                        >
+                            Open workspace
+                        </Button>
+                    ) : null
+                }
+            >
+                {isLoadingItems || !item ? (
+                    <Group justify="center" p="5rem">
+                        <Loader color="gray" size="sm" />
+                    </Group>
+                ) : (
+                    <Box className={styles.layout}>
+                        <Stack className={styles.main} gap={0}>
+                            <Group
+                                gap="xs"
+                                align="center"
+                                wrap="wrap"
+                                className={styles.metaRow}
+                            >
+                                <CategoryBadge
+                                    variant="dot"
+                                    label={
+                                        threadReviewRootCauseLabels[
+                                            item.primaryRootCause
+                                        ]
+                                    }
+                                    color={
+                                        threadReviewRootCauseColors[
+                                            item.primaryRootCause
+                                        ]
+                                    }
+                                />
+                                {targetAnchor && (
+                                    <Tooltip
+                                        label={targetAnchor}
+                                        withArrow
+                                        openDelay={300}
+                                        multiline
+                                        maw={340}
+                                    >
+                                        <Text className={styles.targetChip}>
+                                            {targetAnchor}
+                                        </Text>
+                                    </Tooltip>
+                                )}
+                                {item.findingCount > 1 && (
+                                    <Text className={styles.recurrence}>
+                                        Recurs {item.findingCount}×
+                                    </Text>
                                 )}
                             </Group>
 
-                            {showEvidence &&
-                            threadData &&
-                            projectUuid &&
-                            agentUuid ? (
-                                <Box
-                                    className={`${styles.panel} ${styles.evidenceScroll}`}
-                                >
-                                    <AgentChatDisplay
-                                        thread={threadData}
-                                        projectUuid={projectUuid}
-                                        agentUuid={agentUuid}
-                                        renderArtifactsInline
-                                        showAddToEvalsButton
-                                    />
-                                </Box>
-                            ) : (
-                                <Box className={styles.panel}>
-                                    <RemediationActivityTimeline
-                                        reviewItem={item}
-                                    />
-                                </Box>
-                            )}
-                        </Stack>
-                    </Stack>
+                            <Stack gap="sm">
+                                <Text className={styles.sectionLabel}>
+                                    Description
+                                </Text>
+                                {reasoningText && (
+                                    <Box className={styles.description}>
+                                        <AiMarkdown>{reasoningText}</AiMarkdown>
+                                    </Box>
+                                )}
+                            </Stack>
 
-                    <Paper
-                        component="aside"
-                        withBorder
-                        radius="md"
-                        p="md"
-                        className={styles.rail}
-                        aria-label="Issue properties"
-                    >
-                        <Stack gap={2}>
-                            <RailRow label="Status">
-                                <Group gap={6} wrap="nowrap">
-                                    <Box
-                                        className={styles.statusDot}
-                                        bg={`${threadReviewStatusColors[item.status]}.6`}
-                                    />
-                                    <Text className={styles.railText}>
-                                        {capitalize(
-                                            item.status.replaceAll('_', ' '),
-                                        )}
+                            <Stack gap="xl" mt="xl">
+                                {/* Activity — the issue lifecycle. Short and
+                                high-signal, so it leads. */}
+                                <Stack gap="sm">
+                                    <Text className={styles.sectionLabel}>
+                                        Activity
                                     </Text>
-                                </Group>
-                            </RailRow>
-                            <RailRow label="Assignee">
-                                <ReviewAssigneeMenu
-                                    projectUuid={item.projectUuid}
-                                    fingerprint={item.fingerprint}
-                                    assignedToUserUuid={item.assignedToUserUuid}
-                                />
-                            </RailRow>
-                            {projectName && (
-                                <RailRow label="Project">
-                                    <Text className={styles.railText}>
-                                        {projectName}
-                                    </Text>
-                                </RailRow>
-                            )}
-                            {seenValue && (
-                                <RailRow label="Seen">
-                                    <Text className={styles.railText}>
-                                        {seenValue}
-                                    </Text>
-                                </RailRow>
-                            )}
-                            {item.linkedPrUrl && (
-                                <RailRow label="Pull request">
-                                    <Anchor
-                                        href={item.linkedPrUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className={styles.railLink}
-                                    >
-                                        <MantineIcon
-                                            icon={IconGitPullRequest}
-                                            size={14}
-                                            stroke={1.4}
+                                    <Box className={styles.panel}>
+                                        <RemediationActivityTimeline
+                                            reviewItem={item}
                                         />
-                                        View PR
-                                    </Anchor>
-                                </RailRow>
-                            )}
+                                    </Box>
+                                </Stack>
+
+                                {/* Evidence — the curated turns the review cited.
+                                The full conversation opens in a stacked modal so
+                                a long thread keeps the room it needs to read.
+                                Manual issues have neither, so the section is
+                                omitted. */}
+                                {(hasThread || hasExcerpts) && (
+                                    <Stack gap="sm">
+                                        <Group
+                                            justify="space-between"
+                                            align="center"
+                                            wrap="nowrap"
+                                        >
+                                            <Text
+                                                className={styles.sectionLabel}
+                                            >
+                                                Evidence
+                                            </Text>
+                                            {hasThread && (
+                                                <Button
+                                                    variant="subtle"
+                                                    color="gray"
+                                                    size="compact-xs"
+                                                    className={
+                                                        styles.conversationButton
+                                                    }
+                                                    onClick={openThread}
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconMessages}
+                                                            size={14}
+                                                            stroke={1.6}
+                                                        />
+                                                    }
+                                                    rightSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconArrowRight
+                                                            }
+                                                            size={13}
+                                                            stroke={1.6}
+                                                        />
+                                                    }
+                                                >
+                                                    Read full conversation
+                                                </Button>
+                                            )}
+                                        </Group>
+                                        {hasExcerpts ? (
+                                            <EvidenceExcerpts
+                                                excerpts={excerpts}
+                                            />
+                                        ) : (
+                                            <Text
+                                                className={styles.evidenceEmpty}
+                                            >
+                                                No excerpts were captured — open
+                                                the full conversation to see
+                                                what triggered this.
+                                            </Text>
+                                        )}
+                                    </Stack>
+                                )}
+                            </Stack>
                         </Stack>
 
-                        <Box className={styles.railActions}>
-                            <ReviewItemActions
-                                reviewItem={item}
-                                mode="drawer"
-                                hideWorkspaceLink
+                        <Stack gap="sm" className={styles.railColumn}>
+                            <Paper
+                                component="aside"
+                                withBorder
+                                radius="md"
+                                p="md"
+                                aria-label="Issue properties"
+                            >
+                                <Stack gap={2}>
+                                    <RailRow label="Status">
+                                        <Box
+                                            className={styles.statusPill}
+                                            component="span"
+                                        >
+                                            <Box
+                                                className={styles.statusDot}
+                                                bg={`${threadReviewStatusColors[item.status]}.6`}
+                                            />
+                                            <Text className={styles.railText}>
+                                                {capitalize(
+                                                    item.status.replaceAll(
+                                                        '_',
+                                                        ' ',
+                                                    ),
+                                                )}
+                                            </Text>
+                                        </Box>
+                                    </RailRow>
+                                    <RailRow label="Assignee">
+                                        <ReviewAssigneeMenu
+                                            projectUuid={item.projectUuid}
+                                            fingerprint={item.fingerprint}
+                                            assignedToUserUuid={
+                                                item.assignedToUserUuid
+                                            }
+                                        />
+                                    </RailRow>
+                                    {projectName && (
+                                        <RailRow label="Project">
+                                            <Text className={styles.railText}>
+                                                {projectName}
+                                            </Text>
+                                        </RailRow>
+                                    )}
+                                    {seenValue && (
+                                        <RailRow label="Seen">
+                                            <Text className={styles.railText}>
+                                                {seenValue}
+                                            </Text>
+                                        </RailRow>
+                                    )}
+                                    {item.linkedPrUrl && (
+                                        <RailRow label="Pull request">
+                                            <Anchor
+                                                href={item.linkedPrUrl}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className={styles.railLink}
+                                            >
+                                                <MantineIcon
+                                                    icon={IconGitPullRequest}
+                                                    size={14}
+                                                    stroke={1.4}
+                                                />
+                                                View PR
+                                            </Anchor>
+                                        </RailRow>
+                                    )}
+                                </Stack>
+
+                                <Box className={styles.railActions}>
+                                    <ReviewItemActions
+                                        reviewItem={item}
+                                        mode="drawer"
+                                        hideWorkspaceLink
+                                        hideBlockedReason
+                                    />
+                                </Box>
+                            </Paper>
+
+                            {blockedReasonLabel && (
+                                <Group
+                                    className={styles.blockedNote}
+                                    gap={10}
+                                    wrap="nowrap"
+                                    align="flex-start"
+                                >
+                                    <MantineIcon
+                                        icon={IconInfoCircle}
+                                        size={14}
+                                        stroke={1.6}
+                                        color="ldGray.5"
+                                    />
+                                    <Stack gap={2}>
+                                        <Text fz="xs" fw={600} c="ldGray.7">
+                                            {blockedReasonLabel}
+                                        </Text>
+                                        {blockedReasonDescription && (
+                                            <Text
+                                                fz="xs"
+                                                c="ldGray.6"
+                                                lh={1.45}
+                                            >
+                                                {blockedReasonDescription}
+                                            </Text>
+                                        )}
+                                    </Stack>
+                                </Group>
+                            )}
+                        </Stack>
+                    </Box>
+                )}
+            </MantineModal>
+
+            {projectUuid && agentUuid && threadUuid && (
+                <MantineModal
+                    opened={threadOpened}
+                    onClose={closeThread}
+                    size="46rem"
+                    title="Conversation"
+                    cancelLabel={false}
+                    modalBodyProps={{ px: 0, py: 0 }}
+                    bodyScrollAreaMaxHeight="calc(85vh - 130px)"
+                    headerActions={
+                        <Anchor
+                            href={`/projects/${projectUuid}/ai-agents/${agentUuid}/threads/${threadUuid}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.toggle}
+                        >
+                            Open in tab
+                            <MantineIcon
+                                icon={IconExternalLink}
+                                size={13}
+                                stroke={1.5}
                             />
-                        </Box>
-                    </Paper>
-                </Box>
+                        </Anchor>
+                    }
+                >
+                    {threadData ? (
+                        <AgentChatDisplay
+                            thread={threadData}
+                            projectUuid={projectUuid}
+                            agentUuid={agentUuid}
+                            height="auto"
+                            renderArtifactsInline
+                            showAddToEvalsButton
+                        />
+                    ) : (
+                        <Group justify="center" p="4rem">
+                            <Loader color="gray" size="sm" />
+                        </Group>
+                    )}
+                </MantineModal>
             )}
-        </MantineModal>
+        </>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/IssueDetailModal.tsx
@@ -14,13 +14,12 @@ import {
     IconArrowRight,
     IconExternalLink,
     IconGitPullRequest,
-    IconLayoutColumns,
     IconMessages,
 } from '@tabler/icons-react';
 import { type FC, useMemo } from 'react';
-import { Link } from 'react-router';
 import { LightdashUserAvatar } from '../../../../../components/Avatar';
 import { AiMarkdown } from '../../../../../components/common/AiMarkdown';
+import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { useProjects } from '../../../../../hooks/useProjects';
@@ -45,6 +44,8 @@ import {
     writebackBlockedReasonDescriptions,
     writebackBlockedReasonLabels,
 } from './reviewItemDetails';
+import { ReviewPriorityMenu } from './ReviewPriorityMenu';
+import { ReviewWorkspaceSummary } from './ReviewWorkspaceSummary';
 import {
     THREAD_REVIEW_ITEM_STATUSES,
     threadReviewRootCauseColors,
@@ -96,7 +97,10 @@ export const IssueDetailModal: FC<Props> = ({
             { enabled: isOpen },
         );
     const { data: projects = [] } = useProjects();
-    const { data: agent } = useProjectAiAgent(projectUuid, agentUuid);
+    const { data: agent } = useProjectAiAgent(
+        projectUuid ?? undefined,
+        agentUuid ?? undefined,
+    );
 
     const item = useMemo(
         () =>
@@ -143,10 +147,6 @@ export const IssueDetailModal: FC<Props> = ({
         ? (writebackBlockedReasonDescriptions[blockedReason] ?? null)
         : null;
 
-    const workspaceUrl = item
-        ? `/generalSettings/ai/reviews/${encodeURIComponent(item.fingerprint)}`
-        : null;
-
     const headerTitle = item ? getIssueTitle(item) : 'Issue';
 
     return (
@@ -168,23 +168,13 @@ export const IssueDetailModal: FC<Props> = ({
                 modalBodyProps={{ py: 'lg' }}
                 bodyScrollAreaMaxHeight="calc(85vh - 120px)"
                 headerActions={
-                    item?.remediation && workspaceUrl ? (
-                        <Button
-                            component={Link}
-                            to={workspaceUrl}
-                            onClick={onClose}
-                            size="xs"
-                            variant="default"
-                            radius="md"
-                            leftSection={
-                                <MantineIcon
-                                    icon={IconLayoutColumns}
-                                    size={14}
-                                />
-                            }
-                        >
-                            Open workspace
-                        </Button>
+                    item ? (
+                        <ReviewItemActions
+                            reviewItem={item}
+                            mode="header"
+                            hideWorkspaceLink
+                            hideBlockedReason
+                        />
                     ) : null
                 }
             >
@@ -201,39 +191,30 @@ export const IssueDetailModal: FC<Props> = ({
                                 wrap="wrap"
                                 className={styles.metaRow}
                             >
-                                <Box
-                                    component="span"
-                                    className={styles.causeBadge}
-                                >
-                                    <Box
-                                        component="span"
-                                        className={styles.causeDot}
-                                        bg={`${threadReviewRootCauseColors[item.primaryRootCause]}.6`}
-                                    />
-                                    {
+                                <CategoryBadge
+                                    color={
+                                        threadReviewRootCauseColors[
+                                            item.primaryRootCause
+                                        ]
+                                    }
+                                    label={
                                         threadReviewRootCauseLabels[
                                             item.primaryRootCause
                                         ]
                                     }
-                                </Box>
+                                />
                                 {targetAnchor && (
-                                    <>
-                                        <Box
-                                            component="span"
-                                            className={styles.metaSep}
-                                        />
-                                        <Tooltip
-                                            label={targetAnchor}
-                                            withArrow
-                                            openDelay={300}
-                                            multiline
-                                            maw={340}
-                                        >
-                                            <Text className={styles.targetChip}>
-                                                {targetAnchor}
-                                            </Text>
-                                        </Tooltip>
-                                    </>
+                                    <Tooltip
+                                        label={targetAnchor}
+                                        withArrow
+                                        openDelay={300}
+                                        multiline
+                                        maw={340}
+                                    >
+                                        <Text className={styles.targetChip}>
+                                            {targetAnchor}
+                                        </Text>
+                                    </Tooltip>
                                 )}
                                 {item.findingCount > 1 && (
                                     <>
@@ -369,6 +350,14 @@ export const IssueDetailModal: FC<Props> = ({
                                             </Text>
                                         </Box>
                                     </RailRow>
+                                    <RailRow label="Priority">
+                                        <ReviewPriorityMenu
+                                            fingerprint={item.fingerprint}
+                                            priority={item.priority}
+                                            bordered={false}
+                                            className={styles.railBadge}
+                                        />
+                                    </RailRow>
                                     <RailRow label="Assignee">
                                         <ReviewAssigneeMenu
                                             projectUuid={item.projectUuid}
@@ -376,6 +365,7 @@ export const IssueDetailModal: FC<Props> = ({
                                             assignedToUserUuid={
                                                 item.assignedToUserUuid
                                             }
+                                            withName
                                         />
                                     </RailRow>
                                     {agent && (
@@ -427,6 +417,11 @@ export const IssueDetailModal: FC<Props> = ({
                                     )}
                                 </Stack>
 
+                                <ReviewWorkspaceSummary
+                                    reviewItem={item}
+                                    onNavigate={onClose}
+                                />
+
                                 {blockedReasonDescription && (
                                     <Stack
                                         gap={3}
@@ -440,15 +435,6 @@ export const IssueDetailModal: FC<Props> = ({
                                         </Text>
                                     </Stack>
                                 )}
-
-                                <Box className={styles.railActions}>
-                                    <ReviewItemActions
-                                        reviewItem={item}
-                                        mode="drawer"
-                                        hideWorkspaceLink
-                                        hideBlockedReason
-                                    />
-                                </Box>
                             </Box>
                         </Stack>
                     </Box>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
@@ -2,6 +2,9 @@
    same index reads as the same semantic shade in both schemes — no
    light-dark() needed for grays here. */
 
+/* Log layout: a fixed timestamp gutter on the left, the spine and typed
+   node next, then the event. Timestamps align as a column of tabular
+   numerals so the lifecycle reads like a ledger. */
 .timeline {
     list-style: none;
     margin: 0;
@@ -12,26 +15,38 @@
 .timeline::before {
     content: '';
     position: absolute;
-    left: 2.5px;
-    top: 7px;
-    bottom: 7px;
+    left: 66.5px;
+    top: 8px;
+    bottom: 8px;
     width: 1px;
     background: var(--mantine-color-ldGray-1);
 }
 
 .item {
-    position: relative;
-    padding: 0 0 14px 18px;
+    display: grid;
+    grid-template-columns: 52px 6px minmax(0, 1fr);
+    column-gap: 12px;
+    padding: 0 0 16px 0;
 }
 
 .item:last-child {
     padding-bottom: 0;
 }
 
+.when {
+    grid-column: 1;
+    text-align: right;
+    font-size: 10.5px;
+    font-variant-numeric: tabular-nums;
+    line-height: 17px;
+    color: var(--mantine-color-ldGray-5);
+    white-space: nowrap;
+}
+
 .node {
-    position: absolute;
-    left: 0;
-    top: 5px;
+    grid-column: 2;
+    align-self: start;
+    margin-top: 5.5px;
     width: 6px;
     height: 6px;
     border-radius: 50%;
@@ -41,11 +56,53 @@
 }
 
 .item[data-done] .node {
-    background: var(--mantine-color-ldGray-5);
-    border-color: var(--mantine-color-ldGray-5);
+    background: var(--mantine-color-ldGray-4);
+    border-color: var(--mantine-color-ldGray-4);
+}
+
+/* Typed nodes — the color answers "what kind of step was this" at a glance. */
+.item[data-tone='progress'] .node {
+    background: light-dark(
+        var(--mantine-color-teal-6),
+        var(--mantine-color-teal-5)
+    );
+    border-color: transparent;
+}
+
+.item[data-tone='pr'] .node {
+    background: light-dark(
+        var(--mantine-color-indigo-6),
+        var(--mantine-color-indigo-4)
+    );
+    border-color: transparent;
+}
+
+.item[data-tone='success'] .node {
+    background: light-dark(
+        var(--mantine-color-green-6),
+        var(--mantine-color-green-5)
+    );
+    border-color: transparent;
+}
+
+.item[data-tone='danger'] .node {
+    background: light-dark(
+        var(--mantine-color-red-6),
+        var(--mantine-color-red-5)
+    );
+    border-color: transparent;
+}
+
+.item[data-tone='attention'] .node {
+    background: light-dark(
+        var(--mantine-color-orange-5),
+        var(--mantine-color-orange-4)
+    );
+    border-color: transparent;
 }
 
 .item[data-live] .node {
+    background: var(--mantine-color-body);
     border-color: light-dark(
         var(--mantine-color-teal-8),
         var(--mantine-color-teal-4)
@@ -55,14 +112,16 @@
 }
 
 .event {
+    grid-column: 3;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 6px;
-    font-size: 12px;
-    font-weight: 450;
+    font-size: 12.5px;
+    font-weight: 500;
     letter-spacing: -0.01em;
-    color: var(--mantine-color-ldGray-8);
+    line-height: 17px;
+    color: var(--mantine-color-ldGray-9);
 }
 
 .author {
@@ -79,18 +138,11 @@
     color: light-dark(var(--mantine-color-teal-8), var(--mantine-color-teal-4));
 }
 
-.when {
-    float: right;
-    font-size: 10px;
-    font-variant-numeric: tabular-nums;
-    color: var(--mantine-color-ldGray-4);
-    margin-left: var(--mantine-spacing-xs);
-}
-
 .meta {
-    font-size: 11px;
-    line-height: 1.4;
-    margin-top: 1px;
+    grid-column: 3;
+    font-size: 11.5px;
+    line-height: 1.5;
+    margin-top: 2px;
     color: var(--mantine-color-ldGray-6);
     overflow-wrap: anywhere;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.module.css
@@ -12,16 +12,16 @@
 .timeline::before {
     content: '';
     position: absolute;
-    left: 3.5px;
-    top: 8px;
-    bottom: 8px;
+    left: 2.5px;
+    top: 7px;
+    bottom: 7px;
     width: 1px;
-    background: var(--mantine-color-ldGray-2);
+    background: var(--mantine-color-ldGray-1);
 }
 
 .item {
     position: relative;
-    padding: 0 0 10px 18px;
+    padding: 0 0 14px 18px;
 }
 
 .item:last-child {
@@ -31,18 +31,18 @@
 .node {
     position: absolute;
     left: 0;
-    top: 4px;
-    width: 8px;
-    height: 8px;
+    top: 5px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     background: var(--mantine-color-body);
-    border: 1.5px solid var(--mantine-color-ldGray-4);
+    border: 1px solid var(--mantine-color-ldGray-3);
     z-index: 1;
 }
 
 .item[data-done] .node {
-    background: var(--mantine-color-ldGray-9);
-    border-color: var(--mantine-color-ldGray-9);
+    background: var(--mantine-color-ldGray-5);
+    border-color: var(--mantine-color-ldGray-5);
 }
 
 .item[data-live] .node {
@@ -60,9 +60,9 @@
     flex-wrap: wrap;
     gap: 6px;
     font-size: 12px;
-    font-weight: 500;
+    font-weight: 450;
     letter-spacing: -0.01em;
-    color: var(--mantine-color-ldGray-9);
+    color: var(--mantine-color-ldGray-8);
 }
 
 .author {
@@ -83,7 +83,7 @@
     float: right;
     font-size: 10px;
     font-variant-numeric: tabular-nums;
-    color: var(--mantine-color-ldGray-5);
+    color: var(--mantine-color-ldGray-4);
     margin-left: var(--mantine-spacing-xs);
 }
 
@@ -97,8 +97,8 @@
 
 .meta a,
 .metaLink {
-    color: var(--mantine-color-ldGray-9);
+    color: var(--mantine-color-ldGray-7);
     text-decoration: none;
-    border-bottom: 1px solid var(--mantine-color-ldGray-3);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
     cursor: pointer;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/RemediationActivityTimeline.tsx
@@ -30,6 +30,11 @@ const formatWhen = (occurredAt: Date | string, previous: Date | null) => {
 const truncate = (text: string, max = 90) =>
     text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
 
+// Tones color the timeline node by what the event means: teal for fix
+// progress, indigo for PR motion, green for verified/resolved, red for
+// failures, orange for recurrences. Neutral events stay gray.
+type TimelineTone = 'progress' | 'pr' | 'success' | 'danger' | 'attention';
+
 type TimelineRow = {
     key: string;
     label: string;
@@ -37,13 +42,14 @@ type TimelineRow = {
     when: string;
     state: 'done' | 'live';
     author: ReactNode;
+    tone?: TimelineTone;
 };
 
 const humanizeStatus = (status: string) => status.replaceAll('_', ' ');
 
 const issueEventRow = (
     event: Extract<AiAgentReviewActivityEvent, { kind: 'issue' }>,
-): Pick<TimelineRow, 'label' | 'meta'> => {
+): Pick<TimelineRow, 'label' | 'meta' | 'tone'> => {
     switch (event.eventType) {
         case 'created':
             return { label: 'Issue opened', meta: null };
@@ -60,7 +66,11 @@ const issueEventRow = (
                 meta: null,
             };
         case 'recurred':
-            return { label: 'Recurred — seen again', meta: null };
+            return {
+                label: 'Recurred — seen again',
+                meta: null,
+                tone: 'attention',
+            };
         case 'priority_changed':
             return {
                 label: 'Priority changed',
@@ -72,7 +82,7 @@ const issueEventRow = (
                 meta: truncate(event.payload.body, 160),
             };
         default:
-            return { label: 'Activity', meta: null };
+            return { label: 'Updated', meta: null };
     }
 };
 
@@ -88,7 +98,7 @@ const buildThreadPath = (
 const eventRow = (
     event: AiAgentReviewRemediationEvent,
     reviewItem: AiAgentReviewItemSummary,
-): Pick<TimelineRow, 'label' | 'meta'> => {
+): Pick<TimelineRow, 'label' | 'meta' | 'tone'> => {
     const remediation = reviewItem.remediation;
     switch (event.eventType) {
         case 'finding_opened': {
@@ -135,11 +145,13 @@ const eventRow = (
             return {
                 label: 'Writeback ran',
                 meta: files ? `Edited ${files}${counts}` : null,
+                tone: 'progress',
             };
         }
         case 'pr_opened':
             return {
                 label: 'Pull request opened',
+                tone: 'pr',
                 meta: (
                     <Anchor
                         href={event.payload.prUrl}
@@ -153,8 +165,23 @@ const eventRow = (
                     </Anchor>
                 ),
             };
+        case 'pr_updated':
+            return {
+                label: 'Pull request updated',
+                tone: 'pr',
+                meta: event.payload.prUrl ? (
+                    <Anchor
+                        href={event.payload.prUrl}
+                        target="_blank"
+                        className={styles.metaLink}
+                        inherit
+                    >
+                        View PR
+                    </Anchor>
+                ) : null,
+            };
         case 'preview_compiled':
-            return { label: 'Preview compiled', meta: null };
+            return { label: 'Preview compiled', meta: null, tone: 'progress' };
         case 'verification_completed': {
             const threadPath = buildThreadPath(
                 remediation?.previewProjectUuid ?? null,
@@ -163,6 +190,7 @@ const eventRow = (
             );
             return {
                 label: 'Fix verified',
+                tone: 'success',
                 meta: threadPath ? (
                     <Anchor
                         component={Link}
@@ -176,18 +204,19 @@ const eventRow = (
             };
         }
         case 'pr_merged':
-            return { label: 'Pull request merged', meta: null };
+            return { label: 'Pull request merged', meta: null, tone: 'pr' };
         case 'pr_closed':
             return { label: 'Pull request closed', meta: null };
         case 'resolved':
-            return { label: 'Resolved', meta: null };
+            return { label: 'Resolved', meta: null, tone: 'success' };
         case 'failed':
             return {
                 label: 'Failed',
                 meta: event.payload.errorMessage,
+                tone: 'danger',
             };
         default:
-            return { label: 'Activity', meta: null };
+            return { label: 'Updated', meta: null };
     }
 };
 
@@ -279,6 +308,7 @@ export const RemediationActivityTimeline: FC<Props> = ({ reviewItem }) => {
                     className={styles.item}
                     data-done={row.state === 'done' || undefined}
                     data-live={row.state === 'live' || undefined}
+                    data-tone={row.tone}
                 >
                     <span className={styles.when}>{row.when}</span>
                     <div className={styles.node} />

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Group,
     Menu,
     ScrollArea,
     Text,
@@ -21,6 +22,8 @@ type Props = {
     assignedToUserUuid: string | null;
     /** CSS module class applied to the wrapper Box (for hover visibility control) */
     className?: string;
+    /** Compact avatar + name row (e.g. the issue rail) instead of avatar only. */
+    withName?: boolean;
 };
 
 export const ReviewAssigneeMenu: FC<Props> = ({
@@ -28,6 +31,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
     fingerprint,
     assignedToUserUuid,
     className,
+    withName = false,
 }) => {
     // Source the candidate list from the same hook the project users & groups
     // table uses, so anyone who can access the project is assignable — not just
@@ -81,26 +85,40 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                         onPointerDown={(e) => e.stopPropagation()}
                     >
                         <Tooltip label={assigneeName ?? 'Assign'} withinPortal>
-                            {assignee ? (
-                                <LightdashUserAvatar
-                                    name={assigneeName ?? undefined}
-                                    size="sm"
-                                    radius="xl"
-                                />
-                            ) : (
-                                <LightdashUserAvatar
-                                    size="sm"
-                                    radius="xl"
-                                    variant="light"
-                                    color="gray"
-                                >
-                                    <MantineIcon
-                                        icon={IconUserPlus}
-                                        size={12}
-                                        color="dimmed"
+                            <Group gap={6} wrap="nowrap">
+                                {assignee ? (
+                                    <LightdashUserAvatar
+                                        name={assigneeName ?? undefined}
+                                        size={withName ? 18 : 'sm'}
+                                        radius="xl"
                                     />
-                                </LightdashUserAvatar>
-                            )}
+                                ) : (
+                                    <LightdashUserAvatar
+                                        size={withName ? 18 : 'sm'}
+                                        radius="xl"
+                                        variant="light"
+                                        color="gray"
+                                    >
+                                        <MantineIcon
+                                            icon={IconUserPlus}
+                                            size={12}
+                                            color="dimmed"
+                                        />
+                                    </LightdashUserAvatar>
+                                )}
+                                {withName && (
+                                    // ff needed: the UnstyledButton ancestor
+                                    // reintroduces the UA's button font.
+                                    <Text
+                                        fz={12}
+                                        fw={500}
+                                        c="ldGray.9"
+                                        ff="var(--mantine-font-family)"
+                                    >
+                                        {assigneeName ?? 'Assign'}
+                                    </Text>
+                                )}
+                            </Group>
                         </Tooltip>
                     </UnstyledButton>
                 </Menu.Target>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -24,6 +24,7 @@ import {
 import { ProjectContextWritebackModal } from './ProjectContextWritebackModal';
 import {
     shouldShowWritebackBlockedReason,
+    writebackBlockedReasonDescriptions,
     writebackBlockedReasonLabels,
 } from './reviewItemDetails';
 
@@ -32,12 +33,15 @@ type ReviewItemActionsProps = {
     mode?: 'table' | 'drawer';
     /** Suppress the "Open workspace" button (e.g. when it lives elsewhere). */
     hideWorkspaceLink?: boolean;
+    /** Suppress the writeback-blocked note (e.g. when it's rendered elsewhere). */
+    hideBlockedReason?: boolean;
 };
 
 export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
     reviewItem,
     mode = 'table',
     hideWorkspaceLink = false,
+    hideBlockedReason = false,
 }) => {
     const createWriteback = useCreateAiAgentReviewItemWriteback();
     const updateStatus = useUpdateAiAgentReviewItemStatus();
@@ -75,6 +79,11 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
         : current.writebackEligibility.reason;
     const blockedReasonLabel = shouldShowWritebackBlockedReason(blockedReason)
         ? writebackBlockedReasonLabels[blockedReason]
+        : null;
+    const blockedReasonDescription = shouldShowWritebackBlockedReason(
+        blockedReason,
+    )
+        ? (writebackBlockedReasonDescriptions[blockedReason] ?? null)
         : null;
     const previewsDiff = current.primaryRootCause === 'project_context';
 
@@ -265,21 +274,42 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                         )}
                     </Group>
 
-                    {!canCreatePr &&
+                    {!hideBlockedReason &&
+                        !canCreatePr &&
                         !current.linkedPrUrl &&
                         !isWritebackInFlight &&
-                        blockedReasonLabel && (
+                        blockedReasonLabel &&
+                        (mode === 'drawer' ? (
+                            <Group
+                                gap={10}
+                                wrap="nowrap"
+                                align="flex-start"
+                                maw={360}
+                            >
+                                <MantineIcon
+                                    icon={IconInfoCircle}
+                                    size={20}
+                                    stroke={1.6}
+                                    color="ldGray.5"
+                                />
+                                <Stack gap={2}>
+                                    <Text fz="xs" fw={600} c="ldGray.7">
+                                        {blockedReasonLabel}
+                                    </Text>
+                                    {blockedReasonDescription && (
+                                        <Text fz="xs" c="ldGray.6" lh={1.45}>
+                                            {blockedReasonDescription}
+                                        </Text>
+                                    )}
+                                </Stack>
+                            </Group>
+                        ) : (
                             <Tooltip
                                 label={blockedReasonLabel}
                                 withArrow
                                 openDelay={300}
-                                disabled={mode === 'drawer'}
                             >
-                                <Group
-                                    gap={4}
-                                    wrap="nowrap"
-                                    maw={mode === 'drawer' ? 360 : 220}
-                                >
+                                <Group gap={4} wrap="nowrap" maw={220}>
                                     <MantineIcon
                                         icon={IconInfoCircle}
                                         size="xs"
@@ -288,13 +318,13 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                                         fz="xs"
                                         c="ldGray.6"
                                         fw={500}
-                                        lineClamp={mode === 'drawer' ? 3 : 1}
+                                        lineClamp={1}
                                     >
                                         {blockedReasonLabel}
                                     </Text>
                                 </Group>
                             </Tooltip>
-                        )}
+                        ))}
                 </Stack>
             )}
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewItemActions.tsx
@@ -30,7 +30,12 @@ import {
 
 type ReviewItemActionsProps = {
     reviewItem: AiAgentReviewItemSummary;
-    mode?: 'table' | 'drawer';
+    /**
+     * `header` renders the compact modal-header form: the stage's primary
+     * action (Accept / Open workspace / Create PR) with Dismiss demoted to a
+     * quiet secondary beside it, and no blocked-reason note.
+     */
+    mode?: 'table' | 'drawer' | 'header';
     /** Suppress the "Open workspace" button (e.g. when it lives elsewhere). */
     hideWorkspaceLink?: boolean;
     /** Suppress the writeback-blocked note (e.g. when it's rendered elsewhere). */
@@ -93,16 +98,19 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
             ? current.remediation.errorMessage
             : null;
     const buttonSize: 'xs' | 'compact-xs' =
-        mode === 'drawer' ? 'xs' : 'compact-xs';
+        mode === 'table' ? 'compact-xs' : 'xs';
     const stopPropagation = (event: SyntheticEvent) => event.stopPropagation();
-    const errorIconSize = mode === 'drawer' ? 16 : 15;
+    const errorIconSize = mode === 'table' ? 15 : 16;
+    // In the header the stage's primary action reads as the app's primary
+    // (filled dark) and Dismiss demotes to a quiet secondary beside it.
+    const isHeader = mode === 'header';
 
     return (
         <>
             {isWritebackInFlight ? (
-                // The drawer's Activity timeline owns the live progress row —
+                // The modal's Activity timeline owns the live progress row —
                 // a second spinner in the corner would duplicate it.
-                mode === 'drawer' ? null : (
+                mode !== 'table' ? null : (
                     <Tooltip label={phase} withArrow openDelay={300}>
                         <Group gap={8} wrap="nowrap" maw={180}>
                             <Loader size={12} color="ldGray.5" />
@@ -118,7 +126,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                         size={buttonSize}
                         radius="md"
                         variant="filled"
-                        color="indigo"
+                        color={isHeader ? 'dark' : 'indigo'}
                         loading={updateStatus.isLoading}
                         onClick={(event) => {
                             stopPropagation(event);
@@ -163,8 +171,9 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                                       onClick={stopPropagation}
                                       size={buttonSize}
                                       fz="xs"
-                                      variant="light"
-                                      color="indigo"
+                                      radius={isHeader ? 'md' : undefined}
+                                      variant={isHeader ? 'filled' : 'light'}
+                                      color={isHeader ? 'dark' : 'indigo'}
                                       leftSection={
                                           <MantineIcon
                                               size="sm"
@@ -275,6 +284,7 @@ export const ReviewItemActions: FC<ReviewItemActionsProps> = ({
                     </Group>
 
                     {!hideBlockedReason &&
+                        !isHeader &&
                         !canCreatePr &&
                         !current.linkedPrUrl &&
                         !isWritebackInFlight &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
@@ -11,6 +11,10 @@ import {
 type Props = {
     fingerprint: string;
     priority: AiAgentReviewItemPriority;
+    /** Render as a bare dot + label (no chip) — e.g. in the issue rail. */
+    bordered?: boolean;
+    /** Extra class for the badge — e.g. rail typography overrides. */
+    className?: string;
 };
 
 const priorities: AiAgentReviewItemPriority[] = [
@@ -21,7 +25,12 @@ const priorities: AiAgentReviewItemPriority[] = [
     'none',
 ];
 
-export const ReviewPriorityMenu: FC<Props> = ({ fingerprint, priority }) => {
+export const ReviewPriorityMenu: FC<Props> = ({
+    fingerprint,
+    priority,
+    bordered = true,
+    className,
+}) => {
     const updatePriority = useUpdateAiAgentReviewItemPriority();
 
     return (
@@ -35,6 +44,8 @@ export const ReviewPriorityMenu: FC<Props> = ({ fingerprint, priority }) => {
                     <CategoryBadge
                         color={reviewPriorityColors[priority]}
                         label={reviewPriorityLabels[priority]}
+                        bordered={bordered}
+                        className={className}
                     />
                 </UnstyledButton>
             </Menu.Target>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.module.css
@@ -1,0 +1,66 @@
+/* Rail workspace summary — the entry point plus the verdict state. */
+.workspace {
+    margin-top: var(--mantine-spacing-lg);
+    padding-top: var(--mantine-spacing-md);
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--mantine-color-ldGray-6);
+}
+
+/* Verdict line — mirrors the workspace header's "Verdict ready" state. */
+.verdict {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--mantine-color-ldGray-9);
+}
+
+.verdictDot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--mantine-color-body);
+    border: 1px solid var(--mantine-color-ldGray-3);
+}
+
+.verdict[data-state='ready'] .verdictDot {
+    background: light-dark(
+        var(--mantine-color-green-6),
+        var(--mantine-color-green-5)
+    );
+    border-color: transparent;
+}
+
+.verdict[data-state='ready'] {
+    color: light-dark(
+        var(--mantine-color-green-8),
+        var(--mantine-color-green-4)
+    );
+}
+
+.verdict[data-state='live'] .verdictDot {
+    border-color: light-dark(
+        var(--mantine-color-teal-8),
+        var(--mantine-color-teal-4)
+    );
+    box-shadow: 0 0 0 3px
+        light-dark(rgba(12, 133, 99, 0.12), rgba(56, 217, 169, 0.16));
+}
+
+.verdict[data-state='live'] {
+    color: light-dark(var(--mantine-color-teal-8), var(--mantine-color-teal-4));
+}
+
+.verdict[data-state='pending'] {
+    color: var(--mantine-color-ldGray-5);
+    font-weight: 400;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewWorkspaceSummary.tsx
@@ -1,0 +1,70 @@
+import { type AiAgentReviewItemSummary } from '@lightdash/common';
+import { Box, Button, Stack, Text } from '@mantine-8/core';
+import { IconLayoutColumns } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { Link } from 'react-router';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { useAiAgentReviewItemActivity } from '../../hooks/useAiAgentAdmin';
+import styles from './ReviewWorkspaceSummary.module.css';
+
+type Props = {
+    reviewItem: AiAgentReviewItemSummary;
+    onNavigate?: () => void;
+};
+
+/**
+ * Rail summary of the remediation workspace: the entry point, and whether
+ * the verification verdict is in — the one status the rail should answer.
+ */
+export const ReviewWorkspaceSummary: FC<Props> = ({
+    reviewItem,
+    onNavigate,
+}) => {
+    const remediation = reviewItem.remediation;
+    const { data: activity } = useAiAgentReviewItemActivity(
+        reviewItem.fingerprint,
+        { enabled: remediation !== null },
+    );
+
+    if (!remediation) {
+        return null;
+    }
+
+    const workspaceUrl = `/generalSettings/ai/issues/${encodeURIComponent(
+        reviewItem.fingerprint,
+    )}`;
+
+    const verdictReady =
+        activity?.events.some(
+            (event) =>
+                event.kind === 'remediation' &&
+                event.eventType === 'verification_completed',
+        ) ?? false;
+    const verdict = verdictReady
+        ? ({ state: 'ready', label: 'Verdict ready' } as const)
+        : activity?.liveState === 'verifying'
+          ? ({ state: 'live', label: 'Verifying the fix…' } as const)
+          : ({ state: 'pending', label: 'No verdict yet' } as const);
+
+    return (
+        <Stack gap="sm" className={styles.workspace}>
+            <Text className={styles.label}>Workspace</Text>
+            <Button
+                component={Link}
+                to={workspaceUrl}
+                onClick={onNavigate}
+                size="xs"
+                color="dark"
+                radius="md"
+                fullWidth
+                leftSection={<MantineIcon icon={IconLayoutColumns} size={14} />}
+            >
+                Open workspace
+            </Button>
+            <Box className={styles.verdict} data-state={verdict.state}>
+                <Box component="span" className={styles.verdictDot} />
+                {verdict.label}
+            </Box>
+        </Stack>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/evidenceExcerptHelpers.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/evidenceExcerptHelpers.ts
@@ -1,0 +1,14 @@
+import { type AiAgentEvidenceExcerpt } from '@lightdash/common';
+
+export const getRenderableExcerpts = (
+    excerpts: AiAgentEvidenceExcerpt[],
+): AiAgentEvidenceExcerpt[] =>
+    excerpts.filter(
+        (excerpt) => !excerpt.redacted && excerpt.text.trim().length > 0,
+    );
+
+const CONTEXT_PREFIX = /^previous turn \([^)]*\):\s*prompt=/i;
+
+/** Strip the "previous turn (uuid): prompt=" wrapper off context excerpts. */
+export const cleanExcerptText = (text: string): string =>
+    text.replace(CONTEXT_PREFIX, '').trim();

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -74,6 +74,26 @@ export const writebackBlockedReasonLabels: Record<
     writeback_in_progress: 'Writeback is already in progress',
 };
 
+/**
+ * One-line explanations of what a blocked reason means and how to unblock it.
+ * Only the actionable reasons get a description; the rest fall back to the
+ * short label alone.
+ */
+export const writebackBlockedReasonDescriptions: Partial<
+    Record<AiAgentReviewItemWritebackBlockedReason, string>
+> = {
+    unsupported_source_control:
+        'Connect this project to GitHub or GitLab so Lightdash can open a pull request that fixes issues like this for you.',
+    reviews_disabled:
+        'Turn on Issues for your organization to let agents file and fix issues automatically.',
+    git_app_not_installed:
+        'Install the Lightdash app on your repository so it can open pull requests.',
+    project_context_disabled:
+        'Enable project context so Lightdash can propose updates to your project knowledge.',
+    missing_writeback_config:
+        'Ask an admin to configure the writeback runtime to enable automatic fixes.',
+};
+
 export const shouldShowWritebackBlockedReason = (
     reason: AiAgentReviewItemWritebackBlockedReason | null,
 ): reason is Exclude<


### PR DESCRIPTION
## Summary

Two related Issues-board improvements on this branch:

1. **Discoverability (ZAP-516)** — keep the Issues board reachable from the Ask AI navbar even when no findings exist yet.
2. **Issue modal evidence rework** — make a long source thread readable again inside the issue modal.

**Top of the Issues stack** — stacked on #24876. Linear: ZAP-516.

## 1. Board discoverability (ZAP-516)

- The Ask AI navbar button previously showed a board link only when `reviewCount > 0`. Now that issues can be filed manually, when **reviews are enabled but nothing is open yet** the button surfaces a lightweight dropdown — "No open issues yet… Go to the issues board →".
- With open items, the existing findings preview (trend chart) is unchanged. Without review access, the plain Ask AI button is unchanged.

## 2. Issue modal evidence rework

The modal rendered the **entire** agent thread under "Evidence" in a `44vh` nested-scroll box beside the property rail — scrollbar-in-a-scrollbar, crushed chat width, edge-fade clipping. The curated `evidenceExcerpts` the classifier actually cited were never shown.

- **Evidence = curated excerpts** — `latestFinding.evidenceExcerpts` rendered as a labeled quote stack (markdown via `AiMarkdown`), with the noisy `previous turn (uuid): prompt=` context prefix stripped.
- **Read full conversation** — pinned in the Evidence header (always reachable, no scrolling); opens the full thread in a **stacked modal** (lazy-loaded; "Open in tab" preserved). No more nested scroll.
- **Description** heading + markdown-rendered reasoning.
- **Affected-target chip** (truncated + tooltip) and **Recurs N×** tag next to the category badge.
- **Writeback-blocked note** moved below the property card with a plain-language explanation of what it means (e.g. why a GitHub/GitLab connection matters).

No backend changes — `evidenceExcerpts` was already on the item. The full thread now lazy-loads only when the stacked modal opens, so the issue modal opens faster.

## Regression analysis

Frontend-only, scoped to `IssueDetailModal` + the shared `ReviewItemActions` writeback note. The note change also applies to `ThreadPreviewSidebar` (same `mode="drawer"`), which is intended — both surfaces get the fuller explanation. No change to system-role / service-account / custom-role behavior.

## Test plan

- `pnpm -F frontend typecheck:fast` clean; oxlint clean; oxfmt-formatted.
- New unit tests: `EvidenceExcerpts` (excerpt filtering, context-prefix stripping, label rendering) + `IssueDetailModal` (excerpts shown, stacked modal opens on demand, thread query gated until opened, empty-excerpts fallback). 13 tests pass.
- Manual: verified live on Jaffle (light mode) — excerpts + markdown render, "Read full conversation" opens the stacked thread, target chip truncates with tooltip, disclaimer sits below the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)