### PR TITLE
ci: AI review validates flagged REST/MCP breaks, not just migrations (PROD-8359)

### DIFF
--- a/.github/workflows/release-safety-pr.yml
+++ b/.github/workflows/release-safety-pr.yml
@@ -19,6 +19,7 @@ on:
       - 'packages/common/src/schemas/json/mcp-tools-1.0.json'
       - 'release-safety.overrides.json'
       - 'scripts/gen-release-safety.ts'
+      - 'scripts/ai-migration-review.ts'
       - 'scripts/sql-migration-lint.ts'
       - 'scripts/rest-api-diff.ts'
       - 'scripts/mcp-tools-diff.ts'

--- a/docs/superpowers/specs/2026-06-29-prod-8359-release-safety-marker-design.md
+++ b/docs/superpowers/specs/2026-06-29-prod-8359-release-safety-marker-design.md
@@ -1,8 +1,8 @@
 # Release-Safety Marker — Design (PROD-8359 / #24441)
 
-**Status:** Feature-complete — P1–P4 + P6 + the deterministic SQL-shape linter all built; P6 activated. Marker DARK-LAUNCHED behind a kill-switch (publishes nothing yet) with a PR preview comment for visibility. Only P5 (Helm) remains parked.
+**Status:** Feature-complete — P1–P4 + P6 + the deterministic SQL-shape linter all built; P6 activated. P6 EXTENDED so the AI is the validation layer for ALL deterministic detectors (migrations AND flagged REST/MCP breaking changes), not migrations alone. Marker DARK-LAUNCHED behind a kill-switch (publishes nothing yet) with a PR preview comment for visibility. P5 (Helm) parked; the config-only/serialization blind-spot blast-radius scan is a deliberate follow-up.
 **Ticket:** PROD-8359 · GitHub issue lightdash/lightdash#24441
-**Branch / PR:** `prod-8359-release-safety` → PR lightdash/lightdash#24879 (draft)
+**Branch / PR:** `prod-8359-release-safety` (merged) → continued on `prod-8359-ai-breaking-changes`
 
 ## Status & resume
 
@@ -85,6 +85,31 @@
   when the SQL linter did not already prove a break, key-present only; any degrade
   leaves `"unknown"` and never fails the release.
 
