### PR TITLE
demo: genuine breaking drop — still-used column (PROD-8359 matrix, do not merge)

### DIFF
--- a/packages/backend/src/database/migrations/20260629030000_demo_drop_organization_name.ts
+++ b/packages/backend/src/database/migrations/20260629030000_demo_drop_organization_name.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+// DEMO MIGRATION (PROD-8359 test matrix) — do not merge.
+// Drops a column the app CODE still references (organization_name). The AI review
+// should grep the previous release, find live reads/writes, and confirm this is a
+// genuine break (not an expand/contract) → Recreate.
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('organization_name');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.string('organization_name').nullable();
+    });
+}


### PR DESCRIPTION
Test-matrix PR: drops `organizations.organization_name`, which the app code still references. The AI review should confirm a genuine break (not an expand/contract) → `rollingUpdateSafe: false`, Recreate, plus the 'what you should do' advice. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)