### PR TITLE
ci: expand/contract → derive minPreviousVersion + advise both paths on breaks (PROD-8359)

### DIFF
--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -309,9 +309,9 @@ test('sqlLint breaking sets rollingUpdateSafe false + adds "sql-lint" capability
     assert.ok(/Migration linter detected breaking/.test(m.compatibility.notes));
 });
 
-test('high-confidence AI "safe" OVERRIDES a linter flag (expand/contract clearance)', () => {
+test('high-confidence AI "safe" OVERRIDES a linter flag + derives a minPreviousVersion floor', () => {
     const m = buildMarker({
-        ...base,
+        ...base, // previousVersion: '0.3260.2'
         migrations: migPresent,
         sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
         aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'old code has zero refs to the dropped column.' },
@@ -319,9 +319,40 @@ test('high-confidence AI "safe" OVERRIDES a linter flag (expand/contract clearan
     // AI wins: the drop is the contract step of an expand/contract → safe
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
     assert.strictEqual(m.compatibility.recommendedStrategy, 'RollingUpdate');
-    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review']);
     assert.ok(/CLEARED a deterministic linter flag/.test(m.compatibility.notes));
-    assert.ok(/expand\/contract/.test(m.compatibility.notes));
+    assert.ok(/Safe ONLY when upgrading from 0\.3260\.2/.test(m.compatibility.notes));
+    // ...and the safe verdict is made honest with an auto-derived upgrade floor
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'sql-lint', 'ai-review', 'upgrade']);
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3260.2');
+    assert.strictEqual(m.upgrade.requiredStop, false);
+    assert.ok(/Auto-derived/.test(m.upgrade.note ?? ''));
+});
+
+test('a human-authored minPreviousVersion (overrides) wins over the auto-derived floor', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'cleared.' },
+        upgrade: { consulted: true, minPreviousVersion: '0.3100.0', requiredStop: true, note: 'maintainer set this' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3100.0'); // overrides win
+    assert.strictEqual(m.upgrade.requiredStop, true);
+    assert.strictEqual(m.upgrade.note, 'maintainer set this');
+});
+
+test('no expand/contract derivation when the AI cleared a linter-CLEAN migration', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: false, findings: [] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'additive, verified.' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    // additive clearance is not an expand/contract → no auto floor, no upgrade cap
+    assert.ok(!m.capabilities.includes('upgrade'));
+    assert.strictEqual(m.upgrade.minPreviousVersion, null);
 });
 
 test('AI "breaking" confirms a linter flag → stays false', () => {

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -252,6 +252,12 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // (or the honest default) in place — so the AI can only ever make the marker
     // MORE accurate, never downgrade a deterministic break to "unknown". It never
     // applies on a no-migration or first release.
+    // True when the AI cleared a linter-flagged destructive change as the safe
+    // "contract" step of an expand/contract — the verdict it reached by verifying
+    // the PREVIOUS release (previousVersion) no longer uses the object.
+    const aiClearedExpandContract = Boolean(
+        linterFlagged && aiReview && aiReview.rollingUpdateSafe === true,
+    );
     if (aiReview && present === true) {
         capabilities.push('ai-review');
         if (aiReview.rollingUpdateSafe !== 'unknown') {
@@ -259,7 +265,7 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
             recommendedStrategy = aiReview.recommendedStrategy;
             notes =
                 linterFlagged && aiReview.rollingUpdateSafe === true
-                    ? `AI migration review CLEARED a deterministic linter flag — it verified the previous release no longer uses the changed object (expand/contract): ${aiReview.summary} ${BLIND_SPOT_NOTE}`
+                    ? `AI migration review CLEARED a deterministic linter flag — it verified the previous release (${previousVersion ?? 'unknown'}) no longer uses the changed object (expand/contract): ${aiReview.summary} Safe ONLY when upgrading from ${previousVersion ?? 'that release'} or later. ${BLIND_SPOT_NOTE}`
                     : `AI migration review: ${aiReview.summary} ${BLIND_SPOT_NOTE}`;
         }
     }
@@ -292,12 +298,37 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         requiredStop: false,
         note: null,
     };
+    let upgradeKnown = false;
     if (input.upgrade && input.upgrade.consulted) {
         upgrade = {
             minPreviousVersion: input.upgrade.minPreviousVersion,
             requiredStop: input.upgrade.requiredStop,
             note: input.upgrade.note,
         };
+        upgradeKnown = true;
+    }
+
+    // Expand/contract floor: when the AI cleared a destructive change as the
+    // "contract" step, the "safe" verdict was only verified against previousVersion
+    // — upgrading from an EARLIER release (which may still use the object) is not
+    // verified. Record that as the minimum-previous-version floor so an operator
+    // skipping up from an older version is protected. previousVersion is a provably
+    // safe value (the release we actually checked); the author can lower it via the
+    // overrides file if the "expand" shipped earlier. A human-authored
+    // minPreviousVersion (from the overrides file) always wins.
+    if (aiClearedExpandContract && upgrade.minPreviousVersion === null && previousVersion) {
+        upgrade = {
+            minPreviousVersion: previousVersion,
+            requiredStop: upgrade.requiredStop,
+            note:
+                `Auto-derived: the AI verified the change is safe via expand/contract from ${previousVersion}. ` +
+                `Upgrading from an earlier release is NOT verified — set a lower minPreviousVersion in ` +
+                `release-safety.overrides.json if the app stopped using the object before then.`,
+        };
+        upgradeKnown = true;
+    }
+
+    if (upgradeKnown) {
         capabilities.push('upgrade');
     }
 

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -112,6 +112,42 @@ test('linterBreaking flag still shows breaking when the AI did NOT clear it', ()
     assert.ok(body.includes('⚠️ breaking schema op(s) found'));
 });
 