+- **P6 EXTENDED — AI is the validation layer for every deterministic detector**
+  (`scripts/ai-migration-review.ts`, fn renamed `aiRollingUpdateReview`, alias
+  kept). Previously the AI ran only on migration-bearing releases. Now it runs to
+  VALIDATE whatever the deterministic detectors flag: migrations (as before, incl.
+  expand/contract clearance) AND a `oasdiff` REST break OR an MCP tool-surface
+  break — even on a release with NO schema migration. The reviewer is fed the
+  detectors' breaking lists and reasons "would an in-flight consumer break during
+  the rollout?" — the highest-stakes one being the bundled frontend (an
+  already-loaded OLD frontend tab hits NEW pods, and vice versa, until the rollout
+  finishes and the user reloads). A change that only affects EXTERNAL third-party
+  API scripts is a consumer concern (still surfaced in `api.*`) but not a reason to
+  block a RollingUpdate; the AI says so and leans safe for the rolling-update
+  question. New read-only tools scope to BOTH sides — `grep_new_code`,
+  `read_new_file`, `diff_file` (the release under review) alongside the existing
+  `grep_old_code` / `read_old_file` (the previous release). **Precedence
+  (`buildMarker`):** a deterministic REST/MCP break is a `nonMigrationHazard`; on a
+  no-migration release it moves the base from the silent `true` to a cautious
+  `unknown`/Recreate (never falsely safe off "no migrations"), then the AI's
+  definitive verdict resolves it — high-confidence `safe` → `true`/RollingUpdate,
+  `breaking` → `false`/Recreate, inconclusive leaves the cautious `unknown`. The AI
+  remains the ONLY path to `true`. `api.rest`/`api.mcp` still independently record
+  the external-consumer signal. Trigger: the generator runs the REST + MCP diffs
+  BEFORE the review, then invokes it when `migrations.present` OR a REST/MCP break
+  was flagged. Gating (`--ai-review` + `RELEASE_SAFETY_MARKER_ENABLED` + key)
+  unchanged; any degrade leaves the cautious default and never fails the release.
 - **Kill-switch (dark launch)** — `RELEASE_SAFETY_MARKER_ENABLED` env (default
   `false`). While off, `gen-release-safety.ts` computes + logs the marker but
   writes no file AND skips the paid AI review (a dark release publishes nothing
@@ -111,7 +136,25 @@
   (read-only token). The published asset stays dark — the comment is informational.
 
 **Remaining:**
-- **Caching/cost:** P6 is cheap now; no further work needed unless cost regresses.
+- **Config-only / serialization blind-spot scan (deferred follow-up):** the AI now
+  validates the EXISTING detectors' findings (migrations + REST/MCP). It does not
+  yet *trigger* on code-only / config-only changes that carry no migration and no
+  API-spec change — env-var default changes, removed/renamed Helm values, and
+  serialization/payload-shape changes to shared state (graphile-worker job payloads
+  in `packages/common/src/types/scheduler*.ts` + `packages/backend/src/scheduler/`,
+  the NATS async-query envelope in `packages/backend/src/{clients/NatsClient,nats}`,
+  the config contract in `packages/backend/src/config/`, the MCP SSE stream
+  envelope). The intended mechanism is a deterministic blast-radius pre-scan that
+  buckets the changed-file list by high-signal path heuristics (a sibling of the SQL
+  linter — a TRIGGER + curated input for the AI, never a deterministic verdict) and
+  feeds the candidate files to the same reviewer via the new `diff_file`/
+  `grep_new_code` tools. Scoped tight (shared-state + config paths only, excluding
+  entities/chart-config which change every release and co-occur with migrations) to
+  bound cost/noise. A prototype `coexistence-scan.ts` was built and set aside per
+  the agreed sequencing (validate existing checks first, blast-radius later).
+- **Caching/cost:** the broadened trigger means the AI now runs on more releases
+  (any REST/MCP break, not migrations alone); still prompt-cached and gated behind
+  the kill-switch, but watch cost once live.
 - **Operator/maintainer docs:** publish the `jq`-gating recipes + the
   `release-safety.overrides.json` required-stop authoring flow (the only manual
   step in the system).
@@ -129,14 +172,16 @@
   `unknown → true` (variance can only over-recommend `Recreate`).
 
 **Resume pointers:**
-- Worktree: `~/projects/worktrees/lightdash/prod-8359-release-safety`.
+- Worktree: `~/projects/worktrees/lightdash/prod-8359-ai-breaking-changes`
+  (previous, merged: `prod-8359-release-safety`).
 - Run the generator: `npx tsx scripts/gen-release-safety.ts --version X --previous-version Y --last-tag Y [--ai-review]`.
 - Run just the REST diff: `npx tsx scripts/rest-api-diff.ts --last-tag Y [--new-ref HEAD]` (needs `oasdiff` on PATH or `OASDIFF_BIN`).
 - Run just the MCP diff: `npx tsx scripts/mcp-tools-diff.ts --last-tag Y [--new-ref HEAD]` (needs the committed `mcp-tools-1.0.json` present at both refs).
 - Run just the SQL linter: `npx tsx scripts/sql-migration-lint.ts --last-tag Y` (scans migrations added in `Y..HEAD`).
 - Run just the upgrade resolver: `npx tsx scripts/upgrade-overrides.ts --version X [--overrides release-safety.overrides.json]`.
 - Regenerate the MCP snapshot: `pnpm generate:mcp-tools-snapshot` (CI guard: `pnpm check:mcp-tools-snapshot`). Runs inside `postgenerate-api`.
-- Tests: `npx tsx scripts/{gen-release-safety,sql-migration-lint,rest-api-diff,mcp-tools-diff,upgrade-overrides}.test.ts` (73 total). Backtest: `npx tsx scripts/release-safety-backtest.ts 300`.
+- Tests: `npx tsx scripts/{gen-release-safety,sql-migration-lint,rest-api-diff,mcp-tools-diff,upgrade-overrides,expand-version,release-safety-pr-comment}.test.ts` (110 total). Backtest: `npx tsx scripts/release-safety-backtest.ts 300`.
+- Typecheck (worktree has no node_modules — use the main repo's tsc): `~/projects/lightdash/node_modules/.bin/tsc --ignoreConfig --ignoreDeprecations 6.0 --noEmit --skipLibCheck --strict --module nodenext --moduleResolution nodenext --target es2022 --lib es2022,dom --types node --typeRoots ~/projects/lightdash/node_modules/@types scripts/*.ts`.
 - AI runs need `ANTHROPIC_API_KEY` — it's a per-engineer 1Password item
   (`scripts/dev-op-pull.sh` + `scripts/dev-secrets.manifest.json`, account
   `lightdash.1password.com`).
@@ -239,6 +284,13 @@ surfaced as a loud `notes` warning. `ee` is true iff any added file is under
 
 ## P6 implementation — AI migration-safety review
 
+> **Extended (see "P6 EXTENDED" in Status & resume):** this section describes the
+> original migration-only reviewer. The reviewer (`aiRollingUpdateReview`) now also
+> validates flagged REST/MCP breaking changes and is fed the detectors' breaking
+> lists + new-side tools (`grep_new_code`/`read_new_file`/`diff_file`); the
+> `perMigration` field generalised to `findings` with a `surface` tag. The
+> migration logic below is unchanged.
+
 `scripts/ai-migration-review.ts` — an **agentic** reviewer that resolves
 `rollingUpdateSafe: "unknown"` into a real `true`/`false`. It runs only when the
 cheap detector found migrations (the ~10% of releases the backtest flagged), so
@@ -295,10 +347,19 @@ its cost is bounded.
 
 ## Known blind spots (must stay documented)
 
-The marker does **not** detect code-only or config-only breaking changes (env var
-defaults, removed Helm values, serialization/protocol changes) — these crash old
-pods with no migration. The marker must never be read as "safe to RollingUpdate"
-beyond what `capabilities[]` says was checked.
+The marker still does **not** *trigger* on code-only or config-only breaking
+changes that carry no migration and no API-spec change (env var defaults, removed
+Helm values, serialization/protocol/payload-shape changes to shared state) — these
+can break a co-existing version with no migration to flag them. Closing this is the
+deferred blast-radius follow-up above; until it lands, the marker must never be read
+as "safe to RollingUpdate" beyond what `capabilities[]` says was checked.
+
+What the extended P6 DID close: a flagged REST/MCP breaking change is no longer
+treated as purely an external-consumer concern — the AI now validates whether it
+breaks an in-flight consumer (notably the bundled frontend) during the rollout and
+folds that into `rollingUpdateSafe`. The residual blind spot is specifically the
+changes NO deterministic detector flags (no migration, no OpenAPI/MCP-snapshot
+diff).
 
 ## Complementary follow-up (out of scope here)
 

--- a/scripts/ai-migration-review.ts
+++ b/scripts/ai-migration-review.ts
@@ -1,23 +1,36 @@
 /**
- * AI migration-safety review (PROD-8359, Phase 6).
+ * AI rolling-update compatibility review (PROD-8359, Phase 6 — extended).
  *
- * Gated second stage for the release-safety marker: when a release contains
- * migrations and rollingUpdateSafe is "unknown", ask Claude whether the new
- * migrations are backward-compatible with the PREVIOUS release's running code
- * during a rolling deployment.
+ * The intelligent VALIDATION layer over the marker's deterministic detectors.
+ * When a release contains migrations and/or the deterministic detectors flag a
+ * breaking change (the SQL-shape linter on migrations, `oasdiff` on the REST spec,
+ * the MCP tool-surface snapshot diff), this reviewer asks Claude the one question
+ * a shape-only check can't answer: would the PREVIOUS release's running code keep
+ * working during a rolling deployment?
  *
- * This is an AGENTIC reviewer — Claude gets two read-only tools scoped to the
- * previous release's source (`grep_old_code`, `read_old_file`, both via
- * `git ... <lastTag>`) so it can check whether the old code actually reads or
- * writes the columns/tables/constraints a migration changes. Without that, a
- * migration can only ever be classified "needs-review"; with it, additive-but-
- * app-dependent migrations can be positively cleared to "safe".
+ * During a Kubernetes rolling update the migration runs FIRST, then the new app
+ * rolls out gradually — so the previous release's pods (and an already-loaded
+ * frontend, and external API/MCP clients) keep serving traffic against the new
+ * schema / new API until the rollout finishes. Shape alone never decides safety:
+ *   - a destructive migration is safe IF the old code stopped using the object
+ *     (expand/contract); an "additive" one is unsafe if a new constraint rejects
+ *     what the old code still writes;
+ *   - a "breaking" REST/MCP change flagged by oasdiff/the snapshot may break the
+ *     in-flight frontend (old JS → new pod, or new JS → old pod) OR may only
+ *     affect a removed/external surface no in-flight consumer hits.
+ * Only reading the old AND new code can tell — which is what this agent does.
  *
- * Raw Messages API via global fetch (Node 20+); no SDK dependency. The system
- * prompt and the migration-files turn carry `cache_control` so the large prefix
- * is read from cache (~0.1x) across the tool loop instead of re-billed each turn.
+ * AGENTIC: Claude gets read-only tools scoped to BOTH sides — `grep_old_code` /
+ * `read_old_file` (the PREVIOUS release, via `git … <lastTag>`) and `grep_new_code`
+ * / `read_new_file` / `diff_file` (the release under review, via `git … <newRef>`)
+ * — so it can trace whether a changed object/endpoint is actually read or served by
+ * the code that keeps running mid-rollout.
  *
- * Importable: `aiMigrationReview(opts)` returns a structured result, or `null`
+ * Raw Messages API via global fetch (Node 20+); no SDK dependency. System prompt,
+ * the inputs turn, and a single rolling breakpoint carry `cache_control` so the
+ * large prefix is read from cache (~0.1x) across the tool loop.
+ *
+ * Importable: `aiRollingUpdateReview(opts)` returns a structured result, or `null`
  * on any fail-safe degrade (error / refusal / truncation / budget exhaustion).
  * The generator treats `null` as "leave rollingUpdateSafe unknown".
  *
@@ -37,9 +50,21 @@ const MAX_FILE_CHARS = 8000;
 const MAX_TOOL_CALLS = 40;
 const MAX_GREP_LINES = 80;
 const MAX_READ_CHARS = 12000;
+const MAX_DIFF_CHARS = 16000;
 const MAX_TOKENS = 16000;
 
 export type TriState = boolean | 'unknown';
+
+/** A surface the review can pass judgement on. */
+export type ReviewSurface = 'migration' | 'rest-api' | 'mcp-api' | 'other';
+
+export interface AiReviewFinding {
+    surface: ReviewSurface;
+    /** The thing judged: a migration basename, an endpoint, a tool name, … */
+    ref: string;
+    classification: string;
+    reason: string;
+}
 
 export interface AiReviewResult {
     modelVerdict: 'safe' | 'breaking' | 'unknown';
@@ -47,7 +72,7 @@ export interface AiReviewResult {
     rollingUpdateSafe: TriState;
     recommendedStrategy: 'Recreate' | 'RollingUpdate';
     summary: string;
-    perMigration: Array<{ file: string; classification: string; reason: string }>;
+    findings: AiReviewFinding[];
     toolCalls: number;
     usage: { input: number; output: number; cacheRead: number };
 }
@@ -81,20 +106,20 @@ function makeTools() {
         {
             name: 'grep_old_code',
             description:
-                "Search the PREVIOUS release's source (the code that keeps running during the rolling update) for a regex. Use this to find where a column/table/constraint the migration changes is read or written. Returns matching lines (file:line:text), capped.",
+                "Search the PREVIOUS release's source (the code that keeps running during the rolling update) for a regex. Use this to find where a column/table/constraint a migration changes — or an endpoint/tool an API change touches — is read, written, or called. Returns matching lines (file:line:text), capped.",
             input_schema: {
                 type: 'object',
                 additionalProperties: false,
                 required: ['pattern'],
                 properties: {
                     pattern: { type: 'string', description: 'An extended regex (ERE) to search for — alternation a|b and groups (…) work unescaped.' },
-                    path_glob: { type: 'string', description: "Optional pathspec to limit the search, e.g. 'packages/backend/src'." },
+                    path_glob: { type: 'string', description: "Optional pathspec to limit the search, e.g. 'packages/backend/src' or 'packages/frontend/src'." },
                 },
             },
         },
         {
             name: 'read_old_file',
-            description: "Read a file from the PREVIOUS release's source by path. Returns the file content (capped). Use after grep to inspect how a schema object is used.",
+            description: "Read a file from the PREVIOUS release's source by path. Returns the file content (capped). Use after grep to inspect how a schema object/endpoint is used by the code that keeps running mid-rollout.",
             input_schema: {
                 type: 'object',
                 additionalProperties: false,
@@ -102,15 +127,54 @@ function makeTools() {
                 properties: { path: { type: 'string', description: 'Repo-relative path, e.g. packages/backend/src/models/Foo.ts' } },
             },
         },
+        {
+            name: 'grep_new_code',
+            description:
+                "Search the NEW release-under-review source for a regex (same engine as grep_old_code). Use to see how the change re-shapes an object/endpoint/tool, or whether the bundled frontend now depends on a new API shape. Returns matching lines (file:line:text), capped.",
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['pattern'],
+                properties: {
+                    pattern: { type: 'string', description: 'An extended regex (ERE).' },
+                    path_glob: { type: 'string', description: 'Optional pathspec to limit the search.' },
+                },
+            },
+        },
+        {
+            name: 'read_new_file',
+            description: "Read a file from the NEW release-under-review source by path. Returns the file content (capped).",
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['path'],
+                properties: { path: { type: 'string', description: 'Repo-relative path.' } },
+            },
+        },
+        {
+            name: 'diff_file',
+            description: "Show what changed in ONE file between the previous release and the release under review (git diff <lastTag>..<newRef> -- <path>). Use to see exactly how a flagged file (a migration, an API handler, a serializer) was modified. Returns a unified diff, capped.",
+            input_schema: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['path'],
+                properties: { path: { type: 'string', description: 'Repo-relative path to diff.' } },
+            },
+        },
     ];
 }
 
