### PR TITLE
chore(graphite): move AI review rules into repo files

### DIFF
--- a/.github/rules/api-backwards-compatibility.md
+++ b/.github/rules/api-backwards-compatibility.md
@@ -1,0 +1,45 @@
+# API backwards-compatibility review rules
+
+Applies to changes in `packages/backend/**/*.ts` and `packages/common/**/*.ts` that touch the HTTP API contract (request/response shapes, endpoints, status codes, error shapes).
+
+The backend serves clients it does **not** control and that may be **many versions behind**:
+- **Customer-built automation and scripts** that call our public REST API directly (via PATs, service accounts, CI/CD pipelines). These are written and pinned by customers, are completely outside our control, and are typically not versioned at all — assume they read responses and send requests in exactly the shape they were written against.
+- The `@lightdash/cli`
+- Chart-as-code
+- The `@lightdash/sdk` embed bundle (a frozen frontend pinned by the embedder)
+
+These clients upgrade Lightdash without re-installing, so **a newer server must stay backwards compatible with older clients**. You cannot retro-fix a shipped or customer-owned client — their code already reads fields unguarded and sends fixed request shapes, so the only remedy lives in the backend.
+
+> Reference incident: removing `echarts6` from the health response broke every chart in old SDK bundles that read `health.echarts6.enabled` unguarded (`Cannot read properties of undefined`). Fix was to re-add `echarts6: { enabled: false }` — hardcode-to-keep, don't delete.
+
+## API surface to treat as a public contract
+
+- Every endpoint exposed via `tsoa` controllers (`packages/backend/src/**/*Controller.ts`, reflected in `packages/backend/src/generated/swagger.json`)
+- The health response and the embed endpoints (`packages/backend/src/ee/**`)
+- Any GET response shape external consumers read (query results, content, saved charts, dashboards, spaces)
+- The `packages/common` types those requests/responses serialize
+
+When unsure whether an external client reads a field, **assume it does**.
+
+## Flag these as breaking (call out + require confirmation)
+
+- Removing or renaming a **response** field a client reads
+- Narrowing a response field: present→optional, non-null→nullable, type change, or removing an **enum value** old code switches on
+- Removing/renaming an **endpoint**, or changing its path / method / status codes / error shape
+- Tightening a **request**: new required param, optional→required, or stricter validation — an old client sends the old shape → 4xx
+
+## These are safe
+
+- Adding an optional response field
+- Adding a new endpoint
+- Adding an optional request param with a default
+- Widening accepted request types
+
+## When you find a break
+
+Do not accept "the current first-party frontend guards it" — old shipped clients don't, and neither do the customer scripts and automation built directly on the API. Name the field/endpoint and the old-client failure mode (what crashes, what status), then require one of:
+- keep the field (hardcode a safe value, as `echarts6` did)
+- keep accepting the old request shape
+- version the endpoint
+
+If the break is intentional and acceptable, get explicit confirmation. For an endpoint being retired, it must go through the deprecation flow (deprecation headers + sunset date) before removal — see `docs/` deprecation guidance — never delete past the sunset date without it.

