### PR TITLE
feat: add dynamic SI compact formatting (duplicate of #24790)

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3724,6 +3724,7 @@ const models: TsoaRoute.Models = {
     Compact: {
         dataType: 'refEnum',
         enums: [
+            'auto',
             'thousands',
             'millions',
             'billions',
@@ -3822,6 +3823,36 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterAutocompleteValue: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string' },
+                value: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterAutocompleteConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                fetchFromWarehouse: { dataType: 'boolean', required: true },
+                values: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'FilterAutocompleteValue',
+                    },
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FieldType: {
         dataType: 'refEnum',
         enums: ['metric', 'dimension'],
@@ -3868,7 +3899,18 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     Format: {
         dataType: 'refEnum',
-        enums: ['km', 'mi', 'usd', 'gbp', 'eur', 'jpy', 'dkk', 'id', 'percent'],
+        enums: [
+            'km',
+            'mi',
+            'si',
+            'usd',
+            'gbp',
+            'eur',
+            'jpy',
+            'dkk',
+            'id',
+            'percent',
+        ],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FieldUrl: {
@@ -3961,28 +4003,7 @@ const models: TsoaRoute.Models = {
                 },
             },
             richText: { dataType: 'string' },
-            filterAutocomplete: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    fetchFromWarehouse: {
-                        dataType: 'boolean',
-                        required: true,
-                    },
-                    values: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                value: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                label: { dataType: 'string' },
-                            },
-                        },
-                    },
-                },
-            },
+            filterAutocomplete: { ref: 'FilterAutocompleteConfig' },
             spotlight: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -7124,28 +7145,7 @@ const models: TsoaRoute.Models = {
                 },
             },
             richText: { dataType: 'string' },