-function runTool(name: string, input: Record<string, unknown>, lastTag: string): { text: string; isError: boolean } {
-    if (name === 'grep_old_code') {
+interface ToolRefs {
+    lastTag: string;
+    newRef: string;
+}
+
+function runTool(name: string, input: Record<string, unknown>, refs: ToolRefs): { text: string; isError: boolean } {
+    const grepAt = (ref: string): { text: string; isError: boolean } => {
         const pattern = String(input.pattern ?? '');
         if (!pattern) return { text: 'error: empty pattern', isError: true };
         // -E: extended regex (the model writes ERE-style alternation/groups by default)
-        const args = ['grep', '-n', '-I', '-E', '--no-color', '-e', pattern, lastTag];
+        const args = ['grep', '-n', '-I', '-E', '--no-color', '-e', pattern, ref];
         if (input.path_glob) args.push('--', String(input.path_glob));
         const { ok, out } = git(args);
         if (!ok) return { text: `git grep failed: ${out}`, isError: true };
@@ -118,13 +182,27 @@ function runTool(name: string, input: Record<string, unknown>, lastTag: string):
         const shown = lines.slice(0, MAX_GREP_LINES).join('\n');
         const suffix = lines.length > MAX_GREP_LINES ? `\n... (${lines.length - MAX_GREP_LINES} more matches; refine the pattern)` : '';
         return { text: lines.length ? shown + suffix : '(no matches)', isError: false };
-    }
-    if (name === 'read_old_file') {
+    };
+    const readAt = (ref: string): { text: string; isError: boolean } => {
         const path = String(input.path ?? '');
         if (!path) return { text: 'error: empty path', isError: true };
-        const { ok, out } = git(['show', `${lastTag}:${path}`]);
-        if (!ok) return { text: `cannot read ${path} at ${lastTag}: ${out}`, isError: true };
+        const { ok, out } = git(['show', `${ref}:${path}`]);
+        if (!ok) return { text: `cannot read ${path} at ${ref}: ${out}`, isError: true };
         const body = out.length > MAX_READ_CHARS ? `${out.slice(0, MAX_READ_CHARS)}\n... (truncated)` : out;
+        return { text: body, isError: false };
+    };
+
+    if (name === 'grep_old_code') return grepAt(refs.lastTag);
+    if (name === 'read_old_file') return readAt(refs.lastTag);
+    if (name === 'grep_new_code') return grepAt(refs.newRef);
+    if (name === 'read_new_file') return readAt(refs.newRef);
+    if (name === 'diff_file') {
+        const path = String(input.path ?? '');
+        if (!path) return { text: 'error: empty path', isError: true };
+        const { ok, out } = git(['diff', `${refs.lastTag}..${refs.newRef}`, '--', path]);
+        if (!ok) return { text: `cannot diff ${path}: ${out}`, isError: true };
+        if (!out.trim()) return { text: '(no changes to that path in this range)', isError: false };
+        const body = out.length > MAX_DIFF_CHARS ? `${out.slice(0, MAX_DIFF_CHARS)}\n... (diff truncated)` : out;
         return { text: body, isError: false };
     }
     return { text: `unknown tool ${name}`, isError: true };
@@ -133,27 +211,30 @@ function runTool(name: string, input: Record<string, unknown>, lastTag: string):
 const SCHEMA_DOC = `{
   "verdict": "safe" | "breaking" | "unknown",
   "confidence": "low" | "medium" | "high",
-  "perMigration": [{ "file": "<basename>", "classification": "additive-safe" | "breaking" | "needs-review", "reason": "<one sentence, cite old-code evidence where you checked it>" }],
+  "findings": [{ "surface": "migration" | "rest-api" | "mcp-api" | "other", "ref": "<migration basename / endpoint / tool name>", "classification": "additive-safe" | "breaking" | "needs-review", "reason": "<one sentence, cite old/new-code evidence where you checked it>" }],
   "summary": "<2-3 sentences>"
 }`;
 
-const SYSTEM = `You review database migrations for rolling-deployment safety in a self-hosted app (Lightdash; Knex.js migrations on Postgres).
+const SYSTEM = `You review a release for ROLLING-DEPLOYMENT safety in a self-hosted app (Lightdash; Knex.js migrations on Postgres; an Express REST API consumed by a bundled React frontend; an MCP tool server).
 
-During a Kubernetes rolling update the migration runs FIRST, then the new app rolls out gradually — so the PREVIOUS release's application code keeps serving traffic against the ALREADY-MIGRATED schema until the rollout finishes. Decide whether the migrations below would break that previous-version code.
+During a Kubernetes rolling update the database migration runs FIRST, then the new app rolls out gradually — so until the rollout finishes the PREVIOUS release's application code keeps serving traffic against the ALREADY-MIGRATED schema, an already-loaded frontend keeps calling whichever pod (old or new) it lands on, and external REST/MCP clients keep calling too. Your job: decide whether anything in this release would break the previous release's running code (or break already-running clients) during that overlap window.
 
-Your central question for EVERY migration — destructive OR additive in shape — is: does the PREVIOUS release's running code SUPPORT this schema change? Can it keep reading and writing correctly against the migrated schema? Check every migration, not only the destructive-looking ones. An "additive" shape is NOT automatically safe: a new NOT NULL column the old INSERTs don't populate, a new UNIQUE / CHECK / FOREIGN KEY constraint the old writes can violate, a narrowed type, a new enum value the old code doesn't expect on read, or a data backfill can all break old code that doesn't know about them. Equally, a destructive shape is not automatically unsafe (see expand/contract below). Shape alone never decides it — the old code does.
+You are the VALIDATION layer over deterministic detectors. They flag changes by SHAPE; you decide whether the shape is actually breaking by reading the code. The inputs you may be given:
 
-You have read-only tools (grep_old_code, read_old_file) that read the PREVIOUS release's source. USE THEM on every migration: identify the schema objects it changes (tables, columns, constraints, indexes, types, enums) and grep the old code to see whether/how they're read or written and whether the old write paths still satisfy any new constraints. App support you can only guess from the migration text is "needs-review"; app support you have verified against the old code can be "additive-safe" or "breaking".
+1. MIGRATIONS (the added Knex migration files, inline). Central question for EVERY migration — destructive OR additive in shape — is: does the PREVIOUS release's running code SUPPORT this schema change? An "additive" shape is NOT automatically safe (a new NOT NULL column old INSERTs don't populate, a new UNIQUE/CHECK/FOREIGN KEY the old writes can violate, a narrowed type, a new enum value the old read path doesn't expect, a data backfill). A destructive shape is NOT automatically unsafe: under expand/contract a drop/rename is safe IF the previous release already stopped using the object — VERIFY with grep_old_code that there are ZERO references; a guess is needs-review, never safe.
 
-A destructive operation shape is NOT automatically breaking. Under the expand/contract (parallel change) pattern a drop or rename is split across releases: an earlier release stops using the object ("expand"), and a later release removes it ("contract"). The contract step is SAFE precisely because the previous release's code no longer touches the object. Your job is to read the old code and tell which case this is — a deterministic shape-only linter cannot, which is why you exist.
+2. REST API BREAKING CHANGES (flagged by oasdiff on the OpenAPI spec). For each: does it break a consumer that is live DURING the rollout? The highest-stakes consumer is the bundled frontend — an already-loaded OLD frontend tab will hit NEW pods (and a NEW frontend will hit OLD pods) until the rollout completes and the user reloads. Use grep_old_code / grep_new_code over packages/frontend/src to see whether the frontend actually calls the changed endpoint with the changed shape. classification: breaking if an in-flight frontend (or a documented internal caller) would get errors mid-rollout; additive-safe if you VERIFY no in-flight consumer depends on the removed/changed part (e.g. a newly-removed endpoint the frontend already stopped calling, or an added optional field); needs-review if you can't tell. A change that only affects EXTERNAL third-party API scripts (not the in-flight frontend) is a consumer concern but NOT by itself a reason to block a RollingUpdate — say so in the reason and lean additive-safe for the rolling-update question while noting the external break.
+
+3. MCP TOOL BREAKING CHANGES (flagged by the tool-surface snapshot diff). Same logic for MCP clients/agents: a removed tool, a newly-required input, a removed input, or a retyped input breaks an agent mid-call. Judge whether an in-flight MCP session would break.
+
+USE THE TOOLS on everything you're given — identify the schema objects / endpoints / tools involved and trace them through the old and new code. Verified-from-code judgements can be additive-safe or breaking; anything you can only guess is needs-review.
 
 Classification rules:
-- additive-safe: an added object (nullable column, column with a default, new table, CONCURRENT index, new enum value) for which you have VERIFIED the old code keeps working — it can omit/ignore the new column, a default covers old inserts, the old read path tolerates new enum values, and no newly-added constraint rejects what the old code still writes. "Additive shape" alone is not enough; confirm the old code path.
-- additive-safe via expand/contract: a drop or rename of a column/table/constraint is safe IF you VERIFY with grep_old_code that the PREVIOUS release's code has ZERO references to it (the "expand" already shipped, this is the "contract"). You MUST run the grep and see no reads/writes; a guess is needs-review, never safe.
-- breaking: NOT NULL without default; a drop/rename of an object the old code STILL references (grep found reads/writes); type narrowing; a CHECK/FOREIGN KEY that could reject rows the old code still writes; a non-concurrent index on a large/hot table; a data backfill that rewrites values the old code depends on.
-- needs-review: you could not verify the old-code behaviour the safety depends on.
+- additive-safe: you VERIFIED the previous release's running code (and any in-flight client) keeps working — old inserts still satisfy every constraint, old reads tolerate the new shape, a dropped/renamed object has ZERO old references, a "breaking" API change touches nothing the in-flight frontend/clients use.
+- breaking: NOT NULL without default; a drop/rename of an object the old code STILL references; a type narrowing; a CHECK/FK that could reject rows the old code writes; a non-concurrent index on a large/hot table; a data backfill the old code depends on; a REST/MCP change an in-flight frontend or client would hit and error on.
+- needs-review: you could not verify the behaviour the safety depends on.
 
-Be conservative: overall verdict is "safe" with confidence "high" ONLY when EVERY migration is additive-safe (verified, including any expand/contract drop confirmed unreferenced). Any breaking → verdict "breaking". Any unresolved needs-review → verdict at most "unknown".
+Be conservative: overall verdict is "safe" with confidence "high" ONLY when EVERY input is additive-safe (verified). Any breaking → verdict "breaking". Any unresolved needs-review → verdict at most "unknown".
 
 When you have finished investigating, reply with ONE JSON object and NOTHING else, matching:
 ${SCHEMA_DOC}`;
@@ -213,17 +294,58 @@ export interface AiReviewOpts {
     apiKey: string;
     lastTag: string;
     version: string;
+    /** New side to diff/read against; defaults to HEAD. */
+    newRef?: string;
+    /** Deterministic REST breaking changes (oasdiff text) to validate. */
+    restBreaking?: string[];
+    /** Deterministic MCP tool-surface breaking changes to validate. */
+    mcpBreaking?: string[];
     log?: (msg: string) => void;
+}
+
+/** Build the inputs-turn text from whatever surfaces were flagged. */
+function buildInputsText(opts: {
+    version: string;
+    lastTag: string;
+    migrationFiles: string[];
+    migrationBlocks: string[];
+    restBreaking: string[];
+    mcpBreaking: string[];
+}): string {
+    const sections: string[] = [
+        `Release ${opts.version} since ${opts.lastTag}. Investigate every input below against the ${opts.lastTag} (old) and new code using your tools, then give the JSON verdict.`,
+    ];
+    if (opts.migrationBlocks.length) {
+        sections.push(
+            `## Migrations (${opts.migrationBlocks.length} added)\n\n${opts.migrationBlocks.join('\n\n')}`,
+        );
+    }
+    if (opts.restBreaking.length) {
+        sections.push(
+            `## REST API changes flagged breaking by oasdiff (${opts.restBreaking.length})\n\nValidate each against the in-flight frontend (packages/frontend/src) and documented internal callers:\n${opts.restBreaking.map((c) => `- ${c}`).join('\n')}`,
+        );
+    }
+    if (opts.mcpBreaking.length) {
+        sections.push(
+            `## MCP tool-surface changes flagged breaking (${opts.mcpBreaking.length})\n\nValidate whether an in-flight MCP client/agent would break:\n${opts.mcpBreaking.map((c) => `- ${c}`).join('\n')}`,
+        );
+    }
+    return sections.join('\n\n');
 }
 
 /**
  * Runs the agentic review. Returns a structured result, or `null` on any
  * fail-safe degrade (the caller must treat null as "stay unknown / Recreate").
+ * Returns null immediately when there is nothing to review (no migrations and no
+ * flagged REST/MCP breaking changes).
  */
