### PR TITLE
ci: let the AI review override the SQL linter via expand/contract (PROD-8359)

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -85,9 +85,9 @@ jobs:
           # nothing is published.
           RELEASE_SAFETY_MARKER_ENABLED: 'true'
           # The AI migration review runs on READY PRs only (a real "about to merge"
-          # signal), never on drafts (still churning — not worth the spend). It's
-          # still gated downstream to migration-bearing PRs where the deterministic
-          # linter didn't already decide, and degrades to "unknown" without a key
+          # signal), never on drafts (still churning — not worth the spend). It runs
+          # on ALL migration-bearing PRs (even ones the linter flagged) so it can
+          # clear an expand/contract drop, and degrades to "unknown" without a key
           # (e.g. fork PRs, which don't comment anyway).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
@@ -109,12 +109,23 @@ jobs:
             --out /tmp/release-safety.json \
             ${AI_FLAG}
 
+      - name: Capture raw SQL-linter verdict (for expand/contract attribution)
+        id: lint
+        run: |
+          set -euo pipefail
+          if tsx scripts/sql-migration-lint.ts --last-tag "${{ steps.base.outputs.sha }}" | grep -q '"breaking": true'; then
+            echo "breaking=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Render PR comment
         run: |
           tsx scripts/release-safety-pr-comment.ts \
             --marker /tmp/release-safety.json \
             --base "${{ github.event.pull_request.base.ref }} (${{ steps.base.outputs.short }})" \
             ${{ steps.marker.outputs.draft == 'true' && '--draft' || '' }} \
+            ${{ steps.lint.outputs.breaking == 'true' && '--linter-breaking' || '--no-linter-breaking' }} \
             --out /tmp/release-safety-comment.md
 
       - name: Post or update sticky comment

--- a/scripts/ai-migration-review.ts
+++ b/scripts/ai-migration-review.ts
@@ -143,12 +143,15 @@ During a Kubernetes rolling update the migration runs FIRST, then the new app ro
 
 You have read-only tools (grep_old_code, read_old_file) that read the PREVIOUS release's source. USE THEM: for each migration, identify the schema objects it changes (tables, columns, constraints, indexes) and grep the old code to see whether/how they're read or written. Backward-compatibility you can only guess from the migration text is "needs-review"; backward-compatibility you have verified against the old code can be "additive-safe" or "breaking".
 
+A destructive operation shape is NOT automatically breaking. Under the expand/contract (parallel change) pattern a drop or rename is split across releases: an earlier release stops using the object ("expand"), and a later release removes it ("contract"). The contract step is SAFE precisely because the previous release's code no longer touches the object. Your job is to read the old code and tell which case this is — a deterministic shape-only linter cannot, which is why you exist.
+
 Classification rules:
 - additive-safe: nullable column, column with default, new table, index created CONCURRENTLY, new enum value — AND nothing in the old code path breaks.
-- breaking: NOT NULL without default, drop/rename column or table, type narrowing, a CHECK/FOREIGN KEY that could reject rows the old code still writes, a non-concurrent index on a large/hot table, a data backfill that rewrites values the old code depends on.
+- additive-safe via expand/contract: a drop or rename of a column/table/constraint is safe IF you VERIFY with grep_old_code that the PREVIOUS release's code has ZERO references to it (the "expand" already shipped, this is the "contract"). You MUST run the grep and see no reads/writes; a guess is needs-review, never safe.
+- breaking: NOT NULL without default; a drop/rename of an object the old code STILL references (grep found reads/writes); type narrowing; a CHECK/FOREIGN KEY that could reject rows the old code still writes; a non-concurrent index on a large/hot table; a data backfill that rewrites values the old code depends on.
 - needs-review: you could not verify the old-code behaviour the safety depends on.
 
