### PR TITLE
demo: simulate an additive migration (PROD-8359 AI-review validation — do not merge)

### DIFF
--- a/packages/backend/src/database/migrations/20260629010000_demo_add_dashboard_preview_url.ts
+++ b/packages/backend/src/database/migrations/20260629010000_demo_add_dashboard_preview_url.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+// DEMO MIGRATION (PROD-8359 preview validation) — do not merge.
+// Adds a NULLABLE column to an existing table. This is additive: the previous
+// release's pods can keep inserting/reading rows without it during a rolling
+// update. The SQL linter stays clean, so the AI migration review runs and should
+// verify the old code doesn't depend on the new column and clear it to safe.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('dashboards', (table) => {
+        table.text('preview_image_url').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('dashboards', (table) => {
+        table.dropColumn('preview_image_url');
+    });
+}


### PR DESCRIPTION
Validation PR for the release-safety AI migration review (PROD-8359). Adds a **nullable** column — additive, so the SQL linter stays clean and the AI migration review runs on this ready PR and should verify the previous release's code doesn't depend on the new column.

**Do not merge** — closed once the preview comment is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)