-export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewResult | null> {
+export async function aiRollingUpdateReview(opts: AiReviewOpts): Promise<AiReviewResult | null> {
     const log = opts.log ?? (() => {});
+    const newRef = opts.newRef ?? 'HEAD';
+    const restBreaking = opts.restBreaking ?? [];
+    const mcpBreaking = opts.mcpBreaking ?? [];
     const paths = addedMigrationPaths(opts.lastTag);
-    if (paths.length === 0) return null;
+    if (paths.length === 0 && restBreaking.length === 0 && mcpBreaking.length === 0) return null;
 
     const fileBlocks = paths.map((p) => {
         let body = fs.readFileSync(p, 'utf-8');
@@ -235,20 +357,26 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
     const messages: unknown[] = [
         {
             role: 'user',
-            // cache_control here caches the (large, stable) migration-files prefix
-            // so the tool loop re-reads it at ~0.1x instead of full price each turn.
+            // cache_control here caches the (large, stable) inputs prefix so the
+            // tool loop re-reads it at ~0.1x instead of full price each turn.
             content: [
                 {
                     type: 'text',
-                    text:
-                        `Release ${opts.version} adds ${paths.length} migration(s) since ${opts.lastTag}. Investigate each against the ${opts.lastTag} app code using your tools, then give the JSON verdict.\n\n` +
-                        fileBlocks.join('\n\n'),
+                    text: buildInputsText({
+                        version: opts.version,
+                        lastTag: opts.lastTag,
+                        migrationFiles: paths,
+                        migrationBlocks: fileBlocks,
+                        restBreaking,
+                        mcpBreaking,
+                    }),
                     cache_control: { type: 'ephemeral' },
                 },
             ],
         },
     ];
 
+    const refs: ToolRefs = { lastTag: opts.lastTag, newRef };
     let toolCalls = 0;
     let inTok = 0;
     let outTok = 0;
@@ -257,9 +385,8 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
     for (let turn = 0; turn < MAX_TOOL_CALLS + 1; turn += 1) {
         // Rolling cache breakpoint: cache the growing transcript so each turn
         // re-reads prior turns at ~0.1x. Keep the static breakpoints (system +
-        // the first migration-files message) and move a single rolling one onto
-        // the last block of the last message — total stays within the 4-breakpoint
-        // limit (system + files + rolling = 3).
+        // the first inputs message) and move a single rolling one onto the last
+        // block of the last message — total stays within the 4-breakpoint limit.
         markRollingCache(messages);
         let resp;
         try {
@@ -281,7 +408,7 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
         if (toolUses.length === 0) {
             const textBlock = resp.content.find((b) => b.type === 'text' && b.text);
             if (!textBlock?.text) { log('degrade: no final text'); return null; }
-            let v: { verdict: 'safe' | 'breaking' | 'unknown'; confidence: 'low' | 'medium' | 'high'; perMigration: AiReviewResult['perMigration']; summary: string };
+            let v: { verdict: 'safe' | 'breaking' | 'unknown'; confidence: 'low' | 'medium' | 'high'; findings: AiReviewFinding[]; summary: string };
             try {
                 v = extractJson(textBlock.text) as typeof v;
             } catch {
@@ -298,7 +425,7 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
                 rollingUpdateSafe,
                 recommendedStrategy: rollingUpdateSafe === true ? 'RollingUpdate' : 'Recreate',
                 summary: v.summary,
-                perMigration: v.perMigration,
+                findings: Array.isArray(v.findings) ? v.findings : [],
                 toolCalls,
                 usage: { input: inTok, output: outTok, cacheRead },
             };
@@ -307,7 +434,7 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
         if (toolCalls >= MAX_TOOL_CALLS) { log(`degrade: tool-call budget exhausted (${MAX_TOOL_CALLS})`); return null; }
         const results = toolUses.map((tu) => {
             toolCalls += 1;
-            const r = runTool(tu.name as string, (tu.input ?? {}) as Record<string, unknown>, opts.lastTag);
+            const r = runTool(tu.name as string, (tu.input ?? {}) as Record<string, unknown>, refs);
             return { type: 'tool_result', tool_use_id: tu.id, content: r.text, is_error: r.isError };
         });
         messages.push({ role: 'user', content: results });
@@ -315,6 +442,9 @@ export async function aiMigrationReview(opts: AiReviewOpts): Promise<AiReviewRes
     log('degrade: loop did not converge');
     return null;
 }
+
+/** @deprecated renamed to aiRollingUpdateReview; kept as an alias for callers. */
+export const aiMigrationReview = aiRollingUpdateReview;
 
 // ---- CLI --------------------------------------------------------------------
 
@@ -332,21 +462,21 @@ async function main(): Promise<void> {
 
     const paths = addedMigrationPaths(lastTag);
     if (paths.length === 0) {
-        console.log(`No migrations added in ${lastTag}..HEAD — nothing to review.`);
-        return;
+        console.log(`No migrations added in ${lastTag}..HEAD. (Pass REST/MCP breaking inputs via the generator to review those surfaces.)`);
+    } else {
+        console.log(`\n=== AI rolling-update review: ${lastTag} → ${version} (${paths.length} migrations) ===`);
     }
-    console.log(`\n=== AI migration review: ${lastTag} → ${version} (${paths.length} migrations) ===`);
-    const r = await aiMigrationReview({ apiKey, lastTag, version, log: (m) => console.log(m) });
+    const r = await aiRollingUpdateReview({ apiKey, lastTag, version, newRef: arg('new-ref'), log: (m) => console.log(m) });
     if (!r) {
-        console.log(`→ rollingUpdateSafe: "unknown"  recommendedStrategy: Recreate  (fail-safe degrade)`);
+        console.log(`→ rollingUpdateSafe: "unknown"  recommendedStrategy: Recreate  (nothing to review or fail-safe degrade)`);
         return;
     }
     console.log(`model verdict : ${r.modelVerdict} (confidence: ${r.confidence})  [${r.toolCalls} tool calls]`);
     console.log(`→ rollingUpdateSafe: ${JSON.stringify(r.rollingUpdateSafe)}  recommendedStrategy: ${r.recommendedStrategy}`);
     console.log(`summary       : ${r.summary}\n`);
-    for (const m of r.perMigration) {
-        console.log(`  • ${m.file.split('/').pop()}`);
-        console.log(`      [${m.classification}] ${m.reason}`);
+    for (const f of r.findings) {
+        console.log(`  • [${f.surface}] ${f.ref}`);
+        console.log(`      [${f.classification}] ${f.reason}`);
     }
     console.log(`\ntokens: in=${r.usage.input} out=${r.usage.output} cache_read=${r.usage.cacheRead}`);
 }

--- a/scripts/gen-release-safety.test.ts
+++ b/scripts/gen-release-safety.test.ts
@@ -201,7 +201,7 @@ test('aiReview flips a migration-bearing release to its verdict + adds capabilit
     assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
     assert.strictEqual(m.compatibility.recommendedStrategy, 'RollingUpdate');
     assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review']);
-    assert.ok(/AI migration review:/.test(m.compatibility.notes));
+    assert.ok(/AI rolling-update review:/.test(m.compatibility.notes));
 });
 
 test('aiReview "breaking" verdict sets rollingUpdateSafe false', () => {
@@ -461,6 +461,83 @@ test('unchecked/null mcpApi leaves the stub and does NOT claim the capability', 
         mcpApi: null,
     });
     assert.ok(!m2.capabilities.includes('mcp'));
+});
+
+// --- AI validates non-migration breaks (REST/MCP) ----------------------------
+
+const noMig = { present: false as const, count: 0, files: [], ee: false, deletedHistorical: [] };
+
+test('REST break with NO migration → base "unknown" (cautious), not silently safe', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        restApi: { checked: true, breaking: true, changes: ['DELETE /api/v1/foo — endpoint removed'] },
+    });
+    // no migration would normally be "true"; a flagged REST break makes it unknown
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, 'unknown');
+    assert.strictEqual(m.compatibility.recommendedStrategy, 'Recreate');
+    assert.ok(/breaking REST API change/.test(m.compatibility.notes));
+    // AI did not run here, so no ai-review capability — but rest is claimed
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'rest']);
+});
+
+test('REST break + AI "safe/high" verdict → RollingUpdate (in-flight frontend unaffected)', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        restApi: { checked: true, breaking: true, changes: ['DELETE /api/v1/legacy — removed'] },
+        aiReview: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', summary: 'Endpoint is external-only; the bundled frontend never calls it.' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    assert.strictEqual(m.compatibility.recommendedStrategy, 'RollingUpdate');
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review', 'rest']);
+    assert.ok(/AI rolling-update review:/.test(m.compatibility.notes));
+});
+
+test('REST break + AI "breaking" verdict → false (an in-flight consumer breaks)', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        restApi: { checked: true, breaking: true, changes: ['GET /api/v1/saved — response field removed'] },
+        aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'The bundled frontend reads the removed field.' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
+    assert.strictEqual(m.compatibility.recommendedStrategy, 'Recreate');
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review', 'rest']);
+});
+
+test('REST break + inconclusive AI ("unknown") → stays "unknown" (never asserts safe)', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        restApi: { checked: true, breaking: true, changes: ['PATCH /api/v1/x — param now required'] },
+        aiReview: { rollingUpdateSafe: 'unknown', recommendedStrategy: 'Recreate', summary: 'Could not determine frontend usage.' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, 'unknown');
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review', 'rest']);
+});
+
+test('MCP break with NO migration + AI "breaking" → false', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        mcpApi: { checked: true, breaking: true, changes: ['MCP tool `run_query` removed'] },
+        aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'An in-flight agent session would fail the call.' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, false);
+    assert.deepStrictEqual(m.capabilities, ['migrations', 'ai-review', 'mcp']);
+});
+
+test('a clean REST surface does NOT make a no-migration release "unknown"', () => {
+    const m = buildMarker({
+        ...base,
+        migrations: noMig,
+        restApi: { checked: true, breaking: false, changes: [] },
+        // an aiReview passed here must be ignored — nothing was flagged to validate
+        aiReview: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', summary: 'should be ignored' },
+    });
+    assert.strictEqual(m.compatibility.rollingUpdateSafe, true);
+    assert.ok(!m.capabilities.includes('ai-review'));
 });
 
 // --- upgrade overrides (P4) --------------------------------------------------