-            filterAutocomplete: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    fetchFromWarehouse: {
-                        dataType: 'boolean',
-                        required: true,
-                    },
-                    values: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                value: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                label: { dataType: 'string' },
-                            },
-                        },
-                    },
-                },
-            },
+            filterAutocomplete: { ref: 'FilterAutocompleteConfig' },
             spotlight: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -14165,11 +14165,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -14227,11 +14227,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['accepted'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['accepted'],
                                                         },
                                                         {
                                                             dataType:
@@ -14360,29 +14360,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 verifiedChartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -14407,6 +14384,29 @@ const models: TsoaRoute.Models = {
                                                                                                             ],
                                                                                                     },
                                                                                                 chartUsage:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14474,7 +14474,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14482,11 +14482,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -14501,7 +14497,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14509,7 +14505,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -14718,29 +14718,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     verifiedChartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -14765,6 +14742,29 @@ const models: TsoaRoute.Models = {
                                                                                                                 ],
                                                                                                         },
                                                                                                     chartUsage:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -15478,6 +15478,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15555,77 +15626,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15657,12 +15657,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15670,6 +15664,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15816,11 +15816,11 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['rejected'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['rejected'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15887,7 +15887,7 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                searchRank:
+                                                                                chartUsage:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -15910,7 +15910,7 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                chartUsage:
+                                                                                searchRank:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -20482,6 +20482,7 @@ const models: TsoaRoute.Models = {
                 workGroup: { dataType: 'string' },
                 assumeRoleExternalId: { dataType: 'string' },
                 assumeRoleArn: { dataType: 'string' },
+                sessionToken: { dataType: 'string' },
                 secretAccessKey: { dataType: 'string' },
                 accessKeyId: { dataType: 'string' },
                 authenticationType: { ref: 'AthenaAuthenticationType' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3851,6 +3851,7 @@
             },
             "Compact": {
                 "enum": [
+                    "auto",
                     "thousands",
                     "millions",
                     "billions",
@@ -3952,6 +3953,33 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "FilterAutocompleteValue": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value"],
+                "type": "object"
+            },
+            "FilterAutocompleteConfig": {
+                "properties": {
+                    "fetchFromWarehouse": {
+                        "type": "boolean"
+                    },
+                    "values": {
+                        "items": {
+                            "$ref": "#/components/schemas/FilterAutocompleteValue"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["fetchFromWarehouse"],
+                "type": "object"
+            },
             "FieldType": {
                 "enum": ["metric", "dimension"],
                 "type": "string"
@@ -4010,6 +4038,7 @@
                 "enum": [
                     "km",
                     "mi",
+                    "si",
                     "usd",
                     "gbp",
                     "eur",
@@ -4214,28 +4243,7 @@
                         "type": "string"
                     },
                     "filterAutocomplete": {
-                        "properties": {
-                            "fetchFromWarehouse": {
-                                "type": "boolean"
-                            },
-                            "values": {
-                                "items": {
-                                    "properties": {
-                                        "value": {
-                                            "type": "string"
-                                        },
-                                        "label": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["value"],
-                                    "type": "object"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["fetchFromWarehouse"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/FilterAutocompleteConfig"
                     },
                     "spotlight": {
                         "properties": {
@@ -8342,28 +8350,7 @@
                         "type": "string"
                     },
                     "filterAutocomplete": {
-                        "properties": {
-                            "fetchFromWarehouse": {
-                                "type": "boolean"
-                            },
-                            "values": {
-                                "items": {
-                                    "properties": {
-                                        "value": {
-                                            "type": "string"
-                                        },
-                                        "label": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["value"],
-                                    "type": "object"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["fetchFromWarehouse"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/FilterAutocompleteConfig"
                     },
                     "spotlight": {
                         "properties": {
@@ -15724,8 +15711,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15783,8 +15770,8 @@
                                                     "userFeedback": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "accepted",
-                                                            "rejected"
+                                                            "rejected",
+                                                            "accepted"
                                                         ]
                                                     },
                                                     "changeUuid": {
@@ -15833,17 +15820,17 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "verifiedChartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -15874,16 +15861,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "requiredFilters": {
@@ -15993,17 +15980,17 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "verifiedChartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
                                                                                     "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -16387,6 +16374,32 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16414,32 +16427,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "compile",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16459,9 +16446,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16525,8 +16512,8 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
                                                             "timeout"
                                                         ]
                                                     }
@@ -16545,12 +16532,12 @@
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -20725,6 +20712,9 @@
                         "type": "string"
                     },
                     "assumeRoleArn": {
+                        "type": "string"
+                    },
+                    "sessionToken": {
                         "type": "string"
                     },
                     "secretAccessKey": {
@@ -41633,7 +41623,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3254.2",
+        "version": "0.3260.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -60,6 +60,7 @@
         "Compact": {
             "type": "string",
             "enum": [
+                "auto",
                 "thousands",
                 "millions",
                 "billions",

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -480,6 +480,7 @@
         },
         "Compact": {
             "enum": [
+                "auto",
                 "thousands",
                 "millions",
                 "billions",
@@ -1333,6 +1334,7 @@
             "enum": [
                 "km",
                 "mi",
+                "si",
                 "usd",
                 "gbp",
                 "eur",

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -189,6 +189,7 @@
                             "compact": {
                                 "type": "string",
                                 "enum": [
+                                    "auto",
                                     "thousands",
                                     "millions",
                                     "billions",
@@ -604,6 +605,7 @@
                                 "compact": {
                                     "type": "string",
                                     "enum": [
+                                        "auto",
                                         "thousands",
                                         "millions",
                                         "billions",
@@ -1215,6 +1217,7 @@
                                 "compact": {
                                     "type": "string",
                                     "enum": [
+                                        "auto",
                                         "thousands",
                                         "millions",
                                         "billions",
@@ -1507,6 +1510,7 @@
                         "compact": {
                             "type": "string",
                             "enum": [
+                                "auto",
                                 "thousands",
                                 "millions",
                                 "billions",
@@ -1758,6 +1762,7 @@
                                 "compact": {
                                     "type": "string",
                                     "enum": [
+                                        "auto",
                                         "thousands",
                                         "millions",
                                         "billions",

--- a/packages/common/src/schemas/json/model-as-code-1.0.json
+++ b/packages/common/src/schemas/json/model-as-code-1.0.json
@@ -483,6 +483,7 @@
                 },
                 "compact": {
                     "enum": [
+                        "auto",
                         "thousands",
                         "thousand",
                         "K",
@@ -613,6 +614,7 @@
                 },
                 "compact": {
                     "enum": [
+                        "auto",
                         "thousands",
                         "thousand",
                         "K",

--- a/packages/common/src/types/field.test.ts
+++ b/packages/common/src/types/field.test.ts
@@ -115,6 +115,7 @@ describe('field util functions', () => {
             expect(isFormat('dkk')).toBe(true);
             expect(isFormat('id')).toBe(true);
             expect(isFormat('percent')).toBe(true);
+            expect(isFormat('si')).toBe(true);
         });
 
         it('should return false for invalid formats', () => {

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -11,6 +11,7 @@ import { type MetricFilterRule } from './filter';
 import type { TimeFrames } from './timeFrames';
 
 export enum Compact {
+    AUTO = 'auto',
     THOUSANDS = 'thousands',
     MILLIONS = 'millions',
     BILLIONS = 'billions',
@@ -78,6 +79,14 @@ type CompactConfig = {
 export type CompactOrAlias = Compact | (typeof CompactAlias)[number];
 
 export const CompactConfigMap: Record<Compact, CompactConfig> = {
+    [Compact.AUTO]: {
+        compact: Compact.AUTO,
+        alias: [],
+        orderOfMagnitude: 0,
+        convertFn: (value: number) => value,
+        label: 'Auto (K, M, B, T)',
+        suffix: '',
+    },
     [Compact.THOUSANDS]: {
         compact: Compact.THOUSANDS,
         alias: ['K', 'thousand'],
@@ -815,6 +824,7 @@ export enum MetricType {
 export enum Format {
     KM = 'km',
     MI = 'mi',
+    SI = 'si',
     USD = 'usd',
     GBP = 'gbp',
     EUR = 'eur',
@@ -1081,10 +1091,19 @@ export function getCompactOptionsForFormatType(
 ): Compact[] {
     if (type === CustomFormatType.BYTES_IEC) return IECByteCompacts;
     if (type === CustomFormatType.BYTES_SI) return SIByteCompacts;
-    return [
+    const numericCompacts = [
         Compact.THOUSANDS,
         Compact.MILLIONS,
         Compact.BILLIONS,
         Compact.TRILLIONS,
     ];
+
+    if (
+        type === CustomFormatType.NUMBER ||
+        type === CustomFormatType.CURRENCY
+    ) {
+        return [Compact.AUTO, ...numericCompacts];
+    }
+
+    return numericCompacts;
 }

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -246,6 +246,14 @@ describe('Formatting', () => {
                 type: CustomFormatType.ID,
             });
         });
+
+        test(`when it is ${Format.SI.toUpperCase()} getCustomFormatFromLegacy should return the correct CustomFormat options`, () => {
+            expect(getCustomFormatFromLegacy({ format: Format.SI })).toEqual({
+                type: CustomFormatType.NUMBER,
+                compact: Compact.AUTO,
+                round: undefined,
+            });
+        });
     });
 
     describe('applying CustomFormat to value', () => {
@@ -690,10 +698,15 @@ describe('Formatting', () => {
         });
 
         describe('when applying compact', () => {
+            const AUTO = Compact.AUTO;
             const K = Compact.THOUSANDS;
             const M = Compact.MILLIONS;
             const B = Compact.BILLIONS;
             const T = Compact.TRILLIONS;
+            const autoConfig = {
+                type: CustomFormatType.NUMBER,
+                compact: AUTO,
+            };
 
             const thousandsConfig = {
                 type: CustomFormatType.NUMBER,
@@ -722,6 +735,41 @@ describe('Formatting', () => {
                 expect(applyCustomFormat(5000000000, trillionsConfig)).toEqual(
                     '0.005T',
                 );
+            });
+
+            test('it should dynamically pick the compact style', () => {
+                expect(applyCustomFormat(999, autoConfig)).toEqual('999');
+                expect(applyCustomFormat(1000, autoConfig)).toEqual('1K');
+                expect(applyCustomFormat(1200, autoConfig)).toEqual('1.2K');
+                expect(applyCustomFormat(1200000, autoConfig)).toEqual('1.2M');
+                expect(applyCustomFormat(-1200000, autoConfig)).toEqual(
+                    '-1.2M',
+                );
+            });
+
+            test('it should apply dynamic compact with round, separators, prefix and suffix', () => {
+                expect(
+                    applyCustomFormat(1200, { ...autoConfig, round: 0 }),
+                ).toEqual('1K');
+                expect(
+                    applyCustomFormat(1234567890123456, {
+                        ...autoConfig,
+                        separator: NumberSeparator.COMMA_PERIOD,
+                        prefix: '~',
+                        suffix: ' total',
+                    }),
+                ).toEqual('~1,234.568T total');
+            });
+
+            test('it should apply dynamic compact with currency', () => {
+                expect(
+                    applyCustomFormat(1200, {
+                        type: CustomFormatType.CURRENCY,
+                        compact: AUTO,
+                        currency: 'USD',
+                        round: 1,
+                    }),
+                ).toEqual('$1.2K');
             });
 
             test('when applying round it should return the right style', () => {

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -698,11 +698,13 @@ describe('Formatting', () => {
         });
 
         describe('when applying compact', () => {
-            const AUTO = Compact.AUTO;
-            const K = Compact.THOUSANDS;
-            const M = Compact.MILLIONS;
-            const B = Compact.BILLIONS;
-            const T = Compact.TRILLIONS;
+            const {
+                AUTO,
+                THOUSANDS: K,
+                MILLIONS: M,
+                BILLIONS: B,
+                TRILLIONS: T,
+            } = Compact;
             const autoConfig = {
                 type: CustomFormatType.NUMBER,
                 compact: AUTO,
@@ -2637,6 +2639,23 @@ describe('Formatting', () => {
                     formattedValueWithCustomFormat,
                 );
             });
+        });
+
+        test('should not convert dynamic auto compact to a static format expression', () => {
+            expect(
+                convertCustomFormatToFormatExpression({
+                    type: CustomFormatType.NUMBER,
+                    compact: Compact.AUTO,
+                }),
+            ).toBeNull();
+
+            expect(
+                convertCustomFormatToFormatExpression({
+                    type: CustomFormatType.CURRENCY,
+                    currency: Format.USD,
+                    compact: Compact.AUTO,
+                }),
+            ).toBeNull();
         });
     });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1050,9 +1050,18 @@ const customFormatConversionFnMap: Record<
     },
 };
 
+const hasDynamicCompact = (format: CustomFormat) =>
+    format.compact === Compact.AUTO &&
+    (format.type === CustomFormatType.NUMBER ||
+        format.type === CustomFormatType.CURRENCY);
+
 export function convertCustomFormatToFormatExpression(
     format: CustomFormat,
 ): string | null {
+    if (hasDynamicCompact(format)) {
+        return null;
+    }
+
     // ECMA-376 format expression
     let defaultFormatExpression: string | null = null;
     let conversions: Array<string> = [];

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -10,6 +10,7 @@ import {
 } from 'numfmt';
 import { LightdashParameters } from '../compiler/parameters';
 import {
+    Compact,
     CompactConfigMap,
     CustomFormatType,
     DimensionType,
@@ -515,6 +516,12 @@ export function getCustomFormatFromLegacy({
                 compact,
                 round,
             };
+        case Format.SI:
+            return {
+                type: CustomFormatType.NUMBER,
+                compact: Compact.AUTO,
+                round,
+            };
         case Format.PERCENT:
             return {
                 type: CustomFormatType.PERCENT,
@@ -650,6 +657,30 @@ function applyCompact(
 } {
     if (format?.compact === undefined)
         return { compactValue: Number(value), compactSuffix: '' };
+
+    if (format.compact === Compact.AUTO) {
+        const numberValue = Number(value);
+        const compactConfig = [
+            Compact.TRILLIONS,
+            Compact.BILLIONS,
+            Compact.MILLIONS,
+            Compact.THOUSANDS,
+        ]
+            .map((compact) => CompactConfigMap[compact])
+            .find(
+                ({ orderOfMagnitude }) =>
+                    Math.abs(numberValue) >= 10 ** orderOfMagnitude,
+            );
+
+        if (compactConfig) {
+            return {
+                compactValue: compactConfig.convertFn(numberValue),
+                compactSuffix: compactConfig.suffix,
+            };
+        }
+
+        return { compactValue: numberValue, compactSuffix: '' };
+    }
 
     const compactConfig = findCompactConfig(format.compact);
 
@@ -989,6 +1020,10 @@ const customFormatConversionFnMap: Record<
     },
     compact: (formatExpression, format) => {
         if (format.compact) {
+            if (format.compact === Compact.AUTO) {
+                return formatExpression;
+            }
+
             const compactConfig = findCompactConfig(format.compact);
             if (compactConfig) {
                 // Check if this is a binary (IEC) byte unit, like KiB, MiB, etc.

--- a/packages/common/src/visualizations/CartesianChartDataModel.test.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.test.ts
@@ -1,0 +1,24 @@
+import { Format } from '../types/field';
+import { CartesianChartDataModel } from './CartesianChartDataModel';
+
+describe('CartesianChartDataModel formatters', () => {
+    test('formats SI tooltip values dynamically', () => {
+        const formatter = CartesianChartDataModel.getTooltipFormatter(Format.SI);
+
+        expect(formatter?.(999)).toEqual('999');
+        expect(formatter?.(1200)).toEqual('1.2K');
+        expect(formatter?.(1200000)).toEqual('1.2M');
+    });
+
+    test('formats SI value labels dynamically', () => {
+        const formatter = CartesianChartDataModel.getValueFormatter(Format.SI);
+
+        expect(
+            formatter?.({
+                dimensionNames: ['category', 'value'],
+                encode: { y: [1] },
+                value: ['Jan', 1200000],
+            }),
+        ).toEqual('1.2M');
+    });
+});

--- a/packages/common/src/visualizations/CartesianChartDataModel.test.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.test.ts
@@ -3,7 +3,9 @@ import { CartesianChartDataModel } from './CartesianChartDataModel';
 
 describe('CartesianChartDataModel formatters', () => {
     test('formats SI tooltip values dynamically', () => {
-        const formatter = CartesianChartDataModel.getTooltipFormatter(Format.SI);
+        const formatter = CartesianChartDataModel.getTooltipFormatter(
+            Format.SI,
+        );
 
         expect(formatter?.(999)).toEqual('999');
         expect(formatter?.(1200)).toEqual('1.2K');
@@ -17,7 +19,7 @@ describe('CartesianChartDataModel formatters', () => {
             formatter?.({
                 dimensionNames: ['category', 'value'],
                 encode: { y: [1] },
-                value: ['Jan', 1200000],
+                value: { category: 'Jan', value: 1200000 },
             }),
         ).toEqual('1.2M');
     });

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -20,6 +20,7 @@ import {
     applyCustomFormat,
     formatDateWithPattern,
     formatNumberValue,
+    getCustomFormatFromLegacy,
 } from '../utils/formatting';
 import {
     getAxisLabelStyle,
@@ -118,6 +119,10 @@ export class CartesianChartDataModel {
                     type: CustomFormatType.PERCENT,
                 });
         }
+        if (format === Format.SI) {
+            return (value: number) =>
+                applyCustomFormat(value, getCustomFormatFromLegacy({ format }));
+        }
         return undefined;
     }
 
@@ -151,6 +156,17 @@ export class CartesianChartDataModel {
                 return applyCustomFormat(value, {
                     type: CustomFormatType.PERCENT,
                 });
+            };
+        }
+        if (format === Format.SI) {
+            return (params: AnyType) => {
+                const value =
+                    params.value[params.dimensionNames[params.encode.y[0]]];
+
+                return applyCustomFormat(
+                    value,
+                    getCustomFormatFromLegacy({ format }),
+                );
             };
         }
         return undefined;

--- a/packages/frontend/src/components/DataViz/config/CartesianChartFormatConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartFormatConfig.tsx
@@ -1,7 +1,6 @@
 import { Format } from '@lightdash/common';
 import { Group, Select, Text } from '@mantine-8/core';
 import { IconClearAll, IconPercentage } from '@tabler/icons-react';
-import capitalize from 'lodash/capitalize';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import styles from './CartesianChartFormatConfig.module.css';
@@ -28,15 +27,16 @@ export const CartesianChartFormatConfig: FC<Props> = ({
     onChangeFormat,
     format,
 }) => {
-    const formatOptionsWithNone = ['none', Format.PERCENT];
+    const formatOptions = [
+        { value: 'none', label: 'None' },
+        { value: Format.PERCENT, label: 'Percent' },
+        { value: Format.SI, label: 'SI' },
+    ];
 
     return (
         <Select
             radius="md"
-            data={formatOptionsWithNone.map((option) => ({
-                value: option,
-                label: capitalize(option),
-            }))}
+            data={formatOptions}
             renderOption={({ option }) => (
                 <Group wrap="nowrap" gap="xs">
                     <FormatIcon
@@ -44,11 +44,11 @@ export const CartesianChartFormatConfig: FC<Props> = ({
                             option.value === 'none' ? undefined : option.value
                         }
                     />
-                    <Text>{capitalize(option.value)}</Text>
+                    <Text>{option.label}</Text>
                 </Group>
             )}
             leftSection={format && <FormatIcon format={format} />}
-            value={format ?? formatOptionsWithNone?.[0]}
+            value={format ?? 'none'}
             onChange={(value) => value && onChangeFormat(value)}
             classNames={{
                 input: styles.input,

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -1,4 +1,5 @@
 import {
+    Compact,
     CompactConfigMap,
     convertCustomFormatToFormatExpression,
     currencies,
@@ -136,6 +137,11 @@ export const FormatForm: FC<Props> = ({
     compact = false,
 }) => {
     const formatType = format.type;
+    const formatExpression = convertCustomFormatToFormatExpression(format);
+    const usesRuntimeOnlyFormatExpression =
+        format.compact === Compact.AUTO &&
+        (format.type === CustomFormatType.NUMBER ||
+            format.type === CustomFormatType.CURRENCY);
 
     const isDateField = useMemo(() => {
         return (
@@ -533,8 +539,9 @@ export const FormatForm: FC<Props> = ({
                     <Text size="xs" c="ldGray.5">
                         Format expression:{' '}
                         <Text span fw={500} c="ldGray.7">
-                            {convertCustomFormatToFormatExpression(format) ||
-                                'default'}
+                            {usesRuntimeOnlyFormatExpression
+                                ? 'runtime only'
+                                : formatExpression || 'default'}
                         </Text>
                     </Text>
                 </Grid.Col>

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/common/index.test.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/common/index.test.ts
@@ -1,0 +1,16 @@
+import { Compact } from '@lightdash/common';
+import { describe, expect, test } from 'vitest';
+import { StyleOptions } from '.';
+
+describe('Big Number style options', () => {
+    test('includes Auto and keeps existing fixed compact styles', () => {
+        expect(StyleOptions).toEqual([
+            { value: '', label: 'None' },
+            { value: Compact.AUTO, label: 'Auto (K, M, B, T)' },
+            { value: Compact.THOUSANDS, label: 'thousands (K)' },
+            { value: Compact.MILLIONS, label: 'millions (M)' },
+            { value: Compact.BILLIONS, label: 'billions (B)' },
+            { value: Compact.TRILLIONS, label: 'trillions (T)' },
+        ]);
+    });
+});

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/common/index.ts
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/common/index.ts
@@ -1,9 +1,17 @@
-import { CompactConfigMap } from '@lightdash/common';
+import { Compact, CompactConfigMap } from '@lightdash/common';
+
+const bigNumberCompactOptions = [
+    Compact.AUTO,
+    Compact.THOUSANDS,
+    Compact.MILLIONS,
+    Compact.BILLIONS,
+    Compact.TRILLIONS,
+];
 
 export const StyleOptions = [
     { value: '', label: 'None' },
-    ...Object.values(CompactConfigMap).map(({ compact, label }) => ({
+    ...bigNumberCompactOptions.map((compact) => ({
         value: compact,
-        label,
+        label: CompactConfigMap[compact].label,
     })),
 ];

--- a/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormatRow/FormatRow.tsx
@@ -1,4 +1,6 @@
 import {
+    applyCustomFormat,
+    Compact,
     assertUnreachable,
     CompactConfigMap,
     convertCustomFormatToFormatExpression,
@@ -211,6 +213,14 @@ const getPreviewValue = (
             return dataType === TableCalculationType.TIMESTAMP
                 ? formatTimestamp(sample)
                 : formatDate(sample);
+        }
+
+        if (
+            format.compact === Compact.AUTO &&
+            (format.type === CustomFormatType.NUMBER ||
+                format.type === CustomFormatType.CURRENCY)
+        ) {
+            return applyCustomFormat(NUMERIC_SAMPLE, format);
         }
 
         const expression = convertCustomFormatToFormatExpression(format);


### PR DESCRIPTION
Duplicate of #24790 (original by @nazihkalo, opened from a fork). Re-opened here on a `lightdash/lightdash` branch with the same two commits so CI runs with full access. All credit to the original author.

## Summary
- add native dynamic SI compact formatting via `Compact.AUTO` and legacy `Format.SI`
- dynamically scale numeric and currency values to K/M/B/T by magnitude while preserving fixed compact formats
- expose SI formatting in cartesian axis controls and Auto compact style in Big Number controls
- update chart/model/dbt schemas and add focused formatter/UI option tests

Fixes #20651

## Notes
- Mirrors #24790 exactly (no changes). See that PR for original discussion/review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
