### PR TITLE
demo: simulate a breaking migration (PROD-8359 preview validation — do not merge)

### DIFF
--- a/packages/backend/src/database/migrations/20260629000000_demo_drop_legacy_dashboard_column.ts
+++ b/packages/backend/src/database/migrations/20260629000000_demo_drop_legacy_dashboard_column.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+// DEMO MIGRATION (PROD-8359 preview validation) — do not merge.
+// Drops a column in up(), which is breaking for the previous release's pods
+// during a rolling update: they keep reading the column until the rollout
+// finishes. The release-safety SQL-shape linter should flag this deterministically.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('dashboards', (table) => {
+        table.dropColumn('legacy_layout_config');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('dashboards', (table) => {
+        table.jsonb('legacy_layout_config').nullable();
+    });
+}


### PR DESCRIPTION
Validation PR for the release-safety PR preview (PROD-8359). Adds a migration that drops a column in `up()` — deterministically breaking for a rolling update — to confirm the preview comment surfaces the determination, the check matrix, and the customer-deploy impact on a real PR.

**Do not merge** — this will be closed once the preview comment is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)