### PR TITLE
feat(scheduler): AI-augmented scheduled deliveries

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -428,6 +428,10 @@ import {
     AiRouterTableName,
 } from '../ee/database/entities/aiRouter';
 import {
+    AiSchedulerTable,
+    AiSchedulerTableName,
+} from '../ee/database/entities/aiScheduler';
+import {
     DashboardSummariesTable,
     DashboardSummariesTableName,
 } from '../ee/database/entities/dashboardSummaries';
@@ -576,6 +580,7 @@ declare module 'knex/types/tables' {
         [AiWritebackThreadTableName]: AiWritebackThreadTable;
         [ProjectCiStatusTableName]: ProjectCiStatusTable;
         [AiAgentTableName]: AiAgentTable;
+        [AiSchedulerTableName]: AiSchedulerTable;
         [AiAgentDocumentTableName]: AiAgentDocumentTable;
         [AiAgentDocumentAccessTableName]: AiAgentDocumentAccessTable;
         [AiAgentReviewClassifierRunTableName]: AiAgentReviewClassifierRunTable;

--- a/packages/backend/src/ee/controllers/aiSchedulerController.ts
+++ b/packages/backend/src/ee/controllers/aiSchedulerController.ts
@@ -1,0 +1,93 @@
+import {
+    assertRegisteredAccount,
+    type ApiAiSchedulerConfigResponse,
+    type ApiErrorPayload,
+    type ApiSuccessEmpty,
+    type UpsertAiSchedulerConfig,
+} from '@lightdash/common';
+import {
+    Body,
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Put,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../../auth/account';
+import {
+    allowApiKeyAuthentication,
+    isAuthenticated,
+} from '../../controllers/authentication';
+import { BaseController } from '../../controllers/baseController';
+import { type AiSchedulerService } from '../services/AiSchedulerService';
+
+@Route('/api/v1/schedulers/{schedulerUuid}/ai-config')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Scheduler')
+export class AiSchedulerController extends BaseController {
+    protected getAiSchedulerService() {
+        return this.services.getAiSchedulerService<AiSchedulerService>();
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getAiSchedulerConfig')
+    async getConfig(
+        @Request() req: express.Request,
+        @Path() schedulerUuid: string,
+    ): Promise<ApiAiSchedulerConfigResponse> {
+        assertRegisteredAccount(req.account);
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.getAiSchedulerService().getConfig(
+                toSessionUser(req.account),
+                schedulerUuid,
+            ),
+        };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Put('/')
+    @OperationId('upsertAiSchedulerConfig')
+    async upsertConfig(
+        @Request() req: express.Request,
+        @Path() schedulerUuid: string,
+        @Body() body: UpsertAiSchedulerConfig,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getAiSchedulerService().upsertConfig(
+            toSessionUser(req.account),
+            schedulerUuid,
+            body,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/')
+    @OperationId('deleteAiSchedulerConfig')
+    async deleteConfig(
+        @Request() req: express.Request,
+        @Path() schedulerUuid: string,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.getAiSchedulerService().removeConfig(
+            toSessionUser(req.account),
+            schedulerUuid,
+        );
+        this.setStatus(200);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/ee/database/entities/aiScheduler.ts
+++ b/packages/backend/src/ee/database/entities/aiScheduler.ts
@@ -4,7 +4,7 @@ export const AiSchedulerTableName = 'ai_scheduler';
 
 export type DbAiScheduler = {
     scheduler_uuid: string;
-    type: 'agent' | 'resource';
+    type: 'agentPrompt' | 'savedContent';
     agent_uuid: string | null;
     prompt: string;
     source_thread_uuid: string | null;

--- a/packages/backend/src/ee/database/entities/aiScheduler.ts
+++ b/packages/backend/src/ee/database/entities/aiScheduler.ts
@@ -4,25 +4,31 @@ export const AiSchedulerTableName = 'ai_scheduler';
 
 export type DbAiScheduler = {
     scheduler_uuid: string;
-    agent_uuid: string;
+    type: 'agent' | 'resource';
+    agent_uuid: string | null;
     prompt: string;
     source_thread_uuid: string | null;
     include_source_thread: boolean;
     include_run_history: boolean;
+    report_thread_uuid: string | null;
     created_at: Date;
     updated_at: Date;
 };
 
 export type AiSchedulerTable = Knex.CompositeTableType<
     DbAiScheduler,
-    Omit<DbAiScheduler, 'created_at' | 'updated_at'>,
-    Pick<
-        DbAiScheduler,
-        | 'agent_uuid'
-        | 'prompt'
-        | 'source_thread_uuid'
-        | 'include_source_thread'
-        | 'include_run_history'
-        | 'updated_at'
+    Omit<DbAiScheduler, 'created_at' | 'updated_at' | 'report_thread_uuid'>,
+    Partial<
+        Pick<
+            DbAiScheduler,
+            | 'type'
+            | 'agent_uuid'
+            | 'prompt'
+            | 'source_thread_uuid'
+            | 'include_source_thread'
+            | 'include_run_history'
+            | 'report_thread_uuid'
+            | 'updated_at'
+        >
     >
 >;

--- a/packages/backend/src/ee/database/entities/aiScheduler.ts
+++ b/packages/backend/src/ee/database/entities/aiScheduler.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+export const AiSchedulerTableName = 'ai_scheduler';
+
+export type DbAiScheduler = {
+    scheduler_uuid: string;
+    agent_uuid: string;
+    prompt: string;
+    source_thread_uuid: string | null;
+    include_source_thread: boolean;
+    include_run_history: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type AiSchedulerTable = Knex.CompositeTableType<
+    DbAiScheduler,
+    Omit<DbAiScheduler, 'created_at' | 'updated_at'>,
+    Pick<
+        DbAiScheduler,
+        | 'agent_uuid'
+        | 'prompt'
+        | 'source_thread_uuid'
+        | 'include_source_thread'
+        | 'include_run_history'
+        | 'updated_at'
+    >
+>;

--- a/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
@@ -15,13 +15,16 @@ export async function up(knex: Knex): Promise<void> {
             .references('scheduler_uuid')
             .inTable(SCHEDULER_TABLE)
             .onDelete('CASCADE');
+        table.text('type').notNullable().checkIn(['agent', 'resource']);
+        // Null for 'resource' deliveries, which run on a fast model with no agent.
         table
             .uuid('agent_uuid')
-            .notNullable()
+            .nullable()
             .references('ai_agent_uuid')
             .inTable(AI_AGENT_TABLE)
             .onDelete('CASCADE')
             .index();
+        table.check(`(type = 'agent') = (agent_uuid IS NOT NULL)`);
         table.text('prompt').notNullable();
         table
             .uuid('source_thread_uuid')
@@ -32,6 +35,14 @@ export async function up(knex: Knex): Promise<void> {
             .index();
         table.boolean('include_source_thread').notNullable().defaultTo(true);
         table.boolean('include_run_history').notNullable().defaultTo(false);
+        // Thread an agent delivery builds on across runs for "include run history".
+        table
+            .uuid('report_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(AI_THREAD_TABLE)
+            .onDelete('SET NULL')
+            .index();
         table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
         table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
     });

--- a/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
@@ -15,8 +15,11 @@ export async function up(knex: Knex): Promise<void> {
             .references('scheduler_uuid')
             .inTable(SCHEDULER_TABLE)
             .onDelete('CASCADE');
-        table.text('type').notNullable().checkIn(['agent', 'resource']);
-        // Null for 'resource' deliveries, which run on a fast model with no agent.
+        table
+            .text('type')
+            .notNullable()
+            .checkIn(['agentPrompt', 'savedContent']);
+        // Null for 'savedContent' deliveries, which run on a fast model with no agent.
         table
             .uuid('agent_uuid')
             .nullable()
@@ -24,7 +27,7 @@ export async function up(knex: Knex): Promise<void> {
             .inTable(AI_AGENT_TABLE)
             .onDelete('CASCADE')
             .index();
-        table.check(`(type = 'agent') = (agent_uuid IS NOT NULL)`);
+        table.check(`(type = 'agentPrompt') = (agent_uuid IS NOT NULL)`);
         table.text('prompt').notNullable();
         table
             .uuid('source_thread_uuid')

--- a/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
+++ b/packages/backend/src/ee/database/migrations/20260625120000_add_ai_scheduler_table.ts
@@ -1,0 +1,42 @@
+import { Knex } from 'knex';
+
+const AI_SCHEDULER_TABLE = 'ai_scheduler';
+const SCHEDULER_TABLE = 'scheduler';
+const AI_AGENT_TABLE = 'ai_agent';
+const AI_THREAD_TABLE = 'ai_thread';
+
+// 1:1 EE satellite of the OSS scheduler table — keeps the core table AI-free and
+// lets every reference be a real FK (no row = plain delivery).
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(AI_SCHEDULER_TABLE, (table) => {
+        table
+            .uuid('scheduler_uuid')
+            .primary()
+            .references('scheduler_uuid')
+            .inTable(SCHEDULER_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('agent_uuid')
+            .notNullable()
+            .references('ai_agent_uuid')
+            .inTable(AI_AGENT_TABLE)
+            .onDelete('CASCADE')
+            .index();
+        table.text('prompt').notNullable();
+        table
+            .uuid('source_thread_uuid')
+            .nullable()
+            .references('ai_thread_uuid')
+            .inTable(AI_THREAD_TABLE)
+            .onDelete('SET NULL')
+            .index();
+        table.boolean('include_source_thread').notNullable().defaultTo(true);
+        table.boolean('include_run_history').notNullable().defaultTo(false);
+        table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(AI_SCHEDULER_TABLE);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -119,6 +119,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     schedulerService: repository.getSchedulerService(),
                     aiAgentService:
                         repository.getAiAgentService<AiAgentService>(),
+                    lightdashConfig,
                 }),
             projectContextService: ({ models }) =>
                 new ProjectContextService({

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -32,6 +32,7 @@ import { AiAgentReviewClassifierModel } from './models/AiAgentReviewClassifierMo
 import { AiAgentReviewNotificationModel } from './models/AiAgentReviewNotificationModel';
 import { AiOrganizationSettingsModel } from './models/AiOrganizationSettingsModel';
 import { AiRouterModel } from './models/AiRouterModel';
+import { AiSchedulerModel } from './models/AiSchedulerModel';
 import { AiWritebackThreadModel } from './models/AiWritebackThreadModel';
 import { CommercialFeatureFlagModel } from './models/CommercialFeatureFlagModel';
 import { CommercialSlackAuthenticationModel } from './models/CommercialSlackAuthenticationModel';
@@ -56,6 +57,7 @@ import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiAgentToolsService } from './services/AiAgentToolsService/AiAgentToolsService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
 import { AiRouterService } from './services/AiRouterService/AiRouterService';
+import { AiSchedulerService } from './services/AiSchedulerService';
 import { AiService } from './services/AiService/AiService';
 import { AiWritebackService } from './services/AiWritebackService/AiWritebackService';
 import { WritebackPreviewService } from './services/AiWritebackService/WritebackPreviewService';
@@ -108,6 +110,16 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
+            aiSchedulerService: ({ models, repository }) =>
+                new AiSchedulerService({
+                    aiSchedulerModel:
+                        models.getAiSchedulerModel<AiSchedulerModel>(),
+                    schedulerModel: models.getSchedulerModel(),
+                    userModel: models.getUserModel(),
+                    schedulerService: repository.getSchedulerService(),
+                    aiAgentService:
+                        repository.getAiAgentService<AiAgentService>(),
+                }),
             projectContextService: ({ models }) =>
                 new ProjectContextService({
                     projectModel: models.getProjectModel(),
@@ -755,6 +767,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     lightdashConfig,
                     encryptionUtil: utils.getEncryptionUtil(),
                 }),
+            aiSchedulerModel: ({ database }) =>
+                new AiSchedulerModel({ database }),
             aiAgentDocumentModel: ({ database }) =>
                 new AiAgentDocumentModel({ database }),
             aiWritebackThreadModel: ({ database }) =>
@@ -822,6 +836,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 fileStorageClient: context.clients.getFileStorageClient(),
                 schedulerClient: context.clients.getSchedulerClient(),
                 aiAgentService: context.serviceRepository.getAiAgentService(),
+                aiSchedulerService:
+                    context.serviceRepository.getAiSchedulerService<AiSchedulerService>(),
                 catalogService: context.serviceRepository.getCatalogService(),
                 encryptionUtil: context.utils.getEncryptionUtil(),
                 msTeamsClient: context.clients.getMsTeamsClient(),

--- a/packages/backend/src/ee/models/AiSchedulerModel.ts
+++ b/packages/backend/src/ee/models/AiSchedulerModel.ts
@@ -1,5 +1,7 @@
 import {
-    type AiSchedulerConfig,
+    UnexpectedDatabaseError,
+    type AiSchedulerAgentConfig,
+    type AiSchedulerResourceConfig,
     type UpsertAiSchedulerConfig,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -8,14 +10,59 @@ import {
     DbAiScheduler,
 } from '../database/entities/aiScheduler';
 
-const fromRow = (row: DbAiScheduler): AiSchedulerConfig => ({
-    schedulerUuid: row.scheduler_uuid,
-    agentUuid: row.agent_uuid,
-    prompt: row.prompt,
-    sourceThreadUuid: row.source_thread_uuid,
-    includeSourceThread: row.include_source_thread,
-    includeRunHistory: row.include_run_history,
-});
+// Server-only view: adds the persistent report thread the worker builds on
+// across runs. Kept out of the API-facing AiSchedulerConfig.
+export type AiSchedulerAgentConfigInternal = AiSchedulerAgentConfig & {
+    reportThreadUuid: string | null;
+};
+
+export type AiSchedulerConfigInternal =
+    | AiSchedulerAgentConfigInternal
+    | AiSchedulerResourceConfig;
+
+const fromRow = (row: DbAiScheduler): AiSchedulerConfigInternal => {
+    if (row.type === 'resource') {
+        return {
+            type: 'resource',
+            schedulerUuid: row.scheduler_uuid,
+            prompt: row.prompt,
+        };
+    }
+    if (!row.agent_uuid) {
+        throw new UnexpectedDatabaseError(
+            `Agent scheduler config ${row.scheduler_uuid} is missing an agent`,
+        );
+    }
+    return {
+        type: 'agent',
+        schedulerUuid: row.scheduler_uuid,
+        agentUuid: row.agent_uuid,
+        prompt: row.prompt,
+        sourceThreadUuid: row.source_thread_uuid,
+        includeSourceThread: row.include_source_thread,
+        includeRunHistory: row.include_run_history,
+        reportThreadUuid: row.report_thread_uuid,
+    };
+};
+
+const toRow = (config: UpsertAiSchedulerConfig) =>
+    config.type === 'agent'
+        ? {
+              type: 'agent' as const,
+              agent_uuid: config.agentUuid,
+              prompt: config.prompt,
+              source_thread_uuid: config.sourceThreadUuid,
+              include_source_thread: config.includeSourceThread,
+              include_run_history: config.includeRunHistory,
+          }
+        : {
+              type: 'resource' as const,
+              agent_uuid: null,
+              prompt: config.prompt,
+              source_thread_uuid: null,
+              include_source_thread: false,
+              include_run_history: false,
+          };
 
 export class AiSchedulerModel {
     private readonly database: Knex;
@@ -24,7 +71,9 @@ export class AiSchedulerModel {
         this.database = database;
     }
 
-    async find(schedulerUuid: string): Promise<AiSchedulerConfig | null> {
+    async find(
+        schedulerUuid: string,
+    ): Promise<AiSchedulerConfigInternal | null> {
         const row = await this.database(AiSchedulerTableName)
             .where('scheduler_uuid', schedulerUuid)
             .first();
@@ -36,24 +85,22 @@ export class AiSchedulerModel {
         config: UpsertAiSchedulerConfig,
         trx?: Knex,
     ): Promise<void> {
+        const row = toRow(config);
         await (trx ?? this.database)(AiSchedulerTableName)
-            .insert({
-                scheduler_uuid: schedulerUuid,
-                agent_uuid: config.agentUuid,
-                prompt: config.prompt,
-                source_thread_uuid: config.sourceThreadUuid,
-                include_source_thread: config.includeSourceThread,
-                include_run_history: config.includeRunHistory,
-            })
+            .insert({ scheduler_uuid: schedulerUuid, ...row })
             .onConflict('scheduler_uuid')
-            .merge({
-                agent_uuid: config.agentUuid,
-                prompt: config.prompt,
-                source_thread_uuid: config.sourceThreadUuid,
-                include_source_thread: config.includeSourceThread,
-                include_run_history: config.includeRunHistory,
-                updated_at: new Date(),
-            });
+            .merge({ ...row, updated_at: new Date() });
+    }
+
+    // Remembers the thread an agent run built on so the next run can continue it.
+    async setReportThread(
+        schedulerUuid: string,
+        reportThreadUuid: string,
+        trx?: Knex,
+    ): Promise<void> {
+        await (trx ?? this.database)(AiSchedulerTableName)
+            .where('scheduler_uuid', schedulerUuid)
+            .update({ report_thread_uuid: reportThreadUuid });
     }
 
     // Explicit detach. Deleting the agent needs no code — agent_uuid is ON DELETE

--- a/packages/backend/src/ee/models/AiSchedulerModel.ts
+++ b/packages/backend/src/ee/models/AiSchedulerModel.ts
@@ -1,7 +1,7 @@
 import {
     UnexpectedDatabaseError,
-    type AiSchedulerAgentConfig,
-    type AiSchedulerResourceConfig,
+    type AiSchedulerAgentPromptConfig,
+    type AiSchedulerSavedContentConfig,
     type UpsertAiSchedulerConfig,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -12,18 +12,19 @@ import {
 
 // Server-only view: adds the persistent report thread the worker builds on
 // across runs. Kept out of the API-facing AiSchedulerConfig.
-export type AiSchedulerAgentConfigInternal = AiSchedulerAgentConfig & {
-    reportThreadUuid: string | null;
-};
+export type AiSchedulerAgentPromptConfigInternal =
+    AiSchedulerAgentPromptConfig & {
+        reportThreadUuid: string | null;
+    };
 
 export type AiSchedulerConfigInternal =
-    | AiSchedulerAgentConfigInternal
-    | AiSchedulerResourceConfig;
+    | AiSchedulerAgentPromptConfigInternal
+    | AiSchedulerSavedContentConfig;
 
 const fromRow = (row: DbAiScheduler): AiSchedulerConfigInternal => {
-    if (row.type === 'resource') {
+    if (row.type === 'savedContent') {
         return {
-            type: 'resource',
+            type: 'savedContent',
             schedulerUuid: row.scheduler_uuid,
             prompt: row.prompt,
         };
@@ -34,7 +35,7 @@ const fromRow = (row: DbAiScheduler): AiSchedulerConfigInternal => {
         );
     }
     return {
-        type: 'agent',
+        type: 'agentPrompt',
         schedulerUuid: row.scheduler_uuid,
         agentUuid: row.agent_uuid,
         prompt: row.prompt,
@@ -46,9 +47,9 @@ const fromRow = (row: DbAiScheduler): AiSchedulerConfigInternal => {
 };
 
 const toRow = (config: UpsertAiSchedulerConfig) =>
-    config.type === 'agent'
+    config.type === 'agentPrompt'
         ? {
-              type: 'agent' as const,
+              type: 'agentPrompt' as const,
               agent_uuid: config.agentUuid,
               prompt: config.prompt,
               source_thread_uuid: config.sourceThreadUuid,
@@ -56,7 +57,7 @@ const toRow = (config: UpsertAiSchedulerConfig) =>
               include_run_history: config.includeRunHistory,
           }
         : {
-              type: 'resource' as const,
+              type: 'savedContent' as const,
               agent_uuid: null,
               prompt: config.prompt,
               source_thread_uuid: null,

--- a/packages/backend/src/ee/models/AiSchedulerModel.ts
+++ b/packages/backend/src/ee/models/AiSchedulerModel.ts
@@ -1,0 +1,66 @@
+import {
+    type AiSchedulerConfig,
+    type UpsertAiSchedulerConfig,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AiSchedulerTableName,
+    DbAiScheduler,
+} from '../database/entities/aiScheduler';
+
+const fromRow = (row: DbAiScheduler): AiSchedulerConfig => ({
+    schedulerUuid: row.scheduler_uuid,
+    agentUuid: row.agent_uuid,
+    prompt: row.prompt,
+    sourceThreadUuid: row.source_thread_uuid,
+    includeSourceThread: row.include_source_thread,
+    includeRunHistory: row.include_run_history,
+});
+
+export class AiSchedulerModel {
+    private readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async find(schedulerUuid: string): Promise<AiSchedulerConfig | null> {
+        const row = await this.database(AiSchedulerTableName)
+            .where('scheduler_uuid', schedulerUuid)
+            .first();
+        return row ? fromRow(row) : null;
+    }
+
+    async upsert(
+        schedulerUuid: string,
+        config: UpsertAiSchedulerConfig,
+        trx?: Knex,
+    ): Promise<void> {
+        await (trx ?? this.database)(AiSchedulerTableName)
+            .insert({
+                scheduler_uuid: schedulerUuid,
+                agent_uuid: config.agentUuid,
+                prompt: config.prompt,
+                source_thread_uuid: config.sourceThreadUuid,
+                include_source_thread: config.includeSourceThread,
+                include_run_history: config.includeRunHistory,
+            })
+            .onConflict('scheduler_uuid')
+            .merge({
+                agent_uuid: config.agentUuid,
+                prompt: config.prompt,
+                source_thread_uuid: config.sourceThreadUuid,
+                include_source_thread: config.includeSourceThread,
+                include_run_history: config.includeRunHistory,
+                updated_at: new Date(),
+            });
+    }
+
+    // Explicit detach. Deleting the agent needs no code — agent_uuid is ON DELETE
+    // CASCADE.
+    async remove(schedulerUuid: string, trx?: Knex): Promise<void> {
+        await (trx ?? this.database)(AiSchedulerTableName)
+            .where('scheduler_uuid', schedulerUuid)
+            .delete();
+    }
+}

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -22,6 +22,7 @@ import { AiAgentAdminService } from '../services/AiAgentAdminService';
 import { AiAgentReviewClassifierService } from '../services/AiAgentReviewClassifierService';
 import { type AiAgentReviewNotificationService } from '../services/AiAgentReviewNotificationService';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
+import { AiSchedulerService } from '../services/AiSchedulerService';
 import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
@@ -36,6 +37,7 @@ const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
     aiAgentService: AiAgentService;
+    aiSchedulerService: AiSchedulerService;
     aiAgentReviewClassifierService: AiAgentReviewClassifierService;
     aiAgentReviewClassifierModel: AiAgentReviewClassifierModel;
     aiAgentReviewNotificationModel: AiAgentReviewNotificationModel;
@@ -51,6 +53,8 @@ type CommercialSchedulerWorkerArguments = SchedulerWorkerArguments & {
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
     protected readonly aiAgentService: AiAgentService;
+
+    protected readonly aiSchedulerService: AiSchedulerService;
 
     protected readonly aiAgentReviewClassifierService: AiAgentReviewClassifierService;
 
@@ -77,6 +81,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
+        this.aiSchedulerService = args.aiSchedulerService;
         this.aiAgentReviewClassifierService =
             args.aiAgentReviewClassifierService;
         this.aiAgentReviewClassifierModel = args.aiAgentReviewClassifierModel;
@@ -91,6 +96,19 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
         this.projectContextService = args.projectContextService;
         this.projectModel = args.projectModel;
         this.openIdIdentityModel = args.openIdIdentityModel;
+    }
+
+    protected override async getScheduledReport(
+        schedulerUuid: string | undefined,
+        organizationUuid: string,
+    ): Promise<string | null> {
+        if (!schedulerUuid) {
+            return null;
+        }
+        return this.aiSchedulerService.generateScheduledReport(
+            schedulerUuid,
+            organizationUuid,
+        );
     }
 
     protected getCronItems() {

--- a/packages/backend/src/ee/services/AiSchedulerService.ts
+++ b/packages/backend/src/ee/services/AiSchedulerService.ts
@@ -1,0 +1,158 @@
+import { subject } from '@casl/ability';
+import {
+    ForbiddenError,
+    type AiPromptContextInput,
+    type AiSchedulerConfig,
+    type SessionUser,
+    type UpsertAiSchedulerConfig,
+} from '@lightdash/common';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { UserModel } from '../../models/UserModel';
+import { BaseService } from '../../services/BaseService';
+import { SchedulerService } from '../../services/SchedulerService/SchedulerService';
+import { AiSchedulerModel } from '../models/AiSchedulerModel';
+import { AiAgentService } from './AiAgentService/AiAgentService';
+
+type Dependencies = {
+    aiSchedulerModel: AiSchedulerModel;
+    schedulerModel: SchedulerModel;
+    userModel: UserModel;
+    schedulerService: SchedulerService;
+    aiAgentService: AiAgentService;
+};
+
+// Joins a (read-only) OSS scheduler with its EE ai_scheduler config and runs
+// the agent. The OSS scheduler layer stays AI-free.
+export class AiSchedulerService extends BaseService {
+    private readonly aiSchedulerModel: AiSchedulerModel;
+
+    private readonly schedulerModel: SchedulerModel;
+
+    private readonly userModel: UserModel;
+
+    private readonly schedulerService: SchedulerService;
+
+    private readonly aiAgentService: AiAgentService;
+
+    constructor(deps: Dependencies) {
+        super({ serviceName: 'AiSchedulerService' });
+        this.aiSchedulerModel = deps.aiSchedulerModel;
+        this.schedulerModel = deps.schedulerModel;
+        this.userModel = deps.userModel;
+        this.schedulerService = deps.schedulerService;
+        this.aiAgentService = deps.aiAgentService;
+    }
+
+    // Managing a delivery's AI config requires the same `manage` permission as
+    // editing the delivery itself.
+    private async assertCanManageScheduler(
+        user: SessionUser,
+        schedulerUuid: string,
+    ): Promise<{ organizationUuid: string; projectUuid: string }> {
+        const scheduler = await this.schedulerModel.getScheduler(schedulerUuid);
+        const { organizationUuid, projectUuid } =
+            await this.schedulerService.getSchedulerProjectContext(scheduler);
+        if (
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('ScheduledDeliveries', {
+                    organizationUuid,
+                    projectUuid,
+                    userUuid: scheduler.createdBy,
+                    metadata: {
+                        schedulerUuid,
+                        createdByUserUuid: scheduler.createdBy,
+                    },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        return { organizationUuid, projectUuid };
+    }
+
+    async getConfig(
+        user: SessionUser,
+        schedulerUuid: string,
+    ): Promise<AiSchedulerConfig | null> {
+        await this.assertCanManageScheduler(user, schedulerUuid);
+        return this.aiSchedulerModel.find(schedulerUuid);
+    }
+
+    async upsertConfig(
+        user: SessionUser,
+        schedulerUuid: string,
+        config: UpsertAiSchedulerConfig,
+    ): Promise<void> {
+        const { projectUuid } = await this.assertCanManageScheduler(
+            user,
+            schedulerUuid,
+        );
+        // Throws ForbiddenError if the user can't access the agent.
+        await this.aiAgentService.getAgent(user, config.agentUuid, projectUuid);
+        await this.aiSchedulerModel.upsert(schedulerUuid, config);
+    }
+
+    async removeConfig(
+        user: SessionUser,
+        schedulerUuid: string,
+    ): Promise<void> {
+        await this.assertCanManageScheduler(user, schedulerUuid);
+        await this.aiSchedulerModel.remove(schedulerUuid);
+    }
+
+    // The agent's report for a delivery, or null when it has no AI config.
+    async generateScheduledReport(
+        schedulerUuid: string,
+        organizationUuid: string,
+    ): Promise<string | null> {
+        const config = await this.aiSchedulerModel.find(schedulerUuid);
+        if (!config) {
+            return null;
+        }
+
+        const scheduler =
+            await this.schedulerModel.getSchedulerAndTargets(schedulerUuid);
+        const user = await this.userModel.findSessionUserAndOrgByUuid(
+            scheduler.createdBy,
+            organizationUuid,
+        );
+
+        const context: AiPromptContextInput = [];
+        if (scheduler.savedChartUuid) {
+            context.push({
+                type: 'chart',
+                chartUuid: scheduler.savedChartUuid,
+            });
+        }
+        if (scheduler.dashboardUuid) {
+            context.push({
+                type: 'dashboard',
+                dashboardUuid: scheduler.dashboardUuid,
+            });
+        }
+        if (config.includeSourceThread && config.sourceThreadUuid) {
+            context.push({
+                type: 'thread',
+                threadUuid: config.sourceThreadUuid,
+            });
+        }
+
+        const thread = await this.aiAgentService.createAgentThread(
+            user,
+            config.agentUuid,
+            {
+                prompt: config.prompt,
+                context: context.length ? context : undefined,
+            },
+        );
+        if (!thread) {
+            return null;
+        }
+
+        return this.aiAgentService.generateAgentThreadResponse(user, {
+            agentUuid: config.agentUuid,
+            threadUuid: thread.uuid,
+        });
+    }
+}

--- a/packages/backend/src/ee/services/AiSchedulerService.ts
+++ b/packages/backend/src/ee/services/AiSchedulerService.ts
@@ -1,16 +1,26 @@
 import { subject } from '@casl/ability';
 import {
+    assertUnreachable,
     ForbiddenError,
+    getErrorMessage,
     type AiPromptContextInput,
     type AiSchedulerConfig,
+    type AiSchedulerResourceConfig,
+    type SchedulerAndTargets,
     type SessionUser,
     type UpsertAiSchedulerConfig,
 } from '@lightdash/common';
+import { LightdashConfig } from '../../config/parseConfig';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { SchedulerService } from '../../services/SchedulerService/SchedulerService';
-import { AiSchedulerModel } from '../models/AiSchedulerModel';
+import {
+    AiSchedulerModel,
+    type AiSchedulerAgentConfigInternal,
+} from '../models/AiSchedulerModel';
+import { generateScheduledResourceReport } from './ai/agents/scheduledResourceReportGenerator';
+import { getModel } from './ai/models';
 import { AiAgentService } from './AiAgentService/AiAgentService';
 
 type Dependencies = {
@@ -19,6 +29,7 @@ type Dependencies = {
     userModel: UserModel;
     schedulerService: SchedulerService;
     aiAgentService: AiAgentService;
+    lightdashConfig: LightdashConfig;
 };
 
 // Joins a (read-only) OSS scheduler with its EE ai_scheduler config and runs
@@ -34,6 +45,8 @@ export class AiSchedulerService extends BaseService {
 
     private readonly aiAgentService: AiAgentService;
 
+    private readonly lightdashConfig: LightdashConfig;
+
     constructor(deps: Dependencies) {
         super({ serviceName: 'AiSchedulerService' });
         this.aiSchedulerModel = deps.aiSchedulerModel;
@@ -41,6 +54,7 @@ export class AiSchedulerService extends BaseService {
         this.userModel = deps.userModel;
         this.schedulerService = deps.schedulerService;
         this.aiAgentService = deps.aiAgentService;
+        this.lightdashConfig = deps.lightdashConfig;
     }
 
     // Managing a delivery's AI config requires the same `manage` permission as
@@ -76,7 +90,12 @@ export class AiSchedulerService extends BaseService {
         schedulerUuid: string,
     ): Promise<AiSchedulerConfig | null> {
         await this.assertCanManageScheduler(user, schedulerUuid);
-        return this.aiSchedulerModel.find(schedulerUuid);
+        const config = await this.aiSchedulerModel.find(schedulerUuid);
+        if (!config || config.type === 'resource') {
+            return config;
+        }
+        const { reportThreadUuid, ...publicConfig } = config;
+        return publicConfig;
     }
 
     async upsertConfig(
@@ -88,8 +107,14 @@ export class AiSchedulerService extends BaseService {
             user,
             schedulerUuid,
         );
-        // Throws ForbiddenError if the user can't access the agent.
-        await this.aiAgentService.getAgent(user, config.agentUuid, projectUuid);
+        if (config.type === 'agent') {
+            // Throws ForbiddenError if the user can't access the agent.
+            await this.aiAgentService.getAgent(
+                user,
+                config.agentUuid,
+                projectUuid,
+            );
+        }
         await this.aiSchedulerModel.upsert(schedulerUuid, config);
     }
 
@@ -101,7 +126,7 @@ export class AiSchedulerService extends BaseService {
         await this.aiSchedulerModel.remove(schedulerUuid);
     }
 
-    // The agent's report for a delivery, or null when it has no AI config.
+    // The AI report for a delivery, or null when it has no AI config.
     async generateScheduledReport(
         schedulerUuid: string,
         organizationUuid: string,
@@ -118,6 +143,30 @@ export class AiSchedulerService extends BaseService {
             organizationUuid,
         );
 
+        switch (config.type) {
+            case 'agent':
+                return this.generateAgentReport(
+                    user,
+                    schedulerUuid,
+                    config,
+                    scheduler,
+                );
+            case 'resource':
+                return this.generateResourceReport(config, scheduler);
+            default:
+                return assertUnreachable(
+                    config,
+                    'Unknown ai scheduler config type',
+                );
+        }
+    }
+
+    private async generateAgentReport(
+        user: SessionUser,
+        schedulerUuid: string,
+        config: AiSchedulerAgentConfigInternal,
+        scheduler: SchedulerAndTargets,
+    ): Promise<string | null> {
         const context: AiPromptContextInput = [];
         if (scheduler.savedChartUuid) {
             context.push({
@@ -138,21 +187,84 @@ export class AiSchedulerService extends BaseService {
             });
         }
 
-        const thread = await this.aiAgentService.createAgentThread(
+        const threadUuid = await this.resolveReportThread(
             user,
-            config.agentUuid,
-            {
-                prompt: config.prompt,
-                context: context.length ? context : undefined,
-            },
+            schedulerUuid,
+            config,
+            context.length ? context : undefined,
         );
-        if (!thread) {
+        if (!threadUuid) {
             return null;
         }
 
         return this.aiAgentService.generateAgentThreadResponse(user, {
             agentUuid: config.agentUuid,
-            threadUuid: thread.uuid,
+            threadUuid,
         });
+    }
+
+    // Agentless: a fast model writes the message from the prompt alone.
+    private async generateResourceReport(
+        config: AiSchedulerResourceConfig,
+        scheduler: SchedulerAndTargets,
+    ): Promise<string | null> {
+        const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
+            enableReasoning: false,
+            useFastModel: true,
+        });
+        const resource = scheduler.dashboardUuid
+            ? `dashboard "${scheduler.name}"`
+            : `chart "${scheduler.name}"`;
+        return generateScheduledResourceReport(modelOptions, {
+            prompt: config.prompt,
+            resource,
+        });
+    }
+
+    // The thread the agent runs this report in. With run history enabled, runs
+    // share one thread so the agent sees prior deliveries; otherwise each run is
+    // a fresh thread. A remembered thread that's gone or now belongs to another
+    // agent self-heals by starting a new one.
+    private async resolveReportThread(
+        user: SessionUser,
+        schedulerUuid: string,
+        config: AiSchedulerAgentConfigInternal,
+        context: AiPromptContextInput | undefined,
+    ): Promise<string | null> {
+        const body = { prompt: config.prompt, context };
+
+        if (config.includeRunHistory && config.reportThreadUuid) {
+            try {
+                await this.aiAgentService.createAgentThreadMessage(
+                    user,
+                    config.agentUuid,
+                    config.reportThreadUuid,
+                    body,
+                );
+                return config.reportThreadUuid;
+            } catch (e) {
+                this.logger.warn(
+                    `Could not continue report thread ${config.reportThreadUuid} for scheduler ${schedulerUuid}, starting a new one: ${getErrorMessage(
+                        e,
+                    )}`,
+                );
+            }
+        }
+
+        const thread = await this.aiAgentService.createAgentThread(
+            user,
+            config.agentUuid,
+            body,
+        );
+        if (!thread) {
+            return null;
+        }
+        if (config.includeRunHistory) {
+            await this.aiSchedulerModel.setReportThread(
+                schedulerUuid,
+                thread.uuid,
+            );
+        }
+        return thread.uuid;
     }
 }

--- a/packages/backend/src/ee/services/AiSchedulerService.ts
+++ b/packages/backend/src/ee/services/AiSchedulerService.ts
@@ -5,7 +5,7 @@ import {
     getErrorMessage,
     type AiPromptContextInput,
     type AiSchedulerConfig,
-    type AiSchedulerResourceConfig,
+    type AiSchedulerSavedContentConfig,
     type SchedulerAndTargets,
     type SessionUser,
     type UpsertAiSchedulerConfig,
@@ -17,9 +17,9 @@ import { BaseService } from '../../services/BaseService';
 import { SchedulerService } from '../../services/SchedulerService/SchedulerService';
 import {
     AiSchedulerModel,
-    type AiSchedulerAgentConfigInternal,
+    type AiSchedulerAgentPromptConfigInternal,
 } from '../models/AiSchedulerModel';
-import { generateScheduledResourceReport } from './ai/agents/scheduledResourceReportGenerator';
+import { generateScheduledSavedContentReport } from './ai/agents/scheduledSavedContentReportGenerator';
 import { getModel } from './ai/models';
 import { AiAgentService } from './AiAgentService/AiAgentService';
 
@@ -91,7 +91,7 @@ export class AiSchedulerService extends BaseService {
     ): Promise<AiSchedulerConfig | null> {
         await this.assertCanManageScheduler(user, schedulerUuid);
         const config = await this.aiSchedulerModel.find(schedulerUuid);
-        if (!config || config.type === 'resource') {
+        if (!config || config.type === 'savedContent') {
             return config;
         }
         const { reportThreadUuid, ...publicConfig } = config;
@@ -107,7 +107,7 @@ export class AiSchedulerService extends BaseService {
             user,
             schedulerUuid,
         );
-        if (config.type === 'agent') {
+        if (config.type === 'agentPrompt') {
             // Throws ForbiddenError if the user can't access the agent.
             await this.aiAgentService.getAgent(
                 user,
@@ -144,15 +144,15 @@ export class AiSchedulerService extends BaseService {
         );
 
         switch (config.type) {
-            case 'agent':
+            case 'agentPrompt':
                 return this.generateAgentReport(
                     user,
                     schedulerUuid,
                     config,
                     scheduler,
                 );
-            case 'resource':
-                return this.generateResourceReport(config, scheduler);
+            case 'savedContent':
+                return this.generateSavedContentReport(config, scheduler);
             default:
                 return assertUnreachable(
                     config,
@@ -164,7 +164,7 @@ export class AiSchedulerService extends BaseService {
     private async generateAgentReport(
         user: SessionUser,
         schedulerUuid: string,
-        config: AiSchedulerAgentConfigInternal,
+        config: AiSchedulerAgentPromptConfigInternal,
         scheduler: SchedulerAndTargets,
     ): Promise<string | null> {
         const context: AiPromptContextInput = [];
@@ -204,20 +204,20 @@ export class AiSchedulerService extends BaseService {
     }
 
     // Agentless: a fast model writes the message from the prompt alone.
-    private async generateResourceReport(
-        config: AiSchedulerResourceConfig,
+    private async generateSavedContentReport(
+        config: AiSchedulerSavedContentConfig,
         scheduler: SchedulerAndTargets,
     ): Promise<string | null> {
         const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
             enableReasoning: false,
             useFastModel: true,
         });
-        const resource = scheduler.dashboardUuid
+        const content = scheduler.dashboardUuid
             ? `dashboard "${scheduler.name}"`
             : `chart "${scheduler.name}"`;
-        return generateScheduledResourceReport(modelOptions, {
+        return generateScheduledSavedContentReport(modelOptions, {
             prompt: config.prompt,
-            resource,
+            content,
         });
     }
 
@@ -228,7 +228,7 @@ export class AiSchedulerService extends BaseService {
     private async resolveReportThread(
         user: SessionUser,
         schedulerUuid: string,
-        config: AiSchedulerAgentConfigInternal,
+        config: AiSchedulerAgentPromptConfigInternal,
         context: AiPromptContextInput | undefined,
     ): Promise<string | null> {
         const body = { prompt: config.prompt, context };

--- a/packages/backend/src/ee/services/ai/agents/scheduledResourceReportGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/scheduledResourceReportGenerator.ts
@@ -1,0 +1,25 @@
+import { generateText } from 'ai';
+import { GeneratorModelOptions } from '../models/types';
+
+export async function generateScheduledResourceReport(
+    modelOptions: GeneratorModelOptions,
+    { prompt, resource }: { prompt: string; resource: string },
+): Promise<string> {
+    const result = await generateText({
+        model: modelOptions.model,
+        ...modelOptions.callOptions,
+        providerOptions: modelOptions.providerOptions,
+        messages: [
+            {
+                role: 'system',
+                content: `You write the message body for a scheduled delivery of ${resource}. Be concise and factual, and follow the user's instructions about what to report.`,
+            },
+            {
+                role: 'user',
+                content: prompt,
+            },
+        ],
+    });
+
+    return result.text;
+}

--- a/packages/backend/src/ee/services/ai/agents/scheduledSavedContentReportGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/scheduledSavedContentReportGenerator.ts
@@ -1,9 +1,9 @@
 import { generateText } from 'ai';
 import { GeneratorModelOptions } from '../models/types';
 
-export async function generateScheduledResourceReport(
+export async function generateScheduledSavedContentReport(
     modelOptions: GeneratorModelOptions,
-    { prompt, resource }: { prompt: string; resource: string },
+    { prompt, content }: { prompt: string; content: string },
 ): Promise<string> {
     const result = await generateText({
         model: modelOptions.model,
@@ -12,7 +12,7 @@ export async function generateScheduledResourceReport(
         messages: [
             {
                 role: 'system',
-                content: `You write the message body for a scheduled delivery of ${resource}. Be concise and factual, and follow the user's instructions about what to report.`,
+                content: `You write the message body for a scheduled delivery of ${content}. Be concise and factual, and follow the user's instructions about what to report.`,
             },
             {
                 role: 'user',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10636,7 +10636,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiSchedulerAgentConfig: {
+    AiSchedulerAgentPromptConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
@@ -10664,7 +10664,7 @@ const models: TsoaRoute.Models = {
                         agentUuid: { dataType: 'string', required: true },
                         type: {
                             dataType: 'enum',
-                            enums: ['agent'],
+                            enums: ['agentPrompt'],
                             required: true,
                         },
                     },
@@ -10674,7 +10674,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiSchedulerResourceConfig: {
+    AiSchedulerSavedContentConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'intersection',
@@ -10685,7 +10685,7 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         type: {
                             dataType: 'enum',
-                            enums: ['resource'],
+                            enums: ['savedContent'],
                             required: true,
                         },
                     },
@@ -10700,8 +10700,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'union',
             subSchemas: [
-                { ref: 'AiSchedulerAgentConfig' },
-                { ref: 'AiSchedulerResourceConfig' },
+                { ref: 'AiSchedulerAgentPromptConfig' },
+                { ref: 'AiSchedulerSavedContentConfig' },
             ],
             validators: {},
         },
@@ -10731,7 +10731,7 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiSchedulerConfig-or-null_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__':
+    'Pick_AiSchedulerAgentPromptConfig.Exclude_keyofAiSchedulerAgentPromptConfig.schedulerUuid__':
         {
             dataType: 'refAlias',
             type: {
@@ -10739,7 +10739,7 @@ const models: TsoaRoute.Models = {
                 nestedProperties: {
                     type: {
                         dataType: 'enum',
-                        enums: ['agent'],
+                        enums: ['agentPrompt'],
                         required: true,
                     },
                     prompt: { dataType: 'string', required: true },
@@ -10762,15 +10762,15 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_AiSchedulerAgentConfig.schedulerUuid_': {
+    'Omit_AiSchedulerAgentPromptConfig.schedulerUuid_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__',
+            ref: 'Pick_AiSchedulerAgentPromptConfig.Exclude_keyofAiSchedulerAgentPromptConfig.schedulerUuid__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__':
+    'Pick_AiSchedulerSavedContentConfig.Exclude_keyofAiSchedulerSavedContentConfig.schedulerUuid__':
         {
             dataType: 'refAlias',
             type: {
@@ -10778,7 +10778,7 @@ const models: TsoaRoute.Models = {
                 nestedProperties: {
                     type: {
                         dataType: 'enum',
-                        enums: ['resource'],
+                        enums: ['savedContent'],
                         required: true,
                     },
                     prompt: { dataType: 'string', required: true },
@@ -10787,10 +10787,10 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_AiSchedulerResourceConfig.schedulerUuid_': {
+    'Omit_AiSchedulerSavedContentConfig.schedulerUuid_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__',
+            ref: 'Pick_AiSchedulerSavedContentConfig.Exclude_keyofAiSchedulerSavedContentConfig.schedulerUuid__',
             validators: {},
         },
     },
@@ -10800,8 +10800,8 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'union',
             subSchemas: [
-                { ref: 'Omit_AiSchedulerAgentConfig.schedulerUuid_' },
-                { ref: 'Omit_AiSchedulerResourceConfig.schedulerUuid_' },
+                { ref: 'Omit_AiSchedulerAgentPromptConfig.schedulerUuid_' },
+                { ref: 'Omit_AiSchedulerSavedContentConfig.schedulerUuid_' },
             ],
             validators: {},
         },
@@ -14441,11 +14441,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14460,11 +14460,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14479,11 +14479,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14498,11 +14498,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14533,6 +14533,29 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 verifiedChartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -14557,29 +14580,6 @@ const models: TsoaRoute.Models = {
                                                                                                             ],
                                                                                                     },
                                                                                                 chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
-                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -14647,33 +14647,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -14774,6 +14747,33 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                joinedTables:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
                                                                                                 label: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -14811,11 +14811,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14891,6 +14891,29 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
                                                                                                     verifiedChartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -14915,29 +14938,6 @@ const models: TsoaRoute.Models = {
                                                                                                                 ],
                                                                                                         },
                                                                                                     chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
-                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -15008,11 +15008,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15027,11 +15027,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15046,11 +15046,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15093,11 +15093,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15136,117 +15136,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                explore: {
-                                                                    dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            requiredFilters:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'array',
-                                                                                                array: {
-                                                                                                    dataType:
-                                                                                                        'nestedObjectLiteral',
-                                                                                                    nestedProperties:
-                                                                                                        {
-                                                                                                            settings:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'any',
-                                                                                                                },
-                                                                                                            values: {
-                                                                                                                dataType:
-                                                                                                                    'union',
-                                                                                                                subSchemas:
-                                                                                                                    [
-                                                                                                                        {
-                                                                                                                            dataType:
-                                                                                                                                'array',
-                                                                                                                            array: {
-                                                                                                                                dataType:
-                                                                                                                                    'any',
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                            dataType:
-                                                                                                                                'undefined',
-                                                                                                                        },
-                                                                                                                    ],
-                                                                                                            },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            fieldRef:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            fieldId:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                        },
-                                                                                                },
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                            name: {
-                                                                                dataType:
-                                                                                    'string',
-                                                                                required: true,
-                                                                            },
-                                                                        },
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15291,13 +15180,13 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                fieldValueType:
+                                                                                fieldFilterType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                fieldFilterType:
+                                                                                fieldValueType:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
@@ -15390,6 +15279,117 @@ const models: TsoaRoute.Models = {
                                                                         ],
                                                                     required: true,
                                                                 },
+                                                                explore: {
+                                                                    dataType:
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            requiredFilters:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'array',
+                                                                                                array: {
+                                                                                                    dataType:
+                                                                                                        'nestedObjectLiteral',
+                                                                                                    nestedProperties:
+                                                                                                        {
+                                                                                                            settings:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'any',
+                                                                                                                },
+                                                                                                            values: {
+                                                                                                                dataType:
+                                                                                                                    'union',
+                                                                                                                subSchemas:
+                                                                                                                    [
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'array',
+                                                                                                                            array: {
+                                                                                                                                dataType:
+                                                                                                                                    'any',
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'undefined',
+                                                                                                                        },
+                                                                                                                    ],
+                                                                                                            },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldRef:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldId:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                        },
+                                                                                                },
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                            name: {
+                                                                                dataType:
+                                                                                    'string',
+                                                                                required: true,
+                                                                            },
+                                                                        },
+                                                                    required: true,
+                                                                },
                                                                 status: {
                                                                     dataType:
                                                                         'enum',
@@ -15418,17 +15418,17 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                reason: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 exploreLabel:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                reason: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 exploreName:
                                                                                     {
                                                                                         dataType:
@@ -15580,11 +15580,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15599,11 +15599,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15618,11 +15618,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15637,11 +15637,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15651,77 +15651,6 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15799,6 +15728,77 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15830,6 +15830,12 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
+                                                                'unsupported_source_control',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15837,12 +15843,6 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
-                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15882,11 +15882,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15947,11 +15947,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15966,11 +15966,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15985,7 +15985,7 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15993,7 +15993,7 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -16012,11 +16012,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16033,6 +16033,25 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    required: true,
+                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -16041,7 +16060,7 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                chartUsage:
+                                                                                searchRank:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -16064,7 +16083,7 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                searchRank:
+                                                                                chartUsage:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -16113,25 +16132,6 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 type: {
                                                                     dataType:
                                                                         'union',
@@ -16174,11 +16174,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16193,11 +16193,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16212,11 +16212,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16231,11 +16231,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16250,11 +16250,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -131,6 +131,8 @@ import { AiController } from './../ee/controllers/aiController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiRouterController } from './../ee/controllers/aiRouterController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { AiSchedulerController } from './../ee/controllers/aiSchedulerController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AiWritebackController } from './../ee/controllers/AiWritebackController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { AppGenerateController } from './../ee/controllers/appGenerateController';
@@ -3822,6 +3824,36 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterAutocompleteValue: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                label: { dataType: 'string' },
+                value: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    FilterAutocompleteConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                fetchFromWarehouse: { dataType: 'boolean', required: true },
+                values: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'FilterAutocompleteValue',
+                    },
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     FieldType: {
         dataType: 'refEnum',
         enums: ['metric', 'dimension'],
@@ -3961,28 +3993,7 @@ const models: TsoaRoute.Models = {
                 },
             },
             richText: { dataType: 'string' },
-            filterAutocomplete: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    fetchFromWarehouse: {
-                        dataType: 'boolean',
-                        required: true,
-                    },
-                    values: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                value: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                label: { dataType: 'string' },
-                            },
-                        },
-                    },
-                },
-            },
+            filterAutocomplete: { ref: 'FilterAutocompleteConfig' },
             spotlight: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -7124,28 +7135,7 @@ const models: TsoaRoute.Models = {
                 },
             },
             richText: { dataType: 'string' },
-            filterAutocomplete: {
-                dataType: 'nestedObjectLiteral',
-                nestedProperties: {
-                    fetchFromWarehouse: {
-                        dataType: 'boolean',
-                        required: true,
-                    },
-                    values: {
-                        dataType: 'array',
-                        array: {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                value: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                label: { dataType: 'string' },
-                            },
-                        },
-                    },
-                },
-            },
+            filterAutocomplete: { ref: 'FilterAutocompleteConfig' },
             spotlight: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -10632,6 +10622,88 @@ const models: TsoaRoute.Models = {
             ref: 'ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___',
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiSchedulerConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                includeRunHistory: { dataType: 'boolean', required: true },
+                includeSourceThread: { dataType: 'boolean', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                prompt: { dataType: 'string', required: true },
+                agentUuid: { dataType: 'string', required: true },
+                schedulerUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess_AiSchedulerConfig-or-null_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'AiSchedulerConfig' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiAiSchedulerConfigResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccess_AiSchedulerConfig-or-null_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                agentUuid: { dataType: 'string', required: true },
+                prompt: { dataType: 'string', required: true },
+                sourceThreadUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                includeSourceThread: { dataType: 'boolean', required: true },
+                includeRunHistory: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AiSchedulerConfig.schedulerUuid_': {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UpsertAiSchedulerConfig: {
+        dataType: 'refAlias',
+        type: { ref: 'Omit_AiSchedulerConfig.schedulerUuid_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiRouter: {
@@ -14268,11 +14340,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14287,11 +14359,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14306,11 +14378,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14325,11 +14397,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14360,29 +14432,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 verifiedChartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -14429,13 +14478,30 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -14446,6 +14512,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                tableName:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -14580,13 +14652,13 @@ const models: TsoaRoute.Models = {
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                operator:
+                                                                                                                                fieldId:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
                                                                                                                                         required: true,
                                                                                                                                     },
-                                                                                                                                fieldId:
+                                                                                                                                operator:
                                                                                                                                     {
                                                                                                                                         dataType:
                                                                                                                                             'string',
@@ -14638,11 +14710,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14718,29 +14790,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     verifiedChartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -14787,13 +14836,30 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -14804,6 +14870,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    tableName:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -14835,11 +14907,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14854,11 +14926,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14873,11 +14945,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14920,11 +14992,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -14963,23 +15035,115 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                rationale: {
+                                                                explore: {
                                                                     dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
+                                                                        'nestedObjectLiteral',
+                                                                    nestedProperties:
+                                                                        {
+                                                                            requiredFilters:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'union',
+                                                                                    subSchemas:
+                                                                                        [
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'array',
+                                                                                                array: {
+                                                                                                    dataType:
+                                                                                                        'nestedObjectLiteral',
+                                                                                                    nestedProperties:
+                                                                                                        {
+                                                                                                            settings:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'any',
+                                                                                                                },
+                                                                                                            values: {
+                                                                                                                dataType:
+                                                                                                                    'union',
+                                                                                                                subSchemas:
+                                                                                                                    [
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'array',
+                                                                                                                            array: {
+                                                                                                                                dataType:
+                                                                                                                                    'any',
+                                                                                                                            },
+                                                                                                                        },
+                                                                                                                        {
+                                                                                                                            dataType:
+                                                                                                                                'undefined',
+                                                                                                                        },
+                                                                                                                    ],
+                                                                                                            },
+                                                                                                            required:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'boolean',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            tableName:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldRef:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            fieldId:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                            operator:
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'string',
+                                                                                                                    required: true,
+                                                                                                                },
+                                                                                                        },
+                                                                                                },
+                                                                                            },
+                                                                                            {
+                                                                                                dataType:
+                                                                                                    'undefined',
+                                                                                            },
+                                                                                        ],
+                                                                                },
+                                                                            baseTable:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
+                                                                            joinedTables:
+                                                                                {
+                                                                                    dataType:
+                                                                                        'array',
+                                                                                    array: {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                    },
+                                                                                    required: true,
+                                                                                },
+                                                                            label: {
                                                                                 dataType:
                                                                                     'string',
+                                                                                required: true,
                                                                             },
-                                                                            {
+                                                                            name: {
                                                                                 dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
+                                                                                    'string',
+                                                                                required: true,
                                                                             },
-                                                                        ],
+                                                                        },
                                                                     required: true,
                                                                 },
                                                                 fields: {
@@ -15061,17 +15225,6 @@ const models: TsoaRoute.Models = {
                                                                                             ],
                                                                                         required: true,
                                                                                     },
-                                                                                table: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                                fieldId:
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                        required: true,
-                                                                                    },
                                                                                 description:
                                                                                     {
                                                                                         dataType:
@@ -15097,6 +15250,17 @@ const models: TsoaRoute.Models = {
                                                                                         'string',
                                                                                     required: true,
                                                                                 },
+                                                                                fieldId:
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'string',
+                                                                                        required: true,
+                                                                                    },
+                                                                                table: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15106,115 +15270,23 @@ const models: TsoaRoute.Models = {
                                                                     },
                                                                     required: true,
                                                                 },
-                                                                explore: {
+                                                                rationale: {
                                                                     dataType:
-                                                                        'nestedObjectLiteral',
-                                                                    nestedProperties:
-                                                                        {
-                                                                            requiredFilters:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'union',
-                                                                                    subSchemas:
-                                                                                        [
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'array',
-                                                                                                array: {
-                                                                                                    dataType:
-                                                                                                        'nestedObjectLiteral',
-                                                                                                    nestedProperties:
-                                                                                                        {
-                                                                                                            settings:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'any',
-                                                                                                                },
-                                                                                                            values: {
-                                                                                                                dataType:
-                                                                                                                    'union',
-                                                                                                                subSchemas:
-                                                                                                                    [
-                                                                                                                        {
-                                                                                                                            dataType:
-                                                                                                                                'array',
-                                                                                                                            array: {
-                                                                                                                                dataType:
-                                                                                                                                    'any',
-                                                                                                                            },
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                            dataType:
-                                                                                                                                'undefined',
-                                                                                                                        },
-                                                                                                                    ],
-                                                                                                            },
-                                                                                                            required:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'boolean',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            tableName:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            fieldRef:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            operator:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                            fieldId:
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'string',
-                                                                                                                    required: true,
-                                                                                                                },
-                                                                                                        },
-                                                                                                },
-                                                                                            },
-                                                                                            {
-                                                                                                dataType:
-                                                                                                    'undefined',
-                                                                                            },
-                                                                                        ],
-                                                                                },
-                                                                            joinedTables:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'array',
-                                                                                    array: {
-                                                                                        dataType:
-                                                                                            'string',
-                                                                                    },
-                                                                                    required: true,
-                                                                                },
-                                                                            baseTable:
-                                                                                {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
-                                                                            label: {
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
                                                                                 dataType:
                                                                                     'string',
-                                                                                required: true,
                                                                             },
-                                                                            name: {
+                                                                            {
                                                                                 dataType:
-                                                                                    'string',
-                                                                                required: true,
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
                                                                             },
-                                                                        },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 status: {
@@ -15373,6 +15445,13 @@ const models: TsoaRoute.Models = {
                                                     dataType: 'string',
                                                     required: true,
                                                 },
+                                                warnings: {
+                                                    dataType: 'array',
+                                                    array: {
+                                                        dataType: 'string',
+                                                    },
+                                                    required: true,
+                                                },
                                                 status: {
                                                     dataType: 'enum',
                                                     enums: ['success'],
@@ -15384,13 +15463,6 @@ const models: TsoaRoute.Models = {
                                                 },
                                                 uuid: {
                                                     dataType: 'string',
-                                                    required: true,
-                                                },
-                                                warnings: {
-                                                    dataType: 'array',
-                                                    array: {
-                                                        dataType: 'string',
-                                                    },
                                                     required: true,
                                                 },
                                                 name: {
@@ -15407,11 +15479,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15426,11 +15498,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15445,11 +15517,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15464,11 +15536,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15478,6 +15550,77 @@ const models: TsoaRoute.Models = {
                                         {
                                             dataType: 'nestedObjectLiteral',
                                             nestedProperties: {
+                                                steps: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'array',
+                                                            array: {
+                                                                dataType:
+                                                                    'nestedObjectLiteral',
+                                                                nestedProperties:
+                                                                    {
+                                                                        kind: {
+                                                                            dataType:
+                                                                                'union',
+                                                                            subSchemas:
+                                                                                [
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'read',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'edit',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'search',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'compile',
+                                                                                        ],
+                                                                                    },
+                                                                                    {
+                                                                                        dataType:
+                                                                                            'enum',
+                                                                                        enums: [
+                                                                                            'stage',
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            required: true,
+                                                                        },
+                                                                        label: {
+                                                                            dataType:
+                                                                                'string',
+                                                                            required: true,
+                                                                        },
+                                                                    },
+                                                            },
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [null],
+                                                        },
+                                                        {
+                                                            dataType:
+                                                                'undefined',
+                                                        },
+                                                    ],
+                                                },
                                                 previewUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15555,77 +15698,6 @@ const models: TsoaRoute.Models = {
                                                         },
                                                     ],
                                                 },
-                                                steps: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'array',
-                                                            array: {
-                                                                dataType:
-                                                                    'nestedObjectLiteral',
-                                                                nestedProperties:
-                                                                    {
-                                                                        kind: {
-                                                                            dataType:
-                                                                                'union',
-                                                                            subSchemas:
-                                                                                [
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'search',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'compile',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'read',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'edit',
-                                                                                        ],
-                                                                                    },
-                                                                                    {
-                                                                                        dataType:
-                                                                                            'enum',
-                                                                                        enums: [
-                                                                                            'stage',
-                                                                                        ],
-                                                                                    },
-                                                                                ],
-                                                                            required: true,
-                                                                        },
-                                                                        label: {
-                                                                            dataType:
-                                                                                'string',
-                                                                            required: true,
-                                                                        },
-                                                                    },
-                                                            },
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [null],
-                                                        },
-                                                        {
-                                                            dataType:
-                                                                'undefined',
-                                                        },
-                                                    ],
-                                                },
                                                 prUrl: {
                                                     dataType: 'union',
                                                     subSchemas: [
@@ -15657,12 +15729,6 @@ const models: TsoaRoute.Models = {
                                                         {
                                                             dataType: 'enum',
                                                             enums: [
-                                                                'unsupported_source_control',
-                                                            ],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: [
                                                                 'github_not_installed',
                                                             ],
                                                         },
@@ -15670,6 +15736,12 @@ const models: TsoaRoute.Models = {
                                                             dataType: 'enum',
                                                             enums: [
                                                                 'gitlab_not_installed',
+                                                            ],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: [
+                                                                'unsupported_source_control',
                                                             ],
                                                         },
                                                         {
@@ -15709,11 +15781,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15774,11 +15846,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15793,11 +15865,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15812,7 +15884,7 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15820,7 +15892,7 @@ const models: TsoaRoute.Models = {
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
@@ -15839,11 +15911,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -15860,25 +15932,6 @@ const models: TsoaRoute.Models = {
                                                             dataType:
                                                                 'nestedObjectLiteral',
                                                             nestedProperties: {
-                                                                searchQuery: {
-                                                                    dataType:
-                                                                        'union',
-                                                                    subSchemas:
-                                                                        [
-                                                                            {
-                                                                                dataType:
-                                                                                    'string',
-                                                                            },
-                                                                            {
-                                                                                dataType:
-                                                                                    'enum',
-                                                                                enums: [
-                                                                                    null,
-                                                                                ],
-                                                                            },
-                                                                        ],
-                                                                    required: true,
-                                                                },
                                                                 fields: {
                                                                     dataType:
                                                                         'array',
@@ -15887,7 +15940,7 @@ const models: TsoaRoute.Models = {
                                                                             'nestedObjectLiteral',
                                                                         nestedProperties:
                                                                             {
-                                                                                searchRank:
+                                                                                chartUsage:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -15910,7 +15963,7 @@ const models: TsoaRoute.Models = {
                                                                                                 },
                                                                                             ],
                                                                                     },
-                                                                                chartUsage:
+                                                                                searchRank:
                                                                                     {
                                                                                         dataType:
                                                                                             'union',
@@ -15939,17 +15992,17 @@ const models: TsoaRoute.Models = {
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
+                                                                                label: {
+                                                                                    dataType:
+                                                                                        'string',
+                                                                                    required: true,
+                                                                                },
                                                                                 tableName:
                                                                                     {
                                                                                         dataType:
                                                                                             'string',
                                                                                         required: true,
                                                                                     },
-                                                                                label: {
-                                                                                    dataType:
-                                                                                        'string',
-                                                                                    required: true,
-                                                                                },
                                                                                 name: {
                                                                                     dataType:
                                                                                         'string',
@@ -15957,6 +16010,25 @@ const models: TsoaRoute.Models = {
                                                                                 },
                                                                             },
                                                                     },
+                                                                    required: true,
+                                                                },
+                                                                searchQuery: {
+                                                                    dataType:
+                                                                        'union',
+                                                                    subSchemas:
+                                                                        [
+                                                                            {
+                                                                                dataType:
+                                                                                    'string',
+                                                                            },
+                                                                            {
+                                                                                dataType:
+                                                                                    'enum',
+                                                                                enums: [
+                                                                                    null,
+                                                                                ],
+                                                                            },
+                                                                        ],
                                                                     required: true,
                                                                 },
                                                                 type: {
@@ -16001,11 +16073,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16020,11 +16092,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16039,11 +16111,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16058,11 +16130,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16077,11 +16149,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -17403,10 +17475,10 @@ const models: TsoaRoute.Models = {
                         required: true,
                     },
                     createdAt: { dataType: 'datetime', required: true },
+                    agentUuid: { dataType: 'string', required: true },
                     updatedAt: { dataType: 'datetime', required: true },
                     title: { dataType: 'string', required: true },
                     evalUuid: { dataType: 'string', required: true },
-                    agentUuid: { dataType: 'string', required: true },
                 },
                 validators: {},
             },
@@ -20482,6 +20554,7 @@ const models: TsoaRoute.Models = {
                 workGroup: { dataType: 'string' },
                 assumeRoleExternalId: { dataType: 'string' },
                 assumeRoleArn: { dataType: 'string' },
+                sessionToken: { dataType: 'string' },
                 secretAccessKey: { dataType: 'string' },
                 accessKeyId: { dataType: 'string' },
                 authenticationType: { ref: 'AthenaAuthenticationType' },
@@ -31110,7 +31183,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31120,7 +31193,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31130,7 +31203,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31143,7 +31216,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -31805,7 +31878,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31815,7 +31888,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -31825,7 +31898,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -31838,7 +31911,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -47221,6 +47294,210 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'listMyApps',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiSchedulerController_getConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        _req: {
+            in: 'request',
+            name: '_req',
+            required: true,
+            dataType: 'object',
+        },
+        schedulerUuid: {
+            in: 'path',
+            name: 'schedulerUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.get(
+        '/api/v1/schedulers/:schedulerUuid/ai-config',
+        ...fetchMiddlewares<RequestHandler>(AiSchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiSchedulerController.prototype.getConfig,
+        ),
+
+        async function AiSchedulerController_getConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiSchedulerController_getConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiSchedulerController>(
+                        AiSchedulerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiSchedulerController_upsertConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        _req: {
+            in: 'request',
+            name: '_req',
+            required: true,
+            dataType: 'object',
+        },
+        schedulerUuid: {
+            in: 'path',
+            name: 'schedulerUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'UpsertAiSchedulerConfig',
+        },
+    };
+    app.put(
+        '/api/v1/schedulers/:schedulerUuid/ai-config',
+        ...fetchMiddlewares<RequestHandler>(AiSchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiSchedulerController.prototype.upsertConfig,
+        ),
+
+        async function AiSchedulerController_upsertConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiSchedulerController_upsertConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiSchedulerController>(
+                        AiSchedulerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'upsertConfig',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAiSchedulerController_deleteConfig: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        _req: {
+            in: 'request',
+            name: '_req',
+            required: true,
+            dataType: 'object',
+        },
+        schedulerUuid: {
+            in: 'path',
+            name: 'schedulerUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/schedulers/:schedulerUuid/ai-config',
+        ...fetchMiddlewares<RequestHandler>(AiSchedulerController),
+        ...fetchMiddlewares<RequestHandler>(
+            AiSchedulerController.prototype.deleteConfig,
+        ),
+
+        async function AiSchedulerController_deleteConfig(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAiSchedulerController_deleteConfig,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AiSchedulerController>(
+                        AiSchedulerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteConfig',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -10624,25 +10624,85 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AiSchedulerConfig: {
+    AiSchedulerConfigBase: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                includeRunHistory: { dataType: 'boolean', required: true },
-                includeSourceThread: { dataType: 'boolean', required: true },
-                sourceThreadUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
                 prompt: { dataType: 'string', required: true },
-                agentUuid: { dataType: 'string', required: true },
                 schedulerUuid: { dataType: 'string', required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiSchedulerAgentConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiSchedulerConfigBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        includeRunHistory: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
+                        includeSourceThread: {
+                            dataType: 'boolean',
+                            required: true,
+                        },
+                        sourceThreadUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        agentUuid: { dataType: 'string', required: true },
+                        type: {
+                            dataType: 'enum',
+                            enums: ['agent'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiSchedulerResourceConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'AiSchedulerConfigBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        type: {
+                            dataType: 'enum',
+                            enums: ['resource'],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AiSchedulerConfig: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'AiSchedulerAgentConfig' },
+                { ref: 'AiSchedulerResourceConfig' },
+            ],
             validators: {},
         },
     },
@@ -10671,39 +10731,80 @@ const models: TsoaRoute.Models = {
         type: { ref: 'ApiSuccess_AiSchedulerConfig-or-null_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__': {
+    'Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: {
+                        dataType: 'enum',
+                        enums: ['agent'],
+                        required: true,
+                    },
+                    prompt: { dataType: 'string', required: true },
+                    agentUuid: { dataType: 'string', required: true },
+                    sourceThreadUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    includeSourceThread: {
+                        dataType: 'boolean',
+                        required: true,
+                    },
+                    includeRunHistory: { dataType: 'boolean', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AiSchedulerAgentConfig.schedulerUuid_': {
         dataType: 'refAlias',
         type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                agentUuid: { dataType: 'string', required: true },
-                prompt: { dataType: 'string', required: true },
-                sourceThreadUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                includeSourceThread: { dataType: 'boolean', required: true },
-                includeRunHistory: { dataType: 'boolean', required: true },
-            },
+            ref: 'Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_AiSchedulerConfig.schedulerUuid_': {
+    'Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    type: {
+                        dataType: 'enum',
+                        enums: ['resource'],
+                        required: true,
+                    },
+                    prompt: { dataType: 'string', required: true },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Omit_AiSchedulerResourceConfig.schedulerUuid_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__',
+            ref: 'Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpsertAiSchedulerConfig: {
         dataType: 'refAlias',
-        type: { ref: 'Omit_AiSchedulerConfig.schedulerUuid_', validators: {} },
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'Omit_AiSchedulerAgentConfig.schedulerUuid_' },
+                { ref: 'Omit_AiSchedulerResourceConfig.schedulerUuid_' },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AiRouter: {
@@ -47310,12 +47411,7 @@ export function RegisterRoutes(app: Router) {
         string,
         TsoaRoute.ParameterSchema
     > = {
-        _req: {
-            in: 'request',
-            name: '_req',
-            required: true,
-            dataType: 'object',
-        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
         schedulerUuid: {
             in: 'path',
             name: 'schedulerUuid',
@@ -47376,12 +47472,7 @@ export function RegisterRoutes(app: Router) {
         string,
         TsoaRoute.ParameterSchema
     > = {
-        _req: {
-            in: 'request',
-            name: '_req',
-            required: true,
-            dataType: 'object',
-        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
         schedulerUuid: {
             in: 'path',
             name: 'schedulerUuid',
@@ -47448,12 +47539,7 @@ export function RegisterRoutes(app: Router) {
         string,
         TsoaRoute.ParameterSchema
     > = {
-        _req: {
-            in: 'request',
-            name: '_req',
-            required: true,
-            dataType: 'object',
-        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
         schedulerUuid: {
             in: 'path',
             name: 'schedulerUuid',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12105,7 +12105,7 @@
                 "required": ["prompt", "schedulerUuid"],
                 "type": "object"
             },
-            "AiSchedulerAgentConfig": {
+            "AiSchedulerAgentPromptConfig": {
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/AiSchedulerConfigBase"
@@ -12127,7 +12127,7 @@
                             },
                             "type": {
                                 "type": "string",
-                                "enum": ["agent"],
+                                "enum": ["agentPrompt"],
                                 "nullable": false
                             }
                         },
@@ -12142,7 +12142,7 @@
                     }
                 ]
             },
-            "AiSchedulerResourceConfig": {
+            "AiSchedulerSavedContentConfig": {
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/AiSchedulerConfigBase"
@@ -12151,7 +12151,7 @@
                         "properties": {
                             "type": {
                                 "type": "string",
-                                "enum": ["resource"],
+                                "enum": ["savedContent"],
                                 "nullable": false
                             }
                         },
@@ -12163,10 +12163,10 @@
             "AiSchedulerConfig": {
                 "anyOf": [
                     {
-                        "$ref": "#/components/schemas/AiSchedulerAgentConfig"
+                        "$ref": "#/components/schemas/AiSchedulerAgentPromptConfig"
                     },
                     {
-                        "$ref": "#/components/schemas/AiSchedulerResourceConfig"
+                        "$ref": "#/components/schemas/AiSchedulerSavedContentConfig"
                     }
                 ]
             },
@@ -12192,11 +12192,11 @@
             "ApiAiSchedulerConfigResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiSchedulerConfig-or-null_"
             },
-            "Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__": {
+            "Pick_AiSchedulerAgentPromptConfig.Exclude_keyofAiSchedulerAgentPromptConfig.schedulerUuid__": {
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": ["agent"],
+                        "enum": ["agentPrompt"],
                         "nullable": false
                     },
                     "prompt": {
@@ -12227,15 +12227,15 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_AiSchedulerAgentConfig.schedulerUuid_": {
-                "$ref": "#/components/schemas/Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__",
+            "Omit_AiSchedulerAgentPromptConfig.schedulerUuid_": {
+                "$ref": "#/components/schemas/Pick_AiSchedulerAgentPromptConfig.Exclude_keyofAiSchedulerAgentPromptConfig.schedulerUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
-            "Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__": {
+            "Pick_AiSchedulerSavedContentConfig.Exclude_keyofAiSchedulerSavedContentConfig.schedulerUuid__": {
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": ["resource"],
+                        "enum": ["savedContent"],
                         "nullable": false
                     },
                     "prompt": {
@@ -12246,17 +12246,17 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_AiSchedulerResourceConfig.schedulerUuid_": {
-                "$ref": "#/components/schemas/Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__",
+            "Omit_AiSchedulerSavedContentConfig.schedulerUuid_": {
+                "$ref": "#/components/schemas/Pick_AiSchedulerSavedContentConfig.Exclude_keyofAiSchedulerSavedContentConfig.schedulerUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "UpsertAiSchedulerConfig": {
                 "anyOf": [
                     {
-                        "$ref": "#/components/schemas/Omit_AiSchedulerAgentConfig.schedulerUuid_"
+                        "$ref": "#/components/schemas/Omit_AiSchedulerAgentPromptConfig.schedulerUuid_"
                     },
                     {
-                        "$ref": "#/components/schemas/Omit_AiSchedulerResourceConfig.schedulerUuid_"
+                        "$ref": "#/components/schemas/Omit_AiSchedulerSavedContentConfig.schedulerUuid_"
                     }
                 ]
             },
@@ -15970,8 +15970,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -15985,17 +15985,17 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "verifiedChartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -16026,13 +16026,6 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "joinedTables": {
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
@@ -16073,6 +16066,13 @@
                                                                             },
                                                                             "type": "array"
                                                                         },
+                                                                        "joinedTables": {
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "nullable": true
+                                                                        },
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
@@ -16100,8 +16100,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16145,17 +16145,17 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "searchRank": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "verifiedChartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
                                                                                     "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
-                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -16204,8 +16204,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16239,8 +16239,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
                                                             "error",
+                                                            "success",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16267,6 +16267,70 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
+                                                                    "fields": {
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "isFromJoinedTable": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "caseSensitiveFilters": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "true",
+                                                                                        "false",
+                                                                                        "not_applicable"
+                                                                                    ]
+                                                                                },
+                                                                                "fieldFilterType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldValueType": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldType": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "dimension",
+                                                                                        "metric"
+                                                                                    ]
+                                                                                },
+                                                                                "description": {
+                                                                                    "type": "string",
+                                                                                    "nullable": true
+                                                                                },
+                                                                                "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "name": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "isFromJoinedTable",
+                                                                                "caseSensitiveFilters",
+                                                                                "fieldFilterType",
+                                                                                "fieldValueType",
+                                                                                "fieldType",
+                                                                                "description",
+                                                                                "label",
+                                                                                "fieldId",
+                                                                                "table",
+                                                                                "name"
+                                                                            ],
+                                                                            "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
+                                                                    },
                                                                     "explore": {
                                                                         "properties": {
                                                                             "requiredFilters": {
@@ -16304,14 +16368,14 @@
                                                                                 },
                                                                                 "type": "array"
                                                                             },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
                                                                             "joinedTables": {
                                                                                 "items": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
                                                                             },
                                                                             "label": {
                                                                                 "type": "string"
@@ -16321,76 +16385,12 @@
                                                                             }
                                                                         },
                                                                         "required": [
-                                                                            "baseTable",
                                                                             "joinedTables",
+                                                                            "baseTable",
                                                                             "label",
                                                                             "name"
                                                                         ],
                                                                         "type": "object"
-                                                                    },
-                                                                    "fields": {
-                                                                        "items": {
-                                                                            "properties": {
-                                                                                "isFromJoinedTable": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "caseSensitiveFilters": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "true",
-                                                                                        "false",
-                                                                                        "not_applicable"
-                                                                                    ]
-                                                                                },
-                                                                                "fieldValueType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldFilterType": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldType": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "dimension",
-                                                                                        "metric"
-                                                                                    ]
-                                                                                },
-                                                                                "description": {
-                                                                                    "type": "string",
-                                                                                    "nullable": true
-                                                                                },
-                                                                                "label": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "name": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "isFromJoinedTable",
-                                                                                "caseSensitiveFilters",
-                                                                                "fieldValueType",
-                                                                                "fieldFilterType",
-                                                                                "fieldType",
-                                                                                "description",
-                                                                                "label",
-                                                                                "fieldId",
-                                                                                "table",
-                                                                                "name"
-                                                                            ],
-                                                                            "type": "object"
-                                                                        },
-                                                                        "type": "array"
-                                                                    },
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -16401,9 +16401,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "explore",
                                                                     "fields",
                                                                     "rationale",
+                                                                    "explore",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16416,10 +16416,10 @@
                                                                     "candidates": {
                                                                         "items": {
                                                                             "properties": {
-                                                                                "reason": {
+                                                                                "exploreLabel": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "exploreLabel": {
+                                                                                "reason": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "exploreName": {
@@ -16427,8 +16427,8 @@
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "reason",
                                                                                 "exploreLabel",
+                                                                                "reason",
                                                                                 "exploreName"
                                                                             ],
                                                                             "type": "object"
@@ -16539,32 +16539,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "read",
-                                                                        "edit",
-                                                                        "search",
-                                                                        "compile",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16592,6 +16566,32 @@
                                                         ],
                                                         "nullable": true
                                                     },
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "compile",
+                                                                        "search",
+                                                                        "read",
+                                                                        "edit",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16611,9 +16611,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
+                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
-                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16663,8 +16663,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -16676,9 +16676,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "rejected",
                                                             "error",
+                                                            "rejected",
+                                                            "success",
                                                             "timeout"
                                                         ]
                                                     }
@@ -16690,15 +16690,19 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
+                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -16726,10 +16730,6 @@
                                                                 },
                                                                 "type": "array"
                                                             },
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "type": {
                                                                 "type": "string",
                                                                 "enum": [
@@ -16741,8 +16741,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "fields",
                                                             "searchQuery",
+                                                            "fields",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -16750,8 +16750,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3952,6 +3952,33 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "FilterAutocompleteValue": {
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value"],
+                "type": "object"
+            },
+            "FilterAutocompleteConfig": {
+                "properties": {
+                    "fetchFromWarehouse": {
+                        "type": "boolean"
+                    },
+                    "values": {
+                        "items": {
+                            "$ref": "#/components/schemas/FilterAutocompleteValue"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["fetchFromWarehouse"],
+                "type": "object"
+            },
             "FieldType": {
                 "enum": ["metric", "dimension"],
                 "type": "string"
@@ -4214,28 +4241,7 @@
                         "type": "string"
                     },
                     "filterAutocomplete": {
-                        "properties": {
-                            "fetchFromWarehouse": {
-                                "type": "boolean"
-                            },
-                            "values": {
-                                "items": {
-                                    "properties": {
-                                        "value": {
-                                            "type": "string"
-                                        },
-                                        "label": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["value"],
-                                    "type": "object"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["fetchFromWarehouse"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/FilterAutocompleteConfig"
                     },
                     "spotlight": {
                         "properties": {
@@ -8342,28 +8348,7 @@
                         "type": "string"
                     },
                     "filterAutocomplete": {
-                        "properties": {
-                            "fetchFromWarehouse": {
-                                "type": "boolean"
-                            },
-                            "values": {
-                                "items": {
-                                    "properties": {
-                                        "value": {
-                                            "type": "string"
-                                        },
-                                        "label": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": ["value"],
-                                    "type": "object"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        "required": ["fetchFromWarehouse"],
-                        "type": "object"
+                        "$ref": "#/components/schemas/FilterAutocompleteConfig"
                     },
                     "spotlight": {
                         "properties": {
@@ -12108,6 +12093,96 @@
             "ApiMyAppsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___"
             },
+            "AiSchedulerConfig": {
+                "properties": {
+                    "includeRunHistory": {
+                        "type": "boolean"
+                    },
+                    "includeSourceThread": {
+                        "type": "boolean"
+                    },
+                    "sourceThreadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
+                        "type": "string"
+                    },
+                    "schedulerUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "includeRunHistory",
+                    "includeSourceThread",
+                    "sourceThreadUuid",
+                    "prompt",
+                    "agentUuid",
+                    "schedulerUuid"
+                ],
+                "type": "object"
+            },
+            "ApiSuccess_AiSchedulerConfig-or-null_": {
+                "properties": {
+                    "results": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AiSchedulerConfig"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiAiSchedulerConfigResponse": {
+                "$ref": "#/components/schemas/ApiSuccess_AiSchedulerConfig-or-null_"
+            },
+            "Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__": {
+                "properties": {
+                    "agentUuid": {
+                        "type": "string"
+                    },
+                    "prompt": {
+                        "type": "string"
+                    },
+                    "sourceThreadUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "includeSourceThread": {
+                        "type": "boolean"
+                    },
+                    "includeRunHistory": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "agentUuid",
+                    "prompt",
+                    "sourceThreadUuid",
+                    "includeSourceThread",
+                    "includeRunHistory"
+                ],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_AiSchedulerConfig.schedulerUuid_": {
+                "$ref": "#/components/schemas/Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "UpsertAiSchedulerConfig": {
+                "$ref": "#/components/schemas/Omit_AiSchedulerConfig.schedulerUuid_"
+            },
             "AiRouter": {
                 "properties": {
                     "updatedAt": {
@@ -15818,8 +15893,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15833,11 +15908,6 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "verifiedChartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
@@ -15848,13 +15918,18 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -15863,8 +15938,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -15903,10 +15978,10 @@
                                                                                     "fieldRef": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "operator": {
+                                                                                    "fieldId": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldId": {
+                                                                                    "operator": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
@@ -15914,8 +15989,8 @@
                                                                                     "required",
                                                                                     "tableName",
                                                                                     "fieldRef",
-                                                                                    "operator",
-                                                                                    "fieldId"
+                                                                                    "fieldId",
+                                                                                    "operator"
                                                                                 ],
                                                                                 "type": "object"
                                                                             },
@@ -15948,8 +16023,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -15993,11 +16068,6 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "verifiedChartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
@@ -16008,13 +16078,18 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
+                                                                                    "searchRank": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -16023,8 +16098,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -16052,8 +16127,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16087,8 +16162,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
                                                             "success",
+                                                            "error",
                                                             "not_found"
                                                         ]
                                                     }
@@ -16115,9 +16190,66 @@
                                                         "anyOf": [
                                                             {
                                                                 "properties": {
-                                                                    "rationale": {
-                                                                        "type": "string",
-                                                                        "nullable": true
+                                                                    "explore": {
+                                                                        "properties": {
+                                                                            "requiredFilters": {
+                                                                                "items": {
+                                                                                    "properties": {
+                                                                                        "settings": {},
+                                                                                        "values": {
+                                                                                            "items": {},
+                                                                                            "type": "array"
+                                                                                        },
+                                                                                        "required": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "tableName": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldRef": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "fieldId": {
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "required",
+                                                                                        "tableName",
+                                                                                        "fieldRef",
+                                                                                        "fieldId",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "baseTable": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "joinedTables": {
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "label": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "baseTable",
+                                                                            "joinedTables",
+                                                                            "label",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object"
                                                                     },
                                                                     "fields": {
                                                                         "items": {
@@ -16146,17 +16278,17 @@
                                                                                         "metric"
                                                                                     ]
                                                                                 },
-                                                                                "table": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "fieldId": {
-                                                                                    "type": "string"
-                                                                                },
                                                                                 "description": {
                                                                                     "type": "string",
                                                                                     "nullable": true
                                                                                 },
                                                                                 "label": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "fieldId": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "table": {
                                                                                     "type": "string"
                                                                                 },
                                                                                 "name": {
@@ -16169,76 +16301,19 @@
                                                                                 "fieldValueType",
                                                                                 "fieldFilterType",
                                                                                 "fieldType",
-                                                                                "table",
-                                                                                "fieldId",
                                                                                 "description",
                                                                                 "label",
+                                                                                "fieldId",
+                                                                                "table",
                                                                                 "name"
                                                                             ],
                                                                             "type": "object"
                                                                         },
                                                                         "type": "array"
                                                                     },
-                                                                    "explore": {
-                                                                        "properties": {
-                                                                            "requiredFilters": {
-                                                                                "items": {
-                                                                                    "properties": {
-                                                                                        "settings": {},
-                                                                                        "values": {
-                                                                                            "items": {},
-                                                                                            "type": "array"
-                                                                                        },
-                                                                                        "required": {
-                                                                                            "type": "boolean"
-                                                                                        },
-                                                                                        "tableName": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "fieldRef": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "operator": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "fieldId": {
-                                                                                            "type": "string"
-                                                                                        }
-                                                                                    },
-                                                                                    "required": [
-                                                                                        "required",
-                                                                                        "tableName",
-                                                                                        "fieldRef",
-                                                                                        "operator",
-                                                                                        "fieldId"
-                                                                                    ],
-                                                                                    "type": "object"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "joinedTables": {
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array"
-                                                                            },
-                                                                            "baseTable": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "label": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "name": {
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "joinedTables",
-                                                                            "baseTable",
-                                                                            "label",
-                                                                            "name"
-                                                                        ],
-                                                                        "type": "object"
+                                                                    "rationale": {
+                                                                        "type": "string",
+                                                                        "nullable": true
                                                                     },
                                                                     "status": {
                                                                         "type": "string",
@@ -16249,9 +16324,9 @@
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "rationale",
-                                                                    "fields",
                                                                     "explore",
+                                                                    "fields",
+                                                                    "rationale",
                                                                     "status"
                                                                 ],
                                                                 "type": "object"
@@ -16353,6 +16428,12 @@
                                                     "href": {
                                                         "type": "string"
                                                     },
+                                                    "warnings": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
                                                     "status": {
                                                         "type": "string",
                                                         "enum": ["success"],
@@ -16364,12 +16445,6 @@
                                                     "uuid": {
                                                         "type": "string"
                                                     },
-                                                    "warnings": {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
                                                     "name": {
                                                         "type": "string"
                                                     }
@@ -16377,16 +16452,42 @@
                                                 "required": [
                                                     "versionUuids",
                                                     "href",
+                                                    "warnings",
                                                     "status",
                                                     "slug",
                                                     "uuid",
-                                                    "warnings",
                                                     "name"
                                                 ],
                                                 "type": "object"
                                             },
                                             {
                                                 "properties": {
+                                                    "steps": {
+                                                        "items": {
+                                                            "properties": {
+                                                                "kind": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "read",
+                                                                        "edit",
+                                                                        "search",
+                                                                        "compile",
+                                                                        "stage"
+                                                                    ]
+                                                                },
+                                                                "label": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "kind",
+                                                                "label"
+                                                            ],
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array",
+                                                        "nullable": true
+                                                    },
                                                     "previewUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16414,32 +16515,6 @@
                                                         ],
                                                         "nullable": true
                                                     },
-                                                    "steps": {
-                                                        "items": {
-                                                            "properties": {
-                                                                "kind": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "search",
-                                                                        "compile",
-                                                                        "read",
-                                                                        "edit",
-                                                                        "stage"
-                                                                    ]
-                                                                },
-                                                                "label": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "kind",
-                                                                "label"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "type": "array",
-                                                        "nullable": true
-                                                    },
                                                     "prUrl": {
                                                         "type": "string",
                                                         "nullable": true
@@ -16459,9 +16534,9 @@
                                                         "type": "string",
                                                         "enum": [
                                                             "unknown",
-                                                            "unsupported_source_control",
                                                             "github_not_installed",
                                                             "gitlab_not_installed",
+                                                            "unsupported_source_control",
                                                             "pull_request_not_open",
                                                             "git_write_permission",
                                                             null
@@ -16511,8 +16586,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -16524,9 +16599,9 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "rejected",
                                                             "success",
+                                                            "rejected",
+                                                            "error",
                                                             "timeout"
                                                         ]
                                                     }
@@ -16538,19 +16613,15 @@
                                                 "properties": {
                                                     "ranking": {
                                                         "properties": {
-                                                            "searchQuery": {
-                                                                "type": "string",
-                                                                "nullable": true
-                                                            },
                                                             "fields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -16558,10 +16629,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -16570,13 +16641,17 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": "array"
+                                                            },
+                                                            "searchQuery": {
+                                                                "type": "string",
+                                                                "nullable": true
                                                             },
                                                             "type": {
                                                                 "type": "string",
@@ -16589,8 +16664,8 @@
                                                             }
                                                         },
                                                         "required": [
-                                                            "searchQuery",
                                                             "fields",
+                                                            "searchQuery",
                                                             "type"
                                                         ],
                                                         "type": "object"
@@ -16598,8 +16673,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -17880,6 +17955,9 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "agentUuid": {
+                        "type": "string"
+                    },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time"
@@ -17889,18 +17967,15 @@
                     },
                     "evalUuid": {
                         "type": "string"
-                    },
-                    "agentUuid": {
-                        "type": "string"
                     }
                 },
                 "required": [
                     "description",
                     "createdAt",
+                    "agentUuid",
                     "updatedAt",
                     "title",
-                    "evalUuid",
-                    "agentUuid"
+                    "evalUuid"
                 ],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
@@ -20725,6 +20800,9 @@
                         "type": "string"
                     },
                     "assumeRoleArn": {
+                        "type": "string"
+                    },
+                    "sessionToken": {
                         "type": "string"
                     },
                     "secretAccessKey": {
@@ -31727,22 +31805,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -32306,22 +32384,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string__-or-_type-DashboardTileTypes.DATA_APP--properties_58__title-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -41633,7 +41711,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.3254.2",
+        "version": "0.3260.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -43031,6 +43109,129 @@
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": []
+            }
+        },
+        "/api/v1/schedulers/{schedulerUuid}/ai-config": {
+            "get": {
+                "operationId": "getAiSchedulerConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiAiSchedulerConfigResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Scheduler"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "put": {
+                "operationId": "upsertAiSchedulerConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Scheduler"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpsertAiSchedulerConfig"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "deleteAiSchedulerConfig",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": ["Scheduler"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "schedulerUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/org/aiRouter": {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -12093,37 +12093,82 @@
             "ApiMyAppsResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__data-ApiAppSummary-Array--pagination_63_-KnexPaginateArgs-and-_totalPageCount-number--totalResults-number___"
             },
-            "AiSchedulerConfig": {
+            "AiSchedulerConfigBase": {
                 "properties": {
-                    "includeRunHistory": {
-                        "type": "boolean"
-                    },
-                    "includeSourceThread": {
-                        "type": "boolean"
-                    },
-                    "sourceThreadUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "prompt": {
-                        "type": "string"
-                    },
-                    "agentUuid": {
                         "type": "string"
                     },
                     "schedulerUuid": {
                         "type": "string"
                     }
                 },
-                "required": [
-                    "includeRunHistory",
-                    "includeSourceThread",
-                    "sourceThreadUuid",
-                    "prompt",
-                    "agentUuid",
-                    "schedulerUuid"
-                ],
+                "required": ["prompt", "schedulerUuid"],
                 "type": "object"
+            },
+            "AiSchedulerAgentConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiSchedulerConfigBase"
+                    },
+                    {
+                        "properties": {
+                            "includeRunHistory": {
+                                "type": "boolean"
+                            },
+                            "includeSourceThread": {
+                                "type": "boolean"
+                            },
+                            "sourceThreadUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "agentUuid": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": ["agent"],
+                                "nullable": false
+                            }
+                        },
+                        "required": [
+                            "includeRunHistory",
+                            "includeSourceThread",
+                            "sourceThreadUuid",
+                            "agentUuid",
+                            "type"
+                        ],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiSchedulerResourceConfig": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AiSchedulerConfigBase"
+                    },
+                    {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["resource"],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "AiSchedulerConfig": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/AiSchedulerAgentConfig"
+                    },
+                    {
+                        "$ref": "#/components/schemas/AiSchedulerResourceConfig"
+                    }
+                ]
             },
             "ApiSuccess_AiSchedulerConfig-or-null_": {
                 "properties": {
@@ -12147,12 +12192,17 @@
             "ApiAiSchedulerConfigResponse": {
                 "$ref": "#/components/schemas/ApiSuccess_AiSchedulerConfig-or-null_"
             },
-            "Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__": {
+            "Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__": {
                 "properties": {
-                    "agentUuid": {
-                        "type": "string"
+                    "type": {
+                        "type": "string",
+                        "enum": ["agent"],
+                        "nullable": false
                     },
                     "prompt": {
+                        "type": "string"
+                    },
+                    "agentUuid": {
                         "type": "string"
                     },
                     "sourceThreadUuid": {
@@ -12167,8 +12217,9 @@
                     }
                 },
                 "required": [
-                    "agentUuid",
+                    "type",
                     "prompt",
+                    "agentUuid",
                     "sourceThreadUuid",
                     "includeSourceThread",
                     "includeRunHistory"
@@ -12176,12 +12227,38 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_AiSchedulerConfig.schedulerUuid_": {
-                "$ref": "#/components/schemas/Pick_AiSchedulerConfig.Exclude_keyofAiSchedulerConfig.schedulerUuid__",
+            "Omit_AiSchedulerAgentConfig.schedulerUuid_": {
+                "$ref": "#/components/schemas/Pick_AiSchedulerAgentConfig.Exclude_keyofAiSchedulerAgentConfig.schedulerUuid__",
+                "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": ["resource"],
+                        "nullable": false
+                    },
+                    "prompt": {
+                        "type": "string"
+                    }
+                },
+                "required": ["type", "prompt"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "Omit_AiSchedulerResourceConfig.schedulerUuid_": {
+                "$ref": "#/components/schemas/Pick_AiSchedulerResourceConfig.Exclude_keyofAiSchedulerResourceConfig.schedulerUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "UpsertAiSchedulerConfig": {
-                "$ref": "#/components/schemas/Omit_AiSchedulerConfig.schedulerUuid_"
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/Omit_AiSchedulerAgentConfig.schedulerUuid_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Omit_AiSchedulerResourceConfig.schedulerUuid_"
+                    }
+                ]
             },
             "AiRouter": {
                 "properties": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -141,6 +141,7 @@ export type ModelManifest = {
     changesetModel: ChangesetModel;
     /** An implementation signature for these models are not available at this stage */
     aiAgentModel: unknown;
+    aiSchedulerModel: unknown;
     aiAgentDocumentModel: unknown;
     aiWritebackThreadModel: unknown;
     projectCiStatusModel: unknown;
@@ -755,6 +756,10 @@ export class ModelRepository
 
     public getAiAgentModel<ModelImplT>(): ModelImplT {
         return this.getModel('aiAgentModel');
+    }
+
+    public getAiSchedulerModel<ModelImplT>(): ModelImplT {
+        return this.getModel('aiSchedulerModel');
     }
 
     public getAiAgentDocumentModel<ModelImplT>(): ModelImplT {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1246,6 +1246,15 @@ export default class SchedulerTask {
         };
     }
 
+    // EE override point: the AI report for a delivery, or null. No-op in OSS.
+    // eslint-disable-next-line class-methods-use-this
+    protected async getScheduledReport(
+        _schedulerUuid: string | undefined,
+        _organizationUuid: string,
+    ): Promise<string | null> {
+        return null;
+    }
+
     protected async sendSlackNotification(
         jobId: string,
         notification: SlackNotificationPayload,
@@ -1283,6 +1292,14 @@ export default class SchedulerTask {
         try {
             if (!this.slackClient.isEnabled) {
                 throw new Error('Slack app is not configured');
+            }
+
+            const report = await this.getScheduledReport(
+                schedulerUuid,
+                notification.organizationUuid,
+            );
+            if (report) {
+                scheduler.message = report;
             }
 
             const {

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1294,14 +1294,6 @@ export default class SchedulerTask {
                 throw new Error('Slack app is not configured');
             }
 
-            const report = await this.getScheduledReport(
-                schedulerUuid,
-                notification.organizationUuid,
-            );
-            if (report) {
-                scheduler.message = report;
-            }
-
             const {
                 format,
                 savedChartUuid,
@@ -4239,6 +4231,27 @@ export default class SchedulerTask {
                     pageByChannel.slack ??
                     pageByChannel.msteams ??
                     pageByChannel.googlechat;
+            }
+
+            // AI deliveries: generate the agent's report once and reuse it as the
+            // message for every channel. Best-effort — a failure here must not
+            // block the delivery, so we fall back to the configured message.
+            if (scheduler.format !== SchedulerFormat.GSHEETS) {
+                try {
+                    const report = await this.getScheduledReport(
+                        schedulerUuid,
+                        schedulerPayload.organizationUuid,
+                    );
+                    if (report) {
+                        scheduler.message = report;
+                    }
+                } catch (e) {
+                    Logger.error(
+                        `Failed to generate AI report for scheduler ${schedulerUuid}: ${getErrorMessage(
+                            e,
+                        )}`,
+                    );
+                }
             }
 
             const scheduledJobs =

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -152,6 +152,7 @@ interface ServiceManifest {
     embedService: unknown;
     aiService: unknown;
     aiAgentService: unknown;
+    aiSchedulerService: unknown;
     aiAgentToolsService: unknown;
     aiAgentAdminService: unknown;
     aiAgentDocumentService: unknown;
@@ -1362,6 +1363,12 @@ export class ServiceRepository
 
     public getAiAgentService<AiAgentServiceImplT>(): AiAgentServiceImplT {
         return this.getService('aiAgentService');
+    }
+
+    public getAiSchedulerService<
+        AiSchedulerServiceImplT,
+    >(): AiSchedulerServiceImplT {
+        return this.getService('aiSchedulerService');
     }
 
     public getAiAgentToolsService<

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -235,6 +235,7 @@ import {
     type SavedChart,
 } from './savedCharts';
 import {
+    type ApiAiSchedulerConfigResponse,
     type ApiJobScheduledResponse,
     type ApiJobStatusResponse,
     type ApiReassignUserSchedulersResponse,
@@ -1087,6 +1088,7 @@ type ApiResults =
     | ApiExecuteAsyncDashboardChartQueryResults
     | ApiGetAsyncQueryResults
     | ApiSchedulersResponse['results']
+    | ApiAiSchedulerConfigResponse['results']
     | ApiUserSchedulersSummaryResponse['results']
     | ApiReassignUserSchedulersResponse['results']
     | ApiUserActivityDownloadCsv['results']

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -488,16 +488,32 @@ export type ApiSchedulerAndTargetsResponse = {
 };
 
 // A delivery's AI config — kept out of Scheduler so the core type stays AI-free.
-export type AiSchedulerConfig = {
+type AiSchedulerConfigBase = {
     schedulerUuid: string;
-    agentUuid: string;
     prompt: string;
+};
+
+// Runs the prompt through an AI agent, which pulls in the delivery's content.
+export type AiSchedulerAgentConfig = AiSchedulerConfigBase & {
+    type: 'agent';
+    agentUuid: string;
     sourceThreadUuid: string | null;
     includeSourceThread: boolean;
     includeRunHistory: boolean;
 };
 
-export type UpsertAiSchedulerConfig = Omit<AiSchedulerConfig, 'schedulerUuid'>;
+// Runs the prompt against a fast model over the delivery's resource directly.
+export type AiSchedulerResourceConfig = AiSchedulerConfigBase & {
+    type: 'resource';
+};
+
+export type AiSchedulerConfig =
+    | AiSchedulerAgentConfig
+    | AiSchedulerResourceConfig;
+
+export type UpsertAiSchedulerConfig =
+    | Omit<AiSchedulerAgentConfig, 'schedulerUuid'>
+    | Omit<AiSchedulerResourceConfig, 'schedulerUuid'>;
 
 export type ApiAiSchedulerConfigResponse = ApiSuccess<AiSchedulerConfig | null>;
 

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -487,6 +487,20 @@ export type ApiSchedulerAndTargetsResponse = {
     results: SchedulerAndTargets;
 };
 
+// A delivery's AI config — kept out of Scheduler so the core type stays AI-free.
+export type AiSchedulerConfig = {
+    schedulerUuid: string;
+    agentUuid: string;
+    prompt: string;
+    sourceThreadUuid: string | null;
+    includeSourceThread: boolean;
+    includeRunHistory: boolean;
+};
+
+export type UpsertAiSchedulerConfig = Omit<AiSchedulerConfig, 'schedulerUuid'>;
+
+export type ApiAiSchedulerConfigResponse = ApiSuccess<AiSchedulerConfig | null>;
+
 export type ApiAppSchedulersResponse = {
     status: 'ok';
     results: SchedulerAndTargets[];

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -493,27 +493,27 @@ type AiSchedulerConfigBase = {
     prompt: string;
 };
 
-// Runs the prompt through an AI agent, which pulls in the delivery's content.
-export type AiSchedulerAgentConfig = AiSchedulerConfigBase & {
-    type: 'agent';
+// Runs the prompt through a defined AI agent, which pulls in the delivery's content.
+export type AiSchedulerAgentPromptConfig = AiSchedulerConfigBase & {
+    type: 'agentPrompt';
     agentUuid: string;
     sourceThreadUuid: string | null;
     includeSourceThread: boolean;
     includeRunHistory: boolean;
 };
 
-// Runs the prompt against a fast model over the delivery's resource directly.
-export type AiSchedulerResourceConfig = AiSchedulerConfigBase & {
-    type: 'resource';
+// Runs the prompt against a fast model over the delivery's saved content directly.
+export type AiSchedulerSavedContentConfig = AiSchedulerConfigBase & {
+    type: 'savedContent';
 };
 
 export type AiSchedulerConfig =
-    | AiSchedulerAgentConfig
-    | AiSchedulerResourceConfig;
+    | AiSchedulerAgentPromptConfig
+    | AiSchedulerSavedContentConfig;
 
 export type UpsertAiSchedulerConfig =
-    | Omit<AiSchedulerAgentConfig, 'schedulerUuid'>
-    | Omit<AiSchedulerResourceConfig, 'schedulerUuid'>;
+    | Omit<AiSchedulerAgentPromptConfig, 'schedulerUuid'>
+    | Omit<AiSchedulerSavedContentConfig, 'schedulerUuid'>;
 
 export type ApiAiSchedulerConfigResponse = ApiSuccess<AiSchedulerConfig | null>;
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -16,6 +16,7 @@ import {
     IconExternalLink,
     IconEye,
     IconLayoutDashboard,
+    IconSend,
     IconTableShortcut,
     IconTerminal2,
 } from '@tabler/icons-react';
@@ -45,6 +46,7 @@ import {
     useAiAgentStoreDispatch,
     useAiAgentStoreSelector,
 } from '../../store/hooks';
+import { AiScheduleDeliveryModal } from './AiScheduleDeliveryModal';
 
 type Props = {
     projectUuid: string;
@@ -81,6 +83,8 @@ export const AiChartQuickOptions = ({
     const [isSavingToDashboard, setIsSavingToDashboard] = useState(false);
 
     const [opened, { open, close }] = useDisclosure(false);
+    const [scheduleOpened, { open: openSchedule, close: closeSchedule }] =
+        useDisclosure(false);
     const [
         verifyModalOpened,
         { open: openVerifyModal, close: closeVerifyModal },
@@ -353,16 +357,28 @@ export const AiChartQuickOptions = ({
                         <Menu.Label>Quick actions</Menu.Label>
                         {message.savedQueryUuid ? (
                             !isEmbed && (
-                                <Menu.Item
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
-                                    target="_blank"
-                                    leftSection={
-                                        <MantineIcon icon={IconTableShortcut} />
-                                    }
-                                >
-                                    View saved chart
-                                </Menu.Item>
+                                <>
+                                    <Menu.Item
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/saved/${message.savedQueryUuid}`}
+                                        target="_blank"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconTableShortcut}
+                                            />
+                                        }
+                                    >
+                                        View saved chart
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        onClick={openSchedule}
+                                        leftSection={
+                                            <MantineIcon icon={IconSend} />
+                                        }
+                                    >
+                                        Schedule delivery
+                                    </Menu.Item>
+                                </>
                             )
                         ) : (
                             <>
@@ -508,6 +524,15 @@ export const AiChartQuickOptions = ({
                     </Button>
                 }
             />
+            {scheduleOpened && message.savedQueryUuid && (
+                <AiScheduleDeliveryModal
+                    chartUuid={message.savedQueryUuid}
+                    chartName={saveChartOptions.name ?? ''}
+                    agentUuid={agentUuid}
+                    sourceThreadUuid={message.threadUuid}
+                    onClose={closeSchedule}
+                />
+            )}
         </Fragment>
     );
 };

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiScheduleDeliveryModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiScheduleDeliveryModal.tsx
@@ -1,0 +1,58 @@
+import { SchedulerFormat } from '@lightdash/common';
+import { type FC } from 'react';
+import SchedulerModal from '../../../../../features/scheduler/components/SchedulerModal';
+import {
+    useChartSchedulerCreateMutation,
+    useChartSchedulers,
+} from '../../../../../features/scheduler/hooks/useChartSchedulers';
+
+const DELIVERY_FORMATS = [
+    SchedulerFormat.CSV,
+    SchedulerFormat.XLSX,
+    SchedulerFormat.IMAGE,
+    SchedulerFormat.PDF,
+];
+
+type Props = {
+    chartUuid: string;
+    chartName: string;
+    agentUuid: string;
+    sourceThreadUuid: string;
+    onClose: () => void;
+};
+
+// Opens the chart's scheduler form in create mode, pre-filled with the
+// conversation's agent + source thread. Mounted only while open.
+export const AiScheduleDeliveryModal: FC<Props> = ({
+    chartUuid,
+    chartName,
+    agentUuid,
+    sourceThreadUuid,
+    onClose,
+}) => {
+    const schedulersQuery = useChartSchedulers({
+        chartUuid,
+        formats: DELIVERY_FORMATS,
+        includeLatestRun: true,
+    });
+    const createMutation = useChartSchedulerCreateMutation();
+
+    return (
+        <SchedulerModal
+            isOpen
+            isChart
+            defaultCreate
+            resourceUuid={chartUuid}
+            name={chartName}
+            schedulersQuery={schedulersQuery}
+            createMutation={createMutation}
+            initialFormValues={{
+                agentUuid,
+                sourceThreadUuid,
+                includeSourceThread: true,
+                format: SchedulerFormat.IMAGE,
+            }}
+            onClose={onClose}
+        />
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormAiInput.tsx
@@ -1,0 +1,95 @@
+import { Group, Select, Stack, Switch, Textarea } from '@mantine-8/core';
+import { IconSparkles } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useAiAgentButtonVisibility } from '../../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
+import { useProjectAiAgents } from '../../../../ee/features/aiCopilot/hooks/useProjectAiAgents';
+import { useSchedulerFormContext } from './schedulerFormContext';
+
+type Props = {
+    projectUuid: string | undefined;
+    sourceThreadUuid?: string | null;
+};
+
+// Renders nothing when AI agents aren't available for this project.
+export const SchedulerFormAiInput: FC<Props> = ({
+    projectUuid,
+    sourceThreadUuid,
+}) => {
+    const form = useSchedulerFormContext();
+    const isAiVisible = useAiAgentButtonVisibility();
+    const { data: agents } = useProjectAiAgents({
+        projectUuid,
+        redirectOnUnauthorized: false,
+        options: { enabled: isAiVisible },
+    });
+
+    if (!isAiVisible || !agents || agents.length === 0) {
+        return null;
+    }
+
+    const isEnabled = form.values.agentUuid !== null;
+
+    return (
+        <Stack gap="xs">
+            <Group gap="xs">
+                <MantineIcon icon={IconSparkles} />
+                <Switch
+                    label="Write the message with an AI agent"
+                    checked={isEnabled}
+                    onChange={(event) =>
+                        form.setFieldValue(
+                            'agentUuid',
+                            event.currentTarget.checked ? agents[0].uuid : null,
+                        )
+                    }
+                />
+            </Group>
+
+            {isEnabled && (
+                <Stack gap="sm" pl="xl">
+                    <Select
+                        label="Agent"
+                        data={agents.map((agent) => ({
+                            value: agent.uuid,
+                            label: agent.name,
+                        }))}
+                        value={form.values.agentUuid}
+                        onChange={(value) =>
+                            form.setFieldValue('agentUuid', value)
+                        }
+                        allowDeselect={false}
+                        comboboxProps={{ withinPortal: true }}
+                    />
+                    <Textarea
+                        label="Instructions"
+                        description="What the agent should report on. It runs over this delivery's content on every send."
+                        autosize
+                        minRows={2}
+                        {...form.getInputProps('prompt')}
+                    />
+                    <Switch
+                        label="Build on previous deliveries"
+                        description="The agent sees this delivery's recent runs, so it can report on what changed since last time."
+                        checked={form.values.includeRunHistory}
+                        onChange={(event) =>
+                            form.setFieldValue(
+                                'includeRunHistory',
+                                event.currentTarget.checked,
+                            )
+                        }
+                    />
+                    {sourceThreadUuid && (
+                        <Switch
+                            label="Include the source conversation as context"
+                            description="The agent will also see the conversation this delivery was created from."
+                            {...form.getInputProps('includeSourceThread', {
+                                type: 'checkbox',
+                            })}
+                        />
+                    )}
+                </Stack>
+            )}
+        </Stack>
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
@@ -1,11 +1,25 @@
 import { Group, Stack, Switch, Text, Tooltip } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import MDEditor, { commands } from '@uiw/react-md-editor';
+import { type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
+import { SchedulerFormAiInput } from './SchedulerFormAiInput';
 import { useSchedulerFormContext } from './schedulerFormContext';
 
-export const SchedulerFormCustomizationTab = () => {
+type Props = {
+    projectUuid: string | undefined;
+    canUseAiSummary: boolean;
+    sourceThreadUuid?: string | null;
+};
+
+export const SchedulerFormCustomizationTab: FC<Props> = ({
+    projectUuid,
+    canUseAiSummary,
+    sourceThreadUuid,
+}) => {
     const form = useSchedulerFormContext();
+    // When the agent writes the message, its report replaces the manual body.
+    const isAiMessage = canUseAiSummary && form.values.agentUuid !== null;
     return (
         <Stack p="md">
             <Group gap="two">
@@ -29,26 +43,40 @@ export const SchedulerFormCustomizationTab = () => {
                     <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
                 </Tooltip>
             </Group>
-            <Text fw={600} fz="sm">
-                Customize delivery message body
-            </Text>
 
-            <MDEditor
-                preview="edit"
-                commands={[
-                    commands.bold,
-                    commands.italic,
-                    commands.strikethrough,
-                    commands.divider,
-                    commands.link,
-                ]}
-                maxHeight={300}
-                minHeight={100}
-                visibleDragbar
-                value={form.values.message}
-                onChange={(value) => form.setFieldValue('message', value || '')}
-                overflow={false}
-            />
+            {canUseAiSummary && (
+                <SchedulerFormAiInput
+                    projectUuid={projectUuid}
+                    sourceThreadUuid={sourceThreadUuid}
+                />
+            )}
+
+            {!isAiMessage && (
+                <>
+                    <Text fw={600} fz="sm">
+                        Customize delivery message body
+                    </Text>
+
+                    <MDEditor
+                        preview="edit"
+                        commands={[
+                            commands.bold,
+                            commands.italic,
+                            commands.strikethrough,
+                            commands.divider,
+                            commands.link,
+                        ]}
+                        maxHeight={300}
+                        minHeight={100}
+                        visibleDragbar
+                        value={form.values.message}
+                        onChange={(value) =>
+                            form.setFieldValue('message', value || '')
+                        }
+                        overflow={false}
+                    />
+                </>
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/index.tsx
@@ -39,6 +39,7 @@ type Props = {
     isThresholdAlertWithNoFields: boolean;
     numericMetrics: Record<string, any>;
     isDashboardTabsAvailable: boolean;
+    sourceThreadUuid?: string | null;
 };
 
 const SchedulerForm: FC<Props> = ({
@@ -55,6 +56,7 @@ const SchedulerForm: FC<Props> = ({
     isDashboardTabsAvailable,
     onSubmit,
     resource,
+    sourceThreadUuid,
 }) => {
     const isApp = resource?.type === 'app';
     const form = useSchedulerFormContext();
@@ -232,7 +234,15 @@ const SchedulerForm: FC<Props> = ({
                 ) : null}
 
                 <Tabs.Panel value="customization">
-                    <SchedulerFormCustomizationTab />
+                    <SchedulerFormCustomizationTab
+                        projectUuid={projectUuid}
+                        canUseAiSummary={
+                            (resource?.type === 'chart' ||
+                                resource?.type === 'dashboard') &&
+                            !isThresholdAlert
+                        }
+                        sourceThreadUuid={sourceThreadUuid}
+                    />
                 </Tabs.Panel>
                 {isDashboard ? (
                     <Tabs.Panel value="preview">

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -143,7 +143,7 @@ export const getFormValuesFromScheduler = (
     aiConfig?: AiSchedulerConfig | null,
 ): SchedulerFormValues => {
     const options = schedulerData.options;
-    const agentConfig = aiConfig?.type === 'agent' ? aiConfig : null;
+    const agentConfig = aiConfig?.type === 'agentPrompt' ? aiConfig : null;
 
     const formOptions = { ...DEFAULT_VALUES.options };
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -9,6 +9,7 @@ import {
     NotificationFrequency,
     SchedulerFormat,
     ThresholdOperator,
+    type AiSchedulerConfig,
     type CreateSchedulerAndTargetsWithoutIds,
     type CreateSchedulerTarget,
     type Dashboard,
@@ -54,7 +55,16 @@ export interface SchedulerFormValues {
     }>;
     includeLinks: boolean;
     notificationFrequency?: NotificationFrequency;
+    // Form-local only — saved via the ai-config endpoint, not the scheduler payload.
+    agentUuid: string | null;
+    prompt: string;
+    sourceThreadUuid: string | null;
+    includeSourceThread: boolean;
+    includeRunHistory: boolean;
 }
+
+const DEFAULT_AI_PROMPT =
+    'Summarise this and call out any notable changes or trends.';
 
 const [SchedulerFormProvider, useSchedulerFormContext, useSchedulerForm] =
     createFormContext<SchedulerFormValues>();
@@ -87,6 +97,11 @@ export const DEFAULT_VALUES: SchedulerFormValues = {
     selectedTabs: null,
     thresholds: [],
     includeLinks: true,
+    agentUuid: null,
+    prompt: DEFAULT_AI_PROMPT,
+    sourceThreadUuid: null,
+    includeSourceThread: false,
+    includeRunHistory: false,
 };
 
 export const DEFAULT_VALUES_ALERT: SchedulerFormValues = {
@@ -125,6 +140,7 @@ export const getSelectedTabsForDashboardScheduler = (
 
 export const getFormValuesFromScheduler = (
     schedulerData: SchedulerAndTargets,
+    aiConfig?: AiSchedulerConfig | null,
 ): SchedulerFormValues => {
     const options = schedulerData.options;
 
@@ -191,6 +207,11 @@ export const getFormValuesFromScheduler = (
         thresholds: schedulerData.thresholds,
         notificationFrequency: schedulerData.notificationFrequency,
         includeLinks: schedulerData.includeLinks !== false,
+        agentUuid: aiConfig?.agentUuid ?? null,
+        prompt: aiConfig?.prompt ?? DEFAULT_AI_PROMPT,
+        sourceThreadUuid: aiConfig?.sourceThreadUuid ?? null,
+        includeSourceThread: aiConfig?.includeSourceThread ?? false,
+        includeRunHistory: aiConfig?.includeRunHistory ?? false,
     };
 };
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/schedulerFormContext.ts
@@ -143,6 +143,7 @@ export const getFormValuesFromScheduler = (
     aiConfig?: AiSchedulerConfig | null,
 ): SchedulerFormValues => {
     const options = schedulerData.options;
+    const agentConfig = aiConfig?.type === 'agent' ? aiConfig : null;
 
     const formOptions = { ...DEFAULT_VALUES.options };
 
@@ -207,11 +208,11 @@ export const getFormValuesFromScheduler = (
         thresholds: schedulerData.thresholds,
         notificationFrequency: schedulerData.notificationFrequency,
         includeLinks: schedulerData.includeLinks !== false,
-        agentUuid: aiConfig?.agentUuid ?? null,
-        prompt: aiConfig?.prompt ?? DEFAULT_AI_PROMPT,
-        sourceThreadUuid: aiConfig?.sourceThreadUuid ?? null,
-        includeSourceThread: aiConfig?.includeSourceThread ?? false,
-        includeRunHistory: aiConfig?.includeRunHistory ?? false,
+        agentUuid: agentConfig?.agentUuid ?? null,
+        prompt: agentConfig?.prompt ?? DEFAULT_AI_PROMPT,
+        sourceThreadUuid: agentConfig?.sourceThreadUuid ?? null,
+        includeSourceThread: agentConfig?.includeSourceThread ?? false,
+        includeRunHistory: agentConfig?.includeRunHistory ?? false,
     };
 };
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -27,6 +27,7 @@ import useToaster from '../../../hooks/toaster/useToaster';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useFetchRunLogs } from '../hooks/useScheduler';
 import { States } from '../utils';
+import { type SchedulerFormValues } from './SchedulerForm/schedulerFormContext';
 import { SchedulerModalCreateOrEdit } from './SchedulerModalCreateOrEdit';
 import SchedulerRunsHistoryModal from './SchedulerRunsHistoryModal';
 import SchedulersList from './SchedulersList';
@@ -59,6 +60,10 @@ const SchedulersModal: FC<
         >;
         /** If provided, opens directly in edit mode for this scheduler */
         initialSchedulerUuid?: string;
+        /** Opens directly in create mode (skips the list). */
+        defaultCreate?: boolean;
+        /** Create-mode only: pre-fills the new delivery. */
+        initialFormValues?: Partial<SchedulerFormValues>;
         searchQuery?: string;
         onSearchQueryChange?: (searchQuery: string | undefined) => void;
     }
@@ -75,11 +80,18 @@ const SchedulersModal: FC<
     availableParameters,
     onClose = () => {},
     initialSchedulerUuid,
+    defaultCreate = false,
+    initialFormValues,
     searchQuery,
     onSearchQueryChange,
 }) => {
     const [modalState, setModalState] = useState<States>(
-        initialSchedulerUuid ? States.EDIT : States.LIST,
+        // eslint-disable-next-line no-nested-ternary
+        initialSchedulerUuid
+            ? States.EDIT
+            : defaultCreate
+              ? States.CREATE
+              : States.LIST,
     );
     const [schedulerUuidToEdit, setSchedulerUuidToEdit] = useState<
         string | undefined
@@ -266,6 +278,9 @@ const SchedulersModal: FC<
                 resourceUuid={resourceUuid}
                 schedulerUuidToEdit={
                     modalState === States.EDIT ? schedulerUuidToEdit : undefined
+                }
+                initialFormValues={
+                    modalState === States.CREATE ? initialFormValues : undefined
                 }
                 createMutation={createMutation}
                 onClose={onClose}

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -1,4 +1,5 @@
 import {
+    getErrorMessage,
     getMetricsFromItemsMap,
     getTableCalculationsFromItemsMap,
     isNumericItem,
@@ -28,6 +29,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import DocumentationHelpButton from '../../../components/DocumentationHelpButton';
 import { useDashboardQuery } from '../../../hooks/dashboard/useDashboard';
+import useToaster from '../../../hooks/toaster/useToaster';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import useUser from '../../../hooks/user/useUser';
 import useTracking from '../../../providers/Tracking/useTracking';
@@ -85,6 +87,7 @@ const useSchedulerFormModal = ({
 }: UseSchedulerFormModalProps) => {
     const isEditMode = !!schedulerUuid;
     const queryClient = useQueryClient();
+    const { showToastError } = useToaster();
 
     // For edit mode - fetch existing scheduler
     const scheduler = useScheduler(schedulerUuid ?? '', {
@@ -93,7 +96,9 @@ const useSchedulerFormModal = ({
 
     const aiConfig = useAiSchedulerConfig(schedulerUuid);
     const sourceThreadUuid =
-        aiConfig.data?.sourceThreadUuid ??
+        (aiConfig.data?.type === 'agent'
+            ? aiConfig.data.sourceThreadUuid
+            : null) ??
         initialFormValues?.sourceThreadUuid ??
         null;
 
@@ -296,19 +301,30 @@ const useSchedulerFormModal = ({
                 : (await createMutation.mutateAsync({ resourceUuid, data }))
                       .schedulerUuid;
 
-            if (values.agentUuid) {
-                await upsertAiSchedulerConfig(savedSchedulerUuid, {
-                    agentUuid: values.agentUuid,
-                    prompt: values.prompt,
-                    sourceThreadUuid: values.includeSourceThread
-                        ? values.sourceThreadUuid
-                        : null,
-                    includeSourceThread: values.includeSourceThread,
-                    includeRunHistory: values.includeRunHistory,
+            // The scheduler itself saved (success toast already shown by the
+            // mutation); the AI-config save is separate, so surface its own
+            // failure instead of letting it reject silently.
+            try {
+                if (values.agentUuid) {
+                    await upsertAiSchedulerConfig(savedSchedulerUuid, {
+                        type: 'agent',
+                        agentUuid: values.agentUuid,
+                        prompt: values.prompt,
+                        sourceThreadUuid: values.includeSourceThread
+                            ? values.sourceThreadUuid
+                            : null,
+                        includeSourceThread: values.includeSourceThread,
+                        includeRunHistory: values.includeRunHistory,
+                    });
+                } else if (isEditMode) {
+                    // Cleared the agent → detach any existing config.
+                    await deleteAiSchedulerConfig(savedSchedulerUuid);
+                }
+            } catch (e) {
+                showToastError({
+                    title: 'Delivery saved, but its AI settings could not be saved',
+                    subtitle: getErrorMessage(e),
                 });
-            } else if (isEditMode) {
-                // Cleared the agent → detach any existing config.
-                await deleteAiSchedulerConfig(savedSchedulerUuid);
             }
             await queryClient.invalidateQueries([
                 AI_SCHEDULER_CONFIG_KEY,
@@ -321,6 +337,7 @@ const useSchedulerFormModal = ({
             createMutation,
             resourceUuid,
             formResource?.type,
+            showToastError,
             queryClient,
         ],
     );

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -96,7 +96,7 @@ const useSchedulerFormModal = ({
 
     const aiConfig = useAiSchedulerConfig(schedulerUuid);
     const sourceThreadUuid =
-        (aiConfig.data?.type === 'agent'
+        (aiConfig.data?.type === 'agentPrompt'
             ? aiConfig.data.sourceThreadUuid
             : null) ??
         initialFormValues?.sourceThreadUuid ??
@@ -307,7 +307,7 @@ const useSchedulerFormModal = ({
             try {
                 if (values.agentUuid) {
                     await upsertAiSchedulerConfig(savedSchedulerUuid, {
-                        type: 'agent',
+                        type: 'agentPrompt',
                         agentUuid: values.agentUuid,
                         prompt: values.prompt,
                         sourceThreadUuid: values.includeSourceThread

--- a/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModalCreateOrEdit.tsx
@@ -21,7 +21,7 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { IconBell, IconChevronLeft, IconSend } from '@tabler/icons-react';
-import { type UseMutationResult } from '@tanstack/react-query';
+import { useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, type FC } from 'react';
 import ErrorState from '../../../components/common/ErrorState';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -33,6 +33,12 @@ import useUser from '../../../hooks/user/useUser';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { isInvalidCronExpression } from '../../../utils/fieldValidators';
+import {
+    AI_SCHEDULER_CONFIG_KEY,
+    deleteAiSchedulerConfig,
+    upsertAiSchedulerConfig,
+    useAiSchedulerConfig,
+} from '../hooks/useAiSchedulerConfig';
 import { useScheduler, useSendNowScheduler } from '../hooks/useScheduler';
 import { useSchedulersUpdateMutation } from '../hooks/useSchedulersUpdateMutation';
 import SchedulerForm from './SchedulerForm';
@@ -44,6 +50,7 @@ import {
     SchedulerFormProvider,
     transformFormValues,
     useSchedulerForm,
+    type SchedulerFormValues,
 } from './SchedulerForm/schedulerFormContext';
 import { Limit } from './types';
 
@@ -61,6 +68,7 @@ interface UseSchedulerFormModalProps {
     onBack: () => void;
     itemsMap?: ItemsMap;
     currentParameterValues?: ParametersValuesMap;
+    initialFormValues?: Partial<SchedulerFormValues>;
 }
 
 const useSchedulerFormModal = ({
@@ -73,13 +81,21 @@ const useSchedulerFormModal = ({
     onBack,
     itemsMap,
     currentParameterValues,
+    initialFormValues,
 }: UseSchedulerFormModalProps) => {
     const isEditMode = !!schedulerUuid;
+    const queryClient = useQueryClient();
 
     // For edit mode - fetch existing scheduler
     const scheduler = useScheduler(schedulerUuid ?? '', {
         enabled: isEditMode,
     });
+
+    const aiConfig = useAiSchedulerConfig(schedulerUuid);
+    const sourceThreadUuid =
+        aiConfig.data?.sourceThreadUuid ??
+        initialFormValues?.sourceThreadUuid ??
+        null;
 
     // For edit mode - update mutation
     const updateMutation = useSchedulersUpdateMutation(schedulerUuid ?? '');
@@ -142,14 +158,17 @@ const useSchedulerFormModal = ({
     const form = useSchedulerForm({
         initialValues:
             scheduler.data !== undefined
-                ? getFormValuesFromScheduler({
-                      ...scheduler.data,
-                      ...getSelectedTabsForDashboardScheduler(
-                          scheduler.data,
-                          isDashboardTabsAvailable,
-                          dashboard,
-                      ),
-                  })
+                ? getFormValuesFromScheduler(
+                      {
+                          ...scheduler.data,
+                          ...getSelectedTabsForDashboardScheduler(
+                              scheduler.data,
+                              isDashboardTabsAvailable,
+                              dashboard,
+                          ),
+                      },
+                      aiConfig.data,
+                  )
                 : isThresholdAlert
                   ? DEFAULT_VALUES_ALERT
                   : {
@@ -166,6 +185,7 @@ const useSchedulerFormModal = ({
                             Object.keys(dashboardParameterValues).length > 0
                                 ? dashboardParameterValues
                                 : undefined,
+                        ...initialFormValues,
                     },
         validateInputOnBlur: ['options.customLimit'],
 
@@ -233,20 +253,23 @@ const useSchedulerFormModal = ({
     useEffect(() => {
         if (scheduler.data) {
             form.setValues(
-                getFormValuesFromScheduler({
-                    ...scheduler.data,
-                    ...getSelectedTabsForDashboardScheduler(
-                        scheduler.data,
-                        isDashboardTabsAvailable,
-                        dashboard,
-                    ),
-                }),
+                getFormValuesFromScheduler(
+                    {
+                        ...scheduler.data,
+                        ...getSelectedTabsForDashboardScheduler(
+                            scheduler.data,
+                            isDashboardTabsAvailable,
+                            dashboard,
+                        ),
+                    },
+                    aiConfig.data,
+                ),
             );
             form.resetDirty();
         }
         // We only want to sync when the data actually arrives or dashboard changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [scheduler.data, isDashboardTabsAvailable, dashboard]);
+    }, [scheduler.data, aiConfig.data, isDashboardTabsAvailable, dashboard]);
 
     // Handle mutation success
     useEffect(() => {
@@ -263,15 +286,34 @@ const useSchedulerFormModal = ({
         }
     }, [isEditMode, createMutation, onBack]);
 
-    // Submit handler
+    // Scheduler save + AI-config save chained behind one action (uuid is only
+    // known after a create).
     const handleSubmit = useCallback(
-        (values: typeof form.values) => {
+        async (values: typeof form.values) => {
             const data = transformFormValues(values, formResource?.type);
-            if (isEditMode) {
-                updateMutation.mutate(data);
-            } else {
-                createMutation.mutate({ resourceUuid, data });
+            const savedSchedulerUuid = isEditMode
+                ? (await updateMutation.mutateAsync(data)).schedulerUuid
+                : (await createMutation.mutateAsync({ resourceUuid, data }))
+                      .schedulerUuid;
+
+            if (values.agentUuid) {
+                await upsertAiSchedulerConfig(savedSchedulerUuid, {
+                    agentUuid: values.agentUuid,
+                    prompt: values.prompt,
+                    sourceThreadUuid: values.includeSourceThread
+                        ? values.sourceThreadUuid
+                        : null,
+                    includeSourceThread: values.includeSourceThread,
+                    includeRunHistory: values.includeRunHistory,
+                });
+            } else if (isEditMode) {
+                // Cleared the agent → detach any existing config.
+                await deleteAiSchedulerConfig(savedSchedulerUuid);
             }
+            await queryClient.invalidateQueries([
+                AI_SCHEDULER_CONFIG_KEY,
+                savedSchedulerUuid,
+            ]);
         },
         [
             isEditMode,
@@ -279,6 +321,7 @@ const useSchedulerFormModal = ({
             createMutation,
             resourceUuid,
             formResource?.type,
+            queryClient,
         ],
     );
 
@@ -381,6 +424,7 @@ const useSchedulerFormModal = ({
         numericMetrics,
         isDashboardTabsAvailable,
         requiredFiltersWithoutValues,
+        sourceThreadUuid,
     };
 };
 
@@ -401,6 +445,8 @@ interface Props {
     availableParameters?: ParameterDefinitions;
     /** undefined = create mode, string = edit mode */
     schedulerUuidToEdit: string | undefined;
+    /** Create-mode only: pre-fills the new delivery. */
+    initialFormValues?: Partial<SchedulerFormValues>;
 }
 
 export const SchedulerModalCreateOrEdit: FC<Props> = ({
@@ -415,6 +461,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
     availableParameters,
     onClose,
     onBack,
+    initialFormValues,
 }) => {
     // URL param handling is done in SchedulerModal parent component
     const schedulerUuid = schedulerUuidToEdit;
@@ -436,6 +483,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         numericMetrics,
         isDashboardTabsAvailable,
         requiredFiltersWithoutValues,
+        sourceThreadUuid,
     } = useSchedulerFormModal({
         schedulerUuid,
         resourceUuid,
@@ -446,6 +494,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
         onBack,
         itemsMap,
         currentParameterValues,
+        initialFormValues,
     });
 
     return (
@@ -585,6 +634,7 @@ export const SchedulerModalCreateOrEdit: FC<Props> = ({
                                 isDashboardTabsAvailable={
                                     isDashboardTabsAvailable
                                 }
+                                sourceThreadUuid={sourceThreadUuid}
                             />
                         </>
                     )}

--- a/packages/frontend/src/features/scheduler/hooks/useAiSchedulerConfig.ts
+++ b/packages/frontend/src/features/scheduler/hooks/useAiSchedulerConfig.ts
@@ -1,0 +1,44 @@
+import {
+    type AiSchedulerConfig,
+    type ApiAiSchedulerConfigResponse,
+    type ApiError,
+    type ApiSuccessEmpty,
+    type UpsertAiSchedulerConfig,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+const AI_CONFIG_KEY = 'ai_scheduler_config';
+
+const getAiSchedulerConfig = (schedulerUuid: string) =>
+    lightdashApi<ApiAiSchedulerConfigResponse['results']>({
+        url: `/schedulers/${schedulerUuid}/ai-config`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const useAiSchedulerConfig = (schedulerUuid: string | undefined) =>
+    useQuery<AiSchedulerConfig | null, ApiError>({
+        queryKey: [AI_CONFIG_KEY, schedulerUuid],
+        queryFn: () => getAiSchedulerConfig(schedulerUuid!),
+        enabled: !!schedulerUuid,
+    });
+
+export const AI_SCHEDULER_CONFIG_KEY = AI_CONFIG_KEY;
+
+export const upsertAiSchedulerConfig = (
+    schedulerUuid: string,
+    data: UpsertAiSchedulerConfig,
+) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/schedulers/${schedulerUuid}/ai-config`,
+        method: 'PUT',
+        body: JSON.stringify(data),
+    });
+
+export const deleteAiSchedulerConfig = (schedulerUuid: string) =>
+    lightdashApi<ApiSuccessEmpty['results']>({
+        url: `/schedulers/${schedulerUuid}/ai-config`,
+        method: 'DELETE',
+        body: undefined,
+    });


### PR DESCRIPTION
### Description

Adds an optional AI layer to scheduled deliveries. A delivery's AI config lives in a 1:1 EE-only `ai_scheduler` satellite table keyed by `scheduler_uuid`, so the OSS scheduler table, model, and types stay AI-free and every reference is a real DB-enforced foreign key.

**The config is a discriminated union on `type`:**

- **`agentPrompt`** — runs the prompt through a defined AI agent, which pulls in the delivery's chart/dashboard (and optionally a source conversation) as context. Supports "build on previous deliveries" by reusing a persistent agent thread across runs (`report_thread_uuid`).
- **`savedContent`** — runs the prompt against a fast model directly over the delivery's saved chart/dashboard, no agent. Groundwork for agentless scheduled prompts (no UI yet).

`agent_uuid` is nullable, gated by a CHECK so `type = 'agentPrompt'` ⇔ `agent_uuid IS NOT NULL`. Deleting an agent cascades its config away; a deleted source/report thread is nulled.

### Backend

- `ai_scheduler` table (single migration) + EE entity/model
- `AiSchedulerService` joins the read-only OSS scheduler with its config and runs either the agent or the fast model; `GET/PUT/DELETE /schedulers/{uuid}/ai-config`, authorised by manage-scheduler (+ use-agent for `agentPrompt` configs)
- the scheduler worker runs the report through an overridable OSS hook (no-op in OSS), implemented in the EE `CommercialSchedulerWorker`
- the report is generated **once** in `handleScheduledDelivery` and reused as the message for **every** channel (Slack, email, Teams, Google Chat), and is **best-effort** — a failure logs and falls back to the configured message instead of aborting the delivery

### Frontend

- AI section inline in the scheduler form (create + edit); one save persists the scheduler (OSS) and the AI config (EE) behind a single action, with the AI-config save surfacing its own errors
- "Schedule delivery" entry from an AI conversation, pre-filled with the agent and source thread