-Be conservative: overall verdict is "safe" with confidence "high" ONLY when EVERY migration is additive-safe (verified). Any breaking → verdict "breaking". Any unresolved needs-review → verdict at most "unknown".
+Be conservative: overall verdict is "safe" with confidence "high" ONLY when EVERY migration is additive-safe (verified, including any expand/contract drop confirmed unreferenced). Any breaking → verdict "breaking". Any unresolved needs-review → verdict at most "unknown".
 
 When you have finished investigating, reply with ONE JSON object and NOTHING else, matching:
 ${SCHEMA_DOC}`;

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -309,16 +309,43 @@ test('sqlLint breaking sets rollingUpdateSafe false + adds "sql-lint" capability
     assert.ok(/Migration linter detected breaking/.test(m.compatibility.notes));
 });
 
-test('sqlLint breaking is AUTHORITATIVE over an AI "safe" verdict', () => {
+test('high-confidence AI "safe" OVERRIDES a linter flag (expand/contract clearance)', () => {
     const m = buildMarker({
         ...base,
         migrations: migPresent,
         sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
-        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'looks additive' },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'old code has zero refs to the dropped column.' },
     });
-    // linter wins: stays false, AI is NOT applied, ai-review capability NOT claimed
+    // AI wins: the drop is the contract step of an expand/contract → safe
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(m.compatibility.recommendedStrategy, 'RollingUpdate');
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review']);
+    assert.ok(/CLEARED a deterministic linter flag/.test(m.compatibility.notes));
+    assert.ok(/expand\/contract/.test(m.compatibility.notes));
+});
+
+test('AI "breaking" confirms a linter flag → stays false', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
+        aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'old code still reads the column.' },
+    });
     assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
-    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint']);
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review']);
+});
+
+test('inconclusive AI ("unknown") does NOT downgrade a linter flag — floor holds at false', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
+        aiReview: { rollingUpdateSafe: 'unknown', recommendedStrategy: 'Recreate', summary: 'could not verify.' },
+    });
+    // AI ran (capability claimed) but stayed unknown → linter floor of false is kept
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review']);
+    assert.ok(/Migration linter detected breaking/.test(m.compatibility.notes));
 });
 
 test('sqlLint clean leaves verdict unknown and claims the capability', () => {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -224,13 +224,15 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
 
     const capabilities = ['migrations'];
 
-    // Deterministic SQL-shape linter — the non-LLM floor. Runs only for a
-    // migration-bearing release. A "breaking" finding is AUTHORITATIVE: it sets
-    // rollingUpdateSafe false and wins over the AI review below. A clean run
-    // claims the capability but leaves the verdict for the AI / the "unknown"
-    // default — the linter only knows common destructive shapes, so "no findings"
-    // is not "safe".
-    const lintBreaking = Boolean(sqlLint?.ran && sqlLint.breaking && present === true);
+    // Deterministic SQL-shape linter — the non-LLM FLOOR. Runs only for a
+    // migration-bearing release and sets a breaking BASELINE the AI can override
+    // below. It judges by operation shape, so its "breaking" can be a false
+    // positive: a drop/rename is actually safe when the previous release already
+    // stopped using the object (the "contract" step of an expand/contract). Only
+    // reading the old code — which the AI does — can tell, so the linter is a
+    // floor, not the last word. A clean run claims the capability but leaves the
+    // verdict open (no findings ≠ safe; the linter only knows common shapes).
+    const linterFlagged = Boolean(sqlLint?.ran && sqlLint.breaking && present === true);
     if (sqlLint?.ran && present === true) {
         capabilities.push('sql-lint');
         if (sqlLint.breaking) {
@@ -241,16 +243,25 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         }
     }
 
-    // P6: a gated AI review can resolve the "unknown" verdict for a
-    // migration-bearing release. It only ever overrides when migrations are
-    // present (never invents a verdict for a no-migration or first release), and
-    // never when the deterministic linter already proved a break — the linter's
-    // FALSE is authoritative and the AI cannot flip it back to safe.
-    if (aiReview && present === true && !lintBreaking) {
-        rollingUpdateSafe = aiReview.rollingUpdateSafe;
-        recommendedStrategy = aiReview.recommendedStrategy;
-        notes = `AI migration review: ${aiReview.summary} ${BLIND_SPOT_NOTE}`;
+    // P6: the AI migration review — the intelligent check. Runs on ALL
+    // migration-bearing releases (even when the linter flagged a shape) because it
+    // can read the previous release's code and recognise an expand/contract: a
+    // drop/rename is safe if the old code no longer references the object. A
+    // DEFINITIVE AI verdict (high-confidence safe → true, or breaking → false)
+    // overrides the linter floor; an inconclusive AI ("unknown") leaves the floor
+    // (or the honest default) in place — so the AI can only ever make the marker
+    // MORE accurate, never downgrade a deterministic break to "unknown". It never
+    // applies on a no-migration or first release.
+    if (aiReview && present === true) {
         capabilities.push('ai-review');
+        if (aiReview.rollingUpdateSafe !== 'unknown') {
+            rollingUpdateSafe = aiReview.rollingUpdateSafe;
+            recommendedStrategy = aiReview.recommendedStrategy;
+            notes =
+                linterFlagged && aiReview.rollingUpdateSafe === true
+                    ? `AI migration review CLEARED a deterministic linter flag — it verified the previous release no longer uses the changed object (expand/contract): ${aiReview.summary} ${BLIND_SPOT_NOTE}`
+                    : `AI migration review: ${aiReview.summary} ${BLIND_SPOT_NOTE}`;
+        }
     }
 
     // P2: a deterministic REST API breaking-change diff (oasdiff). `checked: false`
@@ -404,8 +415,9 @@ async function main(): Promise<void> {
     }
 
     // Deterministic SQL-shape linter — the always-on floor. Runs (no flag, no
-    // key) whenever the cheap detector found migrations. A "breaking" finding is
-    // authoritative and short-circuits the (paid, non-deterministic) AI review.
+    // key) whenever the cheap detector found migrations. Its "breaking" is a
+    // baseline, NOT the last word: the AI review below can clear a flagged
+    // drop/rename when it verifies the previous release no longer uses the object.
     let sqlLint: SqlLintSummary | null = null;
     if (migrations?.present === true && args.lastTag) {
         const r = lintMigrations({ lastTag: args.lastTag, log: (m) => console.warn(`[sql-lint] ${m}`) });
@@ -415,14 +427,14 @@ async function main(): Promise<void> {
         );
     }
 
-    // P6: gated AI review. Only runs when the cheap detector found migrations
-    // (so ~10% of releases), a key is present, AND the deterministic linter did
-    // not already prove a break (no point paying for a tool-loop to confirm it).
-    // Any degrade leaves the verdict at its honest "unknown" — the review can only
-    // ever make the marker more informative, never falsely safe, never fails the
-    // release.
+    // P6: gated AI review. Runs on ALL migration-bearing releases (not only the
+    // linter-clean ones) when a key is present — it's the only check that can read
+    // the previous release's code and recognise an expand/contract, so it may
+    // safely clear a shape the linter flagged. Any degrade leaves the verdict at
+    // the linter floor / honest "unknown" — the review can only ever make the
+    // marker more accurate, never falsely safe, and never fails the release.
     let aiReview: AiReviewSummary | null = null;
-    if (wantAiReview && markerEnabled && migrations?.present === true && args.lastTag && !sqlLint?.breaking) {
+    if (wantAiReview && markerEnabled && migrations?.present === true && args.lastTag) {
         const apiKey = process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
             console.warn('[release-safety] --ai-review requested but ANTHROPIC_API_KEY not set; rollingUpdateSafe stays "unknown"');

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -88,6 +88,30 @@ test('ready PR, AI ran but stayed unknown => no "mark ready" nudge, no false "re
     assert.ok(!body.includes('release-time only'));
 });
 
+test('expand/contract clearance: linter flagged but AI cleared => Safe + explained', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['drop.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review CLEARED a deterministic linter flag — it verified the previous release no longer uses the changed object (expand/contract): ...' },
+    }), { draft: false, linterBreaking: true });
+    assert.ok(body.includes('Safe to RollingUpdate'));
+    assert.ok(/expand\/contract/.test(body));
+    assert.ok(body.includes('AI cleared it — see below'));
+    assert.ok(/contract.* step of an expand\/contract/.test(body));
+    // not a "Recreate required"
+    assert.ok(!body.includes('Recreate required'));
+});
+
+test('linterBreaking flag still shows breaking when the AI did NOT clear it', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['drop.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', notes: 'Migration linter detected breaking schema operations (...).' },
+    }), { draft: false, linterBreaking: true });
+    assert.ok(body.includes('Recreate required'));
+    assert.ok(body.includes('⚠️ breaking schema op(s) found'));
+});
+
 test('required stop is surfaced prominently', () => {
     const body = renderPrComment(baseMarker({
         upgrade: { minPreviousVersion: '0.3200.0', requiredStop: true, note: 'Index rebuild.' },

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -52,6 +52,13 @@ export interface RenderOpts {
      * AI-refined verdict.
      */
     draft?: boolean;
+    /**
+     * Raw verdict of the deterministic SQL linter (independent of the final
+     * marker verdict). Lets the comment show the linter's finding even when the
+     * AI later overrode it — e.g. "linter flagged a drop, AI cleared it via
+     * expand/contract". Falls back to inferring from the marker notes.
+     */
+    linterBreaking?: boolean;
 }
 
 const LINTER_NOTE_PREFIX = 'Migration linter detected breaking';
@@ -67,10 +74,16 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const migrationsPresent = marker.migrations.present;
     const restBreaking = marker.api.rest.checked && marker.api.rest.breaking === true;
     const mcpBreaking = marker.api.mcp.checked && marker.api.mcp.breaking === true;
+    // The linter's own finding, independent of the final verdict. Prefer the
+    // explicit signal; otherwise infer it from the notes (only detectable while
+    // the linter verdict still stands).
     const lintFlagged =
-        caps.has('sql-lint') &&
-        rollingUpdateSafe === false &&
-        marker.compatibility.notes.startsWith(LINTER_NOTE_PREFIX);
+        opts.linterBreaking ??
+        (caps.has('sql-lint') &&
+            rollingUpdateSafe === false &&
+            marker.compatibility.notes.startsWith(LINTER_NOTE_PREFIX));
+    // The linter flagged a destructive shape but the AI cleared it (expand/contract).
+    const aiClearedLinter = lintFlagged && rollingUpdateSafe === true && caps.has('ai-review');
 
     // ---- determination ------------------------------------------------------
     const lines: string[] = [];
@@ -84,6 +97,8 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         lines.push('⚠️ **Recreate required** — a breaking schema change was detected; the previous version would not survive a rolling update.');
     } else if (rollingUpdateSafe === 'unknown') {
         lines.push('❓ **Recreate recommended** — this change touches the schema and backward-compatibility was not verified.');
+    } else if (aiClearedLinter) {
+        lines.push('✅ **Safe to RollingUpdate** — the SQL linter flagged a destructive shape, but the AI review verified the previous release no longer uses it (expand/contract).');
     } else if (migrationsPresent === true) {
         lines.push('✅ **Safe to RollingUpdate** — migrations were verified backward-compatible.');
     } else {
@@ -103,7 +118,9 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     const sqlResult = !caps.has('sql-lint')
         ? '—'
         : lintFlagged
-        ? '⚠️ breaking schema op(s) found'
+        ? aiClearedLinter
+            ? '⚠️ flagged a destructive shape (AI cleared it — see below)'
+            : '⚠️ breaking schema op(s) found'
         : '✅ no breaking shapes found';
 
     const aiResult = caps.has('ai-review')
@@ -154,6 +171,8 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         consequence.push(
             `- ❓ Backward-compatibility was not verified, so customers reading the marker get **recommendedStrategy: Recreate** as the cautious default.${aiHint}`,
         );
+    } else if (aiClearedLinter) {
+        consequence.push('- ✅ The SQL linter flagged a destructive shape (e.g. a drop), but the AI review read the previous release’s code and confirmed it no longer references the object — the **contract** step of an expand/contract. A **RollingUpdate** is safe; old pods won’t touch what’s being removed.');
     } else if (migrationsPresent === true) {
         consequence.push('- ✅ Migrations were verified additive/backward-compatible, so a **RollingUpdate** is safe — no special handling for customers.');
     } else {
@@ -208,6 +227,11 @@ function main(): void {
     const body = renderPrComment(marker, {
         baseLabel: arg('base'),
         draft: process.argv.includes('--draft'),
+        linterBreaking: process.argv.includes('--linter-breaking')
+            ? true
+            : process.argv.includes('--no-linter-breaking')
+            ? false
+            : undefined,
     });
     const out = arg('out');
     if (out) {


### PR DESCRIPTION
Follow-up to the release-safety marker. The deterministic SQL linter judges by operation *shape*, so its breaking verdict on a drop/rename is a false positive when the object was already abandoned in an earlier release — making this PR the safe **contract** step of an expand/contract. The AI review reads the previous release's code and can verify that, so the linter becomes a *floor* the AI can override (high-confidence safe only). The AI now runs on all migration-bearing PRs, and the PR comment explains any expand/contract clearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)