### PR TITLE
test(warehouses): migrate from jest to vitest

### DIFF
--- a/packages/warehouses/jest.config.js
+++ b/packages/warehouses/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    preset: 'ts-jest',
-    testEnvironment: 'node',
-    automock: false,
-    testPathIgnorePatterns: ['/node_modules/', '/dist/'],
-    maxWorkers: '50%',
-};

--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -19,7 +19,7 @@
     "fix-lint": "pnpm run linter ./src --fix",
     "format": "oxfmt ./src --check",
     "fix-format": "oxfmt ./src",
-    "test": "jest",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "typecheck:fast": "tsgo --project tsconfig.fast.json --noEmit",
     "copy-files": "copyfiles -u 1 src/warehouseClients/ca-bundle-aws-redshift.crt src/warehouseClients/ca-bundle-aws-rds-global.pem dist/",
@@ -55,6 +55,7 @@
     "@types/ssh2": "1.11.15",
     "@typescript/native-preview": "7.0.0-dev.20260527.2",
     "copyfiles": "2.4.1",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "4.1.6"
   }
 }

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-arrow-callback, func-names */
 import {
     AthenaAuthenticationType,
     CreateAthenaCredentials,
@@ -7,15 +8,21 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 
-const mockAthenaClient = jest.fn();
-jest.mock('@aws-sdk/client-athena', () => ({
-    ...jest.requireActual('@aws-sdk/client-athena'),
+const { mockAthenaClient } = vi.hoisted(() => ({
+    mockAthenaClient: vi.fn(),
+}));
+vi.mock('@aws-sdk/client-athena', async () => ({
+    ...(await vi.importActual<typeof import('@aws-sdk/client-athena')>(
+        '@aws-sdk/client-athena',
+    )),
     AthenaClient: mockAthenaClient,
 }));
 
-const mockFromTemporaryCredentials = jest.fn(() => 'sts-credentials');
+const { mockFromTemporaryCredentials } = vi.hoisted(() => ({
+    mockFromTemporaryCredentials: vi.fn(() => 'sts-credentials'),
+}));
 
-jest.mock('@aws-sdk/credential-providers', () => ({
+vi.mock('@aws-sdk/credential-providers', () => ({
     fromTemporaryCredentials: mockFromTemporaryCredentials,
 }));
 
@@ -51,8 +58,10 @@ describe('convertDataTypeToDimensionType', () => {
 
 describe('AthenaWarehouseClient', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
-        mockAthenaClient.mockImplementation(() => ({}));
+        vi.clearAllMocks();
+        mockAthenaClient.mockImplementation(function () {
+            return {};
+        });
     });
 
     describe('authentication', () => {
@@ -206,9 +215,9 @@ describe('AthenaWarehouseClient', () => {
         };
 
         const setMockSendToReject = (error: Error) => {
-            mockAthenaClient.mockImplementation(() => ({
-                send: jest.fn().mockRejectedValue(error),
-            }));
+            mockAthenaClient.mockImplementation(function () {
+                return { send: vi.fn().mockRejectedValue(error) };
+            });
         };
 
         test('translates UnrecognizedClientException into WarehouseConnectionError with hint', async () => {

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.mock.ts
@@ -57,7 +57,7 @@ const metadata = {
 export const getTableResponse = {
     id: 'myTable',
     bigQuery: { projectId: 'myDatabase' },
-    getMetadata: jest.fn(() => [metadata]),
+    getMetadata: vi.fn(() => [metadata]),
 };
 
 export const rows: Record<string, AnyType>[] = [
@@ -83,7 +83,7 @@ const mockStreamRow = () =>
 
 export const createJobResponse = [
     {
-        getQueryResults: jest.fn(() => [rows, undefined, metadata]),
-        getQueryResultsStream: jest.fn(mockStreamRow),
+        getQueryResults: vi.fn(() => [rows, undefined, metadata]),
+        getQueryResultsStream: vi.fn(mockStreamRow),
     },
 ];

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -1,4 +1,5 @@
 import { Dataset } from '@google-cloud/bigquery';
+import type { Mock, MockInstance } from 'vitest';
 import {
     BigquerySqlBuilder,
     BigqueryWarehouseClient,
@@ -19,7 +20,7 @@ describe('BigqueryWarehouseClient', () => {
     it('expect query rows with mapped values', async () => {
         const warehouse = new BigqueryWarehouseClient(credentials);
 
-        (warehouse.client.createQueryJob as jest.Mock) = jest.fn(
+        (warehouse.client.createQueryJob as Mock) = vi.fn(
             () => createJobResponse,
         );
 
@@ -27,12 +28,12 @@ describe('BigqueryWarehouseClient', () => {
 
         expect(results.fields).toEqual(expectedFields);
         expect(results.rows[0]).toEqual(expectedRow);
-        expect(
-            warehouse.client.createQueryJob as jest.Mock,
-        ).toHaveBeenCalledTimes(1);
+        expect(warehouse.client.createQueryJob as Mock).toHaveBeenCalledTimes(
+            1,
+        );
     });
     it('expect schema with bigquery types mapped to dimension types', async () => {
-        const getTableMock = jest
+        const getTableMock = vi
             .fn()
             .mockImplementationOnce(() => getTableResponse);
         Dataset.prototype.table = getTableMock;
@@ -46,10 +47,10 @@ describe('BigqueryWarehouseClient', () => {
 });
 
 describe('BigqueryWarehouseClient.sanitizeLabelsWithValues', () => {
-    let warnSpy: jest.SpyInstance;
+    let warnSpy: MockInstance;
 
     beforeEach(() => {
-        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
     afterEach(() => {

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-arrow-callback, func-names */
 import {
     DatabricksSqlBuilder,
     DatabricksWarehouseClient,
@@ -5,22 +6,26 @@ import {
 import { credentials, rows, schema } from './DatabricksWarehouseClient.mock';
 import { expectedFields } from './WarehouseClient.mock';
 
-jest.mock('@databricks/sql', () => ({
-    ...jest.requireActual('@databricks/sql'),
-    DBSQLClient: jest.fn(() => ({
-        connect: jest.fn(() => ({
-            openSession: jest.fn(() => ({
-                executeStatement: jest.fn(() => ({
-                    getSchema: jest.fn(async () => schema),
-                    fetchChunk: jest.fn(async () => rows),
-                    hasMoreRows: jest.fn(async () => false),
-                    close: jest.fn(async () => undefined),
+vi.mock('@databricks/sql', async () => ({
+    ...(await vi.importActual<typeof import('@databricks/sql')>(
+        '@databricks/sql',
+    )),
+    DBSQLClient: vi.fn(function () {
+        return {
+            connect: vi.fn(() => ({
+                openSession: vi.fn(() => ({
+                    executeStatement: vi.fn(() => ({
+                        getSchema: vi.fn(async () => schema),
+                        fetchChunk: vi.fn(async () => rows),
+                        hasMoreRows: vi.fn(async () => false),
+                        close: vi.fn(async () => undefined),
+                    })),
+                    close: vi.fn(async () => undefined),
                 })),
-                close: jest.fn(async () => undefined),
+                close: vi.fn(async () => undefined),
             })),
-            close: jest.fn(async () => undefined),
-        })),
-    })),
+        };
+    }),
 }));
 
 describe('DatabricksWarehouseClient', () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -8,12 +8,13 @@ import {
     WeekDay,
 } from '@lightdash/common';
 import fs from 'fs/promises';
+import type { Mock } from 'vitest';
 import {
     DuckdbWarehouseClient,
     mapFieldTypeFromTypeId,
 } from './DuckdbWarehouseClient';
 
-const createInstanceMock = jest.fn();
+const createInstanceMock = vi.fn();
 
 // Must provide DuckDBTypeId since mapFieldTypeFromTypeId references it at runtime
 const DUCKDB_TYPE_IDS = {
@@ -44,39 +45,35 @@ const DUCKDB_TYPE_IDS = {
     BLOB: 18,
 } as const;
 
-jest.mock(
-    '@duckdb/node-api',
-    () => ({
-        DuckDBTypeId: {
-            BOOLEAN: 1,
-            TINYINT: 2,
-            SMALLINT: 3,
-            INTEGER: 4,
-            BIGINT: 5,
-            UTINYINT: 6,
-            USMALLINT: 7,
-            UINTEGER: 8,
-            UBIGINT: 9,
-            FLOAT: 10,
-            DOUBLE: 11,
-            TIMESTAMP: 12,
-            DATE: 13,
-            TIME: 14,
-            DECIMAL: 19,
-            HUGEINT: 25,
-            TIMESTAMP_S: 27,
-            TIMESTAMP_MS: 28,
-            TIMESTAMP_NS: 29,
-            TIMESTAMP_TZ: 31,
-            TIME_TZ: 32,
-            UHUGEINT: 49,
-        },
-        DuckDBInstance: {
-            create: (...args: unknown[]) => createInstanceMock(...args),
-        },
-    }),
-    { virtual: true },
-);
+vi.mock('@duckdb/node-api', () => ({
+    DuckDBTypeId: {
+        BOOLEAN: 1,
+        TINYINT: 2,
+        SMALLINT: 3,
+        INTEGER: 4,
+        BIGINT: 5,
+        UTINYINT: 6,
+        USMALLINT: 7,
+        UINTEGER: 8,
+        UBIGINT: 9,
+        FLOAT: 10,
+        DOUBLE: 11,
+        TIMESTAMP: 12,
+        DATE: 13,
+        TIME: 14,
+        DECIMAL: 19,
+        HUGEINT: 25,
+        TIMESTAMP_S: 27,
+        TIMESTAMP_MS: 28,
+        TIMESTAMP_NS: 29,
+        TIMESTAMP_TZ: 31,
+        TIME_TZ: 32,
+        UHUGEINT: 49,
+    },
+    DuckDBInstance: {
+        create: (...args: unknown[]) => createInstanceMock(...args),
+    },
+}));
 
 const getMockStreamResult = (
     chunks: Record<string, unknown>[][],
@@ -103,19 +100,19 @@ const createMockExtractStatements = (
         statementType: number;
     }>,
 ) =>
-    jest.fn(async () => ({
+    vi.fn(async () => ({
         count: overrides?.count ?? 1,
         prepare: async () => ({
             statementType: overrides?.statementType ?? 1, // SELECT
-            destroySync: jest.fn(),
+            destroySync: vi.fn(),
         }),
     }));
 
 const createMockConnection = (
-    streamMock: jest.Mock,
-    runMock: jest.Mock = jest.fn(),
+    streamMock: Mock,
+    runMock: Mock = vi.fn(),
     opts?: {
-        extractStatements?: jest.Mock;
+        extractStatements?: Mock;
     },
 ) => ({
     connect: async () => ({
@@ -123,10 +120,10 @@ const createMockConnection = (
         stream: streamMock,
         extractStatements:
             opts?.extractStatements ?? createMockExtractStatements(),
-        closeSync: jest.fn(),
-        disconnectSync: jest.fn(),
+        closeSync: vi.fn(),
+        disconnectSync: vi.fn(),
     }),
-    closeSync: jest.fn(),
+    closeSync: vi.fn(),
 });
 
 describe('mapFieldTypeFromTypeId', () => {
@@ -191,7 +188,7 @@ describe('mapFieldTypeFromTypeId', () => {
 
 describe('DuckdbWarehouseClient', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
         DuckdbWarehouseClient.resetSharedDuckdbStateForTesting();
     });
 
@@ -204,7 +201,7 @@ describe('DuckdbWarehouseClient', () => {
             },
         ];
 
-        const streamMock = jest.fn(async () =>
+        const streamMock = vi.fn(async () =>
             getMockStreamResult(
                 [rows],
                 [
@@ -240,14 +237,14 @@ describe('DuckdbWarehouseClient', () => {
         const chunk1 = [{ id: 1 }, { id: 2 }];
         const chunk2 = [{ id: 3 }];
 
-        const streamMock = jest.fn(async () =>
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([chunk1, chunk2], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
         createInstanceMock.mockResolvedValue(createMockConnection(streamMock));
 
         const client = DuckdbWarehouseClient.createForPreAggregate();
-        const streamCallback = jest.fn();
+        const streamCallback = vi.fn();
         const result = await client.executeAsyncQuery(
             {
                 sql: 'SELECT id FROM t',
@@ -267,7 +264,7 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should handle empty result set', async () => {
-        const streamMock = jest.fn(async () =>
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -281,8 +278,8 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should set timezone, S3 config, and shared resource limits before streaming', async () => {
-        const runMock = jest.fn();
-        const streamMock = jest.fn(async () =>
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -332,8 +329,8 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should use DuckDB credential chain for S3 config without static credentials', async () => {
-        const runMock = jest.fn();
-        const streamMock = jest.fn(async () =>
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -372,8 +369,8 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should use static DuckDB S3 credentials when configured', async () => {
-        const runMock = jest.fn();
-        const streamMock = jest.fn(async () =>
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -412,8 +409,8 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should treat instanceCacheKey as the shared instance identity', async () => {
-        const runMock = jest.fn();
-        const streamMock = jest.fn(async () =>
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -477,7 +474,7 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should log structured DuckDB profile metrics with query tags', async () => {
-        const runMock = jest.fn(async (sql: string) => {
+        const runMock = vi.fn(async (sql: string) => {
             const match = sql.match(/^PRAGMA profiling_output='(.+)';$/);
             if (match) {
                 await fs.writeFile(
@@ -499,10 +496,10 @@ describe('DuckdbWarehouseClient', () => {
                 );
             }
         });
-        const streamMock = jest.fn(async () =>
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
-        const logger = { info: jest.fn() };
+        const logger = { info: vi.fn() };
 
         createInstanceMock.mockResolvedValue(
             createMockConnection(streamMock, runMock),
@@ -538,7 +535,7 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should log raw profile timings when DuckDB reports cpu above latency', async () => {
-        const runMock = jest.fn(async (sql: string) => {
+        const runMock = vi.fn(async (sql: string) => {
             const match = sql.match(/^PRAGMA profiling_output='(.+)';$/);
             if (match) {
                 await fs.writeFile(
@@ -553,10 +550,10 @@ describe('DuckdbWarehouseClient', () => {
                 );
             }
         });
-        const streamMock = jest.fn(async () =>
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
-        const logger = { info: jest.fn() };
+        const logger = { info: vi.fn() };
 
         createInstanceMock.mockResolvedValue(
             createMockConnection(streamMock, runMock),
@@ -600,12 +597,12 @@ describe('DuckdbWarehouseClient', () => {
                 statementType: 4,
             },
         ])('should reject $name', async ({ sql, statementType }) => {
-            const streamMock = jest.fn(async () =>
+            const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
             );
 
             createInstanceMock.mockResolvedValue(
-                createMockConnection(streamMock, jest.fn(), {
+                createMockConnection(streamMock, vi.fn(), {
                     extractStatements: createMockExtractStatements({
                         statementType,
                     }),
@@ -620,12 +617,12 @@ describe('DuckdbWarehouseClient', () => {
         });
 
         it('should reject multiple statements', async () => {
-            const streamMock = jest.fn(async () =>
+            const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
             );
 
             createInstanceMock.mockResolvedValue(
-                createMockConnection(streamMock, jest.fn(), {
+                createMockConnection(streamMock, vi.fn(), {
                     extractStatements: createMockExtractStatements({
                         count: 2,
                     }),
@@ -643,7 +640,7 @@ describe('DuckdbWarehouseClient', () => {
         it.each(['current_setting', 'duckdb_settings', 'duckdb_secrets'])(
             'should reject queries with %s()',
             async (blockedFunction) => {
-                const streamMock = jest.fn(async () =>
+                const streamMock = vi.fn(async () =>
                     getMockStreamResult(
                         [[{ val: 1 }]],
                         [DUCKDB_TYPE_IDS.INTEGER],
@@ -664,7 +661,7 @@ describe('DuckdbWarehouseClient', () => {
         );
 
         it('should ignore blocked functions inside SQL comments', async () => {
-            const streamMock = jest.fn(async () =>
+            const streamMock = vi.fn(async () =>
                 getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
             );
 
@@ -681,8 +678,8 @@ describe('DuckdbWarehouseClient', () => {
         });
 
         it('should allow COPY statements in runSql', async () => {
-            const streamMock = jest.fn();
-            const runMock = jest.fn();
+            const streamMock = vi.fn();
+            const runMock = vi.fn();
 
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
@@ -718,8 +715,8 @@ describe('DuckdbWarehouseClient', () => {
                 statementType: 21,
             },
         ])('should reject $name in runSql', async ({ sql, statementType }) => {
-            const streamMock = jest.fn();
-            const runMock = jest.fn();
+            const streamMock = vi.fn();
+            const runMock = vi.fn();
 
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
@@ -737,8 +734,8 @@ describe('DuckdbWarehouseClient', () => {
         });
 
         it('should reject introspection functions in runSql', async () => {
-            const streamMock = jest.fn();
-            const runMock = jest.fn();
+            const streamMock = vi.fn();
+            const runMock = vi.fn();
 
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock),
@@ -758,7 +755,7 @@ describe('DuckdbWarehouseClient', () => {
         });
 
         it('should allow valid SELECT queries', async () => {
-            const streamMock = jest.fn(async () =>
+            const streamMock = vi.fn(async () =>
                 getMockStreamResult(
                     [[{ id: 1, name: 'test' }]],
                     [DUCKDB_TYPE_IDS.INTEGER, DUCKDB_TYPE_IDS.VARCHAR],
@@ -790,8 +787,8 @@ describe('DuckdbWarehouseClient', () => {
             expectedPath: 'md:my_database?motherduck_token=my_motherduck_token',
         },
     ])('should $name', async ({ credentials, expectedPath }) => {
-        const runMock = jest.fn();
-        const streamMock = jest.fn(async () =>
+        const runMock = vi.fn();
+        const streamMock = vi.fn(async () =>
             getMockStreamResult([[{ id: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
         );
 
@@ -847,7 +844,7 @@ describe('DuckdbWarehouseClient', () => {
     });
 
     it('should default getFields database to the configured DuckDB database', async () => {
-        const runMock = jest.fn(async () => ({
+        const runMock = vi.fn(async () => ({
             getRowObjects: async () => [
                 {
                     column_name: 'order_id',
@@ -861,7 +858,7 @@ describe('DuckdbWarehouseClient', () => {
         }));
 
         createInstanceMock.mockResolvedValue(
-            createMockConnection(jest.fn(), runMock),
+            createMockConnection(vi.fn(), runMock),
         );
 
         const client = new DuckdbWarehouseClient({
@@ -891,18 +888,16 @@ describe('DuckdbWarehouseClient', () => {
 
     describe('DuckLake bootstrap', () => {
         const captureRunMock = () =>
-            jest.fn().mockResolvedValue({
+            vi.fn().mockResolvedValue({
                 getRowObjects: async () => [],
             });
 
-        const collectStatements = (runMock: jest.Mock): string[] =>
+        const collectStatements = (runMock: Mock): string[] =>
             runMock.mock.calls.map((c) => c[0] as string);
 
         it('attaches a postgres-catalog + S3 DuckLake in the correct order', async () => {
             const runMock = captureRunMock();
-            const streamMock = jest.fn(async () =>
-                getMockStreamResult([[]], []),
-            );
+            const streamMock = vi.fn(async () => getMockStreamResult([[]], []));
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock),
             );
@@ -976,9 +971,7 @@ describe('DuckdbWarehouseClient', () => {
 
         it('uses inline ATTACH (no ducklake secret) for SQLite catalog + local data path', async () => {
             const runMock = captureRunMock();
-            const streamMock = jest.fn(async () =>
-                getMockStreamResult([[]], []),
-            );
+            const streamMock = vi.fn(async () => getMockStreamResult([[]], []));
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock),
             );
@@ -1015,14 +1008,12 @@ describe('DuckdbWarehouseClient', () => {
 
         it('rejects user SQL that contains ATTACH even in DuckLake mode', async () => {
             const runMock = captureRunMock();
-            const streamMock = jest.fn(async () =>
-                getMockStreamResult([[]], []),
-            );
-            const extractStatements = jest.fn(async () => ({
+            const streamMock = vi.fn(async () => getMockStreamResult([[]], []));
+            const extractStatements = vi.fn(async () => ({
                 count: 1,
                 prepare: async () => ({
                     statementType: 25, // ATTACH
-                    destroySync: jest.fn(),
+                    destroySync: vi.fn(),
                 }),
             }));
             createInstanceMock.mockResolvedValue(
@@ -1052,9 +1043,7 @@ describe('DuckdbWarehouseClient', () => {
 
         it('keeps autoload disabled for non-DuckLake modes', async () => {
             const runMock = captureRunMock();
-            const streamMock = jest.fn(async () =>
-                getMockStreamResult([[]], []),
-            );
+            const streamMock = vi.fn(async () => getMockStreamResult([[]], []));
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock),
             );

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -1,5 +1,7 @@
+/* eslint-disable prefer-arrow-callback, func-names */
 import * as pg from 'pg';
 import { PassThrough } from 'stream';
+import type { Mock } from 'vitest';
 import {
     PostgresSqlBuilder,
     PostgresWarehouseClient,
@@ -16,38 +18,43 @@ import {
     expectedWarehouseSchema,
 } from './WarehouseClient.mock';
 
-jest.mock('pg', () => ({
-    ...jest.requireActual('pg'),
-    Pool: jest.fn(() => ({
-        connect: jest.fn((callback) => {
-            callback(
-                null,
-                {
-                    query: jest.fn((arg: unknown) => {
-                        // Session statements (SET statement_timeout / timezone)
-                        // are issued as plain string queries and must return a
-                        // thenable, not a stream.
-                        if (typeof arg === 'string') {
-                            return Promise.resolve({ rows: [], fields: [] });
-                        }
-                        const mockedStream = new PassThrough();
-                        setTimeout(() => {
-                            mockedStream.emit('data', {
-                                row: expectedRow,
-                                fields: queryColumnsMock,
-                            });
-                            mockedStream.end();
-                        }, 100);
-                        return mockedStream;
-                    }),
-                    on: jest.fn(async () => undefined),
-                },
-                jest.fn(),
-            );
-        }),
-        end: jest.fn(async () => undefined),
-        on: jest.fn(async () => undefined),
-    })),
+vi.mock('pg', async () => ({
+    ...(await vi.importActual<{ default: typeof import('pg') }>('pg')).default,
+    Pool: vi.fn(function () {
+        return {
+            connect: vi.fn((callback) => {
+                callback(
+                    null,
+                    {
+                        query: vi.fn((arg: unknown) => {
+                            // Session statements (SET statement_timeout / timezone)
+                            // are issued as plain string queries and must return a
+                            // thenable, not a stream.
+                            if (typeof arg === 'string') {
+                                return Promise.resolve({
+                                    rows: [],
+                                    fields: [],
+                                });
+                            }
+                            const mockedStream = new PassThrough();
+                            setTimeout(() => {
+                                mockedStream.emit('data', {
+                                    row: expectedRow,
+                                    fields: queryColumnsMock,
+                                });
+                                mockedStream.end();
+                            }, 100);
+                            return mockedStream;
+                        }),
+                        on: vi.fn(async () => undefined),
+                    },
+                    vi.fn(),
+                );
+            }),
+            end: vi.fn(async () => undefined),
+            on: vi.fn(async () => undefined),
+        };
+    }),
 }));
 
 describe('PostgresWarehouseClient', () => {
@@ -59,69 +66,73 @@ describe('PostgresWarehouseClient', () => {
     });
     it('expect schema with postgres types mapped to dimension types', async () => {
         const warehouse = new PostgresWarehouseClient(credentials);
-        (pg.Pool as unknown as jest.Mock)
-            .mockImplementationOnce(() => ({
-                connect: jest.fn((callback) => {
-                    callback(
-                        null,
-                        {
-                            query: jest.fn((arg: unknown) => {
-                                if (typeof arg === 'string') {
-                                    return Promise.resolve({
-                                        rows: [],
-                                        fields: [],
-                                    });
-                                }
-                                const mockedStream = new PassThrough();
-                                setTimeout(() => {
-                                    mockedStream.emit('data', {
-                                        row: { version: 'PostgreSQL 15.4' },
-                                        fields: [],
-                                    });
-                                    mockedStream.end();
-                                }, 100);
-                                return mockedStream;
-                            }),
-                            on: jest.fn(async () => undefined),
-                        },
-                        jest.fn(),
-                    );
-                }),
-                end: jest.fn(async () => undefined),
-                on: jest.fn(async () => undefined),
-            }))
-            .mockImplementationOnce(() => ({
-                connect: jest.fn((callback) => {
-                    callback(
-                        null,
-                        {
-                            query: jest.fn((arg: unknown) => {
-                                if (typeof arg === 'string') {
-                                    return Promise.resolve({
-                                        rows: [],
-                                        fields: [],
-                                    });
-                                }
-                                const mockedStream = new PassThrough();
-                                setTimeout(() => {
-                                    columns.forEach((column) => {
-                                        mockedStream.emit('data', {
-                                            row: column,
+        (pg.Pool as unknown as Mock)
+            .mockImplementationOnce(function () {
+                return {
+                    connect: vi.fn((callback) => {
+                        callback(
+                            null,
+                            {
+                                query: vi.fn((arg: unknown) => {
+                                    if (typeof arg === 'string') {
+                                        return Promise.resolve({
+                                            rows: [],
                                             fields: [],
                                         });
-                                    });
-                                    mockedStream.end();
-                                }, 100);
-                                return mockedStream;
-                            }),
-                            on: jest.fn(async () => undefined),
-                        },
-                        jest.fn(),
-                    );
-                }),
-                end: jest.fn(async () => undefined),
-                on: jest.fn(async () => undefined),
-            }));
+                                    }
+                                    const mockedStream = new PassThrough();
+                                    setTimeout(() => {
+                                        mockedStream.emit('data', {
+                                            row: { version: 'PostgreSQL 15.4' },
+                                            fields: [],
+                                        });
+                                        mockedStream.end();
+                                    }, 100);
+                                    return mockedStream;
+                                }),
+                                on: vi.fn(async () => undefined),
+                            },
+                            vi.fn(),
+                        );
+                    }),
+                    end: vi.fn(async () => undefined),
+                    on: vi.fn(async () => undefined),
+                };
+            })
+            .mockImplementationOnce(function () {
+                return {
+                    connect: vi.fn((callback) => {
+                        callback(
+                            null,
+                            {
+                                query: vi.fn((arg: unknown) => {
+                                    if (typeof arg === 'string') {
+                                        return Promise.resolve({
+                                            rows: [],
+                                            fields: [],
+                                        });
+                                    }
+                                    const mockedStream = new PassThrough();
+                                    setTimeout(() => {
+                                        columns.forEach((column) => {
+                                            mockedStream.emit('data', {
+                                                row: column,
+                                                fields: [],
+                                            });
+                                        });
+                                        mockedStream.end();
+                                    }, 100);
+                                    return mockedStream;
+                                }),
+                                on: vi.fn(async () => undefined),
+                            },
+                            vi.fn(),
+                        );
+                    }),
+                    end: vi.fn(async () => undefined),
+                    on: vi.fn(async () => undefined),
+                };
+            });
         expect(await warehouse.getCatalog(config)).toEqual(
             expectedWarehouseSchema,
         );
@@ -133,18 +144,20 @@ describe('PostgresWarehouseClient', () => {
 });
 
 describe('PostgresWarehouseClient statement timeout', () => {
-    const mockPoolWithQuery = (queryMock: jest.Mock) => {
-        (pg.Pool as unknown as jest.Mock).mockImplementationOnce(() => ({
-            connect: jest.fn((callback) => {
-                callback(null, { query: queryMock, on: jest.fn() }, jest.fn());
-            }),
-            end: jest.fn(async () => undefined),
-            on: jest.fn(),
-        }));
+    const mockPoolWithQuery = (queryMock: Mock) => {
+        (pg.Pool as unknown as Mock).mockImplementationOnce(function () {
+            return {
+                connect: vi.fn((callback) => {
+                    callback(null, { query: queryMock, on: vi.fn() }, vi.fn());
+                }),
+                end: vi.fn(async () => undefined),
+                on: vi.fn(),
+            };
+        });
     };
 
     const respondingQueryMock = () =>
-        jest.fn((arg: unknown) => {
+        vi.fn((arg: unknown) => {
             if (typeof arg === 'string') {
                 return Promise.resolve({ rows: [], fields: [] });
             }
@@ -160,7 +173,7 @@ describe('PostgresWarehouseClient statement timeout', () => {
         });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it('sets a server-side statement_timeout using the 9-minute default ceiling', async () => {
@@ -189,8 +202,8 @@ describe('PostgresWarehouseClient statement timeout', () => {
     });
 
     it('rejects with a timeout error when a query stalls past the client backstop', async () => {
-        jest.useFakeTimers();
-        const queryMock = jest.fn((arg: unknown) => {
+        vi.useFakeTimers();
+        const queryMock = vi.fn((arg: unknown) => {
             if (typeof arg === 'string') {
                 return Promise.resolve({ rows: [], fields: [] });
             }
@@ -206,7 +219,7 @@ describe('PostgresWarehouseClient statement timeout', () => {
             'Query timed out after 570s',
         );
         // 9-minute statement_timeout + 30s client buffer = 570s
-        await jest.advanceTimersByTimeAsync(570 * 1000 + 1000);
+        await vi.advanceTimersByTimeAsync(570 * 1000 + 1000);
         await assertion;
     });
 });

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.test.ts
@@ -1,6 +1,7 @@
 import { CreateSnowflakeCredentials, DimensionType } from '@lightdash/common';
 import { createConnection } from 'snowflake-sdk';
 import { Readable } from 'stream';
+import type { Mock } from 'vitest';
 import {
     mapFieldType,
     SnowflakeWarehouseClient,
@@ -24,7 +25,7 @@ const mockStreamRows = () =>
         },
     });
 
-const executeMock = jest.fn(({ sqlText, complete }) => {
+const executeMock = vi.fn(({ sqlText, complete }) => {
     complete(
         undefined,
         {
@@ -37,22 +38,26 @@ const executeMock = jest.fn(({ sqlText, complete }) => {
     );
 });
 
-const getResultsFromQueryIdMock = jest.fn(({ sqlText, queryId }) => ({
+const getResultsFromQueryIdMock = vi.fn(({ sqlText, queryId }) => ({
     streamRows: mockStreamRows,
     getColumns: () => queryColumnsMock,
     getQueryId: () => queryId,
     getNumRows: () => 1,
 }));
 
-jest.mock('snowflake-sdk', () => ({
-    ...jest.requireActual('snowflake-sdk'),
-    createConnection: jest.fn(() => ({
-        connect: jest.fn((callback) => callback(null, {})),
+vi.mock('snowflake-sdk', async () => ({
+    ...(
+        await vi.importActual<{ default: typeof import('snowflake-sdk') }>(
+            'snowflake-sdk',
+        )
+    ).default,
+    createConnection: vi.fn(() => ({
+        connect: vi.fn((callback) => callback(null, {})),
         execute: executeMock,
-        destroy: jest.fn((callback) => callback(null, {})),
+        destroy: vi.fn((callback) => callback(null, {})),
         getResultsFromQueryId: getResultsFromQueryIdMock,
-        getQueryStatus: jest.fn(() => 'SUCCESS'),
-        isStillRunning: jest.fn(() => false),
+        getQueryStatus: vi.fn(() => 'SUCCESS'),
+        isStillRunning: vi.fn(() => false),
     })),
 }));
 
@@ -65,16 +70,16 @@ describe('SnowflakeWarehouseClient', () => {
         expect(results.rows[0]).toEqual(expectedRow);
     });
     it('expect schema with snowflake types mapped to dimension types', async () => {
-        (createConnection as jest.Mock).mockImplementationOnce(() => ({
-            connect: jest.fn((callback) => callback(null, {})),
-            execute: jest.fn(({ sqlText, complete }) => {
+        (createConnection as Mock).mockImplementationOnce(() => ({
+            connect: vi.fn((callback) => callback(null, {})),
+            execute: vi.fn(({ sqlText, complete }) => {
                 complete(
                     undefined,
                     { getColumns: () => queryColumnsMock },
                     columns,
                 );
             }),
-            destroy: jest.fn((callback) => callback(null, {})),
+            destroy: vi.fn((callback) => callback(null, {})),
         }));
         const warehouse = new SnowflakeWarehouseClient(credentials);
         expect(await warehouse.getCatalog(config)).toEqual(

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -9,12 +9,12 @@ import {
 } from './TrinoWarehouseClient.mock';
 import * as wharehouseClient from './WarehouseClient.mock';
 
-const queryResultMock = jest.fn();
+const queryResultMock = vi.fn();
 
-jest.mock('trino-client', () => ({
-    BasicAuth: jest.fn(),
+vi.mock('trino-client', () => ({
+    BasicAuth: vi.fn(),
     Trino: {
-        create: jest.fn(() =>
+        create: vi.fn(() =>
             Promise.resolve({
                 query: queryResultMock,
             }),
@@ -38,7 +38,7 @@ describe('TrinoWarehouseClient', () => {
     it('expect query rows', async () => {
         const warehouse = new TrinoWarehouseClient(credentials);
         queryResultMock.mockReturnValue({
-            next: jest
+            next: vi
                 .fn()
                 .mockResolvedValue({ done: true, value: queryResponse }),
         });
@@ -50,7 +50,7 @@ describe('TrinoWarehouseClient', () => {
     it('expect query has mutiple result chunks', async () => {
         const warehouse = new TrinoWarehouseClient(credentials);
         queryResultMock.mockReturnValue({
-            next: jest
+            next: vi
                 .fn()
                 // First chunk: has nextUri indicating more data available
                 .mockResolvedValueOnce({
@@ -69,7 +69,7 @@ describe('TrinoWarehouseClient', () => {
     it('expect schema with trino types mapped to dimension types', async () => {
         const warehouse = new TrinoWarehouseClient(credentials);
         queryResultMock.mockReturnValue({
-            next: jest
+            next: vi
                 .fn()
                 .mockResolvedValue({ done: true, value: querySchemaResponse }),
         });

--- a/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
+++ b/packages/warehouses/src/warehouseClients/redshiftIamCredentials.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-arrow-callback, func-names */
 import {
     CreateRedshiftCredentials,
     RedshiftAuthenticationType,
@@ -5,27 +6,31 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 
-const mockClusterSend = jest.fn();
-const mockServerlessSend = jest.fn();
+const mockClusterSend = vi.fn();
+const mockServerlessSend = vi.fn();
 
-jest.mock('@aws-sdk/client-redshift', () => ({
-    RedshiftClient: jest.fn(() => ({ send: mockClusterSend })),
-    GetClusterCredentialsCommand: jest.fn((input: unknown) => ({
-        __command: 'cluster',
-        input,
-    })),
+vi.mock('@aws-sdk/client-redshift', () => ({
+    RedshiftClient: vi.fn(function () {
+        return { send: mockClusterSend };
+    }),
+    GetClusterCredentialsCommand: vi.fn(function (input: unknown) {
+        return { __command: 'cluster', input };
+    }),
 }));
 
-jest.mock('@aws-sdk/client-redshift-serverless', () => ({
-    RedshiftServerlessClient: jest.fn(() => ({ send: mockServerlessSend })),
-    GetCredentialsCommand: jest.fn((input: unknown) => ({
-        __command: 'serverless',
-        input,
-    })),
+vi.mock('@aws-sdk/client-redshift-serverless', () => ({
+    RedshiftServerlessClient: vi.fn(function () {
+        return { send: mockServerlessSend };
+    }),
+    GetCredentialsCommand: vi.fn(function (input: unknown) {
+        return { __command: 'serverless', input };
+    }),
 }));
 
-const mockFromTemporaryCredentials = jest.fn(() => 'sts-credentials');
-jest.mock('@aws-sdk/credential-providers', () => ({
+const { mockFromTemporaryCredentials } = vi.hoisted(() => ({
+    mockFromTemporaryCredentials: vi.fn(() => 'sts-credentials'),
+}));
+vi.mock('@aws-sdk/credential-providers', () => ({
     fromTemporaryCredentials: mockFromTemporaryCredentials,
 }));
 
@@ -66,7 +71,7 @@ const serverlessCredentials: CreateRedshiftCredentials = {
 
 describe('getRedshiftAwsCredentials', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
     });
 
     test('returns static credentials when access keys are provided', () => {
@@ -125,7 +130,7 @@ describe('getRedshiftAwsCredentials', () => {
 
 describe('mintRedshiftIamCredentials', () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
     });
 
     test('mints credentials for a provisioned cluster', async () => {

--- a/packages/warehouses/tsconfig.json
+++ b/packages/warehouses/tsconfig.json
@@ -14,7 +14,7 @@
         "moduleResolution": "node10",
         "resolveJsonModule": true,
         "skipLibCheck": true,
-        "types": ["node", "jest"]
+        "types": ["node", "vitest/globals"]
     },
     "include": ["src/**/*.ts", "src/**/*.json"],
     "references": [

--- a/packages/warehouses/vitest.config.ts
+++ b/packages/warehouses/vitest.config.ts
@@ -1,0 +1,19 @@
+import * as path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        name: 'warehouses-unit-tests',
+        include: ['src/**/*.test.ts'],
+        exclude: ['**/node_modules/**', '**/dist/**'],
+        environment: 'node',
+        globals: true,
+        env: { TZ: 'UTC', LANG: 'en_US.UTF-8', NODE_ENV: 'test' },
+        maxWorkers: '50%',
+    },
+    resolve: {
+        alias: {
+            '@lightdash/common': path.resolve(__dirname, '../common/src'),
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1806,6 +1806,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.3.1)(jsdom@26.1.0(canvas@3.2.1))(vite@7.3.5(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.3))
 
 packages:
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->


## Jest → Vitest (before → after)

Migrates `@lightdash/warehouses` off Jest — the heaviest package (109 `jest.fn`, 4 `requireActual`).

| | Before (Jest) | After (Vitest) |
|---|---|---|
| Test files | 11 | 11 |
| Tests | 173 passing | **173 passing** |
| CI `warehouses:test` | 38.8s | _see CI_ |
| Local wall time | — | **~2.9s** |

Notable: `jest.requireActual` → async `vi.importActual` (pg, snowflake-sdk, databricks, athena — CJS modules need `.default` spread); constructor mocks rewritten as `function`/`class` (Vitest requires constructable mocks); `vi.hoisted()` for factory-referenced vars; dropped Jest-only `{ virtual: true }`.
