### PR TITLE
ci: trace the expand version from git history for the upgrade floor (PROD-8359)

### DIFF
--- a/scripts/expand-version.test.ts
+++ b/scripts/expand-version.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the PURE core of expand-version detection (PROD-8359).
+ * Run: `npx tsx scripts/expand-version.test.ts`
+ *
+ * Covers compareVersions and selectFloor (the safe backward-scan). The git IO
+ * (releaseTagsDescFrom / objectPresentAt) is exercised by the CLI against the repo.
+ */
+import * as assert from 'assert';
+import { compareVersions, selectFloor } from './expand-version';
+
+let passed = 0;
+const failures: string[] = [];
+
+function test(name: string, fn: () => void): void {
+    try {
+        fn();
+        passed += 1;
+    } catch (err) {
+        failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+}
+
+// --- compareVersions ---------------------------------------------------------
+
+test('compareVersions orders by numeric semver, not lexically', () => {
+    assert.strictEqual(compareVersions('0.3260.2', '0.3260.10') < 0, true); // 2 < 10 numerically
+    assert.strictEqual(compareVersions('0.3261.0', '0.3260.9') > 0, true);
+    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0);
+});
+
+// --- selectFloor -------------------------------------------------------------
+
+// tagsDesc youngest-first; presentAt(tag) = the object is referenced at that tag.
+const tags = ['0.3260.0', '0.3259.0', '0.3258.0', '0.3257.0', '0.3256.0'];
+
+test('finds the transition: floor is the youngest tag where it became absent', () => {
+    // absent at 3260/3259/3258, present at 3257 and older → expand landed in 3258
+    const presentAt = (t: string) => compareVersions(t, '0.3257.0') <= 0;
+    assert.strictEqual(selectFloor(tags, presentAt), '0.3258.0');
+});
+
+test('absent only at the verified release → floor is that release', () => {
+    // present everywhere except the youngest → the drop is barely safe from 3260
+    const presentAt = (t: string) => t !== '0.3260.0';
+    assert.strictEqual(selectFloor(tags, presentAt), '0.3260.0');
+});
+
+test('absent throughout the scanned window → floor is the oldest scanned (verified absent that far)', () => {
+    const presentAt = () => false;
+    assert.strictEqual(selectFloor(tags, presentAt), '0.3256.0');
+});
+
+test('contradiction — present at the verified release → null (stay conservative)', () => {
+    const presentAt = () => true;
+    assert.strictEqual(selectFloor(tags, presentAt), null);
+});
+
+test('a grep false-positive at an older tag only RAISES the floor (safe direction)', () => {
+    // truly absent from 3258, but a stray match at 3257 (false positive) stops the scan
+    const presentAt = (t: string) => t === '0.3257.0';
+    // floor is 3258 (conservative) rather than 3256 — never lower than the truth
+    assert.strictEqual(selectFloor(tags, presentAt), '0.3258.0');
+});
+
+test('empty tag list → null', () => {
+    assert.strictEqual(selectFloor([], () => false), null);
+});
+
+if (failures.length > 0) {
+    console.error(`\n❌ ${failures.length} failed, ${passed} passed:\n`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+}
+console.log(`✅ ${passed} tests passed`);

--- a/scripts/expand-version.ts
+++ b/scripts/expand-version.ts
@@ -1,0 +1,166 @@
+/**
+ * Expand-version detection (PROD-8359).
+ *
+ * When the AI clears a dropped/renamed object as the "contract" step of an
+ * expand/contract, it only verified safety against ONE release (previousVersion).
+ * This finds the EARLIEST release the object is actually safe to drop from — the
+ * version where the app's code stopped referencing it (the "expand") — so the
+ * marker's upgrade.minPreviousVersion floor is as permissive as is provably safe,
+ * instead of the conservative previousVersion.
+ *
+ * SAFETY — the floor may only be LOWERED on a positively-verified absence:
+ *   - It greps the ACTUAL app code at each release tag (not a string-diff
+ *     heuristic), so a grep FALSE POSITIVE (the name appears in an unrelated
+ *     context) stops the backward scan early → a HIGHER, more conservative floor.
+ *   - It shares the literal-reference assumption of the AI clearance (a column
+ *     reached only via dynamic/ORM magic isn't seen by either), so it adds NO new
+ *     risk beyond what the clearance already accepted.
+ *   - Anything ambiguous (object present at the verified release, no object name
+ *     extracted, a git error) returns null and the caller keeps the conservative
+ *     previousVersion floor.
+ *
+ * CLI:  npx tsx scripts/expand-version.ts --object my_column --from 0.3260.2
+ */
+import { execFileSync } from 'child_process';
+
+/** App code to scan — deliberately EXCLUDES the migration dirs (a migration that
+ *  drops the object references it, which would mask the app-usage signal). */
+export const DEFAULT_CODE_DIRS = [
+    'packages/backend/src',
+    'packages/common/src',
+    'packages/frontend/src',
+    'packages/cli/src',
+    'packages/warehouses/src',
+] as const;
+
+const RELEASE_TAG_RE = /^\d+\.\d+\.\d+$/;
+
+export type PresentAt = (tag: string) => boolean;
+
+/** PURE. Numeric semver compare of two `X.Y.Z` release tags. */
+export function compareVersions(a: string, b: string): number {
+    const pa = a.split('.').map((n) => parseInt(n, 10));
+    const pb = b.split('.').map((n) => parseInt(n, 10));
+    for (let i = 0; i < 3; i += 1) {
+        const d = (pa[i] || 0) - (pb[i] || 0);
+        if (d !== 0) return d > 0 ? 1 : -1;
+    }
+    return 0;
+}
+
+/**
+ * PURE. Given release tags in DESCENDING order (youngest first) where tagsDesc[0]
+ * is the release the object is KNOWN absent in (the AI-verified previousVersion),
+ * walk back while the object stays absent and return the OLDEST tag still verified
+ * absent — i.e. the version the app had stopped referencing it. Stops at the first
+ * tag that still references it (floor = the tag just younger). Returns null on a
+ * contradiction (present at tagsDesc[0]) or no tags.
+ */
+export function selectFloor(tagsDesc: string[], presentAt: PresentAt): string | null {
+    if (tagsDesc.length === 0) return null;
+    if (presentAt(tagsDesc[0])) return null; // contradiction — don't trust, stay conservative
+    let floor = tagsDesc[0];
+    for (let i = 1; i < tagsDesc.length; i += 1) {
+        if (presentAt(tagsDesc[i])) return floor; // older tag still uses it → floor is the younger one
+        floor = tagsDesc[i]; // verified absent here too → lower the floor
+    }
+    return floor; // absent throughout the scanned window → floor = oldest scanned (verified absent that far back)
+}
+
+// ---- IO ---------------------------------------------------------------------
+
+function git(args: string[]): { ok: boolean; out: string } {
+    try {
+        return { ok: true, out: execFileSync('git', args, { encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024 }) };
+    } catch (err) {
+        const e = err as { status?: number; stdout?: Buffer; stderr?: Buffer };
+        if (e.status === 1) return { ok: true, out: e.stdout?.toString() ?? '' }; // grep: no match
+        return { ok: false, out: (e.stderr?.toString() || (err as Error).message).slice(0, 500) };
+    }
+}
+
+/** IO: release tags (`X.Y.Z`) that are ancestors of `fromRef`, youngest-first, capped. */
+export function releaseTagsDescFrom(fromRef: string, max: number): string[] {
+    const { ok, out } = git(['tag', '--merged', fromRef]);
+    if (!ok) return [];
+    return out
+        .split('\n')
+        .map((t) => t.trim())
+        .filter((t) => RELEASE_TAG_RE.test(t))
+        .sort((a, b) => -compareVersions(a, b))
+        .slice(0, max);
+}
+
+/** IO: is `object` referenced in the app code at `tag`? (`git grep -wF`, code dirs only). */
+export function objectPresentAt(tag: string, object: string, codeDirs: readonly string[]): boolean {
+    const { ok, out } = git(['grep', '-l', '-wF', '-e', object, tag, '--', ...codeDirs]);
+    return ok && out.trim().length > 0;
+}
+
+export interface FindExpandFloorOpts {
+    /** Dropped/renamed object names (column/table identifiers). */
+    objects: string[];
+    /** The previous-release ref the AI verified absence against (tag or sha). */
+    fromRef: string;
+    codeDirs?: readonly string[];
+    maxScan?: number;
+    log?: (msg: string) => void;
+}
+
+/**
+ * IO. Best-effort earliest-safe-version across all dropped objects. Returns the
+ * YOUNGEST (max) per-object floor — every "expand" must be complete, so the
+ * latest-removed object governs. Returns null (caller stays conservative) if no
+ * objects, no tags, or any object can't be confidently placed.
+ */
+export function findExpandFloor(opts: FindExpandFloorOpts): string | null {
+    const log = opts.log ?? (() => {});
+    const objects = [...new Set(opts.objects.filter((o) => o && o.length >= 4))]; // skip too-generic names
+    if (objects.length === 0) {
+        log('no sufficiently-specific object names to trace; staying conservative');
+        return null;
+    }
+    const tags = releaseTagsDescFrom(opts.fromRef, opts.maxScan ?? 25);
+    if (tags.length === 0) {
+        log('no release tags reachable from the previous ref; staying conservative');
+        return null;
+    }
+    const codeDirs = opts.codeDirs ?? DEFAULT_CODE_DIRS;
+    let overall: string | null = null;
+    for (const obj of objects) {
+        const floor = selectFloor(tags, (tag) => objectPresentAt(tag, obj, codeDirs));
+        if (!floor) {
+            log(`could not place "${obj}" (present at ${tags[0]} or no tags); staying conservative`);
+            return null;
+        }
+        log(`"${obj}" last referenced before ${floor}`);
+        overall = overall === null || compareVersions(floor, overall) > 0 ? floor : overall;
+    }
+    return overall;
+}
+
+// ---- CLI --------------------------------------------------------------------
+
+function arg(name: string): string | undefined {
+    const i = process.argv.indexOf(`--${name}`);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+function main(): void {
+    const object = arg('object');
+    const fromRef = arg('from');
+    if (!object || !fromRef) throw new Error('--object and --from are required');
+    const floor = findExpandFloor({ objects: [object], fromRef, log: (m) => console.log(`[expand-version] ${m}`) });
+    console.log(JSON.stringify({ object, fromRef, floor }, null, 2));
+}
+
+const invokedDirectly =
+    require.main === module || process.argv[1]?.endsWith('expand-version.ts') === true;
+if (invokedDirectly) {
+    try {
+        main();
+    } catch (err) {
+        console.error(`[expand-version] FAILED: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+    }
+}

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -328,6 +328,19 @@ test('high-confidence AI "safe" OVERRIDES a linter flag + derives a minPreviousV
     assert.ok(/Auto-derived/.test(m.upgrade.note ?? ''));
 });
 
+test('a git-traced expand floor is preferred over the conservative previousVersion', () => {
+    const m = buildMarker({
+        ...base, // previousVersion: '0.3260.2'
+        migrations: migPresent,
+        sqlLint: { ran: true, breaking: true, findings: ['m.ts:3 drops a column [drop-column]'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'cleared.' },
+        expandContractFloor: '0.3240.0', // app stopped using it 20 minors earlier
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(m.upgrade.minPreviousVersion, '0.3240.0'); // traced, more permissive
+    assert.ok(/git history shows the app stopped referencing/.test(m.upgrade.note ?? ''));
+});
+
 test('a human-authored minPreviousVersion (overrides) wins over the auto-derived floor', () => {
     const m = buildMarker({
         ...base,

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -16,7 +16,8 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { aiMigrationReview } from './ai-migration-review';
-import { lintMigrations, renderFindings } from './sql-migration-lint';
+import { lintMigrations, renderFindings, SqlLintFinding } from './sql-migration-lint';
+import { findExpandFloor } from './expand-version';
 import { diffRestApi } from './rest-api-diff';
 import { diffMcpTools } from './mcp-tools-diff';
 import {
@@ -152,6 +153,13 @@ export interface BuildMarkerInput {
      * the honest "unknown" default. Adds "sql-lint" to capabilities when it ran.
      */
     sqlLint?: SqlLintSummary | null;
+    /**
+     * Earliest release the dropped object is provably safe to remove from (the
+     * "expand" version, traced from git history). Used only when the AI cleared an
+     * expand/contract drop, as the auto-derived upgrade.minPreviousVersion in place
+     * of the conservative previousVersion. null → fall back to previousVersion.
+     */
+    expandContractFloor?: string | null;
     /**
      * Optional result of the REST API breaking-change diff (P2). Applied to
      * api.rest and adds "rest" to capabilities only when checked === true. A
@@ -316,14 +324,20 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
     // safe value (the release we actually checked); the author can lower it via the
     // overrides file if the "expand" shipped earlier. A human-authored
     // minPreviousVersion (from the overrides file) always wins.
-    if (aiClearedExpandContract && upgrade.minPreviousVersion === null && previousVersion) {
+    if (aiClearedExpandContract && upgrade.minPreviousVersion === null && (input.expandContractFloor || previousVersion)) {
+        // Prefer the git-traced expand version (earliest release the app stopped
+        // using the object — provably safe and more permissive); fall back to the
+        // conservative previousVersion (the single release the AI verified).
+        const floor = input.expandContractFloor || previousVersion!;
+        const traced = Boolean(input.expandContractFloor);
         upgrade = {
-            minPreviousVersion: previousVersion,
+            minPreviousVersion: floor,
             requiredStop: upgrade.requiredStop,
-            note:
-                `Auto-derived: the AI verified the change is safe via expand/contract from ${previousVersion}. ` +
-                `Upgrading from an earlier release is NOT verified — set a lower minPreviousVersion in ` +
-                `release-safety.overrides.json if the app stopped using the object before then.`,
+            note: traced
+                ? `Auto-derived: git history shows the app stopped referencing the dropped object by ${floor}, so upgrades from ${floor} or later are safe. Set a different minPreviousVersion in release-safety.overrides.json to override.`
+                : `Auto-derived: the AI verified the change is safe via expand/contract from ${floor}. ` +
+                  `Upgrading from an earlier release is NOT verified — set a lower minPreviousVersion in ` +
+                  `release-safety.overrides.json if the app stopped using the object before then.`,
         };
         upgradeKnown = true;
     }
@@ -450,8 +464,10 @@ async function main(): Promise<void> {
     // baseline, NOT the last word: the AI review below can clear a flagged
     // drop/rename when it verifies the previous release no longer uses the object.
     let sqlLint: SqlLintSummary | null = null;
+    let lintFindings: SqlLintFinding[] = [];
     if (migrations?.present === true && args.lastTag) {
         const r = lintMigrations({ lastTag: args.lastTag, log: (m) => console.warn(`[sql-lint] ${m}`) });
+        lintFindings = r.findings;
         sqlLint = { ran: r.ran, breaking: r.breaking, findings: renderFindings(r.findings) };
         console.warn(
             `[release-safety] SQL linter: ${r.breaking ? `BREAKING (${r.findings.length} finding(s))` : 'no breaking shapes found'}`,
@@ -517,6 +533,29 @@ async function main(): Promise<void> {
         });
     }
 
+    // Expand-version tracing: when the AI cleared a linter-flagged drop/rename as
+    // the safe "contract" step, trace from git history the EARLIEST release the
+    // app stopped referencing the object — a more permissive (but still provably
+    // safe) upgrade floor than the conservative previousVersion. Best-effort;
+    // null stays conservative.
+    let expandContractFloor: string | null = null;
+    if (sqlLint?.breaking && aiReview?.rollingUpdateSafe === true && args.lastTag) {
+        const objects = lintFindings
+            .filter((f) => ['drop-column', 'rename-column', 'drop-table', 'rename-table'].includes(f.rule))
+            .map((f) => f.object)
+            .filter((o): o is string => Boolean(o));
+        if (objects.length > 0) {
+            expandContractFloor = findExpandFloor({
+                objects,
+                fromRef: args.lastTag,
+                log: (m) => console.warn(`[expand-version] ${m}`),
+            });
+            if (expandContractFloor) {
+                console.warn(`[release-safety] expand version traced: minPreviousVersion -> ${expandContractFloor}`);
+            }
+        }
+    }
+
     // P4: human-authored upgrade-path overrides. A missing file is fine (mechanism
     // unused); a present-but-malformed file throws here and FAILS the release —
     // never silently drop a maintainer's declared required-stop.
@@ -530,6 +569,7 @@ async function main(): Promise<void> {
         migrations,
         aiReview,
         sqlLint,
+        expandContractFloor,
         restApi,
         mcpApi,
         upgrade,

--- a/scripts/sql-migration-lint.test.ts
+++ b/scripts/sql-migration-lint.test.ts
@@ -43,6 +43,19 @@ test('NOT NULL with a default is not flagged', () => {
 
 // --- breaking shapes ---------------------------------------------------------
 
+test('extracts the dropped/renamed object name for expand-version tracing', () => {
+    const drop = lintSource(`export async function up(knex){ await knex.schema.alterTable('users', t => t.dropColumn('legacy_field')); }`);
+    assert.strictEqual(drop[0]?.object, 'legacy_field');
+    const renameCol = lintSource(`export async function up(knex){ await knex.schema.alterTable('users', t => t.renameColumn('old_name', 'new_name')); }`);
+    assert.strictEqual(renameCol[0]?.object, 'old_name'); // the removed (old) name
+    const dropTable = lintSource(`export async function up(knex){ await knex.schema.dropTableIfExists('audit_log'); }`);
+    assert.strictEqual(dropTable[0]?.object, 'audit_log');
+    // non-string-literal arg → no object captured, but still flagged
+    const dynamic = lintSource(`export async function up(knex){ await knex.schema.alterTable('users', t => t.dropColumn(colName)); }`);
+    assert.strictEqual(dynamic[0]?.rule, 'drop-column');
+    assert.strictEqual(dynamic[0]?.object, undefined);
+});
+
 test('dropColumn in up() is flagged', () => {
     const src = `export async function up(knex){ await knex.schema.alterTable('users', t => { t.dropColumn('legacy'); }); }
 export async function down(knex){ await knex.schema.alterTable('users', t => t.string('legacy')); }`;

--- a/scripts/sql-migration-lint.ts
+++ b/scripts/sql-migration-lint.ts
@@ -33,6 +33,9 @@ export interface SqlLintFinding {
     rule: string;
     message: string;
     snippet: string;
+    /** The dropped/renamed schema object name (column/table), when extractable.
+     *  Used to trace the expand version. undefined for non-string-literal args. */
+    object?: string;
 }
 
 export interface SqlLintResult {
@@ -42,12 +45,14 @@ export interface SqlLintResult {
     findings: SqlLintFinding[];
 }
 
-/** Knex builder calls that are unambiguously destructive to the old code. */
-const METHOD_RULES: { rule: string; re: RegExp; message: string }[] = [
-    { rule: 'drop-column', re: /\.dropColumns?\s*\(/, message: 'drops a column the previous version may still read/write' },
-    { rule: 'rename-column', re: /\.renameColumn\s*\(/, message: 'renames a column the previous version still references' },
-    { rule: 'drop-table', re: /\.dropTable(?:IfExists)?\s*\(/, message: 'drops a table the previous version still references' },
-    { rule: 'rename-table', re: /\.renameTable\s*\(/, message: 'renames a table the previous version still references' },
+/** Knex builder calls that are unambiguously destructive to the old code.
+ *  `objectRe` (optional) captures the affected object name (group 1) from the
+ *  first string-literal argument, for expand-version tracing. */
+const METHOD_RULES: { rule: string; re: RegExp; message: string; objectRe?: RegExp }[] = [
+    { rule: 'drop-column', re: /\.dropColumns?\s*\(/, message: 'drops a column the previous version may still read/write', objectRe: /\.dropColumns?\s*\(\s*['"]([^'"]+)['"]/ },
+    { rule: 'rename-column', re: /\.renameColumn\s*\(/, message: 'renames a column the previous version still references', objectRe: /\.renameColumn\s*\(\s*['"]([^'"]+)['"]/ },
+    { rule: 'drop-table', re: /\.dropTable(?:IfExists)?\s*\(/, message: 'drops a table the previous version still references', objectRe: /\.dropTable(?:IfExists)?\s*\(\s*['"]([^'"]+)['"]/ },
+    { rule: 'rename-table', re: /\.renameTable\s*\(/, message: 'renames a table the previous version still references', objectRe: /\.renameTable\s*\(\s*['"]([^'"]+)['"]/ },
 ];
 
 /** Raw-SQL phrases (only scanned inside statements that call `.raw(`). */
@@ -100,9 +105,15 @@ export function lintSource(source: string): Omit<SqlLintFinding, 'file'>[] {
     const lines = up.split('\n');
     lines.forEach((rawLine, i) => {
         const line = stripLineComment(rawLine);
-        for (const { rule, re, message } of [...METHOD_RULES, ...RAW_RULES]) {
+        for (const { rule, re, message, objectRe } of [...METHOD_RULES, ...RAW_RULES] as {
+            rule: string;
+            re: RegExp;
+            message: string;
+            objectRe?: RegExp;
+        }[]) {
             if (re.test(line)) {
-                findings.push({ line: i + 1, rule, message, snippet: rawLine.trim().slice(0, 200) });
+                const object = objectRe ? line.match(objectRe)?.[1] : undefined;
+                findings.push({ line: i + 1, rule, message, snippet: rawLine.trim().slice(0, 200), object });
             }
         }
     });


### PR DESCRIPTION
When the AI clears a destructive migration as the contract step of an expand/contract, trace from git history the EARLIEST release the app stopped referencing the object, and use that as `upgrade.minPreviousVersion` (more permissive than the conservative previousVersion, while still provably safe — it greps the app code at each release tag and only lowers the floor on verified absence). A human override still wins; ambiguity stays conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)