--- a/.github/rules/backend-review.md
+++ b/.github/rules/backend-review.md
@@ -1,0 +1,113 @@
+# Backend review rules
+
+Applies to `packages/backend/**/*.ts`.
+
+## Architecture Overview
+
+The backend follows a layered architecture pattern with clear separation of concerns:
+
+```
+controllers -> services -> models -> database
+```
+
+### Key Performance Considerations
+
+1. **Database Operations**
+   - Use appropriate indexes for frequently queried columns
+   - Implement query optimization for large datasets
+   - Leverage database connection pooling (using `pg`)
+   - Consider materialized views for complex aggregations
+   - Use batch operations for bulk data operations — `batchInsert` where it makes sense
+
+2. **API Performance**
+   - Use pagination for large result sets — see `packages/common/src/types/paginateResults.ts`
+   - Implement rate limiting for API endpoints
+   - Keep API changes backwards compatible unless the endpoint was deprecated and past the sunset date
+
+3. **Error handling and logging**
+   - Look at `packages/backend/src/errors.ts` to categorise errors correctly. See `packages/backend/src/logging/winston.ts` and `packages/backend/src/sentry.ts` to see what errors are ignored in Sentry
+   - If you can't find a suitable error class instance, create it
+
+4. **Background Jobs**
+   - Use `graphile-worker` for handling long-running tasks — see `packages/backend/src/SchedulerApp.ts` and `packages/backend/src/scheduler/SchedulerWorker.ts` to form your code
+   - Implement proper job retry mechanisms if the default isn't sufficient
+   - Monitor job queue performance
+   - Ensure the necessary payload properties are set so errors can be filtered easily in Sentry — see `packages/backend/src/scheduler/SchedulerTaskTracer.ts`
+
+## Development Guidelines
+
+When building a new endpoint see `packages/backend/src/generated/routes.ts` and `packages/backend/src/generated/swagger.json`, ensure that you make changes to the controller, service, model, but also update types in `packages/common`. Remind the user to call `pnpm generate-api` to rebuild tsoa.
+
+### Testing
+
+Don't write unit tests that test implementation, only write unit tests for new business logic.
+- Good tests: business logic, complex rules, nested conditionals
+- Bad tests: database calls, implementation details, data transformation, prometheus usage
+
+### Controllers
+- Keep controllers thin — delegate business logic to services
+- Implement proper request validation using `zod`
+- Use TypeScript types for request/response
+- Generate API documentation using `tsoa` — good example in `packages/backend/src/controllers/savedChartController.ts`
+
+### Services
+- Implement proper error handling and logging
+- Use appropriate transaction management
+- Implement proper authorization checks and figure out if project or organization should be the base of the permission
+
+### Models
+- Use the Knex query builder efficiently and strongly typed
+- Implement proper database constraints
+- Use appropriate data types for columns
+- Implement proper indexing strategy
+
+### Database
+- Follow migration naming conventions — good example: `packages/backend/src/database/migrations/20250310151004_create_query_history_table.ts`
+- Implement proper rollback strategies
+- Use appropriate database constraints
+- Implement proper indexing strategy
+- Add types for the database entities
+
+## Performance Monitoring
+
+1. **Metrics Collection**
+   - Use Prometheus metrics for monitoring
+   - Track API response times
+   - Monitor database query performance
+   - Track background job execution times
+
+2. **Logging**
+   - Use structured logging with Winston
+   - Implement proper log levels
+   - Include relevant context in logs
+   - Use appropriate log rotation
+
+3. **Error Tracking**
+   - Use Sentry for error tracking
+   - Implement proper error categorization
+   - Track error rates and patterns
+   - Monitor error impact on performance
+
+## Security & Authorization
+
+- Use CASL for permission management
+- Implement proper role-based access control
+- All permission logic is written in `packages/common/src/authorization/organizationMemberAbility.ts` + `packages/common/src/authorization/projectMemberAbility.ts`
+- All service methods must have permission checks
+- Permission checks should use the `createAuditedAbility` method (instead of accessing `user.ability` / `account.user.ability` directly) — see `docs/audit-logging.md`
+- Permission checks always execute against a subject using fields only from the subject
+- Never insert user properties (including the user's org uuid) in the subject field
+- Validate user permissions at the service level
+
+## Code Style
+
+- Prefer dependency injection over imports between files — enables better testing
+
+## Dependencies
+
+Key performance-related dependencies (see `packages/backend/package.json`):
+- `graphile-worker`: background job processing
+- `prom-client`: performance monitoring
+- `winston`: structured logging
+- `knex`: database operations
+- `pg`: PostgreSQL operations

--- a/.github/rules/frontend-review.md
+++ b/.github/rules/frontend-review.md
@@ -1,0 +1,76 @@
+# Frontend review rules
+
+Applies to `packages/frontend/**/*.ts` and `packages/frontend/**/*.tsx`.
+
+You are a Senior Front-End Developer and an expert in ReactJS, JavaScript, TypeScript, HTML, CSS.
+
+- If there were previous comments, keep them! They might be useful
+- If you do not know the answer, say so, instead of guessing
+
+### Coding Environment
+
+- ReactJS v19
+- JavaScript
+- TypeScript v5
+- Mantine v8
+- React Query v4.36
+- React Router v7
+- HTML
+- CSS
+
+## Best Practices
+
+1. **Error Handling**
+   - Implement proper error boundaries
+   - Show user-friendly error messages
+   - Log errors appropriately
+   - Handle network errors gracefully
+
+2. **Documentation**
+   - Document complex components
+   - Add JSDoc comments for functions and hooks
+   - Keep README files up to date
+   - Document prop types and interfaces
+
+3. **Anti-patterns**
+   - Avoid the useEffect + useState antipattern
+   - If you need to use `eslint-disable-line react-hooks/exhaustive-deps`, there's probably a better way of structuring your data. Consider deriving state instead of setting it.
+
+## Development Guidelines
+
+- Pass the `type` keyword when importing types
+
+### General
+- Consider performance, so use `useMemo` and `useCallback` where necessary
+- Always import from `common` as `@lightdash/common`. Never add a suffix/subpath to that import path.
+
+### Components
+- Keep components focused and single-responsibility
+- Implement proper prop types using TypeScript
+- Use Mantine components as the base UI library
+- Implement proper error boundaries
+- Prefer the Mantine `Box` component instead of semantic `<div>`s
+- If you are adding an icon, use `MantineIcon` and pass the react-tabler icon as the `icon` prop
+
+### Modals
+- **Always use `MantineModal`** from `components/common/MantineModal` — never use Mantine's `Modal` directly
+- See `stories/Modal.stories.tsx` for usage examples
+- For forms: use `id` on the form and `form="form-id"` on the submit button
+- For alerts inside modals: use `Callout` with variants `danger`, `warning`, `info`
+
+### Hooks
+- Create custom hooks for reusable logic
+- Follow the pattern in `packages/frontend/src/hooks/organization/useOrganization.ts` if you're calling the API
+- Implement proper cleanup in useEffect
+- Use proper dependency arrays
+- Name effect functions for clarity
+
+### Forms
+- Use Mantine `useForm` with Zod for validation
+- Implement proper error handling
+- Use controlled components where appropriate
+- Implement proper form state management
+- Disable the submit button until the required inputs are set
+
+### Styling
+- Follow the frontend style guide in `.claude/skills/frontend-style-guide/SKILL.md`

--- a/.github/rules/migration-review.md
+++ b/.github/rules/migration-review.md
@@ -1,0 +1,25 @@
+# Migration review rules
+
+Applies to new migration files under `packages/backend/src/database/migrations/**/*.ts` and EE migrations under `packages/backend/src/ee/database/migrations/**/*.ts`.
+
+## New migrations must support old code
+
+If a PR contains a new migration file: the migration must be able to run **before** any code changes. In other words, after your migration the existing code should still run. Only once the migration is safe in isolation can you update the code to use the newly created tables/columns.
+
+### ✅ Allowed operations in migrations
+
+- Creating new columns
+- Creating new tables
+- Making columns nullable
+- Changing / removing / adding indices
+- Adding extensions
+
+### ❌ Dangerous operations in migrations
+
+- Deleting columns
+- Deleting tables
+- Making existing columns not-nullable
+- Changing column types
+- Removing extensions
+- Altering data in existing columns
+- Copying data from one column to another


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Moves our Graphite Diamond AI review rules out of the Graphite web UI and into version-controlled markdown under `.github/rules/`, so they can be reviewed and updated via PR instead of the dashboard. Adds four rule files — backend, frontend, migration safety (including EE migrations), and API backwards-compatibility (covering the SDK embed bundle, the CLI, and customer-built API automation/scripts). Rules use real repo paths and follow Graphite's `.github/rules/*.md` file-based convention. Follow-up is a manual step: point each Graphite rule at its file via "from file path" in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)