--- a/scripts/gen-release-safety.ts
+++ b/scripts/gen-release-safety.ts
@@ -15,7 +15,7 @@
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { aiMigrationReview } from './ai-migration-review';
+import { aiRollingUpdateReview } from './ai-migration-review';
 import { lintMigrations, renderFindings, SqlLintFinding } from './sql-migration-lint';
 import { findExpandFloor } from './expand-version';
 import { diffRestApi } from './rest-api-diff';
@@ -204,16 +204,40 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
 
     const present: TriState = migrations ? migrations.present : 'unknown';
 
+    // A deterministic detector flagged a breaking change on a NON-migration
+    // surface (the REST API via oasdiff, or the MCP tool surface via the snapshot
+    // diff). These can break an in-flight frontend / client mid-rollout, so they
+    // are a rolling-update concern the AI review validates — even on a release
+    // with no schema migration. (They populate api.* regardless; this gate only
+    // governs whether they bear on compatibility.rollingUpdateSafe.)
+    const restBreaking = Boolean(restApi?.checked && restApi.breaking === true);
+    const mcpBreaking = Boolean(input.mcpApi?.checked && input.mcpApi.breaking === true);
+    const nonMigrationHazard = restBreaking || mcpBreaking;
+
     let rollingUpdateSafe: TriState;
     let recommendedStrategy: ReleaseSafetyMarker['compatibility']['recommendedStrategy'];
     let notes: string;
 
