### PR TITLE
demo: required stop via overrides — upgrade signal (PROD-8359 matrix, do not merge)

### DIFF
--- a/release-safety.overrides.json
+++ b/release-safety.overrides.json
@@ -1,9 +1,9 @@
 {
     "$schema": "./scripts/release-safety-overrides.schema.json",
     "default": {
-        "minPreviousVersion": null,
-        "requiredStop": false,
-        "note": null
+        "minPreviousVersion": "0.3200.0",
+        "requiredStop": true,
+        "note": "DEMO required stop (PROD-8359 matrix): operators must land on this release before upgrading further."
     },
     "versions": {}
 }


### PR DESCRIPTION
Test-matrix PR: sets a `requiredStop` + `minPreviousVersion` in release-safety.overrides.json (P4). The marker should carry the upgrade floor + required stop, and the comment should surface it. No migration → no AI. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)