+test('genuine breaking change advises BOTH the merge-now impact and the expand/contract alternative', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['drop.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', notes: 'AI migration review: old code still reads the column.' },
+    }), { draft: false, linterBreaking: true });
+    assert.ok(body.includes('### What you should do'));
+    assert.ok(/If you must merge this change now/.test(body));
+    assert.ok(/Recreate/.test(body));
+    assert.ok(/Safer alternative — expand\/contract/.test(body));
+    assert.ok(/land the app change FIRST/.test(body));
+});
+
+test('expand/contract clearance advises the minPreviousVersion floor + how to lower it', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['drop.ts'], ee: false },
+        previousVersion: '0.3260.2',
+        compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review CLEARED a deterministic linter flag (expand/contract): ...' },
+        upgrade: { minPreviousVersion: '0.3260.2', requiredStop: false, note: 'Auto-derived: ...' },
+    }), { draft: false, linterBreaking: true });
+    assert.ok(body.includes('### What you should do'));
+    assert.ok(/safe \*\*only when upgrading from `0\.3260\.2` or later/.test(body));
+    assert.ok(/auto-sets `upgrade.minPreviousVersion`/.test(body));
+    assert.ok(/release-safety\.overrides\.json/.test(body));
+});
+
+test('a plain safe migration gives no "what you should do" section', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'sql-lint', 'ai-review', 'upgrade'],
+        migrations: { present: true, count: 1, files: ['add.ts'], ee: false },
+        compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review: additive, verified.' },
+    }), { draft: false, linterBreaking: false });
+    assert.ok(!body.includes('### What you should do'));
+});
+
 test('required stop is surfaced prominently', () => {
     const body = renderPrComment(baseMarker({
         upgrade: { minPreviousVersion: '0.3200.0', requiredStop: true, note: 'Index rebuild.' },

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -184,6 +184,29 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     if (restBreaking) consequence.push('- ⚠️ External REST API consumers may break across this upgrade (see `api.rest`).');
     if (mcpBreaking) consequence.push('- ⚠️ MCP clients/agents may break across this upgrade (see `api.mcp`).');
 
+    // ---- what you should do -------------------------------------------------
+    const advice: string[] = [];
+    if (rollingUpdateSafe === false) {
+        advice.push(
+            '**If you must merge this change now:** operators upgrading via a default RollingUpdate would hit the impact above. The marker tells their CI/CD to use **Recreate** (a brief restart instead of a crash loop) — call this out in the release notes, and set a `requiredStop` in `release-safety.overrides.json` if older versions must not skip it.',
+        );
+        advice.push(
+            '**Safer alternative — expand/contract (parallel change):** land the app change FIRST. Open a separate PR to `main` that makes the app stop using the affected object (the *expand*), let it release, then add this migration in a follow-up PR. This preview will then verify the previous release no longer uses it and clear the migration as safe.',
+        );
+    } else if (aiClearedLinter) {
+        const floor = marker.upgrade.minPreviousVersion;
+        advice.push(
+            `This was cleared as the **contract** step of an expand/contract, verified against \`${marker.previousVersion ?? 'the previous release'}\`. It is safe **only when upgrading from ${floor ? `\`${floor}\`` : 'that release'} or later** — an operator skipping up from an older version that still used the object could still crash.`,
+        );
+        advice.push(
+            `The marker auto-sets \`upgrade.minPreviousVersion\`${floor ? ` to \`${floor}\`` : ''} to protect them. If the app actually dropped usage in an **earlier** release, lower it (or set a \`requiredStop\`) in \`release-safety.overrides.json\` so operators aren't forced to stop unnecessarily.`,
+        );
+    } else if (marker.upgrade.requiredStop) {
+        advice.push(
+            `This release is a **required stop**${marker.upgrade.minPreviousVersion ? ` (min previous version \`${marker.upgrade.minPreviousVersion}\`)` : ''}. Make sure the release notes tell operators they cannot skip it.`,
+        );
+    }
+
     // ---- assemble -----------------------------------------------------------
     const baseLine = opts.baseLabel ? `\n> Compared against \`${opts.baseLabel}\`.\n` : '\n';
     const rawJson = JSON.stringify(marker, null, 2);
@@ -199,6 +222,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         '',
         '### What would happen on deploy to customers',
         consequence.join('\n'),
+        ...(advice.length ? ['', '### What you should do', advice.map((a) => `- ${a}`).join('\n')] : []),
         '',
         '<details><summary>Raw marker JSON</summary>\n',
         '```json',


### PR DESCRIPTION
When the AI clears a destructive migration as the contract step of an expand/contract, it only verified safety against the previous release — so the marker now auto-derives `upgrade.minPreviousVersion` (provably safe; a human override wins). The PR comment gains a 'What you should do' section: for a genuine break it advises both the merge-now customer impact and the safer expand/contract path; for a clearance it explains the minPreviousVersion floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)