-    if (present === false) {
-        // No schema migrations in this release. Safe with respect to the migration
-        // check only — see blind-spot note.
+    if (present === false && !nonMigrationHazard) {
+        // No schema migrations and nothing else flagged. Safe with respect to the
+        // checks that ran — see blind-spot note.
         rollingUpdateSafe = true;
         recommendedStrategy = 'RollingUpdate';
         notes = `No database migrations detected in this release. ${BLIND_SPOT_NOTE}`;
+    } else if (present === false && nonMigrationHazard) {
+        // No migration, but a deterministic detector flagged a breaking REST/MCP
+        // change. Whether an in-flight frontend/client actually breaks mid-rollout
+        // depends on who calls it — that's the AI review's call below. Until it's
+        // verified, stay cautious rather than assert safe off "no migrations".
+        const which = [restBreaking ? 'REST API' : null, mcpBreaking ? 'MCP tool' : null]
+            .filter(Boolean)
+            .join(' and ');
+        rollingUpdateSafe = 'unknown';
+        recommendedStrategy = 'Recreate';
+        notes =
+            `No database migrations, but a deterministic check flagged a breaking ${which} change. ` +
+            `Whether an in-flight frontend or client breaks during a rolling update was not automatically ` +
+            `verified; prefer a Recreate strategy or a maintenance window. ${BLIND_SPOT_NOTE}`;
     } else if (present === true) {
         rollingUpdateSafe = 'unknown';
         recommendedStrategy = 'Recreate';
@@ -251,30 +275,33 @@ export function buildMarker(input: BuildMarkerInput): ReleaseSafetyMarker {
         }
     }
 
-    // P6: the AI migration review — the intelligent check. Runs on ALL
-    // migration-bearing releases (even when the linter flagged a shape) because it
-    // can read the previous release's code and recognise an expand/contract: a
-    // drop/rename is safe if the old code no longer references the object. A
-    // DEFINITIVE AI verdict (high-confidence safe → true, or breaking → false)
-    // overrides the linter floor; an inconclusive AI ("unknown") leaves the floor
-    // (or the honest default) in place — so the AI can only ever make the marker
-    // MORE accurate, never downgrade a deterministic break to "unknown". It never
-    // applies on a no-migration or first release.
+    // P6: the AI rolling-update review — the intelligent VALIDATION layer. Runs to
+    // validate whatever the deterministic detectors flagged: ALL migration-bearing
+    // releases (even when the linter flagged a shape — it can read the previous
+    // release's code and recognise an expand/contract, where a drop/rename is safe
+    // because the old code no longer references the object) AND no-migration
+    // releases where a REST/MCP break was flagged (it decides whether an in-flight
+    // frontend/client actually breaks). A DEFINITIVE AI verdict (high-confidence
+    // safe → true, or breaking → false) overrides the linter floor / cautious
+    // default; an inconclusive AI ("unknown") leaves it in place — so the AI can
+    // only ever make the marker MORE accurate, never downgrade a deterministic
+    // break to "unknown". It never applies on a first release or on a release with
+    // nothing flagged (no migration AND no API break).
     // True when the AI cleared a linter-flagged destructive change as the safe
     // "contract" step of an expand/contract — the verdict it reached by verifying
     // the PREVIOUS release (previousVersion) no longer uses the object.
     const aiClearedExpandContract = Boolean(
         linterFlagged && aiReview && aiReview.rollingUpdateSafe === true,
     );
-    if (aiReview && present === true) {
+    if (aiReview && (present === true || nonMigrationHazard)) {
         capabilities.push('ai-review');
         if (aiReview.rollingUpdateSafe !== 'unknown') {
             rollingUpdateSafe = aiReview.rollingUpdateSafe;
             recommendedStrategy = aiReview.recommendedStrategy;
             notes =
                 linterFlagged && aiReview.rollingUpdateSafe === true
-                    ? `AI migration review CLEARED a deterministic linter flag — it verified the previous release (${previousVersion ?? 'unknown'}) no longer uses the changed object (expand/contract): ${aiReview.summary} Safe ONLY when upgrading from ${previousVersion ?? 'that release'} or later. ${BLIND_SPOT_NOTE}`
-                    : `AI migration review: ${aiReview.summary} ${BLIND_SPOT_NOTE}`;
+                    ? `AI rolling-update review CLEARED a deterministic linter flag — it verified the previous release (${previousVersion ?? 'unknown'}) no longer uses the changed object (expand/contract): ${aiReview.summary} Safe ONLY when upgrading from ${previousVersion ?? 'that release'} or later. ${BLIND_SPOT_NOTE}`
+                    : `AI rolling-update review: ${aiReview.summary} ${BLIND_SPOT_NOTE}`;
         }
     }
 
@@ -474,44 +501,11 @@ async function main(): Promise<void> {
         );
     }
 
-    // P6: gated AI review. Runs on ALL migration-bearing releases (not only the
-    // linter-clean ones) when a key is present — it's the only check that can read
-    // the previous release's code and recognise an expand/contract, so it may
-    // safely clear a shape the linter flagged. Any degrade leaves the verdict at
-    // the linter floor / honest "unknown" — the review can only ever make the
-    // marker more accurate, never falsely safe, and never fails the release.
-    let aiReview: AiReviewSummary | null = null;
-    if (wantAiReview && markerEnabled && migrations?.present === true && args.lastTag) {
-        const apiKey = process.env.ANTHROPIC_API_KEY;
-        if (!apiKey) {
-            console.warn('[release-safety] --ai-review requested but ANTHROPIC_API_KEY not set; rollingUpdateSafe stays "unknown"');
-        } else {
-            console.warn('[release-safety] running AI migration review...');
-            const r = await aiMigrationReview({
-                apiKey,
-                lastTag: args.lastTag,
-                version: args.version,
-                log: (m) => console.warn(`[ai-review] ${m}`),
-            });
-            if (r) {
-                aiReview = {
-                    rollingUpdateSafe: r.rollingUpdateSafe,
-                    recommendedStrategy: r.recommendedStrategy,
-                    summary: r.summary,
-                };
-                console.warn(
-                    `[release-safety] AI verdict: ${r.modelVerdict}/${r.confidence} (${r.toolCalls} tool calls) -> rollingUpdateSafe=${JSON.stringify(r.rollingUpdateSafe)}`,
-                );
-            } else {
-                console.warn('[release-safety] AI review degraded; rollingUpdateSafe stays "unknown"');
-            }
-        }
-    }
-
     // P2: deterministic REST API breaking-change diff (oasdiff). Auto-runs when a
     // previous tag exists and oasdiff is available (OASDIFF_BIN or PATH); the CI
     // workflow installs it. Soft fail-safe: any problem leaves api.rest unchecked
-    // and never fails the release.
+    // and never fails the release. Runs BEFORE the AI review so a flagged break can
+    // be handed to the reviewer to validate (does the in-flight frontend break?).
     let restApi: ApiSurface | null = null;
     if (args.lastTag) {
         restApi = diffRestApi({
@@ -531,6 +525,53 @@ async function main(): Promise<void> {
             newRef: 'HEAD',
             log: (m) => console.warn(`[mcp-tools-diff] ${m}`),
         });
+    }
+
+    // P6: gated AI rolling-update review — the VALIDATION layer over the
+    // deterministic detectors. Runs when a key is present AND something was flagged
+    // worth validating: a migration is present (even a linter-clean one — it can
+    // recognise an expand/contract the linter can't), OR a REST/MCP break was
+    // flagged (it decides whether an in-flight frontend/client actually breaks). It
+    // is fed the deterministic breaking lists so it validates exactly what the
+    // detectors found. Any degrade leaves the verdict at the linter floor / cautious
+    // default — the review can only ever make the marker more accurate, never
+    // falsely safe, and never fails the release.
+    const restBreakingChanges =
+        restApi?.checked && restApi.breaking === true ? restApi.changes : [];
+    const mcpBreakingChanges =
+        mcpApi?.checked && mcpApi.breaking === true ? mcpApi.changes : [];
+    const reviewable =
+        migrations?.present === true ||
+        restBreakingChanges.length > 0 ||
+        mcpBreakingChanges.length > 0;
+    let aiReview: AiReviewSummary | null = null;
+    if (wantAiReview && markerEnabled && reviewable && args.lastTag) {
+        const apiKey = process.env.ANTHROPIC_API_KEY;
+        if (!apiKey) {
+            console.warn('[release-safety] --ai-review requested but ANTHROPIC_API_KEY not set; rollingUpdateSafe stays "unknown"');
+        } else {
+            console.warn('[release-safety] running AI rolling-update review...');
+            const r = await aiRollingUpdateReview({
+                apiKey,
+                lastTag: args.lastTag,
+                version: args.version,
+                restBreaking: restBreakingChanges,
+                mcpBreaking: mcpBreakingChanges,
+                log: (m) => console.warn(`[ai-review] ${m}`),
+            });
+            if (r) {
+                aiReview = {
+                    rollingUpdateSafe: r.rollingUpdateSafe,
+                    recommendedStrategy: r.recommendedStrategy,
+                    summary: r.summary,
+                };
+                console.warn(
+                    `[release-safety] AI verdict: ${r.modelVerdict}/${r.confidence} (${r.toolCalls} tool calls) -> rollingUpdateSafe=${JSON.stringify(r.rollingUpdateSafe)}`,
+                );
+            } else {
+                console.warn('[release-safety] AI review degraded; rollingUpdateSafe stays "unknown"');
+            }
+        }
     }
 
     // Expand-version tracing: when the AI cleared a linter-flagged drop/rename as

--- a/scripts/release-safety-pr-comment.test.ts
+++ b/scripts/release-safety-pr-comment.test.ts
@@ -63,7 +63,7 @@ const unknownMigrationMarker = (): Marker => baseMarker({
 test('draft PR with unknown verdict => invites marking ready to run the AI review', () => {
     const body = renderPrComment(unknownMigrationMarker(), { draft: true });
     assert.ok(body.includes('Recreate recommended'));
-    assert.ok(/Mark this PR ready for review.*run the AI migration review/s.test(body));
+    assert.ok(/Mark this PR ready for review.*run the AI rolling-update review/s.test(body));
     assert.ok(body.includes('skipped (draft PR — mark ready to run it)'));
     assert.ok(body.includes('2 added'));
 });
@@ -75,7 +75,7 @@ test('ready PR, AI ran and cleared it => Safe, ai-review row shows ran', () => {
         compatibility: { rollingUpdateSafe: true, recommendedStrategy: 'RollingUpdate', notes: 'AI migration review: verified additive.' },
     }), { draft: false });
     assert.ok(body.includes('Safe to RollingUpdate'));
-    assert.ok(body.includes('✅ ran — verdict folded into the determination'));
+    assert.ok(body.includes('✅ ran — validated the flagged change(s); verdict folded into the determination'));
     // no "mark ready" nudge once it has actually run
     assert.ok(!/Mark this PR ready/.test(body));
 });
@@ -168,6 +168,38 @@ test('REST + MCP breaking changes are flagged in determination and consequences'
     assert.ok(body.includes('REST API breaking change'));
     assert.ok(body.includes('MCP tool breaking change'));
     assert.ok(/1 breaking change\(s\)/.test(body));
+});
+
+test('API-driven break (no migration) reads as an API change, not a schema change', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'ai-review', 'rest', 'upgrade'],
+        migrations: { present: false, count: 0, files: [], ee: false },
+        compatibility: { rollingUpdateSafe: false, recommendedStrategy: 'Recreate', notes: 'AI rolling-update review: the bundled frontend reads the removed field.' },
+        api: {
+            rest: { checked: true, breaking: true, changes: ['GET /api/v1/saved — response field removed'] },
+            mcp: { checked: false, breaking: false, changes: [] },
+        },
+    }), { draft: false });
+    assert.ok(body.includes('Recreate required'));
+    assert.ok(/breaking API change was flagged/.test(body));
+    // it must NOT claim a schema break / crash loop when there's no migration
+    assert.ok(!/breaking schema change was detected/.test(body));
+    assert.ok(/in-flight consumer/.test(body));
+    assert.ok(body.includes('✅ ran — validated the flagged change(s)'));
+});
+
+test('API-driven unknown (no migration) describes an API change, not schema', () => {
+    const body = renderPrComment(baseMarker({
+        capabilities: ['migrations', 'ai-review', 'mcp', 'upgrade'],
+        migrations: { present: false, count: 0, files: [], ee: false },
+        compatibility: { rollingUpdateSafe: 'unknown', recommendedStrategy: 'Recreate', notes: 'AI rolling-update review: could not determine.' },
+        api: {
+            rest: { checked: false, breaking: false, changes: [] },
+            mcp: { checked: true, breaking: true, changes: ['MCP tool `run_query` input now required'] },
+        },
+    }));
+    assert.ok(body.includes('Recreate recommended'));
+    assert.ok(/carries an API change/.test(body));
 });
 
 test('EE migrations are labelled', () => {

--- a/scripts/release-safety-pr-comment.ts
+++ b/scripts/release-safety-pr-comment.ts
@@ -7,9 +7,10 @@
  * which checks ran and what they found, and what would happen when the change is
  * deployed to self-hosted customers.
  *
- * The AI review does not run on PRs (it's release-time only), so a migration PR
- * typically shows "unknown / Recreate" here unless the deterministic SQL linter
- * positively finds a break — the comment says so.
+ * The AI rolling-update review runs on READY PRs (not drafts): it validates
+ * whatever the deterministic detectors flagged — migrations, and REST/MCP breaking
+ * changes — and folds a verdict into the determination. On a draft the comment
+ * invites marking it ready to get that verdict.
  *
  * Pure `renderPrComment` (unit-tested) + a thin IO `main` that reads the marker
  * JSON and prints the comment body.
@@ -47,7 +48,7 @@ export interface RenderOpts {
     /** Human label for the comparison base, e.g. "main (a1b2c3d)". */
     baseLabel?: string;
     /**
-     * True if the PR is a draft. The AI migration review runs only on ready PRs,
+     * True if the PR is a draft. The AI rolling-update review runs only on ready PRs,
      * so on a draft the comment invites the author to mark it ready to get the
      * AI-refined verdict.
      */
@@ -85,6 +86,11 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     // The linter flagged a destructive shape but the AI cleared it (expand/contract).
     const aiClearedLinter = lintFlagged && rollingUpdateSafe === true && caps.has('ai-review');
 
+    // Whether an unsafe/unknown verdict is driven by a schema migration or by a
+    // flagged API break (no migration) — so the wording stays accurate either way.
+    const apiDriven = (restBreaking || mcpBreaking) && migrationsPresent !== true;
+    const breakKind = apiDriven ? 'an API' : 'a schema';
+
     // ---- determination ------------------------------------------------------
     const lines: string[] = [];
     if (marker.upgrade.requiredStop) {
@@ -94,9 +100,15 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         );
     }
     if (rollingUpdateSafe === false) {
-        lines.push('⚠️ **Recreate required** — a breaking schema change was detected; the previous version would not survive a rolling update.');
+        lines.push(
+            apiDriven
+                ? '⚠️ **Recreate required** — a breaking API change was flagged and the AI review found an in-flight consumer (e.g. the bundled frontend) would break during a rolling update.'
+                : '⚠️ **Recreate required** — a breaking schema change was detected; the previous version would not survive a rolling update.',
+        );
     } else if (rollingUpdateSafe === 'unknown') {
-        lines.push('❓ **Recreate recommended** — this change touches the schema and backward-compatibility was not verified.');
+        lines.push(
+            `❓ **Recreate recommended** — this change carries ${breakKind} change and backward-compatibility during a rolling update was not verified.`,
+        );
     } else if (aiClearedLinter) {
         lines.push('✅ **Safe to RollingUpdate** — the SQL linter flagged a destructive shape, but the AI review verified the previous release no longer uses it (expand/contract).');
     } else if (migrationsPresent === true) {
@@ -124,10 +136,10 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         : '✅ no breaking shapes found';
 
     const aiResult = caps.has('ai-review')
-        ? '✅ ran — verdict folded into the determination above'
+        ? '✅ ran — validated the flagged change(s); verdict folded into the determination above'
         : opts.draft
         ? '⏭️ skipped (draft PR — mark ready to run it)'
-        : '⏭️ no verdict (no migrations, inconclusive, or linter already decided)';
+        : '⏭️ skipped (nothing flagged to validate — no migration and no API break)';
 
     const apiResult = (s: ApiSurface, missingNote: string): string => {
         if (!s.checked) return `⏭️ not checked (${missingNote})`;
@@ -147,7 +159,7 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
         '|---|---|---|',
         row('Migrations', migrationsPresent === 'unknown' ? '⚠️' : '✅ ran', migResult),
         row('SQL-shape linter', caps.has('sql-lint') ? '✅ ran' : '⏭️ n/a', sqlResult),
-        row('AI migration review', caps.has('ai-review') ? '✅ ran' : '⏭️ skipped', aiResult),
+        row('AI rolling-update review', caps.has('ai-review') ? '✅ ran' : '⏭️ skipped', aiResult),
         row('REST API (oasdiff)', marker.api.rest.checked ? '✅ ran' : '⏭️ skipped', apiResult(marker.api.rest, 'oasdiff or base spec unavailable')),
         row('MCP tool surface', marker.api.mcp.checked ? '✅ ran' : '⏭️ skipped', apiResult(marker.api.mcp, 'no baseline snapshot')),
         row('Upgrade overrides', caps.has('upgrade') ? '✅ ran' : '⏭️ skipped', upgradeResult),
@@ -158,16 +170,20 @@ export function renderPrComment(marker: Marker, opts: RenderOpts = {}): string {
     consequence.push(
         'On a managed Helm upgrade the migration Job runs first (schema-before-code), then the app does a default **RollingUpdate** — so the *previous* version’s pods keep serving traffic against the already-migrated schema until the rollout finishes.',
     );
-    if (rollingUpdateSafe === false) {
+    if (rollingUpdateSafe === false && apiDriven) {
+        consequence.push(
+            '- ⚠️ A breaking API change means an already-loaded frontend (or other in-flight client) hitting a mix of old and new pods can error mid-rollout. Customers whose CI/CD reads the marker would be told **recommendedStrategy: Recreate** — a brief restart shrinks the window in which both versions serve at once.',
+        );
+    } else if (rollingUpdateSafe === false) {
         consequence.push(
             `- ⚠️ A breaking schema change means those old pods can crash (\`CrashLoopBackOff\`) mid-rollout. Customers whose CI/CD reads the marker would be told **recommendedStrategy: Recreate**${lintFlagged ? ' (flagged deterministically by the SQL linter)' : ''} — a brief restart instead of a crash loop.`,
         );
     } else if (rollingUpdateSafe === 'unknown') {
         const aiHint = opts.draft
-            ? ' **Mark this PR ready for review** to run the AI migration review (it doesn’t run on drafts) — it may refine this to ✅ safe.'
+            ? ' **Mark this PR ready for review** to run the AI rolling-update review (it doesn’t run on drafts) — it may refine this to ✅ safe.'
             : caps.has('ai-review')
             ? ''
-            : ' The AI migration review did not positively clear it.';
+            : ' The AI rolling-update review did not positively clear it.';
         consequence.push(
             `- ❓ Backward-compatibility was not verified, so customers reading the marker get **recommendedStrategy: Recreate** as the cautious default.${aiHint}`,
         );


### PR DESCRIPTION
## What

Extends the release-safety AI review (PROD-8359) so it is the **validation layer for every deterministic detector**, not migrations alone. When `oasdiff` flags a breaking REST change or the MCP tool-surface snapshot diff flags a tool break, the AI now reasons about whether an **in-flight consumer** — notably the bundled frontend, where an already-loaded old tab hits new pods and vice versa during a rolling update — would actually break, and folds that into `compatibility.rollingUpdateSafe`. This runs even on a release with **no schema migration**.

A change that only affects external third-party API scripts stays a consumer concern (recorded in `api.*`) but does not block a RollingUpdate — the AI distinguishes the two.

## How

- **`ai-migration-review.ts`** — `aiMigrationReview` → `aiRollingUpdateReview` (deprecated alias kept). Fed the detectors' breaking lists; new read-only tools `grep_new_code` / `read_new_file` / `diff_file` (the release under review) alongside the existing old-side tools; rewritten system prompt that distinguishes in-flight vs external-only consumers; `perMigration` → `findings` with a `surface` tag; runs when migrations **or** a REST/MCP break is flagged.
- **`gen-release-safety.ts`** — a flagged REST/MCP break is a `nonMigrationHazard`: on a no-migration release it moves the base from a silent `true` to a cautious `unknown` until the AI resolves it (`safe`/high → true, `breaking` → false, inconclusive → stays unknown). The REST + MCP diffs now run **before** the review and feed it. AI remains the only path to `true`.
- **`release-safety-pr-comment.ts`** — determination/matrix read as an *API* change (not schema / `CrashLoopBackOff`) when the verdict is API-driven; "AI rolling-update review" row.
- **Deferred follow-up:** a blast-radius scan of changed files for config-only / serialization blind spots that carry no migration and no API-spec change (documented in the design doc).

## Testing

- 110 unit tests pass across `scripts/*.test.ts` (new cases for the no-migration + REST/MCP precedence paths).
- Typecheck clean.
- Generator smoke-tested end-to-end; reviewer confirmed to short-circuit (no network) when nothing is flagged.

The marker stays **dark-launched** (`RELEASE_SAFETY_MARKER_ENABLED=false`) — this publishes nothing and changes no release behaviour yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)